### PR TITLE
graph searching

### DIFF
--- a/atomic-agent/src/provenance/accumulator.rs
+++ b/atomic-agent/src/provenance/accumulator.rs
@@ -485,6 +485,40 @@ impl ProvenanceAccumulator {
         node_id
     }
 
+    /// Append a raw node with full control over its fields.
+    ///
+    /// This method bypasses the usual edge inference logic and allows
+    /// direct insertion of nodes with custom details. Used for ingesting
+    /// external trace formats (e.g., Sherpa JSONL) that carry their own
+    /// structured data.
+    ///
+    /// Returns the new node's ID.
+    pub fn append_raw_node(
+        &mut self,
+        kind: NodeKind,
+        timestamp: i64,
+        summary: &str,
+        detail: Option<serde_json::Value>,
+    ) -> String {
+        let node = GraphNode {
+            id: self.next_id(),
+            kind,
+            timestamp,
+            summary: summary.to_string(),
+            detail,
+            change_hash: None,
+            tool_name: None,
+            tool_call_id: None,
+            duration_ms: None,
+            classified: false,
+            confidence: None,
+            consolidated_from: Vec::new(),
+        };
+        let node_id = node.id.clone();
+        self.push_node(node);
+        node_id
+    }
+
     /// Mark a human gate as resolved.
     ///
     /// Updates the gate node's detail and clears the pending gate state.
@@ -1010,6 +1044,12 @@ fn convert_node_kind(kind: NodeKind) -> pg::ProvenanceNodeKind {
         NodeKind::HumanGate => pg::ProvenanceNodeKind::HumanGate,
         NodeKind::PatchProposal => pg::ProvenanceNodeKind::PatchProposal,
         NodeKind::Error => pg::ProvenanceNodeKind::Error,
+        NodeKind::Todo => pg::ProvenanceNodeKind::Todo,
+        NodeKind::TodoStatusChange => pg::ProvenanceNodeKind::TodoStatusChange,
+        NodeKind::PhaseTransition => pg::ProvenanceNodeKind::PhaseTransition,
+        NodeKind::Lesson => pg::ProvenanceNodeKind::Lesson,
+        NodeKind::LlmResponse => pg::ProvenanceNodeKind::LlmResponse,
+        NodeKind::HumanGateResolution => pg::ProvenanceNodeKind::HumanGateResolution,
     }
 }
 

--- a/atomic-agent/src/provenance/consolidate.rs
+++ b/atomic-agent/src/provenance/consolidate.rs
@@ -140,7 +140,15 @@ fn find_sequences(nodes: &[GraphNode]) -> Vec<Vec<usize>> {
 
         match node.kind {
             // Structural boundaries break sequences
-            NodeKind::Goal | NodeKind::PatchProposal | NodeKind::HumanGate => {
+            NodeKind::Goal
+            | NodeKind::PatchProposal
+            | NodeKind::HumanGate
+            | NodeKind::Todo
+            | NodeKind::TodoStatusChange
+            | NodeKind::PhaseTransition
+            | NodeKind::Lesson
+            | NodeKind::LlmResponse
+            | NodeKind::HumanGateResolution => {
                 if current.len() >= 2 {
                     sequences.push(std::mem::take(&mut current));
                 } else {

--- a/atomic-agent/src/provenance/types.rs
+++ b/atomic-agent/src/provenance/types.rs
@@ -76,6 +76,24 @@ pub enum NodeKind {
 
     /// Tool failure or session error.
     Error,
+
+    /// A single todo item in the checklist (Sherpa only).
+    Todo,
+
+    /// A todo item's status changed (Sherpa only).
+    TodoStatusChange,
+
+    /// A Petri net phase transition (Sherpa only).
+    PhaseTransition,
+
+    /// An unexpected failure or change of approach (Sherpa only).
+    Lesson,
+
+    /// The LLM's final response for a phase (Sherpa only).
+    LlmResponse,
+
+    /// HumanGate resolution — which command the user chose (Sherpa only).
+    HumanGateResolution,
 }
 
 impl NodeKind {
@@ -108,6 +126,12 @@ impl NodeKind {
             NodeKind::HumanGate => "human_gate",
             NodeKind::PatchProposal => "patch_proposal",
             NodeKind::Error => "error",
+            NodeKind::Todo => "todo",
+            NodeKind::TodoStatusChange => "todo_status_change",
+            NodeKind::PhaseTransition => "phase_transition",
+            NodeKind::Lesson => "lesson",
+            NodeKind::LlmResponse => "llm_response",
+            NodeKind::HumanGateResolution => "human_gate_resolution",
         }
     }
 }
@@ -372,6 +396,18 @@ pub struct GraphStats {
     pub execution_count: u32,
     pub patch_proposal_count: u32,
     pub edge_count: u32,
+    #[serde(default)]
+    pub todo_count: u32,
+    #[serde(default)]
+    pub todo_status_change_count: u32,
+    #[serde(default)]
+    pub phase_transition_count: u32,
+    #[serde(default)]
+    pub lesson_count: u32,
+    #[serde(default)]
+    pub llm_response_count: u32,
+    #[serde(default)]
+    pub human_gate_resolution_count: u32,
 }
 
 impl GraphStats {
@@ -386,6 +422,12 @@ impl GraphStats {
             + self.error_count
             + self.execution_count
             + self.patch_proposal_count
+            + self.todo_count
+            + self.todo_status_change_count
+            + self.phase_transition_count
+            + self.lesson_count
+            + self.llm_response_count
+            + self.human_gate_resolution_count
     }
 
     /// Increment the counter for the given node kind.
@@ -400,6 +442,12 @@ impl GraphStats {
             NodeKind::HumanGate => self.human_gate_count += 1,
             NodeKind::PatchProposal => self.patch_proposal_count += 1,
             NodeKind::Error => self.error_count += 1,
+            NodeKind::Todo => self.todo_count += 1,
+            NodeKind::TodoStatusChange => self.todo_status_change_count += 1,
+            NodeKind::PhaseTransition => self.phase_transition_count += 1,
+            NodeKind::Lesson => self.lesson_count += 1,
+            NodeKind::LlmResponse => self.llm_response_count += 1,
+            NodeKind::HumanGateResolution => self.human_gate_resolution_count += 1,
         }
     }
 

--- a/atomic-agent/src/turn/orchestrator.rs
+++ b/atomic-agent/src/turn/orchestrator.rs
@@ -1133,10 +1133,7 @@ impl TurnOrchestrator {
                 ),
                 "llm_response" => (
                     NodeKind::LlmResponse,
-                    dev_atomic["reply"]
-                        .as_str()
-                        .unwrap_or("llm response")
-                        .to_string(),
+                    truncate_prompt(dev_atomic["reply"].as_str().unwrap_or("llm response"), 200),
                 ),
                 "verification" => (
                     NodeKind::Verification,
@@ -1535,6 +1532,25 @@ fn vendor_from_agent_name(agent_name: &str) -> &'static str {
         "opencode" => "openai",
         _ => "unknown",
     }
+}
+
+/// Truncate a string to `max_len` bytes, breaking at a word boundary where
+/// possible and appending `"..."`.  Mirrors the same helper in sibling modules.
+fn truncate_prompt(prompt: &str, max_len: usize) -> String {
+    let trimmed = prompt.trim();
+    if trimmed.len() <= max_len {
+        return trimmed.to_string();
+    }
+
+    // Try to break at a word boundary in the first `max_len - 3` bytes.
+    let truncated = &trimmed[..max_len.saturating_sub(3)];
+    if let Some(last_space) = truncated.rfind(' ') {
+        if last_space > max_len / 2 {
+            return format!("{}...", &truncated[..last_space]);
+        }
+    }
+
+    format!("{}...", truncated)
 }
 
 impl std::fmt::Debug for TurnOrchestrator {

--- a/atomic-agent/src/turn/orchestrator.rs
+++ b/atomic-agent/src/turn/orchestrator.rs
@@ -1033,12 +1033,18 @@ impl TurnOrchestrator {
         }
     }
 
-    /// Read a Sherpa JSONL trace file and feed each record into the
-    /// provenance accumulator.
+    /// Read a Sherpa JSONL trace file and create provenance nodes for
+    /// every record, preserving the full agent-trace + Sherpa extension data.
     ///
-    /// Best-effort: parse errors on individual lines are logged and skipped.
+    /// Every JSONL line becomes a typed `ProvenanceNode` with the full
+    /// `metadata["dev.atomic"]` payload in its `detail` field. The semantic
+    /// knowledge graph can now query by node kind (Todo, PhaseTransition, etc.)
+    /// without parsing JSON blobs.
+    ///
     /// Returns `true` if at least one record was successfully ingested.
     fn ingest_sherpa_trace(&self, session_id: &str, trace_path: &Path) -> bool {
+        use crate::provenance::types::NodeKind;
+
         let mut acc = match self.load_accumulator(session_id) {
             Some(a) => a,
             None => return false,
@@ -1061,6 +1067,7 @@ impl TurnOrchestrator {
             if line.trim().is_empty() {
                 continue;
             }
+
             let record: serde_json::Value = match serde_json::from_str(line) {
                 Ok(v) => v,
                 Err(e) => {
@@ -1070,75 +1077,95 @@ impl TurnOrchestrator {
             };
 
             let dev_atomic = &record["metadata"]["dev.atomic"];
-            let record_type = dev_atomic["record_type"].as_str().unwrap_or("");
+            let record_type = dev_atomic["record_type"].as_str().unwrap_or("unknown");
             let timestamp = record["timestamp"]
                 .as_str()
                 .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
                 .map(|dt| dt.timestamp())
                 .unwrap_or_else(|| chrono::Utc::now().timestamp());
 
-            match record_type {
-                "intent" => {
-                    let title = dev_atomic["intent_title"].as_str().unwrap_or("");
-                    if !title.is_empty() {
-                        acc.append_goal(title, timestamp);
-                        ingested += 1;
-                    }
-                }
+            // Map record_type to NodeKind.
+            let (kind, summary) = match record_type {
+                "intent" => (
+                    NodeKind::Goal,
+                    dev_atomic["intent_title"]
+                        .as_str()
+                        .unwrap_or("intent")
+                        .to_string(),
+                ),
                 "commitment" => {
-                    // Commitment maps to a write_file/edit_file tool call
-                    let file_path = record["files"]
+                    let file = record["files"]
                         .as_array()
                         .and_then(|f| f.first())
                         .and_then(|f| f["path"].as_str())
                         .unwrap_or("");
-                    let tool_input = serde_json::json!({
-                        "path": file_path,
-                        "todo_id": dev_atomic["todo_id"].as_str().unwrap_or(""),
-                    });
-                    acc.append_tool_call(
-                        "write_file",
-                        None,
-                        Some(&tool_input),
-                        None,
-                        Some("completed"),
-                        None,
-                        timestamp,
+                    (NodeKind::Commitment, format!("wrote {}", file))
+                }
+                "execution" => (
+                    NodeKind::Execution,
+                    dev_atomic["command"]
+                        .as_str()
+                        .unwrap_or("command")
+                        .to_string(),
+                ),
+                "todo" => {
+                    let tid = dev_atomic["todo_id"].as_str().unwrap_or("");
+                    let content = dev_atomic["content"].as_str().unwrap_or("");
+                    (NodeKind::Todo, format!("[{}] {}", tid, content))
+                }
+                "todo_status" => {
+                    let tid = dev_atomic["todo_id"].as_str().unwrap_or("");
+                    let from = dev_atomic["from_status"].as_str().unwrap_or("");
+                    let to = dev_atomic["to_status"].as_str().unwrap_or("");
+                    (
+                        NodeKind::TodoStatusChange,
+                        format!("{}: {} → {}", tid, from, to),
+                    )
+                }
+                "phase_transition" => {
+                    let from = dev_atomic["from_phase"].as_str().unwrap_or("");
+                    let to = dev_atomic["to_phase"].as_str().unwrap_or("");
+                    (NodeKind::PhaseTransition, format!("{} → {}", from, to))
+                }
+                "lesson" => (
+                    NodeKind::Lesson,
+                    dev_atomic["label"].as_str().unwrap_or("lesson").to_string(),
+                ),
+                "llm_response" => (
+                    NodeKind::LlmResponse,
+                    dev_atomic["reply"]
+                        .as_str()
+                        .unwrap_or("llm response")
+                        .to_string(),
+                ),
+                "verification" => (
+                    NodeKind::Verification,
+                    dev_atomic["summary"]
+                        .as_str()
+                        .unwrap_or("verification")
+                        .to_string(),
+                ),
+                "human_gate" => {
+                    let resolution = dev_atomic["resolution"].as_str().unwrap_or("");
+                    (
+                        NodeKind::HumanGateResolution,
+                        format!("resolution: {}", resolution),
+                    )
+                }
+                _ => {
+                    log::debug!(
+                        "sherpa trace: skipping unknown record_type '{}'",
+                        record_type
                     );
-                    ingested += 1;
+                    continue;
                 }
-                "execution" => {
-                    let command = dev_atomic["command"].as_str().unwrap_or("");
-                    let exit_code = dev_atomic["exit_code"].as_i64().unwrap_or(0);
-                    let duration_ms = dev_atomic["duration_ms"].as_u64();
-                    let tool_input = serde_json::json!({ "command": command });
-                    let output = dev_atomic["output_summary"].as_str();
-                    let status = if exit_code == 0 { "completed" } else { "error" };
-                    acc.append_tool_call(
-                        "bash",
-                        None,
-                        Some(&tool_input),
-                        output,
-                        Some(status),
-                        duration_ms,
-                        timestamp,
-                    );
-                    ingested += 1;
-                }
-                "verification" => {
-                    // Verification is a summary — currently no specific accumulator
-                    // method for it, but append_tool_call with a test-like command
-                    // will classify as Verification via the existing classifier.
-                    // The detail is preserved in the ProvenanceGraph via the
-                    // GoalDetail/VerificationDetail in the node detail strings.
-                    // For now, skip — the accumulator already has all the
-                    // constituent nodes from the above records.
-                    ingested += 1;
-                }
-                other => {
-                    log::debug!("sherpa trace: skipping unknown record_type '{}'", other);
-                }
-            }
+            };
+
+            // Create a node with the full dev.atomic payload as detail.
+            // This preserves all the session data (intent description, todo
+            // content, phase timing, etc.) for extraction by populate_session_tables.
+            acc.append_raw_node(kind, timestamp, &summary, Some(dev_atomic.clone()));
+            ingested += 1;
         }
 
         if ingested > 0 {
@@ -1185,12 +1212,18 @@ impl TurnOrchestrator {
 
         // Convert the accumulated graph to a content-addressed ProvenanceGraph
         let change_hashes = vec![outcome.hash];
-        let graph = acc.to_provenance_graph(
+        let mut graph = acc.to_provenance_graph(
             &session.agent_name,
             &session.agent_display_name,
             &session.agent_vendor,
             &change_hashes,
         );
+
+        // Set the Sherpa profile if this is a Sherpa session.
+        // This gates session table population on the server.
+        if session.agent_name == "sherpa" {
+            graph.profile = Some("sherpa-trace/1.0.0".to_string());
+        }
 
         // Save to the repository
         match atomic_repository::Repository::open(&self.repo_root) {

--- a/atomic-agent/src/turn/orchestrator.rs
+++ b/atomic-agent/src/turn/orchestrator.rs
@@ -1081,8 +1081,8 @@ impl TurnOrchestrator {
             let timestamp = record["timestamp"]
                 .as_str()
                 .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
-                .map(|dt| dt.timestamp())
-                .unwrap_or_else(|| chrono::Utc::now().timestamp());
+                .map(|dt| dt.timestamp_millis())
+                .unwrap_or_else(|| chrono::Utc::now().timestamp_millis());
 
             // Map record_type to NodeKind.
             let (kind, summary) = match record_type {

--- a/atomic-core/src/change/mod.rs
+++ b/atomic-core/src/change/mod.rs
@@ -100,6 +100,7 @@ mod local;
 pub mod ops;
 mod provenance;
 pub mod provenance_graph;
+pub mod session;
 mod store;
 
 // Re-export all public types

--- a/atomic-core/src/change/provenance_graph.rs
+++ b/atomic-core/src/change/provenance_graph.rs
@@ -563,6 +563,36 @@ pub enum ProvenanceNodeKind {
     PatchProposal,
     /// Tool failure or session error.
     Error,
+    /// A single todo item in the checklist (Sherpa only).
+    ///
+    /// Emitted during Proposing when the LLM registers todos via the tool.
+    /// Carries content, priority, dependencies in `detail`.
+    Todo,
+    /// A todo item's status changed (Sherpa only).
+    ///
+    /// Tracks the full lifecycle: pending → in_progress → completed.
+    /// Carries from_status, to_status, todo_id in `detail`.
+    TodoStatusChange,
+    /// A Petri net phase transition (Sherpa only).
+    ///
+    /// Records every state machine movement: orienting → proposing, etc.
+    /// Carries from_phase, to_phase, trigger in `detail`.
+    PhaseTransition,
+    /// An unexpected failure or change of approach worth remembering (Sherpa only).
+    ///
+    /// Emitted by the LLM during Executing when something goes wrong.
+    /// The label describes what was learned.
+    Lesson,
+    /// The LLM's final response for a phase (Sherpa only).
+    ///
+    /// Captures what the model actually said (the reply text) and any
+    /// nodes it emitted. Distinct from Verification which is the outcome.
+    LlmResponse,
+    /// HumanGate resolution — which command the user chose (Sherpa only).
+    ///
+    /// Records `/accept`, `/guide [ids]`, `/reject`, `/revise` with the
+    /// contributor attribution map.
+    HumanGateResolution,
 }
 
 impl ProvenanceNodeKind {
@@ -578,6 +608,12 @@ impl ProvenanceNodeKind {
             Self::HumanGate => "human_gate",
             Self::PatchProposal => "patch_proposal",
             Self::Error => "error",
+            Self::Todo => "todo",
+            Self::TodoStatusChange => "todo_status_change",
+            Self::PhaseTransition => "phase_transition",
+            Self::Lesson => "lesson",
+            Self::LlmResponse => "llm_response",
+            Self::HumanGateResolution => "human_gate_resolution",
         }
     }
 }
@@ -673,6 +709,18 @@ pub struct ProvenanceStats {
     pub execution_count: u32,
     pub patch_proposal_count: u32,
     pub edge_count: u32,
+    #[serde(default)]
+    pub todo_count: u32,
+    #[serde(default)]
+    pub todo_status_change_count: u32,
+    #[serde(default)]
+    pub phase_transition_count: u32,
+    #[serde(default)]
+    pub lesson_count: u32,
+    #[serde(default)]
+    pub llm_response_count: u32,
+    #[serde(default)]
+    pub human_gate_resolution_count: u32,
 }
 
 impl ProvenanceStats {
@@ -687,6 +735,12 @@ impl ProvenanceStats {
             + self.error_count
             + self.execution_count
             + self.patch_proposal_count
+            + self.todo_count
+            + self.todo_status_change_count
+            + self.phase_transition_count
+            + self.lesson_count
+            + self.llm_response_count
+            + self.human_gate_resolution_count
     }
 
     /// Increment the counter for the given node kind.
@@ -701,6 +755,12 @@ impl ProvenanceStats {
             ProvenanceNodeKind::HumanGate => self.human_gate_count += 1,
             ProvenanceNodeKind::PatchProposal => self.patch_proposal_count += 1,
             ProvenanceNodeKind::Error => self.error_count += 1,
+            ProvenanceNodeKind::Todo => self.todo_count += 1,
+            ProvenanceNodeKind::TodoStatusChange => self.todo_status_change_count += 1,
+            ProvenanceNodeKind::PhaseTransition => self.phase_transition_count += 1,
+            ProvenanceNodeKind::Lesson => self.lesson_count += 1,
+            ProvenanceNodeKind::LlmResponse => self.llm_response_count += 1,
+            ProvenanceNodeKind::HumanGateResolution => self.human_gate_resolution_count += 1,
         }
     }
 

--- a/atomic-core/src/change/session.rs
+++ b/atomic-core/src/change/session.rs
@@ -184,22 +184,23 @@ impl SessionEvent {
 
 /// Encode a `(provenance_id, seq)` pair as 16 bytes for `SESSION_EVENTS`.
 ///
-/// Layout: `[provenance_id: u64 LE][seq: u64 LE]`
+/// Layout: `[provenance_id: u64 BE][seq: u64 BE]`
 ///
-/// This follows the same pattern as [`encode_stack_seq`](crate::pristine::tables::encode_stack_seq).
+/// Big-endian encoding is required so that lexicographic byte order (used by
+/// the B-tree) matches numeric order, enabling correct prefix range scans.
 #[inline]
 pub fn encode_session_event_key(provenance_id: u64, seq: u64) -> [u8; 16] {
     let mut key = [0u8; 16];
-    key[0..8].copy_from_slice(&provenance_id.to_le_bytes());
-    key[8..16].copy_from_slice(&seq.to_le_bytes());
+    key[0..8].copy_from_slice(&provenance_id.to_be_bytes());
+    key[8..16].copy_from_slice(&seq.to_be_bytes());
     key
 }
 
 /// Decode a `(provenance_id, seq)` pair from 16 bytes.
 #[inline]
 pub fn decode_session_event_key(key: &[u8; 16]) -> (u64, u64) {
-    let provenance_id = u64::from_le_bytes(key[0..8].try_into().unwrap());
-    let seq = u64::from_le_bytes(key[8..16].try_into().unwrap());
+    let provenance_id = u64::from_be_bytes(key[0..8].try_into().unwrap());
+    let seq = u64::from_be_bytes(key[8..16].try_into().unwrap());
     (provenance_id, seq)
 }
 
@@ -208,13 +209,16 @@ pub fn decode_session_event_key(key: &[u8; 16]) -> (u64, u64) {
 /// The `todo_id` string is hashed with Blake3 and the first 8 bytes are used
 /// as a fixed-size discriminant.
 ///
-/// Layout: `[provenance_id: u64 LE][blake3(todo_id)[0..8]]`
+/// Layout: `[provenance_id: u64 BE][blake3(todo_id)[0..8]]`
+///
+/// Big-endian encoding is required so that lexicographic byte order (used by
+/// the B-tree) matches numeric order, enabling correct prefix range scans.
 #[inline]
 pub fn encode_session_todo_key(provenance_id: u64, todo_id: &str) -> [u8; 16] {
     let hash = blake3::hash(todo_id.as_bytes());
     let hash_bytes = hash.as_bytes();
     let mut key = [0u8; 16];
-    key[0..8].copy_from_slice(&provenance_id.to_le_bytes());
+    key[0..8].copy_from_slice(&provenance_id.to_be_bytes());
     key[8..16].copy_from_slice(&hash_bytes[0..8]);
     key
 }
@@ -225,7 +229,7 @@ pub fn encode_session_todo_key(provenance_id: u64, todo_id: &str) -> [u8; 16] {
 /// string is stored inside the [`TodoSnapshot`] value.
 #[inline]
 pub fn decode_session_todo_key_provenance_id(key: &[u8; 16]) -> u64 {
-    u64::from_le_bytes(key[0..8].try_into().unwrap())
+    u64::from_be_bytes(key[0..8].try_into().unwrap())
 }
 
 /// Encode a `(provenance_id, phase_hash)` pair as 16 bytes for `SESSION_PHASES`.
@@ -233,13 +237,16 @@ pub fn decode_session_todo_key_provenance_id(key: &[u8; 16]) -> u64 {
 /// The `phase_name` string is hashed with Blake3 and the first 8 bytes are
 /// used as a fixed-size discriminant.
 ///
-/// Layout: `[provenance_id: u64 LE][blake3(phase_name)[0..8]]`
+/// Layout: `[provenance_id: u64 BE][blake3(phase_name)[0..8]]`
+///
+/// Big-endian encoding is required so that lexicographic byte order (used by
+/// the B-tree) matches numeric order, enabling correct prefix range scans.
 #[inline]
 pub fn encode_session_phase_key(provenance_id: u64, phase_name: &str) -> [u8; 16] {
     let hash = blake3::hash(phase_name.as_bytes());
     let hash_bytes = hash.as_bytes();
     let mut key = [0u8; 16];
-    key[0..8].copy_from_slice(&provenance_id.to_le_bytes());
+    key[0..8].copy_from_slice(&provenance_id.to_be_bytes());
     key[8..16].copy_from_slice(&hash_bytes[0..8]);
     key
 }
@@ -250,18 +257,22 @@ pub fn encode_session_phase_key(provenance_id: u64, phase_name: &str) -> [u8; 16
 /// is stored inside the [`PhaseTimingEntry`] value.
 #[inline]
 pub fn decode_session_phase_key_provenance_id(key: &[u8; 16]) -> u64 {
-    u64::from_le_bytes(key[0..8].try_into().unwrap())
+    u64::from_be_bytes(key[0..8].try_into().unwrap())
 }
 
 /// Encode a provenance-id prefix for range scans on any session table
 /// that uses `[u8; 16]` composite keys.
 ///
-/// Returns a 16-byte key with only `provenance_id` set and the secondary
-/// component zeroed. Used as the start bound for prefix scans.
+/// Returns a 16-byte key with `provenance_id` in the high bytes and the
+/// secondary component zeroed. Used as the start bound for prefix scans:
+/// all keys for a given `provenance_id` lie in `[prefix(id), prefix(id+1))`.
+///
+/// Big-endian encoding ensures this half-open range is correct across all
+/// numeric values of `provenance_id`.
 #[inline]
 pub fn encode_session_prefix(provenance_id: u64) -> [u8; 16] {
     let mut key = [0u8; 16];
-    key[0..8].copy_from_slice(&provenance_id.to_le_bytes());
+    key[0..8].copy_from_slice(&provenance_id.to_be_bytes());
     key
 }
 
@@ -525,7 +536,10 @@ mod tests {
 
     #[test]
     fn test_session_event_key_ordering() {
-        // Keys for the same provenance_id should sort by seq
+        // Keys for the same provenance_id must sort by seq in lexicographic
+        // (B-tree) order across the full u64 range.  Big-endian encoding
+        // guarantees this: the most-significant byte comes first, so byte-wise
+        // comparison matches numeric comparison for all values.
         let k1 = encode_session_event_key(5, 0);
         let k2 = encode_session_event_key(5, 1);
         let k3 = encode_session_event_key(5, 100);
@@ -534,6 +548,21 @@ mod tests {
         assert!(k1 < k2);
         assert!(k2 < k3);
         assert!(k3 < k4, "different provenance_id sorts after");
+
+        // Boundary: seq=255 (single-byte max) vs seq=256 (spills into second byte).
+        // With big-endian encoding this must sort correctly.
+        let k_255 = encode_session_event_key(5, 255);
+        let k_256 = encode_session_event_key(5, 256);
+        assert!(
+            k_255 < k_256,
+            "seq=255 must sort before seq=256 (byte-spill boundary)"
+        );
+
+        // seq=256 on provenance_id=5 must still sort before provenance_id=6.
+        assert!(
+            k_256 < k4,
+            "seq=256 on provenance_id=5 must sort before provenance_id=6"
+        );
     }
 
     #[test]

--- a/atomic-core/src/change/session.rs
+++ b/atomic-core/src/change/session.rs
@@ -1,0 +1,636 @@
+//! Session data types for Sherpa-enriched provenance.
+//!
+//! These types are stored in the session tables in the pristine database
+//! when a provenance graph has `profile == "sherpa-trace/1.0.0"`.
+//! They represent the structured turn data extracted from the Petri net
+//! replay log.
+//!
+//! # Storage Format
+//!
+//! Values are serialized with [postcard](https://docs.rs/postcard) (binary,
+//! compact, no-std compatible). This is the same codec used by
+//! [`ProvenanceGraph`](super::provenance_graph::ProvenanceGraph).
+//!
+//! # Table Layout
+//!
+//! | Table | Key | Value |
+//! |-------|-----|-------|
+//! | `SESSION_INTENTS` | `provenance_id: u64` | `IntentEntry` |
+//! | `SESSION_TODOS` | `(provenance_id, todo_id_hash): [u8; 16]` | `TodoSnapshot` |
+//! | `SESSION_PHASES` | `(provenance_id, phase_hash): [u8; 16]` | `PhaseTimingEntry` |
+//! | `SESSION_EVENTS` | `(provenance_id, seq): [u8; 16]` | `SessionEvent` |
+//!
+//! Composite keys are 16-byte arrays following the same pattern as
+//! `STACK_CHANGES`: first 8 bytes = discriminant (u64 LE), second 8 bytes =
+//! secondary key (u64 LE or first-8-bytes-of-blake3).
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Value types
+// ---------------------------------------------------------------------------
+
+/// Intent metadata for a turn.
+///
+/// Stored in `SESSION_INTENTS` keyed by `provenance_id`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IntentEntry {
+    /// Short human-readable title for the turn's goal.
+    pub title: String,
+    /// Longer description of what the agent was asked to do.
+    pub description: String,
+    /// Zero-based turn index within the session.
+    pub turn_id: u32,
+    /// LLM model identifier (e.g. `"claude-sonnet-4-20250514"`).
+    pub model: String,
+    /// Unique session identifier from the agent framework.
+    pub session_id: String,
+    /// Outcome tag (e.g. `"success"`, `"failure"`, `"partial"`).
+    pub outcome: String,
+    /// Total token count (prompt + completion) for the turn.
+    pub total_tokens: u64,
+    /// Total estimated cost in USD for the turn.
+    pub total_cost_usd: f64,
+}
+
+/// Final state of a todo item at the end of a turn.
+///
+/// Stored in `SESSION_TODOS` keyed by `(provenance_id, todo_id_hash)`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TodoSnapshot {
+    /// Unique todo identifier from the agent framework.
+    pub todo_id: String,
+    /// Human-readable content / description of the todo.
+    pub content: String,
+    /// Owner of the todo (agent name or user).
+    pub owner: String,
+    /// Final status at the end of the turn (e.g. `"done"`, `"in_progress"`).
+    pub final_status: String,
+    /// Priority level (e.g. `"high"`, `"medium"`, `"low"`).
+    pub priority: String,
+    /// Source file path, if the todo is anchored to a file.
+    pub file: Option<String>,
+    /// Start line in the source file (1-based).
+    pub start_line: Option<u32>,
+    /// End line in the source file (1-based, inclusive).
+    pub end_line: Option<u32>,
+    /// ISO-8601 timestamp when work on this todo began.
+    pub started_at: Option<String>,
+    /// ISO-8601 timestamp when this todo was marked complete.
+    pub completed_at: Option<String>,
+}
+
+/// Timing data for a single phase within a turn.
+///
+/// Stored in `SESSION_PHASES` keyed by `(provenance_id, phase_hash)`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PhaseTimingEntry {
+    /// Phase name (e.g. `"plan"`, `"implement"`, `"verify"`).
+    pub phase: String,
+    /// ISO-8601 timestamp when this phase started.
+    pub start_ts: Option<String>,
+    /// ISO-8601 timestamp when this phase ended.
+    pub end_ts: Option<String>,
+    /// Number of input (prompt) tokens consumed during this phase.
+    pub input_tokens: u64,
+    /// Number of output (completion) tokens produced during this phase.
+    pub output_tokens: u64,
+    /// Estimated cost in USD for this phase.
+    pub cost_usd: f64,
+}
+
+/// A single event in the Petri net replay log.
+///
+/// Stored in `SESSION_EVENTS` keyed by `(provenance_id, seq)`.
+/// This is the raw event — the other session tables are derived
+/// summaries for fast lookup.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionEvent {
+    /// Monotonically increasing sequence number within the turn.
+    pub seq: u64,
+    /// ISO-8601 timestamp of the event.
+    pub timestamp: String,
+    /// Event kind discriminator (e.g. `"fire"`, `"deposit"`, `"consume"`).
+    pub event_kind: String,
+    /// Petri net place name, if the event is place-related.
+    pub place: Option<String>,
+    /// Petri net transition name, if the event is a firing.
+    pub transition: Option<String>,
+    /// Token identifier within the Petri net.
+    pub token_id: String,
+    /// Token kind discriminator (e.g. `"intent"`, `"todo"`, `"artifact"`).
+    pub token_kind: String,
+    /// JSON string of the token's data bag.
+    pub token_data: String,
+    /// Agent-trace `record_type` for convenience filtering.
+    pub record_type: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Serialization helpers (postcard)
+// ---------------------------------------------------------------------------
+
+impl IntentEntry {
+    /// Serialize to a compact binary blob via postcard.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        postcard::to_allocvec(self).expect("IntentEntry serialization")
+    }
+
+    /// Deserialize from a postcard binary blob.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, postcard::Error> {
+        postcard::from_bytes(bytes)
+    }
+}
+
+impl TodoSnapshot {
+    /// Serialize to a compact binary blob via postcard.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        postcard::to_allocvec(self).expect("TodoSnapshot serialization")
+    }
+
+    /// Deserialize from a postcard binary blob.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, postcard::Error> {
+        postcard::from_bytes(bytes)
+    }
+}
+
+impl PhaseTimingEntry {
+    /// Serialize to a compact binary blob via postcard.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        postcard::to_allocvec(self).expect("PhaseTimingEntry serialization")
+    }
+
+    /// Deserialize from a postcard binary blob.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, postcard::Error> {
+        postcard::from_bytes(bytes)
+    }
+}
+
+impl SessionEvent {
+    /// Serialize to a compact binary blob via postcard.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        postcard::to_allocvec(self).expect("SessionEvent serialization")
+    }
+
+    /// Deserialize from a postcard binary blob.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, postcard::Error> {
+        postcard::from_bytes(bytes)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Composite key encoding
+// ---------------------------------------------------------------------------
+
+/// Encode a `(provenance_id, seq)` pair as 16 bytes for `SESSION_EVENTS`.
+///
+/// Layout: `[provenance_id: u64 LE][seq: u64 LE]`
+///
+/// This follows the same pattern as [`encode_stack_seq`](crate::pristine::tables::encode_stack_seq).
+#[inline]
+pub fn encode_session_event_key(provenance_id: u64, seq: u64) -> [u8; 16] {
+    let mut key = [0u8; 16];
+    key[0..8].copy_from_slice(&provenance_id.to_le_bytes());
+    key[8..16].copy_from_slice(&seq.to_le_bytes());
+    key
+}
+
+/// Decode a `(provenance_id, seq)` pair from 16 bytes.
+#[inline]
+pub fn decode_session_event_key(key: &[u8; 16]) -> (u64, u64) {
+    let provenance_id = u64::from_le_bytes(key[0..8].try_into().unwrap());
+    let seq = u64::from_le_bytes(key[8..16].try_into().unwrap());
+    (provenance_id, seq)
+}
+
+/// Encode a `(provenance_id, todo_id_hash)` pair as 16 bytes for `SESSION_TODOS`.
+///
+/// The `todo_id` string is hashed with Blake3 and the first 8 bytes are used
+/// as a fixed-size discriminant.
+///
+/// Layout: `[provenance_id: u64 LE][blake3(todo_id)[0..8]]`
+#[inline]
+pub fn encode_session_todo_key(provenance_id: u64, todo_id: &str) -> [u8; 16] {
+    let hash = blake3::hash(todo_id.as_bytes());
+    let hash_bytes = hash.as_bytes();
+    let mut key = [0u8; 16];
+    key[0..8].copy_from_slice(&provenance_id.to_le_bytes());
+    key[8..16].copy_from_slice(&hash_bytes[0..8]);
+    key
+}
+
+/// Decode the `provenance_id` from a `SESSION_TODOS` key.
+///
+/// The second 8 bytes are an opaque hash prefix — the original `todo_id`
+/// string is stored inside the [`TodoSnapshot`] value.
+#[inline]
+pub fn decode_session_todo_key_provenance_id(key: &[u8; 16]) -> u64 {
+    u64::from_le_bytes(key[0..8].try_into().unwrap())
+}
+
+/// Encode a `(provenance_id, phase_hash)` pair as 16 bytes for `SESSION_PHASES`.
+///
+/// The `phase_name` string is hashed with Blake3 and the first 8 bytes are
+/// used as a fixed-size discriminant.
+///
+/// Layout: `[provenance_id: u64 LE][blake3(phase_name)[0..8]]`
+#[inline]
+pub fn encode_session_phase_key(provenance_id: u64, phase_name: &str) -> [u8; 16] {
+    let hash = blake3::hash(phase_name.as_bytes());
+    let hash_bytes = hash.as_bytes();
+    let mut key = [0u8; 16];
+    key[0..8].copy_from_slice(&provenance_id.to_le_bytes());
+    key[8..16].copy_from_slice(&hash_bytes[0..8]);
+    key
+}
+
+/// Decode the `provenance_id` from a `SESSION_PHASES` key.
+///
+/// The second 8 bytes are an opaque hash prefix — the original phase name
+/// is stored inside the [`PhaseTimingEntry`] value.
+#[inline]
+pub fn decode_session_phase_key_provenance_id(key: &[u8; 16]) -> u64 {
+    u64::from_le_bytes(key[0..8].try_into().unwrap())
+}
+
+/// Encode a provenance-id prefix for range scans on any session table
+/// that uses `[u8; 16]` composite keys.
+///
+/// Returns a 16-byte key with only `provenance_id` set and the secondary
+/// component zeroed. Used as the start bound for prefix scans.
+#[inline]
+pub fn encode_session_prefix(provenance_id: u64) -> [u8; 16] {
+    let mut key = [0u8; 16];
+    key[0..8].copy_from_slice(&provenance_id.to_le_bytes());
+    key
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_intent_entry() -> IntentEntry {
+        IntentEntry {
+            title: "Fix authentication bug".into(),
+            description: "The login flow fails when the session token expires".into(),
+            turn_id: 3,
+            model: "claude-sonnet-4-20250514".into(),
+            session_id: "sess-abc123".into(),
+            outcome: "success".into(),
+            total_tokens: 15420,
+            total_cost_usd: 0.0462,
+        }
+    }
+
+    fn sample_todo_snapshot() -> TodoSnapshot {
+        TodoSnapshot {
+            todo_id: "todo-001".into(),
+            content: "Refactor token validation logic".into(),
+            owner: "agent".into(),
+            final_status: "done".into(),
+            priority: "high".into(),
+            file: Some("src/auth/token.rs".into()),
+            start_line: Some(42),
+            end_line: Some(87),
+            started_at: Some("2025-01-15T10:30:00Z".into()),
+            completed_at: Some("2025-01-15T10:32:15Z".into()),
+        }
+    }
+
+    fn sample_phase_timing_entry() -> PhaseTimingEntry {
+        PhaseTimingEntry {
+            phase: "implement".into(),
+            start_ts: Some("2025-01-15T10:30:00Z".into()),
+            end_ts: Some("2025-01-15T10:32:15Z".into()),
+            input_tokens: 8200,
+            output_tokens: 3100,
+            cost_usd: 0.0281,
+        }
+    }
+
+    fn sample_session_event() -> SessionEvent {
+        SessionEvent {
+            seq: 7,
+            timestamp: "2025-01-15T10:30:05.123Z".into(),
+            event_kind: "fire".into(),
+            place: Some("ready".into()),
+            transition: Some("plan_to_implement".into()),
+            token_id: "tok-42".into(),
+            token_kind: "intent".into(),
+            token_data: r#"{"goal":"fix auth"}"#.into(),
+            record_type: Some("transition_fire".into()),
+        }
+    }
+
+    // -- Roundtrip tests --
+
+    #[test]
+    fn test_intent_entry_roundtrip() {
+        let original = sample_intent_entry();
+        let bytes = original.to_bytes();
+        let recovered = IntentEntry::from_bytes(&bytes).unwrap();
+
+        assert_eq!(original, recovered);
+        assert_eq!(recovered.title, "Fix authentication bug");
+        assert_eq!(recovered.turn_id, 3);
+        assert_eq!(recovered.total_tokens, 15420);
+        assert!((recovered.total_cost_usd - 0.0462).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_todo_snapshot_roundtrip() {
+        let original = sample_todo_snapshot();
+        let bytes = original.to_bytes();
+        let recovered = TodoSnapshot::from_bytes(&bytes).unwrap();
+
+        assert_eq!(original, recovered);
+        assert_eq!(recovered.todo_id, "todo-001");
+        assert_eq!(recovered.file, Some("src/auth/token.rs".into()));
+        assert_eq!(recovered.start_line, Some(42));
+        assert_eq!(recovered.end_line, Some(87));
+        assert_eq!(recovered.completed_at, Some("2025-01-15T10:32:15Z".into()));
+    }
+
+    #[test]
+    fn test_phase_timing_entry_roundtrip() {
+        let original = sample_phase_timing_entry();
+        let bytes = original.to_bytes();
+        let recovered = PhaseTimingEntry::from_bytes(&bytes).unwrap();
+
+        assert_eq!(original, recovered);
+        assert_eq!(recovered.phase, "implement");
+        assert_eq!(recovered.input_tokens, 8200);
+        assert_eq!(recovered.output_tokens, 3100);
+        assert!((recovered.cost_usd - 0.0281).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_session_event_roundtrip() {
+        let original = sample_session_event();
+        let bytes = original.to_bytes();
+        let recovered = SessionEvent::from_bytes(&bytes).unwrap();
+
+        assert_eq!(original, recovered);
+        assert_eq!(recovered.seq, 7);
+        assert_eq!(recovered.event_kind, "fire");
+        assert_eq!(recovered.place, Some("ready".into()));
+        assert_eq!(recovered.transition, Some("plan_to_implement".into()));
+        assert_eq!(recovered.record_type, Some("transition_fire".into()));
+    }
+
+    // -- Edge cases --
+
+    #[test]
+    fn test_intent_entry_with_empty_fields() {
+        let entry = IntentEntry {
+            title: String::new(),
+            description: String::new(),
+            turn_id: 0,
+            model: String::new(),
+            session_id: String::new(),
+            outcome: String::new(),
+            total_tokens: 0,
+            total_cost_usd: 0.0,
+        };
+
+        let bytes = entry.to_bytes();
+        let recovered = IntentEntry::from_bytes(&bytes).unwrap();
+
+        assert_eq!(entry, recovered);
+        assert!(recovered.title.is_empty());
+        assert_eq!(recovered.total_tokens, 0);
+        assert!((recovered.total_cost_usd).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_todo_snapshot_with_no_optional_fields() {
+        let snapshot = TodoSnapshot {
+            todo_id: "bare".into(),
+            content: "minimal".into(),
+            owner: "agent".into(),
+            final_status: "pending".into(),
+            priority: "low".into(),
+            file: None,
+            start_line: None,
+            end_line: None,
+            started_at: None,
+            completed_at: None,
+        };
+
+        let bytes = snapshot.to_bytes();
+        let recovered = TodoSnapshot::from_bytes(&bytes).unwrap();
+
+        assert_eq!(snapshot, recovered);
+        assert!(recovered.file.is_none());
+        assert!(recovered.start_line.is_none());
+        assert!(recovered.completed_at.is_none());
+    }
+
+    #[test]
+    fn test_phase_timing_entry_with_no_timestamps() {
+        let entry = PhaseTimingEntry {
+            phase: "unknown".into(),
+            start_ts: None,
+            end_ts: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            cost_usd: 0.0,
+        };
+
+        let bytes = entry.to_bytes();
+        let recovered = PhaseTimingEntry::from_bytes(&bytes).unwrap();
+
+        assert_eq!(entry, recovered);
+        assert!(recovered.start_ts.is_none());
+        assert!(recovered.end_ts.is_none());
+    }
+
+    #[test]
+    fn test_session_event_with_no_optional_fields() {
+        let event = SessionEvent {
+            seq: 0,
+            timestamp: "2025-01-01T00:00:00Z".into(),
+            event_kind: "init".into(),
+            place: None,
+            transition: None,
+            token_id: "tok-0".into(),
+            token_kind: "system".into(),
+            token_data: "{}".into(),
+            record_type: None,
+        };
+
+        let bytes = event.to_bytes();
+        let recovered = SessionEvent::from_bytes(&bytes).unwrap();
+
+        assert_eq!(event, recovered);
+        assert!(recovered.place.is_none());
+        assert!(recovered.transition.is_none());
+        assert!(recovered.record_type.is_none());
+    }
+
+    #[test]
+    fn test_intent_entry_unicode() {
+        let entry = IntentEntry {
+            title: "修复认证错误".into(),
+            description: "ログインフローの修正".into(),
+            turn_id: 1,
+            model: "模型-v1".into(),
+            session_id: "세션-αβγ".into(),
+            outcome: "réussite".into(),
+            total_tokens: 999,
+            total_cost_usd: 1.23,
+        };
+
+        let bytes = entry.to_bytes();
+        let recovered = IntentEntry::from_bytes(&bytes).unwrap();
+
+        assert_eq!(entry, recovered);
+    }
+
+    #[test]
+    fn test_invalid_bytes_returns_error() {
+        let garbage = &[0xFF, 0xFE, 0xFD, 0xFC, 0xFB];
+
+        assert!(IntentEntry::from_bytes(garbage).is_err());
+        assert!(TodoSnapshot::from_bytes(garbage).is_err());
+        assert!(PhaseTimingEntry::from_bytes(garbage).is_err());
+        assert!(SessionEvent::from_bytes(garbage).is_err());
+    }
+
+    #[test]
+    fn test_empty_bytes_returns_error() {
+        assert!(IntentEntry::from_bytes(&[]).is_err());
+        assert!(TodoSnapshot::from_bytes(&[]).is_err());
+        assert!(PhaseTimingEntry::from_bytes(&[]).is_err());
+        assert!(SessionEvent::from_bytes(&[]).is_err());
+    }
+
+    // -- Composite key encoding tests --
+
+    #[test]
+    fn test_session_event_key_roundtrip() {
+        let prov_id = 42u64;
+        let seq = 1337u64;
+
+        let key = encode_session_event_key(prov_id, seq);
+        let (dec_prov, dec_seq) = decode_session_event_key(&key);
+
+        assert_eq!(dec_prov, prov_id);
+        assert_eq!(dec_seq, seq);
+    }
+
+    #[test]
+    fn test_session_event_key_ordering() {
+        // Keys for the same provenance_id should sort by seq
+        let k1 = encode_session_event_key(5, 0);
+        let k2 = encode_session_event_key(5, 1);
+        let k3 = encode_session_event_key(5, 100);
+        let k4 = encode_session_event_key(6, 0);
+
+        assert!(k1 < k2);
+        assert!(k2 < k3);
+        assert!(k3 < k4, "different provenance_id sorts after");
+    }
+
+    #[test]
+    fn test_session_todo_key_deterministic() {
+        let k1 = encode_session_todo_key(10, "todo-abc");
+        let k2 = encode_session_todo_key(10, "todo-abc");
+
+        assert_eq!(k1, k2, "same inputs produce same key");
+    }
+
+    #[test]
+    fn test_session_todo_key_different_ids() {
+        let k1 = encode_session_todo_key(10, "todo-abc");
+        let k2 = encode_session_todo_key(10, "todo-xyz");
+
+        // Same provenance_id, different todo_id → different key
+        assert_ne!(k1, k2);
+        // First 8 bytes (provenance_id) should be the same
+        assert_eq!(k1[0..8], k2[0..8]);
+    }
+
+    #[test]
+    fn test_session_todo_key_provenance_id_decode() {
+        let key = encode_session_todo_key(77, "some-todo");
+        assert_eq!(decode_session_todo_key_provenance_id(&key), 77);
+    }
+
+    #[test]
+    fn test_session_phase_key_deterministic() {
+        let k1 = encode_session_phase_key(10, "plan");
+        let k2 = encode_session_phase_key(10, "plan");
+
+        assert_eq!(k1, k2);
+    }
+
+    #[test]
+    fn test_session_phase_key_different_phases() {
+        let k1 = encode_session_phase_key(10, "plan");
+        let k2 = encode_session_phase_key(10, "implement");
+
+        assert_ne!(k1, k2);
+        assert_eq!(k1[0..8], k2[0..8]);
+    }
+
+    #[test]
+    fn test_session_phase_key_provenance_id_decode() {
+        let key = encode_session_phase_key(88, "verify");
+        assert_eq!(decode_session_phase_key_provenance_id(&key), 88);
+    }
+
+    #[test]
+    fn test_session_prefix() {
+        let prefix = encode_session_prefix(42);
+        let (prov_id, secondary) = decode_session_event_key(&prefix);
+
+        assert_eq!(prov_id, 42);
+        assert_eq!(secondary, 0);
+    }
+
+    #[test]
+    fn test_session_prefix_ordering() {
+        // All keys for provenance_id=5 should be >= prefix(5) and < prefix(6)
+        let prefix_5 = encode_session_prefix(5);
+        let key_5_0 = encode_session_event_key(5, 0);
+        let key_5_max = encode_session_event_key(5, u64::MAX);
+        let prefix_6 = encode_session_prefix(6);
+
+        assert_eq!(prefix_5, key_5_0);
+        assert!(key_5_max < prefix_6);
+    }
+
+    #[test]
+    fn test_session_event_key_boundary_values() {
+        // Min values
+        let key_min = encode_session_event_key(0, 0);
+        let (p, s) = decode_session_event_key(&key_min);
+        assert_eq!(p, 0);
+        assert_eq!(s, 0);
+
+        // Max values
+        let key_max = encode_session_event_key(u64::MAX, u64::MAX);
+        let (p, s) = decode_session_event_key(&key_max);
+        assert_eq!(p, u64::MAX);
+        assert_eq!(s, u64::MAX);
+    }
+
+    #[test]
+    fn test_postcard_is_compact() {
+        // Verify that postcard produces reasonably compact output.
+        // An IntentEntry with short strings should fit in well under 200 bytes.
+        let entry = sample_intent_entry();
+        let bytes = entry.to_bytes();
+
+        assert!(
+            bytes.len() < 200,
+            "expected compact serialization, got {} bytes",
+            bytes.len()
+        );
+    }
+}

--- a/atomic-core/src/pristine/tables.rs
+++ b/atomic-core/src/pristine/tables.rs
@@ -439,6 +439,43 @@ pub const CHANGE_CHUNKS: TableDefinition<&[u8; 36], &[u8; 32]> =
 pub const CHANGE_UNHASHED: TableDefinition<&[u8; 32], &[u8]> =
     TableDefinition::new("change_unhashed");
 
+// Session Tables (Sherpa-enriched provenance data)
+//
+// Populated when `ProvenanceGraph.profile == "sherpa-trace/1.0.0"`.
+// These tables store the structured turn data extracted from the Petri net
+// replay log. Values are postcard-encoded session structs from
+// `atomic_core::change::session`.
+//
+// Composite keys use the same `[u8; 16]` pattern as `STACK_CHANGES`:
+// first 8 bytes = provenance_id (u64 LE), second 8 bytes = secondary
+// component (seq, or first-8-bytes-of-blake3 for string IDs).
+
+/// Session events: (provenance_id, seq) → SessionEvent
+///
+/// The full ordered Petri net replay log for a turn. Each row is one
+/// NetEvent from the JSONL trace file. Keys sort by `(provenance_id, seq)`
+/// in little-endian byte order, enabling prefix scans per provenance graph.
+pub const SESSION_EVENTS: TableDefinition<&[u8; 16], &[u8]> =
+    TableDefinition::new("session_events");
+
+/// Session todos: (provenance_id, todo_id_hash) → TodoSnapshot
+///
+/// Final state of each todo item at the end of the turn. The `todo_id`
+/// string is hashed to a fixed-size key (first 8 bytes of Blake3).
+pub const SESSION_TODOS: TableDefinition<&[u8; 16], &[u8]> = TableDefinition::new("session_todos");
+
+/// Session phases: (provenance_id, phase_hash) → PhaseTimingEntry
+///
+/// Timing breakdown by phase for the turn. The phase name is hashed to
+/// a fixed-size key (first 8 bytes of Blake3).
+pub const SESSION_PHASES: TableDefinition<&[u8; 16], &[u8]> =
+    TableDefinition::new("session_phases");
+
+/// Session intents: provenance_id → IntentEntry
+///
+/// Intent metadata for the turn. One entry per provenance graph.
+pub const SESSION_INTENTS: TableDefinition<u64, &[u8]> = TableDefinition::new("session_intents");
+
 // V3 Change Storage Key Encoding
 
 /// Encode a change-hash + file-index as 36 bytes for CHANGE_GRAPH / CHANGE_SEMANTIC / CHANGE_CHUNKS keys.

--- a/atomic-core/src/pristine/tables.rs
+++ b/atomic-core/src/pristine/tables.rs
@@ -453,8 +453,11 @@ pub const CHANGE_UNHASHED: TableDefinition<&[u8; 32], &[u8]> =
 /// Session events: (provenance_id, seq) → SessionEvent
 ///
 /// The full ordered Petri net replay log for a turn. Each row is one
-/// NetEvent from the JSONL trace file. Keys sort by `(provenance_id, seq)`
-/// in little-endian byte order, enabling prefix scans per provenance graph.
+/// NetEvent from the JSONL trace file. Keys are composite `[u8; 16]`
+/// values `(provenance_id_le, seq_le)` and are ordered lexicographically
+/// by their little-endian byte representation. This groups events by
+/// `provenance_id` for efficient prefix scans, but does *not* guarantee
+/// numeric ordering by `seq` within a provenance.
 pub const SESSION_EVENTS: TableDefinition<&[u8; 16], &[u8]> =
     TableDefinition::new("session_events");
 

--- a/atomic-core/src/pristine/txn/pristine.rs
+++ b/atomic-core/src/pristine/txn/pristine.rs
@@ -101,6 +101,12 @@ impl Pristine {
             // State tables
             write_txn.open_table(STATES)?;
             write_txn.open_table(TAGS)?;
+
+            // Session tables (Sherpa-enriched provenance data)
+            write_txn.open_table(SESSION_EVENTS)?;
+            write_txn.open_table(SESSION_TODOS)?;
+            write_txn.open_table(SESSION_PHASES)?;
+            write_txn.open_table(SESSION_INTENTS)?;
         }
         write_txn.commit()?;
 

--- a/atomic-core/src/pristine/txn/read.rs
+++ b/atomic-core/src/pristine/txn/read.rs
@@ -536,17 +536,17 @@ impl ReadTxn {
         &self,
         provenance_id: u64,
     ) -> PristineResult<Vec<crate::change::session::SessionEvent>> {
-        use crate::change::session::{decode_session_event_key, SessionEvent};
+        use crate::change::session::{encode_session_prefix, SessionEvent};
 
         let table = self.txn.open_table(SESSION_EVENTS)?;
         let mut events = Vec::new();
 
-        for result in table.iter()? {
-            let (key, value) = result?;
-            let (prov_id, _seq) = decode_session_event_key(key.value());
-            if prov_id != provenance_id {
-                continue;
-            }
+        // Use a bounded prefix range instead of a full-table scan.
+        // All keys for `provenance_id` lie in [prefix(id), prefix(id+1)).
+        let start = encode_session_prefix(provenance_id);
+        let end = encode_session_prefix(provenance_id.saturating_add(1));
+        for result in table.range::<&[u8; 16]>(&start..&end)? {
+            let (_key, value) = result?;
             match SessionEvent::from_bytes(value.value()) {
                 Ok(event) => events.push(event),
                 Err(e) => {
@@ -555,6 +555,8 @@ impl ReadTxn {
             }
         }
 
+        // Events are already in seq order because keys encode (provenance_id,
+        // seq) with the same byte layout, but sort explicitly to be safe.
         events.sort_by_key(|e| e.seq);
         Ok(events)
     }
@@ -567,17 +569,17 @@ impl ReadTxn {
         &self,
         provenance_id: u64,
     ) -> PristineResult<Vec<crate::change::session::TodoSnapshot>> {
-        use crate::change::session::{decode_session_todo_key_provenance_id, TodoSnapshot};
+        use crate::change::session::{encode_session_prefix, TodoSnapshot};
 
         let table = self.txn.open_table(SESSION_TODOS)?;
         let mut todos = Vec::new();
 
-        for result in table.iter()? {
-            let (key, value) = result?;
-            let prov_id = decode_session_todo_key_provenance_id(key.value());
-            if prov_id != provenance_id {
-                continue;
-            }
+        // Bounded prefix scan: all todo keys for this provenance_id lie in
+        // [prefix(id), prefix(id+1)).
+        let start = encode_session_prefix(provenance_id);
+        let end = encode_session_prefix(provenance_id.saturating_add(1));
+        for result in table.range::<&[u8; 16]>(&start..&end)? {
+            let (_key, value) = result?;
             match TodoSnapshot::from_bytes(value.value()) {
                 Ok(snapshot) => todos.push(snapshot),
                 Err(e) => {
@@ -597,17 +599,17 @@ impl ReadTxn {
         &self,
         provenance_id: u64,
     ) -> PristineResult<Vec<crate::change::session::PhaseTimingEntry>> {
-        use crate::change::session::{decode_session_phase_key_provenance_id, PhaseTimingEntry};
+        use crate::change::session::{encode_session_prefix, PhaseTimingEntry};
 
         let table = self.txn.open_table(SESSION_PHASES)?;
         let mut phases = Vec::new();
 
-        for result in table.iter()? {
-            let (key, value) = result?;
-            let prov_id = decode_session_phase_key_provenance_id(key.value());
-            if prov_id != provenance_id {
-                continue;
-            }
+        // Bounded prefix scan: all phase keys for this provenance_id lie in
+        // [prefix(id), prefix(id+1)).
+        let start = encode_session_prefix(provenance_id);
+        let end = encode_session_prefix(provenance_id.saturating_add(1));
+        for result in table.range::<&[u8; 16]>(&start..&end)? {
+            let (_key, value) = result?;
             match PhaseTimingEntry::from_bytes(value.value()) {
                 Ok(entry) => phases.push(entry),
                 Err(e) => {

--- a/atomic-core/src/pristine/txn/read.rs
+++ b/atomic-core/src/pristine/txn/read.rs
@@ -525,6 +525,124 @@ impl TreeTxnT for ReadTxn {
     }
 }
 
+// Session data queries
+
+impl ReadTxn {
+    /// Get all session events for a provenance graph.
+    ///
+    /// Returns events in sequence order. Empty if the provenance is not Sherpa
+    /// or has no session data.
+    pub fn get_session_events(
+        &self,
+        provenance_id: u64,
+    ) -> PristineResult<Vec<crate::change::session::SessionEvent>> {
+        use crate::change::session::{decode_session_event_key, SessionEvent};
+
+        let table = self.txn.open_table(SESSION_EVENTS)?;
+        let mut events = Vec::new();
+
+        for result in table.iter()? {
+            let (key, value) = result?;
+            let (prov_id, _seq) = decode_session_event_key(key.value());
+            if prov_id != provenance_id {
+                continue;
+            }
+            match SessionEvent::from_bytes(value.value()) {
+                Ok(event) => events.push(event),
+                Err(e) => {
+                    log::warn!("Failed to deserialize session event: {}", e);
+                }
+            }
+        }
+
+        events.sort_by_key(|e| e.seq);
+        Ok(events)
+    }
+
+    /// Get all todos for a provenance graph.
+    ///
+    /// Returns snapshots of all todo items from the turn.
+    /// Empty if the provenance is not Sherpa or has no session data.
+    pub fn get_session_todos(
+        &self,
+        provenance_id: u64,
+    ) -> PristineResult<Vec<crate::change::session::TodoSnapshot>> {
+        use crate::change::session::{decode_session_todo_key_provenance_id, TodoSnapshot};
+
+        let table = self.txn.open_table(SESSION_TODOS)?;
+        let mut todos = Vec::new();
+
+        for result in table.iter()? {
+            let (key, value) = result?;
+            let prov_id = decode_session_todo_key_provenance_id(key.value());
+            if prov_id != provenance_id {
+                continue;
+            }
+            match TodoSnapshot::from_bytes(value.value()) {
+                Ok(snapshot) => todos.push(snapshot),
+                Err(e) => {
+                    log::warn!("Failed to deserialize todo snapshot: {}", e);
+                }
+            }
+        }
+
+        Ok(todos)
+    }
+
+    /// Get phase timing breakdown for a provenance graph.
+    ///
+    /// Returns timing data for each phase in the turn.
+    /// Empty if the provenance is not Sherpa or has no session data.
+    pub fn get_session_phases(
+        &self,
+        provenance_id: u64,
+    ) -> PristineResult<Vec<crate::change::session::PhaseTimingEntry>> {
+        use crate::change::session::{decode_session_phase_key_provenance_id, PhaseTimingEntry};
+
+        let table = self.txn.open_table(SESSION_PHASES)?;
+        let mut phases = Vec::new();
+
+        for result in table.iter()? {
+            let (key, value) = result?;
+            let prov_id = decode_session_phase_key_provenance_id(key.value());
+            if prov_id != provenance_id {
+                continue;
+            }
+            match PhaseTimingEntry::from_bytes(value.value()) {
+                Ok(entry) => phases.push(entry),
+                Err(e) => {
+                    log::warn!("Failed to deserialize phase timing entry: {}", e);
+                }
+            }
+        }
+
+        Ok(phases)
+    }
+
+    /// Get intent metadata for a provenance graph.
+    ///
+    /// Returns the intent entry if this is a Sherpa provenance, `None` otherwise.
+    pub fn get_session_intent(
+        &self,
+        provenance_id: u64,
+    ) -> PristineResult<Option<crate::change::session::IntentEntry>> {
+        use crate::change::session::IntentEntry;
+
+        let table = self.txn.open_table(SESSION_INTENTS)?;
+
+        match table.get(provenance_id)? {
+            Some(guard) => match IntentEntry::from_bytes(guard.value()) {
+                Ok(entry) => Ok(Some(entry)),
+                Err(e) => {
+                    log::warn!("Failed to deserialize intent entry: {}", e);
+                    Ok(None)
+                }
+            },
+            None => Ok(None),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/atomic-core/src/pristine/txn/write/mod.rs
+++ b/atomic-core/src/pristine/txn/write/mod.rs
@@ -71,7 +71,7 @@ impl<'a> WriteTxn<'a> {
 
         // Gate on profile — only populate for Sherpa graphs.
         match graph.profile.as_deref() {
-            Some(p) if p.starts_with("sherpa-trace") => {}
+            Some("sherpa-trace/1.0.0") => {}
             _ => return Ok(()),
         }
 

--- a/atomic-core/src/pristine/txn/write/mod.rs
+++ b/atomic-core/src/pristine/txn/write/mod.rs
@@ -84,10 +84,22 @@ impl<'a> WriteTxn<'a> {
         let mut seq: u64 = 0;
 
         for node in &graph.nodes {
-            let detail: Option<serde_json::Value> = node
-                .detail
-                .as_deref()
-                .and_then(|s| serde_json::from_str(s).ok());
+            let detail: Option<serde_json::Value> = if let Some(s) = node.detail.as_deref() {
+                match serde_json::from_str(s) {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        eprintln!(
+                            "Warning: failed to parse provenance node detail JSON (node id={}, kind={}): {}",
+                            node.id,
+                            node.kind.label(),
+                            e
+                        );
+                        None
+                    }
+                }
+            } else {
+                None
+            };
 
             // Write every node as a SessionEvent regardless of kind.
             let event = SessionEvent {

--- a/atomic-core/src/pristine/txn/write/mod.rs
+++ b/atomic-core/src/pristine/txn/write/mod.rs
@@ -90,10 +90,23 @@ impl<'a> WriteTxn<'a> {
                 .and_then(|s| serde_json::from_str(s).ok());
 
             // Write every node as a SessionEvent regardless of kind.
+            //
+            // `event_kind` and `record_type` are populated from the original
+            // Sherpa/agent-trace `record_type` field stored in the detail JSON
+            // (e.g. "intent", "todo_status", "phase_transition").  We fall back
+            // to `node.kind.label()` only when no such field is present so that
+            // non-Sherpa nodes still get a meaningful discriminant.
+            let sherpa_record_type = detail
+                .as_ref()
+                .and_then(|d| d["record_type"].as_str())
+                .map(|s| s.to_string());
+            let event_kind = sherpa_record_type
+                .clone()
+                .unwrap_or_else(|| node.kind.label().to_string());
             let event = SessionEvent {
                 seq,
                 timestamp: format_timestamp_ms(node.timestamp),
-                event_kind: node.kind.label().to_string(),
+                event_kind,
                 place: None,
                 transition: None,
                 token_id: node.id.clone(),
@@ -102,7 +115,9 @@ impl<'a> WriteTxn<'a> {
                     _ => "todo".to_string(),
                 },
                 token_data: node.detail.clone().unwrap_or_default(),
-                record_type: Some(node.kind.label().to_string()),
+                record_type: Some(
+                    sherpa_record_type.unwrap_or_else(|| node.kind.label().to_string()),
+                ),
             };
 
             let event_key = encode_session_event_key(provenance_id, seq);

--- a/atomic-core/src/pristine/txn/write/mod.rs
+++ b/atomic-core/src/pristine/txn/write/mod.rs
@@ -52,6 +52,212 @@ impl<'a> WriteTxn<'a> {
             next_inode,
         }
     }
+
+    /// Populate the session tables from a Sherpa provenance graph.
+    ///
+    /// Called during `save_provenance_graph` when the graph has
+    /// `profile == "sherpa-trace/1.0.0"`. Extracts session data from
+    /// the provenance nodes' `detail` fields and writes to the four
+    /// session tables.
+    ///
+    /// Best-effort: parse errors on individual nodes are logged and skipped.
+    pub fn populate_session_tables(
+        &mut self,
+        provenance_id: u64,
+        graph: &crate::change::ProvenanceGraph,
+    ) -> PristineResult<()> {
+        use crate::change::provenance_graph::ProvenanceNodeKind;
+        use crate::change::session::*;
+
+        // Gate on profile — only populate for Sherpa graphs.
+        match graph.profile.as_deref() {
+            Some(p) if p.starts_with("sherpa-trace") => {}
+            _ => return Ok(()),
+        }
+
+        // Open all four tables.
+        let mut events_table = self.txn.open_table(SESSION_EVENTS)?;
+        let mut todos_table = self.txn.open_table(SESSION_TODOS)?;
+        let mut phases_table = self.txn.open_table(SESSION_PHASES)?;
+        let mut intents_table = self.txn.open_table(SESSION_INTENTS)?;
+
+        let mut seq: u64 = 0;
+
+        for node in &graph.nodes {
+            let detail: Option<serde_json::Value> = node
+                .detail
+                .as_deref()
+                .and_then(|s| serde_json::from_str(s).ok());
+
+            // Write every node as a SessionEvent regardless of kind.
+            let event = SessionEvent {
+                seq,
+                timestamp: format_timestamp_ms(node.timestamp),
+                event_kind: node.kind.label().to_string(),
+                place: None,
+                transition: None,
+                token_id: node.id.clone(),
+                token_kind: match node.kind {
+                    ProvenanceNodeKind::Goal => "turn".to_string(),
+                    _ => "todo".to_string(),
+                },
+                token_data: node.detail.clone().unwrap_or_default(),
+                record_type: Some(node.kind.label().to_string()),
+            };
+
+            let event_key = encode_session_event_key(provenance_id, seq);
+            let event_bytes = event.to_bytes();
+            events_table.insert(&event_key, event_bytes.as_slice())?;
+            seq += 1;
+
+            // Extract structured data by node kind.
+            match node.kind {
+                ProvenanceNodeKind::Goal => {
+                    if let Some(ref detail) = detail {
+                        let intent = IntentEntry {
+                            title: detail["intent_title"]
+                                .as_str()
+                                .unwrap_or(&node.summary)
+                                .to_string(),
+                            description: detail["intent_description"]
+                                .as_str()
+                                .unwrap_or("")
+                                .to_string(),
+                            turn_id: detail["intent_turn_id"].as_u64().unwrap_or(0) as u32,
+                            model: detail["model"].as_str().unwrap_or("").to_string(),
+                            session_id: detail["session_id"]
+                                .as_str()
+                                .unwrap_or(&graph.session_id)
+                                .to_string(),
+                            outcome: String::new(),
+                            total_tokens: detail["turn_totals"]["total"].as_u64().unwrap_or(0),
+                            total_cost_usd: detail["turn_totals"]["cost_usd"]
+                                .as_f64()
+                                .unwrap_or(0.0),
+                        };
+                        let intent_bytes = intent.to_bytes();
+                        intents_table.insert(provenance_id, intent_bytes.as_slice())?;
+
+                        // Extract phase timing from GoalDetail.phases
+                        if let Some(phases) = detail["phases"].as_object() {
+                            for (phase_name, phase_data) in phases {
+                                let entry = PhaseTimingEntry {
+                                    phase: phase_name.clone(),
+                                    start_ts: None,
+                                    end_ts: None,
+                                    input_tokens: phase_data["input"].as_u64().unwrap_or(0),
+                                    output_tokens: phase_data["output"].as_u64().unwrap_or(0),
+                                    cost_usd: phase_data["cost_usd"].as_f64().unwrap_or(0.0),
+                                };
+                                let phase_key = encode_session_phase_key(provenance_id, phase_name);
+                                let phase_bytes = entry.to_bytes();
+                                phases_table.insert(&phase_key, phase_bytes.as_slice())?;
+                            }
+                        }
+                    }
+                }
+
+                ProvenanceNodeKind::Commitment => {
+                    if let Some(ref detail) = detail {
+                        let todo_id = detail["todo_id"].as_str().unwrap_or(&node.id).to_string();
+
+                        let snapshot = TodoSnapshot {
+                            todo_id: todo_id.clone(),
+                            content: detail["todo_content"]
+                                .as_str()
+                                .unwrap_or(&node.summary)
+                                .to_string(),
+                            owner: detail["contributor"].as_str().unwrap_or("ai").to_string(),
+                            final_status: "completed".to_string(),
+                            priority: detail["priority"].as_str().unwrap_or("").to_string(),
+                            file: detail["file"].as_str().map(|s| s.to_string()),
+                            start_line: detail["start_line"].as_u64().map(|n| n as u32),
+                            end_line: detail["end_line"].as_u64().map(|n| n as u32),
+                            started_at: None,
+                            completed_at: None,
+                        };
+                        let todo_key = encode_session_todo_key(provenance_id, &todo_id);
+                        let todo_bytes = snapshot.to_bytes();
+                        todos_table.insert(&todo_key, todo_bytes.as_slice())?;
+                    }
+                }
+
+                ProvenanceNodeKind::Verification => {
+                    if let Some(ref detail) = detail {
+                        // Update the intent entry with outcome and totals.
+                        // Read existing bytes in a separate scope so the
+                        // immutable borrow on `intents_table` is released
+                        // before we call `.insert()`.
+                        let existing_bytes: Option<Vec<u8>> = {
+                            match intents_table.get(provenance_id) {
+                                Ok(Some(guard)) => Some(guard.value().to_vec()),
+                                _ => None,
+                            }
+                        };
+
+                        if let Some(bytes) = existing_bytes {
+                            if let Ok(mut intent) = IntentEntry::from_bytes(&bytes) {
+                                intent.outcome = detail["outcome"]
+                                    .as_str()
+                                    .unwrap_or("completed")
+                                    .to_string();
+                                if let Some(t) = detail["turn_tokens_total"].as_u64() {
+                                    intent.total_tokens = t;
+                                }
+                                if let Some(c) = detail["turn_cost_usd"].as_f64() {
+                                    intent.total_cost_usd = c;
+                                }
+                                let intent_bytes = intent.to_bytes();
+                                intents_table.insert(provenance_id, intent_bytes.as_slice())?;
+                            }
+                        }
+                    }
+                }
+
+                ProvenanceNodeKind::Todo => {
+                    if let Some(ref detail) = detail {
+                        let todo_id = detail["todo_id"].as_str().unwrap_or(&node.id).to_string();
+
+                        let snapshot = TodoSnapshot {
+                            todo_id: todo_id.clone(),
+                            content: detail["content"]
+                                .as_str()
+                                .unwrap_or(&node.summary)
+                                .to_string(),
+                            owner: detail["owner"].as_str().unwrap_or("ai").to_string(),
+                            final_status: detail["status"]
+                                .as_str()
+                                .unwrap_or("pending")
+                                .to_string(),
+                            priority: detail["priority"].as_str().unwrap_or("").to_string(),
+                            file: None,
+                            start_line: None,
+                            end_line: None,
+                            started_at: None,
+                            completed_at: None,
+                        };
+                        let todo_key = encode_session_todo_key(provenance_id, &todo_id);
+                        let todo_bytes = snapshot.to_bytes();
+                        todos_table.insert(&todo_key, todo_bytes.as_slice())?;
+                    }
+                }
+
+                _ => {
+                    // Exploration, Execution, Decision, etc. —
+                    // already captured as SessionEvent above.
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Format a Unix epoch milliseconds timestamp to RFC-3339 string.
+fn format_timestamp_ms(epoch_ms: i64) -> String {
+    chrono::DateTime::from_timestamp_millis(epoch_ms)
+        .map(|dt| dt.to_rfc3339())
+        .unwrap_or_else(|| format!("{}", epoch_ms))
 }
 
 mod graph;

--- a/atomic-core/src/pristine/txn/write/mod.rs
+++ b/atomic-core/src/pristine/txn/write/mod.rs
@@ -104,7 +104,7 @@ impl<'a> WriteTxn<'a> {
             // Write every node as a SessionEvent regardless of kind.
             let event = SessionEvent {
                 seq,
-                timestamp: format_timestamp_ms(node.timestamp),
+                timestamp: format_timestamp_ms(node.timestamp * 1000),
                 event_kind: node.kind.label().to_string(),
                 place: None,
                 transition: None,

--- a/atomic-core/src/pristine/txn/write/tests.rs
+++ b/atomic-core/src/pristine/txn/write/tests.rs
@@ -725,4 +725,207 @@ mod tests {
 
         txn.commit().unwrap();
     }
+
+    #[test]
+    fn test_populate_session_tables_sherpa_graph() {
+        use crate::change::provenance_graph::ProvenanceNode;
+        use crate::change::provenance_graph::{
+            ProvenanceGraph, ProvenanceNodeKind, SHERPA_PROFILE,
+        };
+        use crate::change::session::*;
+
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("pristine");
+        let pristine = Pristine::open(&db_path).unwrap();
+
+        let mut txn = pristine.write_txn().unwrap();
+
+        // Build a Sherpa provenance graph with Goal, Commitment, and Verification nodes.
+        let goal_detail = serde_json::json!({
+            "intent_title": "Add login feature",
+            "intent_description": "Implement OAuth2 login flow",
+            "intent_turn_id": 1,
+            "model": "claude-sonnet-4-20250514",
+            "session_id": "sess-abc",
+            "turn_totals": { "total": 5000, "cost_usd": 0.05 },
+            "phases": {
+                "plan": { "input": 1000, "output": 500, "cost_usd": 0.01 },
+                "implement": { "input": 2000, "output": 1500, "cost_usd": 0.03 }
+            }
+        });
+
+        let commitment_detail = serde_json::json!({
+            "todo_id": "todo-42",
+            "todo_content": "Create login endpoint",
+            "contributor": "sherpa",
+            "priority": "high",
+            "file": "src/auth.rs",
+            "start_line": 10,
+            "end_line": 50
+        });
+
+        let verification_detail = serde_json::json!({
+            "outcome": "success",
+            "turn_tokens_total": 6000,
+            "turn_cost_usd": 0.06
+        });
+
+        let graph = ProvenanceGraph::builder("sess-abc", "sherpa")
+            .timestamp(1_700_000_000)
+            .profile(SHERPA_PROFILE)
+            .add_node(ProvenanceNode {
+                id: "node-goal".to_string(),
+                kind: ProvenanceNodeKind::Goal,
+                timestamp: 1_700_000_000_000,
+                summary: "Add login feature".to_string(),
+                detail: Some(goal_detail.to_string()),
+                change_hash: None,
+                tool_name: None,
+                tool_call_id: None,
+                duration_ms: None,
+                classified: false,
+                confidence: None,
+                consolidated_from: vec![],
+            })
+            .add_node(ProvenanceNode {
+                id: "node-commit".to_string(),
+                kind: ProvenanceNodeKind::Commitment,
+                timestamp: 1_700_000_001_000,
+                summary: "Create login endpoint".to_string(),
+                detail: Some(commitment_detail.to_string()),
+                change_hash: None,
+                tool_name: None,
+                tool_call_id: None,
+                duration_ms: None,
+                classified: false,
+                confidence: None,
+                consolidated_from: vec![],
+            })
+            .add_node(ProvenanceNode {
+                id: "node-verify".to_string(),
+                kind: ProvenanceNodeKind::Verification,
+                timestamp: 1_700_000_002_000,
+                summary: "All tests pass".to_string(),
+                detail: Some(verification_detail.to_string()),
+                change_hash: None,
+                tool_name: None,
+                tool_call_id: None,
+                duration_ms: None,
+                classified: false,
+                confidence: None,
+                consolidated_from: vec![],
+            })
+            .build();
+
+        let provenance_id: u64 = 42;
+
+        txn.populate_session_tables(provenance_id, &graph).unwrap();
+
+        // ---- Verify SESSION_EVENTS: 3 events (one per node) ----
+        {
+            let events_table = txn.txn.open_table(SESSION_EVENTS).unwrap();
+            for seq in 0u64..3 {
+                let key = encode_session_event_key(provenance_id, seq);
+                let guard = events_table.get(&key).unwrap().expect("event must exist");
+                let event = SessionEvent::from_bytes(guard.value()).unwrap();
+                assert_eq!(event.seq, seq);
+                assert!(!event.timestamp.is_empty());
+            }
+            // seq 3 should not exist
+            let key3 = encode_session_event_key(provenance_id, 3);
+            assert!(events_table.get(&key3).unwrap().is_none());
+        }
+
+        // ---- Verify SESSION_INTENTS: updated by Verification node ----
+        {
+            let intents_table = txn.txn.open_table(SESSION_INTENTS).unwrap();
+            let guard = intents_table
+                .get(provenance_id)
+                .unwrap()
+                .expect("intent must exist");
+            let intent = IntentEntry::from_bytes(guard.value()).unwrap();
+            assert_eq!(intent.title, "Add login feature");
+            assert_eq!(intent.description, "Implement OAuth2 login flow");
+            assert_eq!(intent.turn_id, 1);
+            assert_eq!(intent.model, "claude-sonnet-4-20250514");
+            assert_eq!(intent.session_id, "sess-abc");
+            // Verification node should have updated outcome and totals
+            assert_eq!(intent.outcome, "success");
+            assert_eq!(intent.total_tokens, 6000);
+            assert!((intent.total_cost_usd - 0.06).abs() < 1e-9);
+        }
+
+        // ---- Verify SESSION_TODOS ----
+        {
+            let todos_table = txn.txn.open_table(SESSION_TODOS).unwrap();
+            let key = encode_session_todo_key(provenance_id, "todo-42");
+            let guard = todos_table.get(&key).unwrap().expect("todo must exist");
+            let todo = TodoSnapshot::from_bytes(guard.value()).unwrap();
+            assert_eq!(todo.todo_id, "todo-42");
+            assert_eq!(todo.content, "Create login endpoint");
+            assert_eq!(todo.owner, "sherpa");
+            assert_eq!(todo.priority, "high");
+            assert_eq!(todo.file, Some("src/auth.rs".to_string()));
+            assert_eq!(todo.start_line, Some(10));
+            assert_eq!(todo.end_line, Some(50));
+        }
+
+        // ---- Verify SESSION_PHASES: two phases from the Goal node ----
+        {
+            let phases_table = txn.txn.open_table(SESSION_PHASES).unwrap();
+
+            let plan_key = encode_session_phase_key(provenance_id, "plan");
+            let guard = phases_table
+                .get(&plan_key)
+                .unwrap()
+                .expect("plan phase must exist");
+            let plan = PhaseTimingEntry::from_bytes(guard.value()).unwrap();
+            assert_eq!(plan.phase, "plan");
+            assert_eq!(plan.input_tokens, 1000);
+            assert_eq!(plan.output_tokens, 500);
+            assert!((plan.cost_usd - 0.01).abs() < 1e-9);
+
+            let impl_key = encode_session_phase_key(provenance_id, "implement");
+            let guard = phases_table
+                .get(&impl_key)
+                .unwrap()
+                .expect("implement phase must exist");
+            let imp = PhaseTimingEntry::from_bytes(guard.value()).unwrap();
+            assert_eq!(imp.phase, "implement");
+            assert_eq!(imp.input_tokens, 2000);
+            assert_eq!(imp.output_tokens, 1500);
+            assert!((imp.cost_usd - 0.03).abs() < 1e-9);
+        }
+
+        txn.commit().unwrap();
+    }
+
+    #[test]
+    fn test_populate_session_tables_skips_non_sherpa() {
+        use crate::change::provenance_graph::ProvenanceGraph;
+
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("pristine");
+        let pristine = Pristine::open(&db_path).unwrap();
+
+        let mut txn = pristine.write_txn().unwrap();
+
+        // Generic graph (no profile) — should be a no-op.
+        let graph = ProvenanceGraph::builder("sess-xyz", "claude-code")
+            .timestamp(1_700_000_000)
+            .build();
+
+        assert!(graph.profile.is_none());
+        txn.populate_session_tables(99, &graph).unwrap();
+
+        // SESSION_EVENTS should be empty for this provenance_id.
+        {
+            use crate::change::session::encode_session_event_key;
+            let events_table = txn.txn.open_table(SESSION_EVENTS).unwrap();
+            let key = encode_session_event_key(99, 0);
+            assert!(events_table.get(&key).unwrap().is_none());
+        }
+
+        txn.commit().unwrap();
+    }
 }

--- a/atomic-core/src/record/context.rs
+++ b/atomic-core/src/record/context.rs
@@ -832,10 +832,6 @@ mod tests {
             Ok(None)
         }
 
-        fn get_deps(&self, _change_id: NodeId) -> Result<Vec<NodeId>, PristineError> {
-            Ok(Vec::new())
-        }
-
         fn get_rev_deps(&self, _dep_id: NodeId) -> Result<Vec<NodeId>, PristineError> {
             Ok(Vec::new())
         }

--- a/atomic-core/src/record/workflow/globalize/options.rs
+++ b/atomic-core/src/record/workflow/globalize/options.rs
@@ -1,6 +1,5 @@
 use super::*;
 
-
 // CONFIGURATION
 
 /// Configuration options for globalization.
@@ -112,7 +111,7 @@ impl GlobalizeOptions {
     /// ```rust
     /// use atomic_core::record::workflow::globalize::GlobalizeOptions;
     ///
-    /// let options = GlobalizeOptions::new().max_hunk_size(1024 * 1024);
+    /// let options = GlobalizeOptions::new().with_max_hunk_size(1024 * 1024);
     /// assert_eq!(options.max_hunk_size(), 1024 * 1024);
     /// ```
     #[must_use]
@@ -133,7 +132,7 @@ impl GlobalizeOptions {
     /// use atomic_core::record::workflow::globalize::GlobalizeOptions;
     /// use atomic_core::change::Encoding;
     ///
-    /// let options = GlobalizeOptions::new().default_encoding(Encoding::Binary);
+    /// let options = GlobalizeOptions::new().with_default_encoding(Encoding::Binary);
     /// assert_eq!(options.default_encoding(), Encoding::Binary);
     /// ```
     #[must_use]

--- a/atomic-repository/src/repository/changes.rs
+++ b/atomic-repository/src/repository/changes.rs
@@ -605,6 +605,12 @@ impl Repository {
             }
         }
 
+        // Populate session tables if this is a Sherpa provenance graph.
+        // The write transaction is still open, so this is atomic with
+        // the provenance registration above.
+        txn.populate_session_tables(prov_id.get(), graph)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
         txn.commit()
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
@@ -729,5 +735,118 @@ impl Repository {
         graphs.sort_by_key(|(_, g)| g.timestamp);
 
         Ok(graphs)
+    }
+
+    // =========================================================================
+    // Session Data Queries (Sherpa-enriched provenance)
+    // =========================================================================
+
+    /// Get the full ordered replay log for a provenance graph.
+    ///
+    /// Returns all session events ordered by sequence number.
+    /// Empty if the provenance is not Sherpa or has no session data.
+    pub fn get_session_events(
+        &self,
+        provenance_hash: &Hash,
+    ) -> Result<Vec<atomic_core::change::session::SessionEvent>, RepositoryError> {
+        let txn = self
+            .pristine
+            .read_txn()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        let provenance_id = txn
+            .get_internal(provenance_hash)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+            .ok_or_else(|| RepositoryError::ChangeNotFound {
+                hash: provenance_hash.to_base32(),
+            })?;
+        txn.get_session_events(provenance_id.get())
+            .map_err(|e| RepositoryError::Database(e.to_string()))
+    }
+
+    /// Get all todos for a provenance graph.
+    ///
+    /// Returns snapshots of all todo items from the turn.
+    /// Empty if the provenance is not Sherpa or has no session data.
+    pub fn get_session_todos(
+        &self,
+        provenance_hash: &Hash,
+    ) -> Result<Vec<atomic_core::change::session::TodoSnapshot>, RepositoryError> {
+        let txn = self
+            .pristine
+            .read_txn()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        let provenance_id = txn
+            .get_internal(provenance_hash)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+            .ok_or_else(|| RepositoryError::ChangeNotFound {
+                hash: provenance_hash.to_base32(),
+            })?;
+        txn.get_session_todos(provenance_id.get())
+            .map_err(|e| RepositoryError::Database(e.to_string()))
+    }
+
+    /// Get phase timing breakdown for a provenance graph.
+    ///
+    /// Returns timing data for each phase in the turn.
+    /// Empty if the provenance is not Sherpa or has no session data.
+    pub fn get_session_phases(
+        &self,
+        provenance_hash: &Hash,
+    ) -> Result<Vec<atomic_core::change::session::PhaseTimingEntry>, RepositoryError> {
+        let txn = self
+            .pristine
+            .read_txn()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        let provenance_id = txn
+            .get_internal(provenance_hash)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+            .ok_or_else(|| RepositoryError::ChangeNotFound {
+                hash: provenance_hash.to_base32(),
+            })?;
+        txn.get_session_phases(provenance_id.get())
+            .map_err(|e| RepositoryError::Database(e.to_string()))
+    }
+
+    /// Get intent metadata for a provenance graph.
+    ///
+    /// Returns the intent entry if this is a Sherpa provenance, `None` otherwise.
+    pub fn get_session_intent(
+        &self,
+        provenance_hash: &Hash,
+    ) -> Result<Option<atomic_core::change::session::IntentEntry>, RepositoryError> {
+        let txn = self
+            .pristine
+            .read_txn()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        let provenance_id = txn
+            .get_internal(provenance_hash)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+            .ok_or_else(|| RepositoryError::ChangeNotFound {
+                hash: provenance_hash.to_base32(),
+            })?;
+        txn.get_session_intent(provenance_id.get())
+            .map_err(|e| RepositoryError::Database(e.to_string()))
+    }
+
+    /// Check if a provenance graph has session data.
+    ///
+    /// Returns `true` if the graph is a Sherpa provenance with populated
+    /// session tables. This is a fast gate for the UI — checking this first
+    /// avoids hitting the session tables for non-Sherpa provenance.
+    pub fn has_session_data(&self, provenance_hash: &Hash) -> bool {
+        let txn = match self.pristine.read_txn() {
+            Ok(t) => t,
+            Err(_) => return false,
+        };
+
+        let provenance_id = match txn.get_internal(provenance_hash) {
+            Ok(Some(id)) => id.get(),
+            _ => return false,
+        };
+
+        txn.get_session_intent(provenance_id)
+            .ok()
+            .flatten()
+            .is_some()
     }
 }


### PR DESCRIPTION
This pull request introduces support for ingesting and representing Sherpa agent trace data in the provenance graph, by adding new node kinds and updating the ingestion pipeline. It enables richer session analysis and querying by making Sherpa-specific events (like todos, phase transitions, and LLM responses) first-class citizens in the provenance model. The changes also update statistics tracking and sequence logic to account for these new node types.

**Sherpa trace support and provenance model extensions:**

* Added new `NodeKind` and `ProvenanceNodeKind` variants for Sherpa-specific events: `Todo`, `TodoStatusChange`, `PhaseTransition`, `Lesson`, `LlmResponse`, and `HumanGateResolution`, with serialization and string representations. [[1]](diffhunk://#diff-a928f9278295f17b8f5106f6ae34630eaaeaea1a9b24425ff1ac0923e2a4b33dR79-R96) [[2]](diffhunk://#diff-9243192ba51b27dbcf283044e41f3a739e629f98b52f36efbaac2936b481324dR566-R595) [[3]](diffhunk://#diff-a928f9278295f17b8f5106f6ae34630eaaeaea1a9b24425ff1ac0923e2a4b33dR129-R134) [[4]](diffhunk://#diff-9243192ba51b27dbcf283044e41f3a739e629f98b52f36efbaac2936b481324dR611-R616)
* Updated the provenance accumulator to allow direct insertion of raw nodes (bypassing edge inference), enabling lossless ingestion of external trace formats like Sherpa JSONL.

**Ingestion and conversion pipeline:**

* Refactored Sherpa trace ingestion to map each JSONL record to a typed provenance node, preserving the full `dev.atomic` payload and mapping record types to the new node kinds. [[1]](diffhunk://#diff-14a88fa2d761bbc5f65378a2b5122fccbc7796d81198288da6aaffd2cd955b09L1036-R1047) [[2]](diffhunk://#diff-14a88fa2d761bbc5f65378a2b5122fccbc7796d81198288da6aaffd2cd955b09L1073-L1142)
* When a Sherpa session is detected, sets the profile on the provenance graph for downstream processing.

**Statistics and sequence logic:**

* Extended `GraphStats` and `ProvenanceStats` to count the new Sherpa node kinds, including serialization defaults and increment logic. [[1]](diffhunk://#diff-a928f9278295f17b8f5106f6ae34630eaaeaea1a9b24425ff1ac0923e2a4b33dR399-R410) [[2]](diffhunk://#diff-9243192ba51b27dbcf283044e41f3a739e629f98b52f36efbaac2936b481324dR712-R723) [[3]](diffhunk://#diff-a928f9278295f17b8f5106f6ae34630eaaeaea1a9b24425ff1ac0923e2a4b33dR425-R430) [[4]](diffhunk://#diff-9243192ba51b27dbcf283044e41f3a739e629f98b52f36efbaac2936b481324dR738-R743) [[5]](diffhunk://#diff-a928f9278295f17b8f5106f6ae34630eaaeaea1a9b24425ff1ac0923e2a4b33dR445-R450) [[6]](diffhunk://#diff-9243192ba51b27dbcf283044e41f3a739e629f98b52f36efbaac2936b481324dR758-R763)
* Updated sequence boundary logic to treat the new node kinds as structural boundaries, affecting how sequences are identified in the provenance graph.

**Other:**

* Exposed the new session module in `atomic-core` for broader use.

These changes collectively make the provenance system more extensible and ready for richer, multi-agent trace analysis.