### PR TITLE
Enhance Sherpa provenance and improve session key handling

### DIFF
--- a/atomic-agent/src/event.rs
+++ b/atomic-agent/src/event.rs
@@ -153,7 +153,7 @@ impl HookType {
     /// ```
     pub fn from_verb(verb: &str) -> Option<Self> {
         match verb {
-            // Session boundaries (shared by Claude Code, Gemini CLI, OpenCode)
+            // Session boundaries (shared by Claude Code, Gemini CLI, OpenCode, Sherpa)
             "session-start" => Some(HookType::SessionStart),
             "session-end" => Some(HookType::SessionEnd),
 
@@ -168,6 +168,12 @@ impl HookType {
             // OpenCode turn boundaries
             "user-prompt" => Some(HookType::TurnStart),
             // OpenCode also uses "stop" for TurnEnd (handled above)
+
+            // Sherpa TUI turn boundaries
+            "turn-start" => Some(HookType::TurnStart),
+            "turn-end" => Some(HookType::TurnEnd),
+            // Sherpa verification triggers turn-end
+            "verification" => Some(HookType::TurnEnd),
 
             // Claude Code tool use
             "pre-task" => Some(HookType::PreToolUse),

--- a/atomic-agent/src/export.rs
+++ b/atomic-agent/src/export.rs
@@ -69,7 +69,7 @@ pub struct TraceRecord {
     /// ISO 8601 / RFC 3339 timestamp.
     pub timestamp: String,
 
-    /// VCS context (best-effort — absent if not a git repo).
+    /// VCS context (best-effort — absent if Atomic stack state is unavailable).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vcs: Option<VcsInfo>,
 

--- a/atomic-agent/src/export.rs
+++ b/atomic-agent/src/export.rs
@@ -1,0 +1,783 @@
+//! agent-trace JSONL export.
+//!
+//! Converts a [`ProvenanceGraph`] to the vendor-neutral `agent-trace` format
+//! and appends it to `.agent-trace/traces.jsonl` in the repository root.
+//!
+//! ## Design
+//!
+//! The export is **best-effort**: every function that performs I/O swallows
+//! errors after logging them so a write failure never blocks the agent session.
+//!
+//! ## File layout
+//!
+//! ```text
+//! {root}/.agent-trace/traces.jsonl   ← one JSON object per line
+//! ```
+//!
+//! Each line is a self-contained [`TraceRecord`].  Consumers can stream the
+//! file with `jq` or load it entirely into memory; the format is compatible
+//! with the broader `agent-trace` ecosystem (Cursor, Amp, Cline, OpenCode).
+//!
+//! ## VCS revision
+//!
+//! The `vcs` field is populated by opening the Atomic repository at `root` and
+//! reading the current stack's Merkle state via
+//! [`atomic_repository::Repository::get_stack_info`].  This gives a
+//! content-addressed, tamper-evident revision that is native to the Atomic
+//! graph model.  Git is not consulted.
+//!
+//! ## Sherpa extension
+//!
+//! When `graph.profile == "sherpa-trace/1.0.0"` the record's
+//! `metadata["dev.atomic"]` object is populated with:
+//!
+//! - `profile`       — [`TraceProfile`] discriminator
+//! - `intent`        — parsed [`GoalDetail`] from the `Goal` node
+//! - `todos`         — list of parsed [`CommitmentDetail`] from `Commitment` nodes
+//! - `verification`  — parsed [`VerificationDetail`] from the `Verification` node
+//!
+//! Non-Sherpa graphs get an empty `metadata["dev.atomic"]` object so consumers
+//! can always rely on the key being present.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use atomic_core::change::provenance_graph::{ProvenanceGraph, ProvenanceNodeKind};
+use atomic_core::types::Base32;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::provenance::detail::{CommitmentDetail, GoalDetail, VerificationDetail};
+
+// ---------------------------------------------------------------------------
+// Top-level record type
+// ---------------------------------------------------------------------------
+
+/// A single line in `.agent-trace/traces.jsonl`.
+///
+/// The schema is vendor-neutral; Sherpa-specific data lives under
+/// `metadata["dev.atomic"]`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceRecord {
+    /// Format version, e.g. `"0.1.0"`.
+    pub version: String,
+
+    /// Unique identifier for this record (UUIDv4 or session-turn composite).
+    pub id: String,
+
+    /// ISO 8601 / RFC 3339 timestamp.
+    pub timestamp: String,
+
+    /// VCS context (best-effort — absent if not a git repo).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vcs: Option<VcsInfo>,
+
+    /// Tool that produced this record.
+    pub tool: ToolInfo,
+
+    /// File-level attribution entries.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub files: Vec<FileEntry>,
+
+    /// Extension metadata.  Always contains at least `"dev.atomic"`.
+    pub metadata: HashMap<String, Value>,
+}
+
+/// VCS snapshot at record creation time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VcsInfo {
+    /// Always `"atomic"`.
+    #[serde(rename = "type")]
+    pub vcs_type: String,
+
+    /// Name of the Atomic stack that was current when the record was written.
+    pub stack: String,
+
+    /// Merkle state of the current stack (base32 Blake3 hash of the applied
+    /// change sequence) at the time the provenance graph was saved.
+    pub revision: String,
+}
+
+/// Tool / producer identification.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolInfo {
+    /// e.g. `"sherpa"` or `"atomic-agent"`.
+    pub name: String,
+
+    /// Crate version string.
+    pub version: String,
+}
+
+/// One file touched in this turn.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileEntry {
+    /// Relative path from the repository root.
+    pub path: String,
+
+    /// Conversations that reference this file.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub conversations: Vec<Conversation>,
+}
+
+/// A single AI-or-human conversation block that produced changes to a file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Conversation {
+    /// Canonical URL for this turn, e.g.
+    /// `"sherpa://sessions/{session_id}/turns/{turn_id}"`.
+    pub url: String,
+
+    /// Who made the changes.
+    pub contributor: ContributorInfo,
+
+    /// Line ranges within the file that were affected.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ranges: Vec<LineRange>,
+
+    /// Cross-references (atomic change hash, todo URL, etc.).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub related: Vec<RelatedRef>,
+}
+
+/// Contributor (AI model or human).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContributorInfo {
+    /// `"ai"` or `"human"`.
+    #[serde(rename = "type")]
+    pub contributor_type: String,
+
+    /// Model identifier, e.g. `"anthropic/claude-sonnet-4-6"`.
+    /// Present only when `type == "ai"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_id: Option<String>,
+}
+
+/// A half-open line range within a file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LineRange {
+    pub start_line: u32,
+    pub end_line: u32,
+}
+
+/// A cross-reference to a related artifact.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelatedRef {
+    /// `"atomic_change"`, `"todo"`, `"issue"`, etc.
+    #[serde(rename = "type")]
+    pub ref_type: String,
+
+    /// URL or identifier.
+    pub url: String,
+}
+
+// ---------------------------------------------------------------------------
+// Conversion
+// ---------------------------------------------------------------------------
+
+/// Convert a [`ProvenanceGraph`] into a [`TraceRecord`] suitable for appending
+/// to `.agent-trace/traces.jsonl`.
+///
+/// `root` is the repository root used for computing relative paths and for
+/// resolving the git HEAD revision.
+///
+/// This function never fails; any missing data is silently omitted.
+pub fn to_agent_trace_record(graph: &ProvenanceGraph, root: &Path) -> TraceRecord {
+    let timestamp = DateTime::<Utc>::from_timestamp(graph.timestamp, 0)
+        .unwrap_or_else(Utc::now)
+        .to_rfc3339();
+
+    // Unique record ID: session + timestamp epoch
+    let id = format!("{}-{}", graph.session_id, graph.timestamp);
+
+    // VCS: best-effort Atomic stack Merkle state
+    let vcs = atomic_revision(root).map(|(stack, revision)| VcsInfo {
+        vcs_type: "atomic".to_string(),
+        stack,
+        revision,
+    });
+
+    // Tool info
+    let tool = ToolInfo {
+        name: graph.agent_name.clone(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    };
+
+    // Build files + metadata["dev.atomic"] by walking nodes
+    let (files, dev_atomic) = build_files_and_metadata(graph);
+
+    let mut metadata: HashMap<String, Value> = HashMap::new();
+    metadata.insert("dev.atomic".to_string(), dev_atomic);
+
+    TraceRecord {
+        version: "0.1.0".to_string(),
+        id,
+        timestamp,
+        vcs,
+        tool,
+        files,
+        metadata,
+    }
+}
+
+/// Append a [`TraceRecord`] as a single JSON line to
+/// `{root}/.agent-trace/traces.jsonl`.
+///
+/// Creates the directory and file if they don't exist.  All errors are
+/// logged and swallowed — never blocks the caller.
+pub fn append_agent_trace(record: &TraceRecord, root: &Path) {
+    let result = try_append_agent_trace(record, root);
+    if let Err(e) = result {
+        log::warn!("agent-trace: failed to append record: {}", e);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Walk the graph nodes and build:
+/// - `files` — per-file `FileEntry` list (from `Commitment` nodes)
+/// - `dev_atomic` — the Sherpa-specific metadata object
+fn build_files_and_metadata(graph: &ProvenanceGraph) -> (Vec<FileEntry>, Value) {
+    // Collect nodes by kind
+    let goal_node = graph
+        .nodes
+        .iter()
+        .find(|n| n.kind == ProvenanceNodeKind::Goal);
+
+    let commitment_nodes: Vec<_> = graph
+        .nodes
+        .iter()
+        .filter(|n| n.kind == ProvenanceNodeKind::Commitment)
+        .collect();
+
+    let execution_nodes: Vec<_> = graph
+        .nodes
+        .iter()
+        .filter(|n| n.kind == ProvenanceNodeKind::Execution)
+        .collect();
+
+    let verification_node = graph
+        .nodes
+        .iter()
+        .find(|n| n.kind == ProvenanceNodeKind::Verification);
+
+    // Parse detail JSON strings into typed structs (best-effort — None on any
+    // parse error so a malformed node never blocks the export).
+    let goal_detail: Option<GoalDetail> = goal_node
+        .and_then(|n| n.detail.as_deref())
+        .and_then(|s| serde_json::from_str(s).ok());
+
+    let commitment_details: Vec<CommitmentDetail> = commitment_nodes
+        .iter()
+        .filter_map(|n| n.detail.as_deref())
+        .filter_map(|s| serde_json::from_str(s).ok())
+        .collect();
+
+    let verification_detail: Option<VerificationDetail> = verification_node
+        .and_then(|n| n.detail.as_deref())
+        .and_then(|s| serde_json::from_str(s).ok());
+
+    // Extract turn/session identifiers from GoalDetail
+    let session_id = goal_detail
+        .as_ref()
+        .map(|g| g.session_id.as_str())
+        .unwrap_or(&graph.session_id)
+        .to_string();
+
+    let turn_id = goal_detail
+        .as_ref()
+        .map(|g| g.intent_turn_id as u64)
+        .unwrap_or(0);
+
+    let model = goal_detail
+        .as_ref()
+        .map(|g| g.model.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    // Build FileEntry list from Commitment nodes
+    let turn_url = format!("sherpa://sessions/{}/turns/{}", session_id, turn_id);
+
+    let mut files: Vec<FileEntry> = Vec::new();
+
+    for (node, cd) in commitment_nodes.iter().zip(commitment_details.iter()) {
+        let path = if cd.file.is_empty() {
+            node.summary.clone()
+        } else {
+            cd.file.clone()
+        };
+
+        let contributor_type = cd.contributor.to_string();
+
+        let ranges: Vec<LineRange> = match (cd.start_line, cd.end_line) {
+            (Some(s), Some(e)) => vec![LineRange {
+                start_line: s,
+                end_line: e,
+            }],
+            _ => vec![],
+        };
+
+        let mut related: Vec<RelatedRef> = Vec::new();
+        if !cd.todo_id.is_empty() {
+            related.push(RelatedRef {
+                ref_type: "todo".to_string(),
+                url: format!(
+                    "sherpa://sessions/{}/turns/{}/todos/{}",
+                    session_id, turn_id, cd.todo_id
+                ),
+            });
+        }
+        if let Some(ref hash) = cd.atomic_change_hash {
+            related.push(RelatedRef {
+                ref_type: "atomic_change".to_string(),
+                url: format!("atomic://changes/{}", hash),
+            });
+        }
+
+        let conversation = Conversation {
+            url: turn_url.clone(),
+            contributor: ContributorInfo {
+                contributor_type,
+                model_id: if model.is_empty() {
+                    None
+                } else {
+                    Some(model.clone())
+                },
+            },
+            ranges,
+            related,
+        };
+
+        // Merge into existing FileEntry for this path, or create a new one
+        if let Some(entry) = files.iter_mut().find(|f| f.path == path) {
+            entry.conversations.push(conversation);
+        } else {
+            files.push(FileEntry {
+                path,
+                conversations: vec![conversation],
+            });
+        }
+    }
+
+    // Build execution list grouped by todo_id for metadata.
+    // Execution nodes are still read as raw Value because ExecutionDetail is
+    // embedded as-is in the todos array — no field access needed on our side.
+    let mut executions_by_todo: HashMap<String, Vec<Value>> = HashMap::new();
+    for node in &execution_nodes {
+        if let Some(detail_str) = &node.detail {
+            if let Ok(detail) = serde_json::from_str::<Value>(detail_str) {
+                let todo_id = detail["todo_id"].as_str().unwrap_or("unknown").to_string();
+                executions_by_todo.entry(todo_id).or_default().push(detail);
+            }
+        }
+    }
+
+    // Attach executions to commitment details for metadata, serializing the
+    // typed CommitmentDetail back to Value so it can be embedded in the JSON.
+    let todos_with_executions: Vec<Value> = commitment_details
+        .iter()
+        .filter_map(|cd| {
+            let mut entry = serde_json::to_value(cd).ok()?;
+            let execs = executions_by_todo
+                .get(&cd.todo_id)
+                .cloned()
+                .unwrap_or_default();
+            if !execs.is_empty() {
+                entry["executions"] = Value::Array(execs);
+            }
+            Some(entry)
+        })
+        .collect();
+
+    // Build the TraceProfile block (present only for Sherpa graphs)
+    let profile_value: Value = if graph
+        .profile
+        .as_deref()
+        .map(|p| p.starts_with("sherpa-trace"))
+        .unwrap_or(false)
+    {
+        let phase = verification_detail
+            .as_ref()
+            .map(|v| v.outcome.to_string())
+            .unwrap_or_else(|| "verification".to_string());
+
+        serde_json::json!({
+            "schema": "sherpa-trace",
+            "schema_version": "1.0.0",
+            "producer": "sherpa",
+            "producer_version": env!("CARGO_PKG_VERSION"),
+            "session_id": session_id,
+            "turn_id": turn_id,
+            "phase": phase,
+        })
+    } else {
+        Value::Null
+    };
+
+    // Assemble dev.atomic metadata
+    let mut dev_atomic = serde_json::json!({});
+
+    if !profile_value.is_null() {
+        dev_atomic["profile"] = profile_value;
+    }
+    if let Some(ref gd) = goal_detail {
+        dev_atomic["intent"] = serde_json::to_value(gd).unwrap_or(Value::Null);
+    }
+    if !todos_with_executions.is_empty() {
+        dev_atomic["todos"] = Value::Array(todos_with_executions);
+    }
+    if let Some(ref vd) = verification_detail {
+        dev_atomic["verification"] = serde_json::to_value(vd).unwrap_or(Value::Null);
+    }
+
+    (files, dev_atomic)
+}
+
+/// Open the Atomic repository at `root` and return `(stack_name, merkle_base32)`
+/// for the current stack.
+///
+/// Returns `None` if the directory is not an Atomic repository or any error
+/// occurs — callers treat absence of VCS info as non-fatal.
+fn atomic_revision(root: &Path) -> Option<(String, String)> {
+    let repo = atomic_repository::Repository::open(root).ok()?;
+    let stack_name = repo.current_stack().to_string();
+    let info = repo.get_stack_info(&stack_name).ok()?;
+    Some((stack_name, info.state.to_base32()))
+}
+
+/// Inner fallible implementation of [`append_agent_trace`].
+fn try_append_agent_trace(record: &TraceRecord, root: &Path) -> std::io::Result<()> {
+    use std::fs::{self, OpenOptions};
+    use std::io::Write;
+
+    let dir = root.join(".agent-trace");
+    fs::create_dir_all(&dir)?;
+
+    let path = dir.join("traces.jsonl");
+    let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
+
+    let line = serde_json::to_string(record)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+    writeln!(file, "{}", line)?;
+
+    log::debug!(
+        "agent-trace: appended record {} to {}",
+        record.id,
+        path.display()
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use atomic_core::change::provenance_graph::{
+        ProvenanceEdge, ProvenanceEdgeKind, ProvenanceNode, ProvenanceNodeKind,
+    };
+
+    fn make_node(
+        id: &str,
+        kind: ProvenanceNodeKind,
+        summary: &str,
+        detail: Option<&str>,
+    ) -> ProvenanceNode {
+        ProvenanceNode {
+            id: id.to_string(),
+            kind,
+            timestamp: 1_700_000_000_000,
+            summary: summary.to_string(),
+            detail: detail.map(|s| s.to_string()),
+            change_hash: None,
+            tool_name: None,
+            tool_call_id: None,
+            duration_ms: None,
+            classified: false,
+            confidence: None,
+            consolidated_from: Vec::new(),
+        }
+    }
+
+    fn sherpa_graph() -> ProvenanceGraph {
+        let goal_detail = serde_json::json!({
+            "intent_title": "Build Hello World CLI",
+            "intent_description": "A simple CLI that prints Hello World",
+            "intent_turn_id": 3,
+            "session_id": "tiny-star-8412",
+            "phases": {
+                "orienting":  { "input": 1000, "output": 200, "cost_usd": 0.006 },
+                "executing":  { "input": 5000, "output": 1000, "cost_usd": 0.05 }
+            },
+            "turn_totals": { "input": 6000, "output": 1200, "total": 7200, "cost_usd": 0.056 },
+            "model": "anthropic/claude-sonnet-4-6",
+            "context_pct": 3.6
+        });
+
+        let commitment_detail = serde_json::json!({
+            "todo_id": "t2",
+            "todo_content": "Create src/index.ts",
+            "priority": "high",
+            "contributor": "ai",
+            "file": "src/index.ts",
+            "start_line": 1,
+            "end_line": 12,
+            "atomic_change_hash": null,
+            "tokens": { "input": 1200, "output": 300, "cost_usd": 0.013 }
+        });
+
+        let execution_detail = serde_json::json!({
+            "todo_id": "t2",
+            "command": "npm install",
+            "exit_code": 0,
+            "duration_ms": 1234,
+            "output_summary": "added 42 packages"
+        });
+
+        let verification_detail = serde_json::json!({
+            "intent_turn_id": 3,
+            "intent_title": "Build Hello World CLI",
+            "outcome": "completed",
+            "summary": "CLI printed Hello World successfully",
+            "turn_cost_usd": 0.056,
+            "turn_tokens_total": 7200,
+            "learnings": { "repo": [], "workflow": [], "code": [] }
+        });
+
+        let nodes = vec![
+            make_node(
+                "g-tiny-3",
+                ProvenanceNodeKind::Goal,
+                "Build Hello World CLI",
+                Some(&goal_detail.to_string()),
+            ),
+            make_node(
+                "c-tiny-3-0",
+                ProvenanceNodeKind::Commitment,
+                "wrote src/index.ts",
+                Some(&commitment_detail.to_string()),
+            ),
+            make_node(
+                "e-tiny-3-0",
+                ProvenanceNodeKind::Execution,
+                "npm install",
+                Some(&execution_detail.to_string()),
+            ),
+            make_node(
+                "v-tiny-3",
+                ProvenanceNodeKind::Verification,
+                "turn 3 completed",
+                Some(&verification_detail.to_string()),
+            ),
+        ];
+
+        let edges = vec![
+            ProvenanceEdge {
+                from: "g-tiny-3".into(),
+                to: "c-tiny-3-0".into(),
+                kind: ProvenanceEdgeKind::LedTo,
+            },
+            ProvenanceEdge {
+                from: "c-tiny-3-0".into(),
+                to: "e-tiny-3-0".into(),
+                kind: ProvenanceEdgeKind::LedTo,
+            },
+            ProvenanceEdge {
+                from: "e-tiny-3-0".into(),
+                to: "v-tiny-3".into(),
+                kind: ProvenanceEdgeKind::LedTo,
+            },
+        ];
+
+        ProvenanceGraph::builder("tiny-star-8412", "sherpa")
+            .agent_display_name("Sherpa")
+            .agent_vendor("atomic")
+            .profile("sherpa-trace/1.0.0")
+            .nodes(nodes)
+            .edges(edges)
+            .timestamp(1_700_000_000)
+            .build()
+    }
+
+    #[test]
+    fn test_record_has_required_fields() {
+        let graph = sherpa_graph();
+        let tmp = tempfile::tempdir().unwrap();
+        let record = to_agent_trace_record(&graph, tmp.path());
+
+        assert_eq!(record.version, "0.1.0");
+        assert!(!record.id.is_empty());
+        assert!(!record.timestamp.is_empty());
+        assert_eq!(record.tool.name, "sherpa");
+    }
+
+    #[test]
+    fn test_record_has_dev_atomic_metadata() {
+        let graph = sherpa_graph();
+        let tmp = tempfile::tempdir().unwrap();
+        let record = to_agent_trace_record(&graph, tmp.path());
+
+        let dev_atomic = &record.metadata["dev.atomic"];
+        assert!(dev_atomic.is_object(), "dev.atomic should be an object");
+        assert_eq!(dev_atomic["profile"]["schema"], "sherpa-trace");
+        assert_eq!(dev_atomic["profile"]["schema_version"], "1.0.0");
+        assert_eq!(dev_atomic["profile"]["session_id"], "tiny-star-8412");
+        assert_eq!(dev_atomic["profile"]["turn_id"], 3);
+    }
+
+    #[test]
+    fn test_record_intent_populated() {
+        let graph = sherpa_graph();
+        let tmp = tempfile::tempdir().unwrap();
+        let record = to_agent_trace_record(&graph, tmp.path());
+
+        let intent = &record.metadata["dev.atomic"]["intent"];
+        assert_eq!(intent["intent_title"], "Build Hello World CLI");
+        assert_eq!(intent["intent_turn_id"], 3);
+    }
+
+    #[test]
+    fn test_record_todos_with_executions() {
+        let graph = sherpa_graph();
+        let tmp = tempfile::tempdir().unwrap();
+        let record = to_agent_trace_record(&graph, tmp.path());
+
+        let todos = &record.metadata["dev.atomic"]["todos"];
+        assert!(todos.is_array());
+        let todos_arr = todos.as_array().unwrap();
+        assert_eq!(todos_arr.len(), 1);
+        assert_eq!(todos_arr[0]["todo_id"], "t2");
+
+        // Execution should be nested under the matching todo
+        let execs = &todos_arr[0]["executions"];
+        assert!(execs.is_array());
+        assert_eq!(execs[0]["command"], "npm install");
+        assert_eq!(execs[0]["exit_code"], 0);
+    }
+
+    #[test]
+    fn test_record_verification_populated() {
+        let graph = sherpa_graph();
+        let tmp = tempfile::tempdir().unwrap();
+        let record = to_agent_trace_record(&graph, tmp.path());
+
+        let verif = &record.metadata["dev.atomic"]["verification"];
+        assert_eq!(verif["outcome"], "completed");
+        assert_eq!(verif["intent_turn_id"], 3);
+    }
+
+    #[test]
+    fn test_record_files_populated() {
+        let graph = sherpa_graph();
+        let tmp = tempfile::tempdir().unwrap();
+        let record = to_agent_trace_record(&graph, tmp.path());
+
+        assert_eq!(record.files.len(), 1);
+        assert_eq!(record.files[0].path, "src/index.ts");
+        assert_eq!(record.files[0].conversations.len(), 1);
+
+        let conv = &record.files[0].conversations[0];
+        assert!(conv.url.contains("tiny-star-8412"));
+        assert_eq!(conv.contributor.contributor_type, "ai");
+        assert_eq!(conv.ranges[0].start_line, 1);
+        assert_eq!(conv.ranges[0].end_line, 12);
+
+        // todo related ref
+        assert!(conv.related.iter().any(|r| r.ref_type == "todo"));
+    }
+
+    #[test]
+    fn test_append_and_read_back() {
+        let graph = sherpa_graph();
+        let tmp = tempfile::tempdir().unwrap();
+        let record = to_agent_trace_record(&graph, tmp.path());
+
+        append_agent_trace(&record, tmp.path());
+
+        let path = tmp.path().join(".agent-trace").join("traces.jsonl");
+        assert!(path.exists());
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let parsed: TraceRecord = serde_json::from_str(contents.trim()).unwrap();
+        assert_eq!(parsed.version, "0.1.0");
+        assert_eq!(
+            parsed.metadata["dev.atomic"]["profile"]["schema"],
+            "sherpa-trace"
+        );
+    }
+
+    #[test]
+    fn test_append_multiple_records_produces_valid_jsonl() {
+        let graph = sherpa_graph();
+        let tmp = tempfile::tempdir().unwrap();
+
+        for _ in 0..3 {
+            let record = to_agent_trace_record(&graph, tmp.path());
+            append_agent_trace(&record, tmp.path());
+        }
+
+        let path = tmp.path().join(".agent-trace").join("traces.jsonl");
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 3);
+
+        // Every line must parse as valid JSON
+        for line in &lines {
+            let v: Value = serde_json::from_str(line).expect("each line must be valid JSON");
+            assert_eq!(v["version"], "0.1.0");
+        }
+    }
+
+    #[test]
+    fn test_append_idempotent_on_existing_dir() {
+        let graph = sherpa_graph();
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Pre-create the directory — should not error
+        std::fs::create_dir_all(tmp.path().join(".agent-trace")).unwrap();
+
+        let record = to_agent_trace_record(&graph, tmp.path());
+        append_agent_trace(&record, tmp.path());
+
+        let path = tmp.path().join(".agent-trace").join("traces.jsonl");
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn test_non_sherpa_graph_still_has_dev_atomic() {
+        // A graph without a profile should still produce a dev.atomic key
+        let graph = ProvenanceGraph::builder("sess-1", "claude-code")
+            .agent_display_name("Claude Code")
+            .timestamp(1_700_000_000)
+            .build();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let record = to_agent_trace_record(&graph, tmp.path());
+
+        assert!(
+            record.metadata.contains_key("dev.atomic"),
+            "dev.atomic key must always be present"
+        );
+        // But no profile sub-key since it's not a sherpa graph
+        assert!(
+            record.metadata["dev.atomic"]["profile"].is_null()
+                || !record.metadata["dev.atomic"]
+                    .as_object()
+                    .map(|o| o.contains_key("profile"))
+                    .unwrap_or(false),
+            "non-sherpa graph should not have profile in dev.atomic"
+        );
+    }
+
+    #[test]
+    fn test_atomic_revision_returns_none_outside_repo() {
+        // A fresh tempdir is not an Atomic repository
+        let tmp = tempfile::tempdir().unwrap();
+        let rev = atomic_revision(tmp.path());
+        assert!(rev.is_none());
+    }
+}

--- a/atomic-agent/src/hooks/mod.rs
+++ b/atomic-agent/src/hooks/mod.rs
@@ -59,6 +59,7 @@
 pub mod claude_code;
 pub mod gemini_cli;
 pub mod opencode;
+pub mod sherpa;
 
 use std::fmt;
 use std::path::Path;
@@ -246,6 +247,7 @@ impl AgentRegistry {
         registry.register(Box::new(claude_code::ClaudeCodeHook::new()));
         registry.register(Box::new(gemini_cli::GeminiCliHook::new()));
         registry.register(Box::new(opencode::OpenCodeHook::new()));
+        registry.register(Box::new(sherpa::SherpaHook::new()));
         registry
     }
 

--- a/atomic-agent/src/hooks/sherpa.rs
+++ b/atomic-agent/src/hooks/sherpa.rs
@@ -1,0 +1,577 @@
+//! Sherpa TUI agent hook adapter for Atomic Agent.
+//!
+//! Handles hook JSON parsing from the Sherpa TUI, which calls
+//! `atomic agent hooks sherpa <verb>` via subprocess at each lifecycle event.
+//!
+//! # Sherpa Hook Architecture
+//!
+//! Unlike external agents (Claude Code, OpenCode) which are separate processes
+//! that call back to `atomic agent hooks`, Sherpa is a TUI that manages its
+//! own session lifecycle internally. It spawns `atomic agent hooks sherpa <verb>`
+//! as a subprocess at four lifecycle points, piping its session JSON to stdin:
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────────────┐
+//! │  Sherpa TUI (atomic-tui)                                                │
+//! │                                                                         │
+//! │  App::new()         ──▶  atomic agent hooks sherpa session-start       │
+//! │  LlmResponse::IntentNode  ──▶  atomic agent hooks sherpa turn-start    │
+//! │  State::Verification ──▶  atomic agent hooks sherpa turn-end           │
+//! │  /exit | /quit | q   ──▶  atomic agent hooks sherpa session-end        │
+//! └─────────────────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Hook Verbs
+//!
+//! | Verb            | HookType       | Description                           |
+//! |-----------------|----------------|---------------------------------------|
+//! | `session-start` | SessionStart   | Sherpa TUI launched, session created   |
+//! | `session-end`   | SessionEnd     | User quit the TUI                      |
+//! | `turn-start`    | TurnStart      | Intent confirmed, Orienting begins     |
+//! | `turn-end`      | TurnEnd        | Verification state reached             |
+//!
+//! # JSON Input Format
+//!
+//! All hooks receive a JSON payload via stdin derived from Sherpa's `Session`
+//! snapshot struct. At minimum every payload contains:
+//!
+//! ```json
+//! {
+//!   "session_id": "rapid-wildflower-4475",
+//!   "cwd": "/path/to/project",
+//!   "model": "claude-sonnet-4-6",
+//!   "provider": "anthropic",
+//!   "turn_number": 3,
+//!   "timestamp": "2025-01-15T10:30:00Z"
+//! }
+//! ```
+//!
+//! `turn-end` additionally carries `intent_title` so the orchestrator can use
+//! it as the atomic record message:
+//!
+//! ```json
+//! {
+//!   "session_id": "rapid-wildflower-4475",
+//!   "cwd": "/path/to/project",
+//!   "model": "claude-sonnet-4-6",
+//!   "provider": "anthropic",
+//!   "turn_number": 3,
+//!   "intent_title": "Add TypeScript hello world scaffold",
+//!   "timestamp": "2025-01-15T10:30:00Z"
+//! }
+//! ```
+//!
+//! # Detection
+//!
+//! Sherpa is considered present if `~/.sherpa/sessions/` exists — the same
+//! directory that `atomic-tui/src/session.rs` writes session snapshots to.
+//!
+//! # Installation
+//!
+//! Sherpa hooks are self-managed by the TUI — there is no config file to edit.
+//! `install()` / `uninstall()` are no-ops that return `Ok`. Detection happens
+//! via the `~/.sherpa/sessions/` directory.
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::error::{AgentError, AgentResult};
+use crate::event::{HookType, TurnEvent};
+use crate::hooks::AgentHook;
+
+/// The Sherpa sessions directory relative to home (`~/.sherpa/sessions/`).
+const SHERPA_SESSIONS_SUBDIR: &[&str] = &[".sherpa", "sessions"];
+
+// ---------------------------------------------------------------------------
+// JSON input structs
+// ---------------------------------------------------------------------------
+
+/// Common fields present in every Sherpa hook payload.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct SherpaHookInput {
+    /// Sherpa session name (e.g. "rapid-wildflower-4475").
+    session_id: String,
+
+    /// Absolute path to the project root (the working directory of the TUI).
+    #[serde(default)]
+    cwd: Option<String>,
+
+    /// LLM model identifier (e.g. "claude-sonnet-4-6").
+    #[serde(default)]
+    model: Option<String>,
+
+    /// LLM provider (e.g. "anthropic", "openai").
+    #[serde(default)]
+    provider: Option<String>,
+
+    /// Current turn counter at the time of the event.
+    #[serde(default)]
+    turn_number: u32,
+
+    /// ISO-8601 timestamp of the event.
+    #[serde(default)]
+    timestamp: Option<String>,
+
+    /// Intent title — present on `turn-start` and `turn-end`.
+    ///
+    /// Used as the atomic record commit message on `turn-end`.
+    #[serde(default)]
+    intent_title: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// SherpaHook
+// ---------------------------------------------------------------------------
+
+/// Agent hook adapter for Sherpa TUI sessions.
+///
+/// Implements [`AgentHook`] so the `TurnOrchestrator` can manage Sherpa
+/// sessions with the same stack-fork / record / switch-back lifecycle as
+/// Claude Code and OpenCode.
+#[derive(Debug, Default)]
+pub struct SherpaHook {
+    _private: (),
+}
+
+impl SherpaHook {
+    /// Create a new `SherpaHook`.
+    pub fn new() -> Self {
+        Self { _private: () }
+    }
+
+    /// Returns the path to `~/.sherpa/sessions/` if the home directory is
+    /// resolvable, otherwise `None`.
+    pub fn sherpa_sessions_dir() -> Option<std::path::PathBuf> {
+        dirs::home_dir().map(|home| {
+            SHERPA_SESSIONS_SUBDIR
+                .iter()
+                .fold(home, |acc, component| acc.join(component))
+        })
+    }
+
+    /// Parse the raw JSON bytes into a [`SherpaHookInput`], returning a
+    /// well-typed [`AgentError`] on failure.
+    fn parse_input(
+        agent: &str,
+        hook_type: HookType,
+        input: &[u8],
+    ) -> AgentResult<(SherpaHookInput, serde_json::Value)> {
+        let raw: serde_json::Value =
+            serde_json::from_slice(input).map_err(|e| AgentError::HookParseFailed {
+                agent: agent.to_string(),
+                hook_type: hook_type.as_str().to_string(),
+                reason: e.to_string(),
+            })?;
+
+        let parsed: SherpaHookInput =
+            serde_json::from_value(raw.clone()).map_err(|e| AgentError::HookParseFailed {
+                agent: agent.to_string(),
+                hook_type: hook_type.as_str().to_string(),
+                reason: e.to_string(),
+            })?;
+
+        Ok((parsed, raw))
+    }
+}
+
+impl AgentHook for SherpaHook {
+    fn name(&self) -> &str {
+        "sherpa"
+    }
+
+    fn display_name(&self) -> &str {
+        "Sherpa"
+    }
+
+    fn parse_event(&self, hook_type: HookType, input: &[u8]) -> AgentResult<TurnEvent> {
+        if input.is_empty() {
+            return Err(AgentError::HookInputEmpty {
+                agent: self.name().to_string(),
+                hook_type: hook_type.as_str().to_string(),
+            });
+        }
+
+        let (parsed, raw) = Self::parse_input(self.name(), hook_type, input)?;
+
+        if parsed.session_id.is_empty() {
+            return Err(AgentError::HookParseFailed {
+                agent: self.name().to_string(),
+                hook_type: hook_type.as_str().to_string(),
+                reason: "session_id is empty".to_string(),
+            });
+        }
+
+        let mut event = TurnEvent::new(parsed.session_id.clone(), hook_type).with_raw_json(raw);
+
+        // Stamp model and provider so the orchestrator can persist them on
+        // the AgentSession — same pattern as OpenCode.
+        if let Some(model) = &parsed.model {
+            if !model.is_empty() {
+                if let Some(ref mut raw_json) = event.raw_json {
+                    if let Some(obj) = raw_json.as_object_mut() {
+                        obj.insert(
+                            "model".to_string(),
+                            serde_json::Value::String(model.clone()),
+                        );
+                    }
+                }
+            }
+        }
+        if let Some(provider) = &parsed.provider {
+            if !provider.is_empty() {
+                if let Some(ref mut raw_json) = event.raw_json {
+                    if let Some(obj) = raw_json.as_object_mut() {
+                        obj.insert(
+                            "provider".to_string(),
+                            serde_json::Value::String(provider.clone()),
+                        );
+                    }
+                }
+            }
+        }
+
+        match hook_type {
+            HookType::TurnStart => {
+                // intent_title doubles as the turn prompt — used by the
+                // orchestrator to set session.current_prompt so the atomic
+                // record message is meaningful.
+                if let Some(title) = &parsed.intent_title {
+                    event = event.with_prompt(title.clone());
+                }
+            }
+
+            HookType::TurnEnd => {
+                // intent_title becomes the change message on record_turn.
+                if let Some(title) = &parsed.intent_title {
+                    event = event.with_prompt(title.clone());
+                }
+
+                // turn_number stored in raw_json so the orchestrator can
+                // include it in the SessionEnvelope.
+                if let Some(ref mut raw_json) = event.raw_json {
+                    if let Some(obj) = raw_json.as_object_mut() {
+                        obj.insert(
+                            "turn_number".to_string(),
+                            serde_json::Value::Number(parsed.turn_number.into()),
+                        );
+                    }
+                }
+            }
+
+            HookType::SessionStart | HookType::SessionEnd => {
+                // No extra fields required beyond the common ones already set.
+            }
+
+            HookType::PreToolUse | HookType::PostToolUse => {
+                // Sherpa does not currently use tool-use hooks — these are
+                // handled inside the TUI itself via TraceEvent. If the verb
+                // is ever emitted we parse it correctly but take no action.
+            }
+        }
+
+        Ok(event)
+    }
+
+    /// Sherpa is self-managed — no config file to write.
+    fn install(&self, _repo_root: &Path) -> AgentResult<usize> {
+        // The Sherpa TUI calls `atomic agent hooks sherpa <verb>` directly.
+        // There is no external config file to patch.
+        Ok(0)
+    }
+
+    /// Sherpa is self-managed — no config file to clean up.
+    fn uninstall(&self, _repo_root: &Path) -> AgentResult<()> {
+        Ok(())
+    }
+
+    /// Sherpa hooks are always "installed" when the TUI binary is present.
+    ///
+    /// We cannot easily introspect the TUI binary from here, so we return
+    /// `true` whenever `~/.sherpa/sessions/` exists (i.e. the TUI has been
+    /// run at least once).
+    fn is_installed(&self, _repo_root: &Path) -> bool {
+        Self::sherpa_sessions_dir()
+            .map(|p| p.is_dir())
+            .unwrap_or(false)
+    }
+
+    fn supported_hooks(&self) -> Vec<HookType> {
+        vec![
+            HookType::SessionStart,
+            HookType::SessionEnd,
+            HookType::TurnStart,
+            HookType::TurnEnd,
+        ]
+    }
+
+    /// Sherpa is present when `~/.sherpa/sessions/` exists.
+    fn detect_presence(&self, _repo_root: &Path) -> bool {
+        Self::sherpa_sessions_dir()
+            .map(|p| p.is_dir())
+            .unwrap_or(false)
+    }
+
+    fn hook_verbs(&self) -> Vec<&str> {
+        vec!["session-start", "session-end", "turn-start", "turn-end"]
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_hook() -> SherpaHook {
+        SherpaHook::new()
+    }
+
+    // --- name / display_name ---
+
+    #[test]
+    fn test_name() {
+        assert_eq!(make_hook().name(), "sherpa");
+    }
+
+    #[test]
+    fn test_display_name() {
+        assert_eq!(make_hook().display_name(), "Sherpa");
+    }
+
+    // --- supported_hooks ---
+
+    #[test]
+    fn test_supported_hooks() {
+        let hooks = make_hook().supported_hooks();
+        assert!(hooks.contains(&HookType::SessionStart));
+        assert!(hooks.contains(&HookType::SessionEnd));
+        assert!(hooks.contains(&HookType::TurnStart));
+        assert!(hooks.contains(&HookType::TurnEnd));
+        // Tool-use hooks are NOT in supported list
+        assert!(!hooks.contains(&HookType::PreToolUse));
+        assert!(!hooks.contains(&HookType::PostToolUse));
+    }
+
+    // --- hook_verbs ---
+
+    #[test]
+    fn test_hook_verbs() {
+        let hook = make_hook();
+        let verbs = hook.hook_verbs();
+        assert!(verbs.contains(&"session-start"));
+        assert!(verbs.contains(&"session-end"));
+        assert!(verbs.contains(&"turn-start"));
+        assert!(verbs.contains(&"turn-end"));
+    }
+
+    // --- install / uninstall are no-ops ---
+
+    #[test]
+    fn test_install_is_noop() {
+        let hook = make_hook();
+        let result = hook.install(Path::new("/tmp"));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 0);
+    }
+
+    #[test]
+    fn test_uninstall_is_noop() {
+        let hook = make_hook();
+        let result = hook.uninstall(Path::new("/tmp"));
+        assert!(result.is_ok());
+    }
+
+    // --- parse_event: empty input ---
+
+    #[test]
+    fn test_parse_event_empty_input() {
+        let hook = make_hook();
+        let result = hook.parse_event(HookType::SessionStart, b"");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, AgentError::HookInputEmpty { .. }));
+    }
+
+    // --- parse_event: invalid JSON ---
+
+    #[test]
+    fn test_parse_event_invalid_json() {
+        let hook = make_hook();
+        let result = hook.parse_event(HookType::SessionStart, b"not json");
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            AgentError::HookParseFailed { .. }
+        ));
+    }
+
+    // --- parse_event: missing session_id ---
+
+    #[test]
+    fn test_parse_event_missing_session_id() {
+        let hook = make_hook();
+        let input = br#"{"cwd": "/tmp", "model": "claude-sonnet-4-6"}"#;
+        let result = hook.parse_event(HookType::SessionStart, input);
+        assert!(result.is_err());
+    }
+
+    // --- parse_event: empty session_id ---
+
+    #[test]
+    fn test_parse_event_empty_session_id() {
+        let hook = make_hook();
+        let input = br#"{"session_id": "", "cwd": "/tmp"}"#;
+        let result = hook.parse_event(HookType::SessionStart, input);
+        assert!(result.is_err());
+    }
+
+    // --- parse_event: session-start ---
+
+    #[test]
+    fn test_parse_session_start() {
+        let hook = make_hook();
+        let input = br#"{
+            "session_id": "rapid-wildflower-4475",
+            "cwd": "/Users/dev/hello-world",
+            "model": "claude-sonnet-4-6",
+            "provider": "anthropic",
+            "turn_number": 0,
+            "timestamp": "2025-01-15T10:30:00Z"
+        }"#;
+        let event = hook.parse_event(HookType::SessionStart, input).unwrap();
+        assert_eq!(event.session_id, "rapid-wildflower-4475");
+        assert_eq!(event.event_type, HookType::SessionStart);
+        assert!(event.prompt.is_none());
+    }
+
+    // --- parse_event: session-start captures model/provider ---
+
+    #[test]
+    fn test_parse_session_start_model_provider_in_raw() {
+        let hook = make_hook();
+        let input = br#"{
+            "session_id": "tiny-star-99",
+            "model": "claude-opus-4",
+            "provider": "anthropic"
+        }"#;
+        let event = hook.parse_event(HookType::SessionStart, input).unwrap();
+        let raw = event.raw_json.unwrap();
+        assert_eq!(raw["model"].as_str(), Some("claude-opus-4"));
+        assert_eq!(raw["provider"].as_str(), Some("anthropic"));
+    }
+
+    // --- parse_event: session-end ---
+
+    #[test]
+    fn test_parse_session_end() {
+        let hook = make_hook();
+        let input = br#"{
+            "session_id": "rapid-wildflower-4475",
+            "cwd": "/Users/dev/hello-world",
+            "turn_number": 3
+        }"#;
+        let event = hook.parse_event(HookType::SessionEnd, input).unwrap();
+        assert_eq!(event.session_id, "rapid-wildflower-4475");
+        assert_eq!(event.event_type, HookType::SessionEnd);
+    }
+
+    // --- parse_event: turn-start carries intent_title as prompt ---
+
+    #[test]
+    fn test_parse_turn_start_sets_prompt() {
+        let hook = make_hook();
+        let input = br#"{
+            "session_id": "rapid-wildflower-4475",
+            "model": "claude-sonnet-4-6",
+            "provider": "anthropic",
+            "turn_number": 1,
+            "intent_title": "Create TypeScript hello world CLI"
+        }"#;
+        let event = hook.parse_event(HookType::TurnStart, input).unwrap();
+        assert_eq!(event.event_type, HookType::TurnStart);
+        assert_eq!(
+            event.prompt.as_deref(),
+            Some("Create TypeScript hello world CLI")
+        );
+    }
+
+    // --- parse_event: turn-start without intent_title has no prompt ---
+
+    #[test]
+    fn test_parse_turn_start_no_intent_title() {
+        let hook = make_hook();
+        let input = br#"{"session_id": "s1", "turn_number": 1}"#;
+        let event = hook.parse_event(HookType::TurnStart, input).unwrap();
+        assert!(event.prompt.is_none());
+    }
+
+    // --- parse_event: turn-end carries intent_title as prompt ---
+
+    #[test]
+    fn test_parse_turn_end_sets_prompt() {
+        let hook = make_hook();
+        let input = br#"{
+            "session_id": "rapid-wildflower-4475",
+            "model": "claude-sonnet-4-6",
+            "provider": "anthropic",
+            "turn_number": 2,
+            "intent_title": "Add TypeScript hello world scaffold"
+        }"#;
+        let event = hook.parse_event(HookType::TurnEnd, input).unwrap();
+        assert_eq!(event.event_type, HookType::TurnEnd);
+        assert_eq!(
+            event.prompt.as_deref(),
+            Some("Add TypeScript hello world scaffold")
+        );
+    }
+
+    // --- parse_event: turn-end stores turn_number in raw_json ---
+
+    #[test]
+    fn test_parse_turn_end_turn_number_in_raw() {
+        let hook = make_hook();
+        let input = br#"{
+            "session_id": "s1",
+            "turn_number": 5,
+            "intent_title": "Fix auth bug"
+        }"#;
+        let event = hook.parse_event(HookType::TurnEnd, input).unwrap();
+        let raw = event.raw_json.unwrap();
+        assert_eq!(raw["turn_number"].as_u64(), Some(5));
+    }
+
+    // --- parse_event: extra fields are ignored ---
+
+    #[test]
+    fn test_parse_extra_fields_ignored() {
+        let hook = make_hook();
+        let input = br#"{
+            "session_id": "s1",
+            "unknown_field": "whatever",
+            "another": 42
+        }"#;
+        let event = hook.parse_event(HookType::SessionStart, input).unwrap();
+        assert_eq!(event.session_id, "s1");
+    }
+
+    // --- default trait ---
+
+    #[test]
+    fn test_default() {
+        let hook = SherpaHook::default();
+        assert_eq!(hook.name(), "sherpa");
+    }
+
+    // --- debug ---
+
+    #[test]
+    fn test_debug() {
+        let hook = make_hook();
+        let s = format!("{:?}", hook);
+        assert!(s.contains("SherpaHook"));
+    }
+}

--- a/atomic-agent/src/lib.rs
+++ b/atomic-agent/src/lib.rs
@@ -86,6 +86,7 @@
 pub mod envelope;
 pub mod error;
 pub mod event;
+pub mod export;
 pub mod hooks;
 pub mod identity;
 pub mod learnings;

--- a/atomic-agent/src/provenance/accumulator.rs
+++ b/atomic-agent/src/provenance/accumulator.rs
@@ -485,6 +485,40 @@ impl ProvenanceAccumulator {
         node_id
     }
 
+    /// Append a raw node with full control over its fields.
+    ///
+    /// This method bypasses the usual edge inference logic and allows
+    /// direct insertion of nodes with custom details. Used for ingesting
+    /// external trace formats (e.g., Sherpa JSONL) that carry their own
+    /// structured data.
+    ///
+    /// Returns the new node's ID.
+    pub fn append_raw_node(
+        &mut self,
+        kind: NodeKind,
+        timestamp: i64,
+        summary: &str,
+        detail: Option<serde_json::Value>,
+    ) -> String {
+        let node = GraphNode {
+            id: self.next_id(),
+            kind,
+            timestamp,
+            summary: summary.to_string(),
+            detail,
+            change_hash: None,
+            tool_name: None,
+            tool_call_id: None,
+            duration_ms: None,
+            classified: false,
+            confidence: None,
+            consolidated_from: Vec::new(),
+        };
+        let node_id = node.id.clone();
+        self.push_node(node);
+        node_id
+    }
+
     /// Mark a human gate as resolved.
     ///
     /// Updates the gate node's detail and clears the pending gate state.
@@ -1010,6 +1044,12 @@ fn convert_node_kind(kind: NodeKind) -> pg::ProvenanceNodeKind {
         NodeKind::HumanGate => pg::ProvenanceNodeKind::HumanGate,
         NodeKind::PatchProposal => pg::ProvenanceNodeKind::PatchProposal,
         NodeKind::Error => pg::ProvenanceNodeKind::Error,
+        NodeKind::Todo => pg::ProvenanceNodeKind::Todo,
+        NodeKind::TodoStatusChange => pg::ProvenanceNodeKind::TodoStatusChange,
+        NodeKind::PhaseTransition => pg::ProvenanceNodeKind::PhaseTransition,
+        NodeKind::Lesson => pg::ProvenanceNodeKind::Lesson,
+        NodeKind::LlmResponse => pg::ProvenanceNodeKind::LlmResponse,
+        NodeKind::HumanGateResolution => pg::ProvenanceNodeKind::HumanGateResolution,
     }
 }
 

--- a/atomic-agent/src/provenance/consolidate.rs
+++ b/atomic-agent/src/provenance/consolidate.rs
@@ -140,7 +140,15 @@ fn find_sequences(nodes: &[GraphNode]) -> Vec<Vec<usize>> {
 
         match node.kind {
             // Structural boundaries break sequences
-            NodeKind::Goal | NodeKind::PatchProposal | NodeKind::HumanGate => {
+            NodeKind::Goal
+            | NodeKind::PatchProposal
+            | NodeKind::HumanGate
+            | NodeKind::Todo
+            | NodeKind::TodoStatusChange
+            | NodeKind::PhaseTransition
+            | NodeKind::Lesson
+            | NodeKind::LlmResponse
+            | NodeKind::HumanGateResolution => {
                 if current.len() >= 2 {
                     sequences.push(std::mem::take(&mut current));
                 } else {

--- a/atomic-agent/src/provenance/detail.rs
+++ b/atomic-agent/src/provenance/detail.rs
@@ -1,0 +1,613 @@
+//! Typed JSON payloads for Sherpa provenance graph nodes.
+//!
+//! Each struct in this module is serialized into `ProvenanceNode::detail` (as a
+//! JSON string) when Sherpa writes a `ProvenanceGraph` with
+//! `profile == "sherpa-trace/1.0.0"`.
+//!
+//! ## Node kind → detail struct mapping
+//!
+//! | `ProvenanceNodeKind` | Detail struct          |
+//! |----------------------|------------------------|
+//! | `Goal`               | [`GoalDetail`]         |
+//! | `Commitment`         | [`CommitmentDetail`]   |
+//! | `Execution`          | [`ExecutionDetail`]    |
+//! | `Verification`       | [`VerificationDetail`] |
+//!
+//! ## Ownership rationale
+//!
+//! These types live in `atomic-agent` (not in `atomic-llm` / `atomic-tui`)
+//! because they are part of the shared provenance schema that every consumer
+//! of a Sherpa-produced `ProvenanceGraph` must agree on:
+//!
+//! - `atomic-agent/src/export.rs` deserializes them to build typed
+//!   `agent-trace` JSONL records.
+//! - `atomic-tui/src/provenance.rs` serializes them when flushing a turn.
+//! - Future consumers (API, UI, attestation) import them from here.
+//!
+//! `atomic-llm/src/trace.rs` re-exports every public item from this module
+//! so existing Sherpa TUI import paths compile without change.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Cost helpers (duplicated from atomic-llm to avoid a circular dependency)
+// ---------------------------------------------------------------------------
+
+/// Cost in USD per 1 000 000 input tokens.
+///
+/// Matches `atomic_llm::trace::COST_PER_M_INPUT` — both sides must stay in sync.
+pub const COST_PER_M_INPUT: f64 = 5.0;
+
+/// Cost in USD per 1 000 000 output tokens.
+///
+/// Matches `atomic_llm::trace::COST_PER_M_OUTPUT` — both sides must stay in sync.
+pub const COST_PER_M_OUTPUT: f64 = 25.0;
+
+/// Compute the USD cost for a pair of token counts.
+///
+/// Uses [`COST_PER_M_INPUT`] and [`COST_PER_M_OUTPUT`] so every layer that
+/// touches token accounting produces identical values.
+///
+/// # Example
+///
+/// ```
+/// use atomic_agent::provenance::detail::compute_cost;
+/// let cost = compute_cost(16_083, 3_746);
+/// let expected = (16_083.0 / 1_000_000.0) * 5.0 + (3_746.0 / 1_000_000.0) * 25.0;
+/// assert!((cost - expected).abs() < 1e-9);
+/// ```
+pub fn compute_cost(input_tokens: u32, output_tokens: u32) -> f64 {
+    (input_tokens as f64 / 1_000_000.0) * COST_PER_M_INPUT
+        + (output_tokens as f64 / 1_000_000.0) * COST_PER_M_OUTPUT
+}
+
+// ---------------------------------------------------------------------------
+// Shared sub-structs
+// ---------------------------------------------------------------------------
+
+/// Token counts and cost for a single phase or todo slice.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PhaseTokens {
+    /// Input tokens consumed.
+    pub input: u32,
+    /// Output tokens produced.
+    pub output: u32,
+    /// Cost in USD computed from [`COST_PER_M_INPUT`] / [`COST_PER_M_OUTPUT`].
+    pub cost_usd: f64,
+}
+
+impl PhaseTokens {
+    /// Build a `PhaseTokens` from raw counts, computing cost automatically.
+    pub fn from_counts(input: u32, output: u32) -> Self {
+        Self {
+            input,
+            output,
+            cost_usd: compute_cost(input, output),
+        }
+    }
+
+    /// Add another `PhaseTokens` into `self` (used for running totals).
+    pub fn add(&mut self, other: &PhaseTokens) {
+        self.input += other.input;
+        self.output += other.output;
+        self.cost_usd = compute_cost(self.input, self.output);
+    }
+}
+
+/// Aggregate token counts across all phases in a turn.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TurnTotals {
+    /// Total input tokens.
+    pub input: u32,
+    /// Total output tokens.
+    pub output: u32,
+    /// `input + output`.
+    pub total: u32,
+    /// Cost in USD.
+    pub cost_usd: f64,
+}
+
+impl TurnTotals {
+    /// Compute totals from a `phases` map.
+    pub fn from_phases(phases: &HashMap<String, PhaseTokens>) -> Self {
+        let input: u32 = phases.values().map(|p| p.input).sum();
+        let output: u32 = phases.values().map(|p| p.output).sum();
+        Self {
+            input,
+            output,
+            total: input + output,
+            cost_usd: compute_cost(input, output),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Learnings
+// ---------------------------------------------------------------------------
+
+/// A code-level finding tied to a specific file and line.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodeFinding {
+    /// Relative path to the file, e.g. `"src/index.ts"`.
+    pub file: String,
+    /// Line number (1-based) relevant to the finding.
+    pub line: u32,
+    /// One-line description of the finding.
+    pub finding: String,
+}
+
+/// Structured learnings captured at `Verification` time.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Learnings {
+    /// Repository-level observations, e.g. build commands, conventions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub repo: Vec<String>,
+    /// Workflow observations, e.g. required tool sequencing.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub workflow: Vec<String>,
+    /// Code-level findings tied to specific files and lines.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub code: Vec<CodeFinding>,
+}
+
+impl Learnings {
+    /// Returns `true` if all fields are empty.
+    pub fn is_empty(&self) -> bool {
+        self.repo.is_empty() && self.workflow.is_empty() && self.code.is_empty()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GoalDetail
+// ---------------------------------------------------------------------------
+
+/// JSON payload for a `ProvenanceNodeKind::Goal` node in a Sherpa graph.
+///
+/// Stored in `ProvenanceNode::detail` as serialized JSON.
+///
+/// # Example
+///
+/// ```json
+/// {
+///   "intent_title": "Build TypeScript Hello World CLI",
+///   "intent_description": "200–500 word narrative spec...",
+///   "intent_turn_id": 3,
+///   "phases": {
+///     "orienting":  { "input": 1842, "output": 312,  "cost_usd": 0.0012 },
+///     "proposing":  { "input": 3201, "output": 891,  "cost_usd": 0.0031 },
+///     "executing":  { "input": 8940, "output": 2103, "cost_usd": 0.0089 },
+///     "grading":    { "input": 2100, "output": 440,  "cost_usd": 0.0018 }
+///   },
+///   "turn_totals": { "input": 16083, "output": 3746, "total": 19829, "cost_usd": 0.0150 },
+///   "model": "anthropic/claude-sonnet-4-6",
+///   "context_pct": 9.9
+/// }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GoalDetail {
+    /// One-line intent title chosen by the agent.
+    pub intent_title: String,
+
+    /// 200–500 word narrative description of the intent.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub intent_description: String,
+
+    /// Monotonically increasing turn index within the session.
+    pub intent_turn_id: u32,
+
+    /// Optional external issue reference, e.g. `"GH-42"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issue_ref: Option<String>,
+
+    /// Human-readable session identifier, e.g. `"tiny-star-8412"`.
+    pub session_id: String,
+
+    /// Per-phase token breakdown.  Keys are lowercase phase names:
+    /// `"orienting"`, `"proposing"`, `"executing"`, `"grading"`.
+    pub phases: HashMap<String, PhaseTokens>,
+
+    /// Aggregate across all phases.
+    pub turn_totals: TurnTotals,
+
+    /// Model identifier used for this turn, e.g. `"anthropic/claude-sonnet-4-6"`.
+    pub model: String,
+
+    /// Fraction of the model's context window used at peak, as a percentage.
+    pub context_pct: f64,
+}
+
+impl GoalDetail {
+    /// Re-derive `turn_totals` from the current `phases` map in place.
+    pub fn recompute_totals(&mut self) {
+        self.turn_totals = TurnTotals::from_phases(&self.phases);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CommitmentDetail
+// ---------------------------------------------------------------------------
+
+/// Who produced the file changes for a given todo.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Contributor {
+    /// All changes written autonomously by the agent.
+    Ai,
+    /// All changes written by the human in guide mode.
+    Human,
+    /// Mix of agent and human changes (detected post-hoc via diff; v1 deferred).
+    Mixed,
+}
+
+impl Default for Contributor {
+    fn default() -> Self {
+        Self::Ai
+    }
+}
+
+impl std::fmt::Display for Contributor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Ai => f.write_str("ai"),
+            Self::Human => f.write_str("human"),
+            Self::Mixed => f.write_str("mixed"),
+        }
+    }
+}
+
+/// JSON payload for a `ProvenanceNodeKind::Commitment` node in a Sherpa graph.
+///
+/// One node is emitted per todo that produced file changes. Stored in
+/// `ProvenanceNode::detail` as serialized JSON.
+///
+/// # Example
+///
+/// ```json
+/// {
+///   "todo_id": "t2",
+///   "todo_content": "Install typescript as a dev dependency",
+///   "priority": "high",
+///   "contributor": "ai",
+///   "file": "package.json",
+///   "start_line": 1,
+///   "end_line": 9,
+///   "atomic_change_hash": "<base32>",
+///   "tokens": { "input": 1203, "output": 287, "cost_usd": 0.0011 }
+/// }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitmentDetail {
+    /// Stable todo identifier, e.g. `"t2"`.
+    pub todo_id: String,
+
+    /// Full text of the todo item.
+    pub todo_content: String,
+
+    /// Priority label, e.g. `"high"`, `"medium"`, `"low"`.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub priority: String,
+
+    /// Who made the changes for this todo.
+    pub contributor: Contributor,
+
+    /// Relative path of the primary file changed, e.g. `"src/index.ts"`.
+    pub file: String,
+
+    /// First line of the changed range (1-based, inclusive).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_line: Option<u32>,
+
+    /// Last line of the changed range (1-based, inclusive).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_line: Option<u32>,
+
+    /// Base32 hash of the corresponding `atomic record` change, if available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub atomic_change_hash: Option<String>,
+
+    /// Token slice attributed to this todo's execution.
+    pub tokens: PhaseTokens,
+}
+
+// ---------------------------------------------------------------------------
+// ExecutionDetail
+// ---------------------------------------------------------------------------
+
+/// JSON payload for a `ProvenanceNodeKind::Execution` node in a Sherpa graph.
+///
+/// One node is emitted per `bash` tool call. Stored in `ProvenanceNode::detail`
+/// as serialized JSON.
+///
+/// # Example
+///
+/// ```json
+/// {
+///   "todo_id": "t2",
+///   "command": "npm install --save-dev typescript",
+///   "exit_code": 0,
+///   "duration_ms": 616,
+///   "output_summary": "added 1 package, audited 2 packages in 616ms"
+/// }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutionDetail {
+    /// ID of the todo that was `InProgress` when this command ran.
+    pub todo_id: String,
+
+    /// Full command string passed to the shell.
+    pub command: String,
+
+    /// Shell exit code (0 = success).
+    pub exit_code: i32,
+
+    /// Wall-clock duration of the command in milliseconds.
+    pub duration_ms: u64,
+
+    /// First `n` bytes of combined stdout/stderr, truncated for storage.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub output_summary: String,
+}
+
+// ---------------------------------------------------------------------------
+// VerificationDetail
+// ---------------------------------------------------------------------------
+
+/// The high-level outcome of a Sherpa turn.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnOutcome {
+    /// All todos completed successfully.
+    Completed,
+    /// Some todos completed, others did not.
+    Partial,
+    /// The turn failed without completing its goal.
+    Failed,
+}
+
+impl Default for TurnOutcome {
+    fn default() -> Self {
+        Self::Completed
+    }
+}
+
+impl std::fmt::Display for TurnOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Completed => f.write_str("completed"),
+            Self::Partial => f.write_str("partial"),
+            Self::Failed => f.write_str("failed"),
+        }
+    }
+}
+
+/// JSON payload for a `ProvenanceNodeKind::Verification` node in a Sherpa graph.
+///
+/// Written when the state machine reaches `State::Verification`. Stored in
+/// `ProvenanceNode::detail` as serialized JSON.
+///
+/// # Example
+///
+/// ```json
+/// {
+///   "intent_turn_id": 3,
+///   "intent_title": "Build TypeScript Hello World CLI for exec demo",
+///   "outcome": "completed",
+///   "summary": "npm start compiled and printed 'Hello World!' — zero exit code",
+///   "turn_cost_usd": 0.0150,
+///   "turn_tokens_total": 19829,
+///   "learnings": { "repo": [...], "workflow": [...], "code": [...] },
+///   "provenance_graph_hash": "<base32>"
+/// }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerificationDetail {
+    /// Turn index of the `Goal` node this verification closes.
+    pub intent_turn_id: u32,
+
+    /// Intent title copied from the matching `Goal` node.
+    pub intent_title: String,
+
+    /// Whether the turn met its goal.
+    pub outcome: TurnOutcome,
+
+    /// One-sentence human-readable description of what happened.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub summary: String,
+
+    /// Total cost for this turn in USD.
+    pub turn_cost_usd: f64,
+
+    /// Total tokens consumed this turn (`input + output`).
+    pub turn_tokens_total: u32,
+
+    /// Structured learnings captured during verification.
+    pub learnings: Learnings,
+
+    /// Base32 hash of the `ProvenanceGraph` after this node was appended,
+    /// set after `repo.save_provenance_graph()` returns.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance_graph_hash: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_cost_zero() {
+        assert_eq!(compute_cost(0, 0), 0.0);
+    }
+
+    #[test]
+    fn test_compute_cost_known_values() {
+        let cost = compute_cost(16_083, 3_746);
+        let expected = (16_083.0 / 1_000_000.0) * 5.0 + (3_746.0 / 1_000_000.0) * 25.0;
+        assert!((cost - expected).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_phase_tokens_from_counts() {
+        let pt = PhaseTokens::from_counts(1_000_000, 0);
+        assert_eq!(pt.input, 1_000_000);
+        assert_eq!(pt.output, 0);
+        assert!((pt.cost_usd - 5.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_phase_tokens_add() {
+        let mut a = PhaseTokens::from_counts(500, 100);
+        let b = PhaseTokens::from_counts(500, 100);
+        a.add(&b);
+        assert_eq!(a.input, 1000);
+        assert_eq!(a.output, 200);
+        assert!((a.cost_usd - compute_cost(1000, 200)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_turn_totals_from_phases() {
+        let mut phases = HashMap::new();
+        phases.insert("orienting".to_string(), PhaseTokens::from_counts(1000, 200));
+        phases.insert("proposing".to_string(), PhaseTokens::from_counts(2000, 400));
+        let totals = TurnTotals::from_phases(&phases);
+        assert_eq!(totals.input, 3000);
+        assert_eq!(totals.output, 600);
+        assert_eq!(totals.total, 3600);
+        assert!((totals.cost_usd - compute_cost(3000, 600)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_goal_detail_roundtrip() {
+        let mut phases = HashMap::new();
+        phases.insert("orienting".to_string(), PhaseTokens::from_counts(1842, 312));
+        phases.insert("proposing".to_string(), PhaseTokens::from_counts(3201, 891));
+        let turn_totals = TurnTotals::from_phases(&phases);
+        let detail = GoalDetail {
+            intent_title: "Build TypeScript Hello World CLI".into(),
+            intent_description: "A spec.".into(),
+            intent_turn_id: 3,
+            issue_ref: Some("GH-42".into()),
+            session_id: "tiny-star-8412".into(),
+            phases,
+            turn_totals,
+            model: "anthropic/claude-sonnet-4-6".into(),
+            context_pct: 9.9,
+        };
+
+        let json = serde_json::to_string(&detail).expect("serialize");
+        let back: GoalDetail = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.intent_title, detail.intent_title);
+        assert_eq!(back.intent_turn_id, 3);
+        assert_eq!(back.issue_ref.as_deref(), Some("GH-42"));
+        assert!(back.phases.contains_key("orienting"));
+    }
+
+    #[test]
+    fn test_commitment_detail_roundtrip() {
+        let detail = CommitmentDetail {
+            todo_id: "t2".into(),
+            todo_content: "Install typescript as a dev dependency".into(),
+            priority: "high".into(),
+            contributor: Contributor::Ai,
+            file: "package.json".into(),
+            start_line: Some(1),
+            end_line: Some(9),
+            atomic_change_hash: None,
+            tokens: PhaseTokens::from_counts(1203, 287),
+        };
+
+        let json = serde_json::to_string(&detail).expect("serialize");
+        let back: CommitmentDetail = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.todo_id, "t2");
+        assert_eq!(back.contributor, Contributor::Ai);
+        assert_eq!(back.start_line, Some(1));
+        assert!(!json.contains("atomic_change_hash"));
+    }
+
+    #[test]
+    fn test_execution_detail_roundtrip() {
+        let detail = ExecutionDetail {
+            todo_id: "t2".into(),
+            command: "npm install --save-dev typescript".into(),
+            exit_code: 0,
+            duration_ms: 616,
+            output_summary: "added 1 package".into(),
+        };
+
+        let json = serde_json::to_string(&detail).expect("serialize");
+        let back: ExecutionDetail = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.exit_code, 0);
+        assert_eq!(back.duration_ms, 616);
+    }
+
+    #[test]
+    fn test_verification_detail_roundtrip() {
+        let detail = VerificationDetail {
+            intent_turn_id: 3,
+            intent_title: "Build TypeScript Hello World CLI".into(),
+            outcome: TurnOutcome::Completed,
+            summary: "npm start printed Hello World!".into(),
+            turn_cost_usd: 0.015,
+            turn_tokens_total: 19_829,
+            learnings: Learnings {
+                repo: vec!["tsc && node dist/index.js is the correct sequence".into()],
+                workflow: vec![],
+                code: vec![CodeFinding {
+                    file: "src/index.ts".into(),
+                    line: 1,
+                    finding: "console.log is sufficient for CLI Hello World output".into(),
+                }],
+            },
+            provenance_graph_hash: Some("ABCDEF123456".into()),
+        };
+
+        let json = serde_json::to_string(&detail).expect("serialize");
+        let back: VerificationDetail = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.outcome, TurnOutcome::Completed);
+        assert_eq!(back.learnings.repo.len(), 1);
+        assert_eq!(back.learnings.code[0].file, "src/index.ts");
+        assert_eq!(back.provenance_graph_hash.as_deref(), Some("ABCDEF123456"));
+        assert!(!json.contains("\"workflow\""));
+    }
+
+    #[test]
+    fn test_contributor_display() {
+        assert_eq!(Contributor::Ai.to_string(), "ai");
+        assert_eq!(Contributor::Human.to_string(), "human");
+        assert_eq!(Contributor::Mixed.to_string(), "mixed");
+    }
+
+    #[test]
+    fn test_turn_outcome_display() {
+        assert_eq!(TurnOutcome::Completed.to_string(), "completed");
+        assert_eq!(TurnOutcome::Partial.to_string(), "partial");
+        assert_eq!(TurnOutcome::Failed.to_string(), "failed");
+    }
+
+    #[test]
+    fn test_learnings_is_empty() {
+        let empty = Learnings::default();
+        assert!(empty.is_empty());
+
+        let non_empty = Learnings {
+            repo: vec!["something".into()],
+            ..Default::default()
+        };
+        assert!(!non_empty.is_empty());
+    }
+
+    #[test]
+    fn test_contributor_default_is_ai() {
+        assert_eq!(Contributor::default(), Contributor::Ai);
+    }
+
+    #[test]
+    fn test_turn_outcome_default_is_completed() {
+        assert_eq!(TurnOutcome::default(), TurnOutcome::Completed);
+    }
+}

--- a/atomic-agent/src/provenance/mod.rs
+++ b/atomic-agent/src/provenance/mod.rs
@@ -30,6 +30,7 @@
 //! - [`types`] — Node, edge, and graph type definitions
 //! - [`classify`] — Rule-based tool call classification
 //! - [`accumulator`] — In-memory DAG builder with persistence
+//! - [`detail`] — Typed JSON payloads for Sherpa provenance nodes
 //!
 //! # Example
 //!
@@ -57,10 +58,15 @@
 pub mod accumulator;
 pub mod classify;
 pub mod consolidate;
+pub mod detail;
 pub mod types;
 
 // Re-export primary types for convenience.
 pub use accumulator::ProvenanceAccumulator;
 pub use classify::{classify_tool_call, summarize_tool_call};
 pub use consolidate::consolidate;
+pub use detail::{
+    CodeFinding, CommitmentDetail, Contributor, ExecutionDetail, GoalDetail, Learnings,
+    PhaseTokens, TurnOutcome, TurnTotals, VerificationDetail, COST_PER_M_INPUT, COST_PER_M_OUTPUT,
+};
 pub use types::{EdgeKind, GraphEdge, GraphNode, GraphStats, NodeKind, SerializedGraph};

--- a/atomic-agent/src/provenance/types.rs
+++ b/atomic-agent/src/provenance/types.rs
@@ -76,6 +76,24 @@ pub enum NodeKind {
 
     /// Tool failure or session error.
     Error,
+
+    /// A single todo item in the checklist (Sherpa only).
+    Todo,
+
+    /// A todo item's status changed (Sherpa only).
+    TodoStatusChange,
+
+    /// A Petri net phase transition (Sherpa only).
+    PhaseTransition,
+
+    /// An unexpected failure or change of approach (Sherpa only).
+    Lesson,
+
+    /// The LLM's final response for a phase (Sherpa only).
+    LlmResponse,
+
+    /// HumanGate resolution — which command the user chose (Sherpa only).
+    HumanGateResolution,
 }
 
 impl NodeKind {
@@ -108,6 +126,12 @@ impl NodeKind {
             NodeKind::HumanGate => "human_gate",
             NodeKind::PatchProposal => "patch_proposal",
             NodeKind::Error => "error",
+            NodeKind::Todo => "todo",
+            NodeKind::TodoStatusChange => "todo_status_change",
+            NodeKind::PhaseTransition => "phase_transition",
+            NodeKind::Lesson => "lesson",
+            NodeKind::LlmResponse => "llm_response",
+            NodeKind::HumanGateResolution => "human_gate_resolution",
         }
     }
 }
@@ -372,6 +396,18 @@ pub struct GraphStats {
     pub execution_count: u32,
     pub patch_proposal_count: u32,
     pub edge_count: u32,
+    #[serde(default)]
+    pub todo_count: u32,
+    #[serde(default)]
+    pub todo_status_change_count: u32,
+    #[serde(default)]
+    pub phase_transition_count: u32,
+    #[serde(default)]
+    pub lesson_count: u32,
+    #[serde(default)]
+    pub llm_response_count: u32,
+    #[serde(default)]
+    pub human_gate_resolution_count: u32,
 }
 
 impl GraphStats {
@@ -386,6 +422,12 @@ impl GraphStats {
             + self.error_count
             + self.execution_count
             + self.patch_proposal_count
+            + self.todo_count
+            + self.todo_status_change_count
+            + self.phase_transition_count
+            + self.lesson_count
+            + self.llm_response_count
+            + self.human_gate_resolution_count
     }
 
     /// Increment the counter for the given node kind.
@@ -400,6 +442,12 @@ impl GraphStats {
             NodeKind::HumanGate => self.human_gate_count += 1,
             NodeKind::PatchProposal => self.patch_proposal_count += 1,
             NodeKind::Error => self.error_count += 1,
+            NodeKind::Todo => self.todo_count += 1,
+            NodeKind::TodoStatusChange => self.todo_status_change_count += 1,
+            NodeKind::PhaseTransition => self.phase_transition_count += 1,
+            NodeKind::Lesson => self.lesson_count += 1,
+            NodeKind::LlmResponse => self.llm_response_count += 1,
+            NodeKind::HumanGateResolution => self.human_gate_resolution_count += 1,
         }
     }
 

--- a/atomic-agent/src/turn/orchestrator.rs
+++ b/atomic-agent/src/turn/orchestrator.rs
@@ -1133,10 +1133,7 @@ impl TurnOrchestrator {
                 ),
                 "llm_response" => (
                     NodeKind::LlmResponse,
-                    dev_atomic["reply"]
-                        .as_str()
-                        .unwrap_or("llm response")
-                        .to_string(),
+                    truncate_prompt(dev_atomic["reply"].as_str().unwrap_or("llm response"), 200),
                 ),
                 "verification" => (
                     NodeKind::Verification,
@@ -1535,6 +1532,25 @@ fn vendor_from_agent_name(agent_name: &str) -> &'static str {
         "opencode" => "openai",
         _ => "unknown",
     }
+}
+
+/// Truncate a string to `max_len` bytes, breaking at a word boundary where
+/// possible and appending `"..."`.  Mirrors the same helper in sibling modules.
+fn truncate_prompt(prompt: &str, max_len: usize) -> String {
+    let trimmed = prompt.trim();
+    if trimmed.len() <= max_len {
+        return trimmed.to_string();
+    }
+
+    // Try to break at a word boundary in the first `max_len - 3` bytes.
+    let truncated = &trimmed[..max_len.saturating_sub(3)];
+    if let Some(last_space) = truncated.rfind(' ') {
+        if last_space > max_len / 2 {
+            return format!("{}...", &truncated[..last_space]);
+        }
+    }
+
+    format!("{}...", truncated)
 }
 
 impl std::fmt::Debug for TurnOrchestrator {

--- a/atomic-agent/src/turn/orchestrator.rs
+++ b/atomic-agent/src/turn/orchestrator.rs
@@ -1033,12 +1033,18 @@ impl TurnOrchestrator {
         }
     }
 
-    /// Read a Sherpa JSONL trace file and feed each record into the
-    /// provenance accumulator.
+    /// Read a Sherpa JSONL trace file and create provenance nodes for
+    /// every record, preserving the full agent-trace + Sherpa extension data.
     ///
-    /// Best-effort: parse errors on individual lines are logged and skipped.
+    /// Every JSONL line becomes a typed `ProvenanceNode` with the full
+    /// `metadata["dev.atomic"]` payload in its `detail` field. The semantic
+    /// knowledge graph can now query by node kind (Todo, PhaseTransition, etc.)
+    /// without parsing JSON blobs.
+    ///
     /// Returns `true` if at least one record was successfully ingested.
     fn ingest_sherpa_trace(&self, session_id: &str, trace_path: &Path) -> bool {
+        use crate::provenance::types::NodeKind;
+
         let mut acc = match self.load_accumulator(session_id) {
             Some(a) => a,
             None => return false,
@@ -1061,6 +1067,7 @@ impl TurnOrchestrator {
             if line.trim().is_empty() {
                 continue;
             }
+
             let record: serde_json::Value = match serde_json::from_str(line) {
                 Ok(v) => v,
                 Err(e) => {
@@ -1070,75 +1077,95 @@ impl TurnOrchestrator {
             };
 
             let dev_atomic = &record["metadata"]["dev.atomic"];
-            let record_type = dev_atomic["record_type"].as_str().unwrap_or("");
+            let record_type = dev_atomic["record_type"].as_str().unwrap_or("unknown");
             let timestamp = record["timestamp"]
                 .as_str()
                 .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
                 .map(|dt| dt.timestamp())
                 .unwrap_or_else(|| chrono::Utc::now().timestamp());
 
-            match record_type {
-                "intent" => {
-                    let title = dev_atomic["intent_title"].as_str().unwrap_or("");
-                    if !title.is_empty() {
-                        acc.append_goal(title, timestamp);
-                        ingested += 1;
-                    }
-                }
+            // Map record_type to NodeKind.
+            let (kind, summary) = match record_type {
+                "intent" => (
+                    NodeKind::Goal,
+                    dev_atomic["intent_title"]
+                        .as_str()
+                        .unwrap_or("intent")
+                        .to_string(),
+                ),
                 "commitment" => {
-                    // Commitment maps to a write_file/edit_file tool call
-                    let file_path = record["files"]
+                    let file = record["files"]
                         .as_array()
                         .and_then(|f| f.first())
                         .and_then(|f| f["path"].as_str())
                         .unwrap_or("");
-                    let tool_input = serde_json::json!({
-                        "path": file_path,
-                        "todo_id": dev_atomic["todo_id"].as_str().unwrap_or(""),
-                    });
-                    acc.append_tool_call(
-                        "write_file",
-                        None,
-                        Some(&tool_input),
-                        None,
-                        Some("completed"),
-                        None,
-                        timestamp,
+                    (NodeKind::Commitment, format!("wrote {}", file))
+                }
+                "execution" => (
+                    NodeKind::Execution,
+                    dev_atomic["command"]
+                        .as_str()
+                        .unwrap_or("command")
+                        .to_string(),
+                ),
+                "todo" => {
+                    let tid = dev_atomic["todo_id"].as_str().unwrap_or("");
+                    let content = dev_atomic["content"].as_str().unwrap_or("");
+                    (NodeKind::Todo, format!("[{}] {}", tid, content))
+                }
+                "todo_status" => {
+                    let tid = dev_atomic["todo_id"].as_str().unwrap_or("");
+                    let from = dev_atomic["from_status"].as_str().unwrap_or("");
+                    let to = dev_atomic["to_status"].as_str().unwrap_or("");
+                    (
+                        NodeKind::TodoStatusChange,
+                        format!("{}: {} → {}", tid, from, to),
+                    )
+                }
+                "phase_transition" => {
+                    let from = dev_atomic["from_phase"].as_str().unwrap_or("");
+                    let to = dev_atomic["to_phase"].as_str().unwrap_or("");
+                    (NodeKind::PhaseTransition, format!("{} → {}", from, to))
+                }
+                "lesson" => (
+                    NodeKind::Lesson,
+                    dev_atomic["label"].as_str().unwrap_or("lesson").to_string(),
+                ),
+                "llm_response" => (
+                    NodeKind::LlmResponse,
+                    dev_atomic["reply"]
+                        .as_str()
+                        .unwrap_or("llm response")
+                        .to_string(),
+                ),
+                "verification" => (
+                    NodeKind::Verification,
+                    dev_atomic["summary"]
+                        .as_str()
+                        .unwrap_or("verification")
+                        .to_string(),
+                ),
+                "human_gate" => {
+                    let resolution = dev_atomic["resolution"].as_str().unwrap_or("");
+                    (
+                        NodeKind::HumanGateResolution,
+                        format!("resolution: {}", resolution),
+                    )
+                }
+                _ => {
+                    log::debug!(
+                        "sherpa trace: skipping unknown record_type '{}'",
+                        record_type
                     );
-                    ingested += 1;
+                    continue;
                 }
-                "execution" => {
-                    let command = dev_atomic["command"].as_str().unwrap_or("");
-                    let exit_code = dev_atomic["exit_code"].as_i64().unwrap_or(0);
-                    let duration_ms = dev_atomic["duration_ms"].as_u64();
-                    let tool_input = serde_json::json!({ "command": command });
-                    let output = dev_atomic["output_summary"].as_str();
-                    let status = if exit_code == 0 { "completed" } else { "error" };
-                    acc.append_tool_call(
-                        "bash",
-                        None,
-                        Some(&tool_input),
-                        output,
-                        Some(status),
-                        duration_ms,
-                        timestamp,
-                    );
-                    ingested += 1;
-                }
-                "verification" => {
-                    // Verification is a summary — currently no specific accumulator
-                    // method for it, but append_tool_call with a test-like command
-                    // will classify as Verification via the existing classifier.
-                    // The detail is preserved in the ProvenanceGraph via the
-                    // GoalDetail/VerificationDetail in the node detail strings.
-                    // For now, skip — the accumulator already has all the
-                    // constituent nodes from the above records.
-                    ingested += 1;
-                }
-                other => {
-                    log::debug!("sherpa trace: skipping unknown record_type '{}'", other);
-                }
-            }
+            };
+
+            // Create a node with the full dev.atomic payload as detail.
+            // This preserves all the session data (intent description, todo
+            // content, phase timing, etc.) for extraction by populate_session_tables.
+            acc.append_raw_node(kind, timestamp, &summary, Some(dev_atomic.clone()));
+            ingested += 1;
         }
 
         if ingested > 0 {
@@ -1185,12 +1212,18 @@ impl TurnOrchestrator {
 
         // Convert the accumulated graph to a content-addressed ProvenanceGraph
         let change_hashes = vec![outcome.hash];
-        let graph = acc.to_provenance_graph(
+        let mut graph = acc.to_provenance_graph(
             &session.agent_name,
             &session.agent_display_name,
             &session.agent_vendor,
             &change_hashes,
         );
+
+        // Set the Sherpa profile if this is a Sherpa session.
+        // This gates session table population on the server.
+        if session.agent_name == "sherpa" {
+            graph.profile = Some("sherpa-trace/1.0.0".to_string());
+        }
 
         // Save to the repository
         match atomic_repository::Repository::open(&self.repo_root) {

--- a/atomic-agent/src/turn/orchestrator.rs
+++ b/atomic-agent/src/turn/orchestrator.rs
@@ -1081,8 +1081,8 @@ impl TurnOrchestrator {
             let timestamp = record["timestamp"]
                 .as_str()
                 .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
-                .map(|dt| dt.timestamp())
-                .unwrap_or_else(|| chrono::Utc::now().timestamp());
+                .map(|dt| dt.timestamp_millis())
+                .unwrap_or_else(|| chrono::Utc::now().timestamp_millis());
 
             // Map record_type to NodeKind.
             let (kind, summary) = match record_type {

--- a/atomic-agent/src/turn/orchestrator.rs
+++ b/atomic-agent/src/turn/orchestrator.rs
@@ -623,6 +623,18 @@ impl TurnOrchestrator {
                             // reuse this turn's prompt as the change message.
                             session.clear_current_prompt();
 
+                            // Sherpa: ingest the JSONL trace file into the provenance accumulator
+                            // so the resulting ProvenanceGraph has rich node data (file attribution,
+                            // bash commands, todo structure) instead of just the thin Goal node.
+                            if let Some(trace_path) = event
+                                .raw_json
+                                .as_ref()
+                                .and_then(|r| r.get("trace_file"))
+                                .and_then(|v| v.as_str())
+                            {
+                                self.ingest_sherpa_trace(session_id, Path::new(trace_path));
+                            }
+
                             // Provenance: inject reasoning blocks as Decision nodes,
                             // then append a patch proposal node and save the graph.
                             self.inject_reasoning_nodes(session_id, &event);
@@ -1019,6 +1031,126 @@ impl TurnOrchestrator {
                 e,
             );
         }
+    }
+
+    /// Read a Sherpa JSONL trace file and feed each record into the
+    /// provenance accumulator.
+    ///
+    /// Best-effort: parse errors on individual lines are logged and skipped.
+    /// Returns `true` if at least one record was successfully ingested.
+    fn ingest_sherpa_trace(&self, session_id: &str, trace_path: &Path) -> bool {
+        let mut acc = match self.load_accumulator(session_id) {
+            Some(a) => a,
+            None => return false,
+        };
+
+        let content = match std::fs::read_to_string(trace_path) {
+            Ok(c) => c,
+            Err(e) => {
+                log::warn!(
+                    "sherpa trace: failed to read {}: {}",
+                    trace_path.display(),
+                    e
+                );
+                return false;
+            }
+        };
+
+        let mut ingested = 0u32;
+        for (line_no, line) in content.lines().enumerate() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let record: serde_json::Value = match serde_json::from_str(line) {
+                Ok(v) => v,
+                Err(e) => {
+                    log::warn!("sherpa trace: line {} parse error: {}", line_no + 1, e);
+                    continue;
+                }
+            };
+
+            let dev_atomic = &record["metadata"]["dev.atomic"];
+            let record_type = dev_atomic["record_type"].as_str().unwrap_or("");
+            let timestamp = record["timestamp"]
+                .as_str()
+                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| dt.timestamp())
+                .unwrap_or_else(|| chrono::Utc::now().timestamp());
+
+            match record_type {
+                "intent" => {
+                    let title = dev_atomic["intent_title"].as_str().unwrap_or("");
+                    if !title.is_empty() {
+                        acc.append_goal(title, timestamp);
+                        ingested += 1;
+                    }
+                }
+                "commitment" => {
+                    // Commitment maps to a write_file/edit_file tool call
+                    let file_path = record["files"]
+                        .as_array()
+                        .and_then(|f| f.first())
+                        .and_then(|f| f["path"].as_str())
+                        .unwrap_or("");
+                    let tool_input = serde_json::json!({
+                        "path": file_path,
+                        "todo_id": dev_atomic["todo_id"].as_str().unwrap_or(""),
+                    });
+                    acc.append_tool_call(
+                        "write_file",
+                        None,
+                        Some(&tool_input),
+                        None,
+                        Some("completed"),
+                        None,
+                        timestamp,
+                    );
+                    ingested += 1;
+                }
+                "execution" => {
+                    let command = dev_atomic["command"].as_str().unwrap_or("");
+                    let exit_code = dev_atomic["exit_code"].as_i64().unwrap_or(0);
+                    let duration_ms = dev_atomic["duration_ms"].as_u64();
+                    let tool_input = serde_json::json!({ "command": command });
+                    let output = dev_atomic["output_summary"].as_str();
+                    let status = if exit_code == 0 { "completed" } else { "error" };
+                    acc.append_tool_call(
+                        "bash",
+                        None,
+                        Some(&tool_input),
+                        output,
+                        Some(status),
+                        duration_ms,
+                        timestamp,
+                    );
+                    ingested += 1;
+                }
+                "verification" => {
+                    // Verification is a summary — currently no specific accumulator
+                    // method for it, but append_tool_call with a test-like command
+                    // will classify as Verification via the existing classifier.
+                    // The detail is preserved in the ProvenanceGraph via the
+                    // GoalDetail/VerificationDetail in the node detail strings.
+                    // For now, skip — the accumulator already has all the
+                    // constituent nodes from the above records.
+                    ingested += 1;
+                }
+                other => {
+                    log::debug!("sherpa trace: skipping unknown record_type '{}'", other);
+                }
+            }
+        }
+
+        if ingested > 0 {
+            self.save_accumulator(session_id, &acc);
+            log::info!(
+                "sherpa trace: ingested {} records from {}",
+                ingested,
+                trace_path.display()
+            );
+        }
+
+        ingested > 0
     }
 
     /// Save the provenance graph for a recorded turn.

--- a/atomic-core/src/change/mod.rs
+++ b/atomic-core/src/change/mod.rs
@@ -100,6 +100,7 @@ mod local;
 pub mod ops;
 mod provenance;
 pub mod provenance_graph;
+pub mod session;
 mod store;
 
 // Re-export all public types

--- a/atomic-core/src/change/provenance_graph.rs
+++ b/atomic-core/src/change/provenance_graph.rs
@@ -121,10 +121,25 @@ use crate::types::Hash;
 const MAGIC: &[u8; 4] = b"PRVG";
 
 /// Current provenance graph schema version.
-const SCHEMA_VERSION: u8 = 1;
+///
+/// v1 → v2: added `profile: Option<String>` as the last field.
+/// The `deserialize` method handles v1 payloads by deserializing into
+/// `ProvenanceGraphV1` and upgrading to `ProvenanceGraph` in-memory.
+const SCHEMA_VERSION: u8 = 2;
 
 /// File extension for provenance graph files.
 pub const PROVENANCE_GRAPH_EXTENSION: &str = "provenance";
+
+/// Profile identifier for Sherpa-structured provenance graphs.
+///
+/// When `ProvenanceGraph.profile` is set to this value, the UI knows the
+/// node `detail` fields contain Sherpa-specific structured JSON
+/// (intent/todos/verification). Absent means a generic agent graph.
+///
+/// Semver rules:
+/// - Minor bump (1.1.0): new optional fields added to any detail struct
+/// - Major bump (2.0.0): breaking change to required fields
+pub const SHERPA_PROFILE: &str = "sherpa-trace/1.0.0";
 
 // =============================================================================
 // ProvenanceGraph
@@ -182,6 +197,28 @@ pub struct ProvenanceGraph {
 
     /// Aggregate statistics for quick filtering without loading the full graph.
     pub stats: ProvenanceStats,
+
+    /// Schema profile identifier.
+    ///
+    /// `None` — generic agent graph (atomic-agent, Claude Code, OpenCode).
+    /// `Some("sherpa-trace/1.0.0")` — Sherpa structured graph: node `detail`
+    /// fields carry intent/todo/execution/verification JSON. Use the
+    /// [`SHERPA_PROFILE`] constant rather than a raw string literal.
+    ///
+    /// The UI checks this field first. If absent it falls back to generic
+    /// rendering. If present it renders the full intent/todo/verification
+    /// panels and applies the versioned detail schema.
+    ///
+    /// Must remain the LAST field in this struct. Postcard uses a positional
+    /// binary format — appending here ensures old serialized graphs (which
+    /// have no profile bytes) still deserialize correctly with `profile: None`.
+    ///
+    /// Note: do NOT add `skip_serializing_if` here. Postcard is a positional
+    /// format — every field must always be present in the byte stream.
+    /// Skipping would cause deserialization to read the wrong bytes for this
+    /// field and corrupt the payload. `None` encodes as a single `0x00` byte.
+    #[serde(default)]
+    pub profile: Option<String>,
 }
 
 impl ProvenanceGraph {
@@ -229,17 +266,44 @@ impl ProvenanceGraph {
             });
         }
 
-        let graph: Self =
-            postcard::from_bytes(&data[4..]).map_err(|e| ProvenanceGraphError::Codec {
-                reason: format!("postcard deserialize failed: {}", e),
-            })?;
+        // Peek at the version byte without fully deserializing.
+        // The first field in the postcard payload is `version: u8`.
+        let version_byte = data[4];
 
-        if graph.version > SCHEMA_VERSION {
+        if version_byte > SCHEMA_VERSION {
             return Err(ProvenanceGraphError::UnsupportedVersion {
-                version: graph.version,
+                version: version_byte,
                 max_supported: SCHEMA_VERSION,
             });
         }
+
+        let graph: Self = if version_byte <= 1 {
+            // v1 payload: no `profile` field. Deserialize into the v1 shim
+            // struct (identical to the current struct minus `profile`) and
+            // upgrade to v2 in-memory with `profile: None`.
+            let v1: ProvenanceGraphV1 =
+                postcard::from_bytes(&data[4..]).map_err(|e| ProvenanceGraphError::Codec {
+                    reason: format!("postcard deserialize failed (v1): {}", e),
+                })?;
+            ProvenanceGraph {
+                version: SCHEMA_VERSION,
+                timestamp: v1.timestamp,
+                session_id: v1.session_id,
+                agent_name: v1.agent_name,
+                agent_display_name: v1.agent_display_name,
+                agent_vendor: v1.agent_vendor,
+                nodes: v1.nodes,
+                edges: v1.edges,
+                changes_explained: v1.changes_explained,
+                previous: v1.previous,
+                stats: v1.stats,
+                profile: None,
+            }
+        } else {
+            postcard::from_bytes(&data[4..]).map_err(|e| ProvenanceGraphError::Codec {
+                reason: format!("postcard deserialize failed: {}", e),
+            })?
+        };
 
         let hash = Hash::of(data);
         Ok((graph, hash))
@@ -441,22 +505,59 @@ impl fmt::Display for ProvenanceNode {
 /// Mirrors `atomic_agent::provenance::types::NodeKind` but is independently
 /// defined in `atomic-core` so the storage layer doesn't depend on the agent
 /// crate.
+///
+/// ## Sherpa Workflow Mapping
+///
+/// When `ProvenanceGraph::profile == "sherpa-trace/1.0.0"` the following
+/// variants are used with Sherpa-specific JSON payloads in `node.detail`:
+///
+/// | Variant        | Sherpa concept                                      | Detail struct       |
+/// |----------------|-----------------------------------------------------|---------------------|
+/// | `Goal`         | IntentNode — turn anchor with phase token breakdown | `GoalDetail`        |
+/// | `Commitment`   | Todo that produced file changes, file attribution   | `CommitmentDetail`  |
+/// | `Execution`    | `bash` tool call linked to the active todo          | `ExecutionDetail`   |
+/// | `Verification` | Verification state — outcome + learnings            | `VerificationDetail`|
+/// | `HumanGate`    | `/accept` or `/guide [ids]` resolution              | *(summary only)*    |
+///
+/// The remaining variants (`Exploration`, `Decision`, `PatchProposal`,
+/// `Error`) are used by the generic `atomic-agent` path and are not emitted
+/// by the Sherpa structured workflow.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ProvenanceNodeKind {
-    /// Human prompt — what was asked for.
+    /// Human prompt / Sherpa intent — what was asked for.
+    ///
+    /// In Sherpa graphs (`profile == "sherpa-trace/1.0.0"`) carries a
+    /// `GoalDetail` JSON payload in `node.detail` with intent fields and
+    /// per-phase token breakdown.
     Goal,
     /// Read/search/grep — understanding the codebase.
     Exploration,
     /// Consolidated: agent chose strategy X over Y.
     Decision,
     /// Write/edit/patch — file changes on disk.
+    ///
+    /// In Sherpa graphs one node is emitted per todo that produced file
+    /// changes. Carries a `CommitmentDetail` JSON payload with todo fields,
+    /// file attribution, and token slice.
     Commitment,
     /// Test/lint/typecheck/build — validating work.
+    ///
+    /// In Sherpa graphs written when the state machine reaches
+    /// `State::Verification`. Carries a `VerificationDetail` JSON payload
+    /// with outcome, learnings, and turn-level cost rollup.
     Verification,
     /// Bash (non-test) or other side effects.
+    ///
+    /// In Sherpa graphs one node is emitted per `bash` tool call. Carries an
+    /// `ExecutionDetail` JSON payload with command, exit code, duration, and
+    /// the active todo ID at time of call.
     Execution,
     /// Permission asked — agent uncertainty surfaced to human.
+    ///
+    /// In Sherpa graphs written on `/accept` or `/guide [ids]` resolution.
+    /// The node summary records which path was taken; contributor attribution
+    /// is propagated to the associated `CommitmentDetail` nodes.
     HumanGate,
     /// Recorded change — the output artifact.
     PatchProposal,
@@ -660,6 +761,33 @@ impl fmt::Display for ProvenanceStats {
 }
 
 // =============================================================================
+// ProvenanceGraphV1  (migration shim — do not use for new code)
+// =============================================================================
+
+/// Schema v1 layout — identical to [`ProvenanceGraph`] but without `profile`.
+///
+/// Used only inside [`ProvenanceGraph::deserialize`] to read files written by
+/// older versions of Atomic. After loading, the caller upgrades to the current
+/// struct by setting `profile: None`.
+#[derive(Serialize, Deserialize)]
+struct ProvenanceGraphV1 {
+    version: u8,
+    timestamp: i64,
+    session_id: String,
+    agent_name: String,
+    #[serde(default)]
+    agent_display_name: String,
+    #[serde(default)]
+    agent_vendor: String,
+    nodes: Vec<ProvenanceNode>,
+    edges: Vec<ProvenanceEdge>,
+    changes_explained: Vec<Hash>,
+    #[serde(default)]
+    previous: Option<Hash>,
+    stats: ProvenanceStats,
+}
+
+// =============================================================================
 // ProvenanceGraphBuilder
 // =============================================================================
 
@@ -669,6 +797,7 @@ pub struct ProvenanceGraphBuilder {
     agent_name: String,
     agent_display_name: String,
     agent_vendor: String,
+    profile: Option<String>,
     nodes: Vec<ProvenanceNode>,
     edges: Vec<ProvenanceEdge>,
     changes_explained: Vec<Hash>,
@@ -684,6 +813,7 @@ impl ProvenanceGraphBuilder {
             agent_name: agent_name.into(),
             agent_display_name: String::new(),
             agent_vendor: String::new(),
+            profile: None,
             nodes: Vec::new(),
             edges: Vec::new(),
             changes_explained: Vec::new(),
@@ -701,6 +831,15 @@ impl ProvenanceGraphBuilder {
     /// Set the AI vendor identifier.
     pub fn agent_vendor(mut self, vendor: impl Into<String>) -> Self {
         self.agent_vendor = vendor.into();
+        self
+    }
+
+    /// Set the schema profile identifier.
+    ///
+    /// Use [`SHERPA_PROFILE`] for Sherpa-structured graphs. Omit for generic
+    /// agent graphs — `profile` defaults to `None` if not set.
+    pub fn profile(mut self, profile: impl Into<String>) -> Self {
+        self.profile = Some(profile.into());
         self
     }
 
@@ -775,6 +914,7 @@ impl ProvenanceGraphBuilder {
             changes_explained: self.changes_explained,
             previous: self.previous,
             stats,
+            profile: self.profile,
         }
     }
 }
@@ -921,17 +1061,79 @@ mod tests {
             .timestamp(1000)
             .build();
 
-        assert_eq!(graph.version, SCHEMA_VERSION);
+        assert_eq!(graph.version, 2);
         assert_eq!(graph.timestamp, 1000);
         assert_eq!(graph.session_id, "sess-1");
         assert_eq!(graph.agent_name, "agent");
         assert!(graph.agent_display_name.is_empty());
         assert!(graph.agent_vendor.is_empty());
+        assert!(graph.profile.is_none());
         assert!(graph.nodes.is_empty());
         assert!(graph.edges.is_empty());
         assert!(graph.changes_explained.is_empty());
         assert!(graph.previous.is_none());
         assert!(graph.stats.is_empty());
+    }
+
+    #[test]
+    fn test_builder_with_sherpa_profile() {
+        let graph = ProvenanceGraph::builder("sess-1", "sherpa")
+            .timestamp(1000)
+            .profile(SHERPA_PROFILE)
+            .build();
+
+        assert_eq!(graph.profile, Some(SHERPA_PROFILE.to_string()));
+    }
+
+    #[test]
+    fn test_profile_none_by_default() {
+        let graph = sample_graph();
+        assert!(graph.profile.is_none());
+    }
+
+    #[test]
+    fn test_profile_roundtrips_through_serialization() {
+        let graph = ProvenanceGraph::builder("sess-1", "sherpa")
+            .timestamp(1000)
+            .profile(SHERPA_PROFILE)
+            .build();
+
+        let bytes = graph.serialize().unwrap();
+        let (loaded, _) = ProvenanceGraph::deserialize(&bytes).unwrap();
+
+        assert_eq!(loaded.profile, Some(SHERPA_PROFILE.to_string()));
+    }
+
+    #[test]
+    fn test_profile_absent_on_old_graph_deserializes_as_none() {
+        // Simulate a v1 payload: build a ProvenanceGraphV1 directly and
+        // serialize it with postcard (no profile field), then wrap it with
+        // the PRVG magic and verify that deserialize upgrades it to v2 with
+        // profile = None.
+        let v1 = ProvenanceGraphV1 {
+            version: 1,
+            timestamp: 500,
+            session_id: "sess-old".into(),
+            agent_name: "claude-code".into(),
+            agent_display_name: String::new(),
+            agent_vendor: String::new(),
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            changes_explained: Vec::new(),
+            previous: None,
+            stats: ProvenanceStats::default(),
+        };
+
+        let payload = postcard::to_allocvec(&v1).unwrap();
+        let mut bytes = b"PRVG".to_vec();
+        bytes.extend_from_slice(&payload);
+
+        let (loaded, _) = ProvenanceGraph::deserialize(&bytes).unwrap();
+
+        assert!(loaded.profile.is_none());
+        // Version is upgraded to current schema version in memory.
+        assert_eq!(loaded.version, 2);
+        assert_eq!(loaded.session_id, "sess-old");
     }
 
     #[test]
@@ -1039,7 +1241,7 @@ mod tests {
         let bytes = graph.serialize().unwrap();
         let (loaded, hash) = ProvenanceGraph::deserialize(&bytes).unwrap();
 
-        assert_eq!(loaded.version, SCHEMA_VERSION);
+        assert_eq!(loaded.version, 2);
         assert_eq!(loaded.session_id, "sess-1");
         assert_eq!(loaded.agent_name, "agent");
         assert_eq!(loaded.timestamp, 1000);

--- a/atomic-core/src/change/provenance_graph.rs
+++ b/atomic-core/src/change/provenance_graph.rs
@@ -563,6 +563,36 @@ pub enum ProvenanceNodeKind {
     PatchProposal,
     /// Tool failure or session error.
     Error,
+    /// A single todo item in the checklist (Sherpa only).
+    ///
+    /// Emitted during Proposing when the LLM registers todos via the tool.
+    /// Carries content, priority, dependencies in `detail`.
+    Todo,
+    /// A todo item's status changed (Sherpa only).
+    ///
+    /// Tracks the full lifecycle: pending → in_progress → completed.
+    /// Carries from_status, to_status, todo_id in `detail`.
+    TodoStatusChange,
+    /// A Petri net phase transition (Sherpa only).
+    ///
+    /// Records every state machine movement: orienting → proposing, etc.
+    /// Carries from_phase, to_phase, trigger in `detail`.
+    PhaseTransition,
+    /// An unexpected failure or change of approach worth remembering (Sherpa only).
+    ///
+    /// Emitted by the LLM during Executing when something goes wrong.
+    /// The label describes what was learned.
+    Lesson,
+    /// The LLM's final response for a phase (Sherpa only).
+    ///
+    /// Captures what the model actually said (the reply text) and any
+    /// nodes it emitted. Distinct from Verification which is the outcome.
+    LlmResponse,
+    /// HumanGate resolution — which command the user chose (Sherpa only).
+    ///
+    /// Records `/accept`, `/guide [ids]`, `/reject`, `/revise` with the
+    /// contributor attribution map.
+    HumanGateResolution,
 }
 
 impl ProvenanceNodeKind {
@@ -578,6 +608,12 @@ impl ProvenanceNodeKind {
             Self::HumanGate => "human_gate",
             Self::PatchProposal => "patch_proposal",
             Self::Error => "error",
+            Self::Todo => "todo",
+            Self::TodoStatusChange => "todo_status_change",
+            Self::PhaseTransition => "phase_transition",
+            Self::Lesson => "lesson",
+            Self::LlmResponse => "llm_response",
+            Self::HumanGateResolution => "human_gate_resolution",
         }
     }
 }
@@ -673,6 +709,18 @@ pub struct ProvenanceStats {
     pub execution_count: u32,
     pub patch_proposal_count: u32,
     pub edge_count: u32,
+    #[serde(default)]
+    pub todo_count: u32,
+    #[serde(default)]
+    pub todo_status_change_count: u32,
+    #[serde(default)]
+    pub phase_transition_count: u32,
+    #[serde(default)]
+    pub lesson_count: u32,
+    #[serde(default)]
+    pub llm_response_count: u32,
+    #[serde(default)]
+    pub human_gate_resolution_count: u32,
 }
 
 impl ProvenanceStats {
@@ -687,6 +735,12 @@ impl ProvenanceStats {
             + self.error_count
             + self.execution_count
             + self.patch_proposal_count
+            + self.todo_count
+            + self.todo_status_change_count
+            + self.phase_transition_count
+            + self.lesson_count
+            + self.llm_response_count
+            + self.human_gate_resolution_count
     }
 
     /// Increment the counter for the given node kind.
@@ -701,6 +755,12 @@ impl ProvenanceStats {
             ProvenanceNodeKind::HumanGate => self.human_gate_count += 1,
             ProvenanceNodeKind::PatchProposal => self.patch_proposal_count += 1,
             ProvenanceNodeKind::Error => self.error_count += 1,
+            ProvenanceNodeKind::Todo => self.todo_count += 1,
+            ProvenanceNodeKind::TodoStatusChange => self.todo_status_change_count += 1,
+            ProvenanceNodeKind::PhaseTransition => self.phase_transition_count += 1,
+            ProvenanceNodeKind::Lesson => self.lesson_count += 1,
+            ProvenanceNodeKind::LlmResponse => self.llm_response_count += 1,
+            ProvenanceNodeKind::HumanGateResolution => self.human_gate_resolution_count += 1,
         }
     }
 

--- a/atomic-core/src/change/session.rs
+++ b/atomic-core/src/change/session.rs
@@ -184,22 +184,23 @@ impl SessionEvent {
 
 /// Encode a `(provenance_id, seq)` pair as 16 bytes for `SESSION_EVENTS`.
 ///
-/// Layout: `[provenance_id: u64 LE][seq: u64 LE]`
+/// Layout: `[provenance_id: u64 BE][seq: u64 BE]`
 ///
-/// This follows the same pattern as [`encode_stack_seq`](crate::pristine::tables::encode_stack_seq).
+/// Big-endian encoding is required so that lexicographic byte order (used by
+/// the B-tree) matches numeric order, enabling correct prefix range scans.
 #[inline]
 pub fn encode_session_event_key(provenance_id: u64, seq: u64) -> [u8; 16] {
     let mut key = [0u8; 16];
-    key[0..8].copy_from_slice(&provenance_id.to_le_bytes());
-    key[8..16].copy_from_slice(&seq.to_le_bytes());
+    key[0..8].copy_from_slice(&provenance_id.to_be_bytes());
+    key[8..16].copy_from_slice(&seq.to_be_bytes());
     key
 }
 
 /// Decode a `(provenance_id, seq)` pair from 16 bytes.
 #[inline]
 pub fn decode_session_event_key(key: &[u8; 16]) -> (u64, u64) {
-    let provenance_id = u64::from_le_bytes(key[0..8].try_into().unwrap());
-    let seq = u64::from_le_bytes(key[8..16].try_into().unwrap());
+    let provenance_id = u64::from_be_bytes(key[0..8].try_into().unwrap());
+    let seq = u64::from_be_bytes(key[8..16].try_into().unwrap());
     (provenance_id, seq)
 }
 
@@ -208,13 +209,16 @@ pub fn decode_session_event_key(key: &[u8; 16]) -> (u64, u64) {
 /// The `todo_id` string is hashed with Blake3 and the first 8 bytes are used
 /// as a fixed-size discriminant.
 ///
-/// Layout: `[provenance_id: u64 LE][blake3(todo_id)[0..8]]`
+/// Layout: `[provenance_id: u64 BE][blake3(todo_id)[0..8]]`
+///
+/// Big-endian encoding is required so that lexicographic byte order (used by
+/// the B-tree) matches numeric order, enabling correct prefix range scans.
 #[inline]
 pub fn encode_session_todo_key(provenance_id: u64, todo_id: &str) -> [u8; 16] {
     let hash = blake3::hash(todo_id.as_bytes());
     let hash_bytes = hash.as_bytes();
     let mut key = [0u8; 16];
-    key[0..8].copy_from_slice(&provenance_id.to_le_bytes());
+    key[0..8].copy_from_slice(&provenance_id.to_be_bytes());
     key[8..16].copy_from_slice(&hash_bytes[0..8]);
     key
 }
@@ -225,7 +229,7 @@ pub fn encode_session_todo_key(provenance_id: u64, todo_id: &str) -> [u8; 16] {
 /// string is stored inside the [`TodoSnapshot`] value.
 #[inline]
 pub fn decode_session_todo_key_provenance_id(key: &[u8; 16]) -> u64 {
-    u64::from_le_bytes(key[0..8].try_into().unwrap())
+    u64::from_be_bytes(key[0..8].try_into().unwrap())
 }
 
 /// Encode a `(provenance_id, phase_hash)` pair as 16 bytes for `SESSION_PHASES`.
@@ -233,13 +237,16 @@ pub fn decode_session_todo_key_provenance_id(key: &[u8; 16]) -> u64 {
 /// The `phase_name` string is hashed with Blake3 and the first 8 bytes are
 /// used as a fixed-size discriminant.
 ///
-/// Layout: `[provenance_id: u64 LE][blake3(phase_name)[0..8]]`
+/// Layout: `[provenance_id: u64 BE][blake3(phase_name)[0..8]]`
+///
+/// Big-endian encoding is required so that lexicographic byte order (used by
+/// the B-tree) matches numeric order, enabling correct prefix range scans.
 #[inline]
 pub fn encode_session_phase_key(provenance_id: u64, phase_name: &str) -> [u8; 16] {
     let hash = blake3::hash(phase_name.as_bytes());
     let hash_bytes = hash.as_bytes();
     let mut key = [0u8; 16];
-    key[0..8].copy_from_slice(&provenance_id.to_le_bytes());
+    key[0..8].copy_from_slice(&provenance_id.to_be_bytes());
     key[8..16].copy_from_slice(&hash_bytes[0..8]);
     key
 }
@@ -250,18 +257,22 @@ pub fn encode_session_phase_key(provenance_id: u64, phase_name: &str) -> [u8; 16
 /// is stored inside the [`PhaseTimingEntry`] value.
 #[inline]
 pub fn decode_session_phase_key_provenance_id(key: &[u8; 16]) -> u64 {
-    u64::from_le_bytes(key[0..8].try_into().unwrap())
+    u64::from_be_bytes(key[0..8].try_into().unwrap())
 }
 
 /// Encode a provenance-id prefix for range scans on any session table
 /// that uses `[u8; 16]` composite keys.
 ///
-/// Returns a 16-byte key with only `provenance_id` set and the secondary
-/// component zeroed. Used as the start bound for prefix scans.
+/// Returns a 16-byte key with `provenance_id` in the high bytes and the
+/// secondary component zeroed. Used as the start bound for prefix scans:
+/// all keys for a given `provenance_id` lie in `[prefix(id), prefix(id+1))`.
+///
+/// Big-endian encoding ensures this half-open range is correct across all
+/// numeric values of `provenance_id`.
 #[inline]
 pub fn encode_session_prefix(provenance_id: u64) -> [u8; 16] {
     let mut key = [0u8; 16];
-    key[0..8].copy_from_slice(&provenance_id.to_le_bytes());
+    key[0..8].copy_from_slice(&provenance_id.to_be_bytes());
     key
 }
 
@@ -525,7 +536,10 @@ mod tests {
 
     #[test]
     fn test_session_event_key_ordering() {
-        // Keys for the same provenance_id should sort by seq
+        // Keys for the same provenance_id must sort by seq in lexicographic
+        // (B-tree) order across the full u64 range.  Big-endian encoding
+        // guarantees this: the most-significant byte comes first, so byte-wise
+        // comparison matches numeric comparison for all values.
         let k1 = encode_session_event_key(5, 0);
         let k2 = encode_session_event_key(5, 1);
         let k3 = encode_session_event_key(5, 100);
@@ -534,6 +548,21 @@ mod tests {
         assert!(k1 < k2);
         assert!(k2 < k3);
         assert!(k3 < k4, "different provenance_id sorts after");
+
+        // Boundary: seq=255 (single-byte max) vs seq=256 (spills into second byte).
+        // With big-endian encoding this must sort correctly.
+        let k_255 = encode_session_event_key(5, 255);
+        let k_256 = encode_session_event_key(5, 256);
+        assert!(
+            k_255 < k_256,
+            "seq=255 must sort before seq=256 (byte-spill boundary)"
+        );
+
+        // seq=256 on provenance_id=5 must still sort before provenance_id=6.
+        assert!(
+            k_256 < k4,
+            "seq=256 on provenance_id=5 must sort before provenance_id=6"
+        );
     }
 
     #[test]

--- a/atomic-core/src/change/session.rs
+++ b/atomic-core/src/change/session.rs
@@ -1,0 +1,636 @@
+//! Session data types for Sherpa-enriched provenance.
+//!
+//! These types are stored in the session tables in the pristine database
+//! when a provenance graph has `profile == "sherpa-trace/1.0.0"`.
+//! They represent the structured turn data extracted from the Petri net
+//! replay log.
+//!
+//! # Storage Format
+//!
+//! Values are serialized with [postcard](https://docs.rs/postcard) (binary,
+//! compact, no-std compatible). This is the same codec used by
+//! [`ProvenanceGraph`](super::provenance_graph::ProvenanceGraph).
+//!
+//! # Table Layout
+//!
+//! | Table | Key | Value |
+//! |-------|-----|-------|
+//! | `SESSION_INTENTS` | `provenance_id: u64` | `IntentEntry` |
+//! | `SESSION_TODOS` | `(provenance_id, todo_id_hash): [u8; 16]` | `TodoSnapshot` |
+//! | `SESSION_PHASES` | `(provenance_id, phase_hash): [u8; 16]` | `PhaseTimingEntry` |
+//! | `SESSION_EVENTS` | `(provenance_id, seq): [u8; 16]` | `SessionEvent` |
+//!
+//! Composite keys are 16-byte arrays following the same pattern as
+//! `STACK_CHANGES`: first 8 bytes = discriminant (u64 LE), second 8 bytes =
+//! secondary key (u64 LE or first-8-bytes-of-blake3).
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Value types
+// ---------------------------------------------------------------------------
+
+/// Intent metadata for a turn.
+///
+/// Stored in `SESSION_INTENTS` keyed by `provenance_id`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IntentEntry {
+    /// Short human-readable title for the turn's goal.
+    pub title: String,
+    /// Longer description of what the agent was asked to do.
+    pub description: String,
+    /// Zero-based turn index within the session.
+    pub turn_id: u32,
+    /// LLM model identifier (e.g. `"claude-sonnet-4-20250514"`).
+    pub model: String,
+    /// Unique session identifier from the agent framework.
+    pub session_id: String,
+    /// Outcome tag (e.g. `"success"`, `"failure"`, `"partial"`).
+    pub outcome: String,
+    /// Total token count (prompt + completion) for the turn.
+    pub total_tokens: u64,
+    /// Total estimated cost in USD for the turn.
+    pub total_cost_usd: f64,
+}
+
+/// Final state of a todo item at the end of a turn.
+///
+/// Stored in `SESSION_TODOS` keyed by `(provenance_id, todo_id_hash)`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TodoSnapshot {
+    /// Unique todo identifier from the agent framework.
+    pub todo_id: String,
+    /// Human-readable content / description of the todo.
+    pub content: String,
+    /// Owner of the todo (agent name or user).
+    pub owner: String,
+    /// Final status at the end of the turn (e.g. `"done"`, `"in_progress"`).
+    pub final_status: String,
+    /// Priority level (e.g. `"high"`, `"medium"`, `"low"`).
+    pub priority: String,
+    /// Source file path, if the todo is anchored to a file.
+    pub file: Option<String>,
+    /// Start line in the source file (1-based).
+    pub start_line: Option<u32>,
+    /// End line in the source file (1-based, inclusive).
+    pub end_line: Option<u32>,
+    /// ISO-8601 timestamp when work on this todo began.
+    pub started_at: Option<String>,
+    /// ISO-8601 timestamp when this todo was marked complete.
+    pub completed_at: Option<String>,
+}
+
+/// Timing data for a single phase within a turn.
+///
+/// Stored in `SESSION_PHASES` keyed by `(provenance_id, phase_hash)`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PhaseTimingEntry {
+    /// Phase name (e.g. `"plan"`, `"implement"`, `"verify"`).
+    pub phase: String,
+    /// ISO-8601 timestamp when this phase started.
+    pub start_ts: Option<String>,
+    /// ISO-8601 timestamp when this phase ended.
+    pub end_ts: Option<String>,
+    /// Number of input (prompt) tokens consumed during this phase.
+    pub input_tokens: u64,
+    /// Number of output (completion) tokens produced during this phase.
+    pub output_tokens: u64,
+    /// Estimated cost in USD for this phase.
+    pub cost_usd: f64,
+}
+
+/// A single event in the Petri net replay log.
+///
+/// Stored in `SESSION_EVENTS` keyed by `(provenance_id, seq)`.
+/// This is the raw event — the other session tables are derived
+/// summaries for fast lookup.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionEvent {
+    /// Monotonically increasing sequence number within the turn.
+    pub seq: u64,
+    /// ISO-8601 timestamp of the event.
+    pub timestamp: String,
+    /// Event kind discriminator (e.g. `"fire"`, `"deposit"`, `"consume"`).
+    pub event_kind: String,
+    /// Petri net place name, if the event is place-related.
+    pub place: Option<String>,
+    /// Petri net transition name, if the event is a firing.
+    pub transition: Option<String>,
+    /// Token identifier within the Petri net.
+    pub token_id: String,
+    /// Token kind discriminator (e.g. `"intent"`, `"todo"`, `"artifact"`).
+    pub token_kind: String,
+    /// JSON string of the token's data bag.
+    pub token_data: String,
+    /// Agent-trace `record_type` for convenience filtering.
+    pub record_type: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Serialization helpers (postcard)
+// ---------------------------------------------------------------------------
+
+impl IntentEntry {
+    /// Serialize to a compact binary blob via postcard.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        postcard::to_allocvec(self).expect("IntentEntry serialization")
+    }
+
+    /// Deserialize from a postcard binary blob.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, postcard::Error> {
+        postcard::from_bytes(bytes)
+    }
+}
+
+impl TodoSnapshot {
+    /// Serialize to a compact binary blob via postcard.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        postcard::to_allocvec(self).expect("TodoSnapshot serialization")
+    }
+
+    /// Deserialize from a postcard binary blob.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, postcard::Error> {
+        postcard::from_bytes(bytes)
+    }
+}
+
+impl PhaseTimingEntry {
+    /// Serialize to a compact binary blob via postcard.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        postcard::to_allocvec(self).expect("PhaseTimingEntry serialization")
+    }
+
+    /// Deserialize from a postcard binary blob.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, postcard::Error> {
+        postcard::from_bytes(bytes)
+    }
+}
+
+impl SessionEvent {
+    /// Serialize to a compact binary blob via postcard.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        postcard::to_allocvec(self).expect("SessionEvent serialization")
+    }
+
+    /// Deserialize from a postcard binary blob.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, postcard::Error> {
+        postcard::from_bytes(bytes)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Composite key encoding
+// ---------------------------------------------------------------------------
+
+/// Encode a `(provenance_id, seq)` pair as 16 bytes for `SESSION_EVENTS`.
+///
+/// Layout: `[provenance_id: u64 LE][seq: u64 LE]`
+///
+/// This follows the same pattern as [`encode_stack_seq`](crate::pristine::tables::encode_stack_seq).
+#[inline]
+pub fn encode_session_event_key(provenance_id: u64, seq: u64) -> [u8; 16] {
+    let mut key = [0u8; 16];
+    key[0..8].copy_from_slice(&provenance_id.to_le_bytes());
+    key[8..16].copy_from_slice(&seq.to_le_bytes());
+    key
+}
+
+/// Decode a `(provenance_id, seq)` pair from 16 bytes.
+#[inline]
+pub fn decode_session_event_key(key: &[u8; 16]) -> (u64, u64) {
+    let provenance_id = u64::from_le_bytes(key[0..8].try_into().unwrap());
+    let seq = u64::from_le_bytes(key[8..16].try_into().unwrap());
+    (provenance_id, seq)
+}
+
+/// Encode a `(provenance_id, todo_id_hash)` pair as 16 bytes for `SESSION_TODOS`.
+///
+/// The `todo_id` string is hashed with Blake3 and the first 8 bytes are used
+/// as a fixed-size discriminant.
+///
+/// Layout: `[provenance_id: u64 LE][blake3(todo_id)[0..8]]`
+#[inline]
+pub fn encode_session_todo_key(provenance_id: u64, todo_id: &str) -> [u8; 16] {
+    let hash = blake3::hash(todo_id.as_bytes());
+    let hash_bytes = hash.as_bytes();
+    let mut key = [0u8; 16];
+    key[0..8].copy_from_slice(&provenance_id.to_le_bytes());
+    key[8..16].copy_from_slice(&hash_bytes[0..8]);
+    key
+}
+
+/// Decode the `provenance_id` from a `SESSION_TODOS` key.
+///
+/// The second 8 bytes are an opaque hash prefix — the original `todo_id`
+/// string is stored inside the [`TodoSnapshot`] value.
+#[inline]
+pub fn decode_session_todo_key_provenance_id(key: &[u8; 16]) -> u64 {
+    u64::from_le_bytes(key[0..8].try_into().unwrap())
+}
+
+/// Encode a `(provenance_id, phase_hash)` pair as 16 bytes for `SESSION_PHASES`.
+///
+/// The `phase_name` string is hashed with Blake3 and the first 8 bytes are
+/// used as a fixed-size discriminant.
+///
+/// Layout: `[provenance_id: u64 LE][blake3(phase_name)[0..8]]`
+#[inline]
+pub fn encode_session_phase_key(provenance_id: u64, phase_name: &str) -> [u8; 16] {
+    let hash = blake3::hash(phase_name.as_bytes());
+    let hash_bytes = hash.as_bytes();
+    let mut key = [0u8; 16];
+    key[0..8].copy_from_slice(&provenance_id.to_le_bytes());
+    key[8..16].copy_from_slice(&hash_bytes[0..8]);
+    key
+}
+
+/// Decode the `provenance_id` from a `SESSION_PHASES` key.
+///
+/// The second 8 bytes are an opaque hash prefix — the original phase name
+/// is stored inside the [`PhaseTimingEntry`] value.
+#[inline]
+pub fn decode_session_phase_key_provenance_id(key: &[u8; 16]) -> u64 {
+    u64::from_le_bytes(key[0..8].try_into().unwrap())
+}
+
+/// Encode a provenance-id prefix for range scans on any session table
+/// that uses `[u8; 16]` composite keys.
+///
+/// Returns a 16-byte key with only `provenance_id` set and the secondary
+/// component zeroed. Used as the start bound for prefix scans.
+#[inline]
+pub fn encode_session_prefix(provenance_id: u64) -> [u8; 16] {
+    let mut key = [0u8; 16];
+    key[0..8].copy_from_slice(&provenance_id.to_le_bytes());
+    key
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_intent_entry() -> IntentEntry {
+        IntentEntry {
+            title: "Fix authentication bug".into(),
+            description: "The login flow fails when the session token expires".into(),
+            turn_id: 3,
+            model: "claude-sonnet-4-20250514".into(),
+            session_id: "sess-abc123".into(),
+            outcome: "success".into(),
+            total_tokens: 15420,
+            total_cost_usd: 0.0462,
+        }
+    }
+
+    fn sample_todo_snapshot() -> TodoSnapshot {
+        TodoSnapshot {
+            todo_id: "todo-001".into(),
+            content: "Refactor token validation logic".into(),
+            owner: "agent".into(),
+            final_status: "done".into(),
+            priority: "high".into(),
+            file: Some("src/auth/token.rs".into()),
+            start_line: Some(42),
+            end_line: Some(87),
+            started_at: Some("2025-01-15T10:30:00Z".into()),
+            completed_at: Some("2025-01-15T10:32:15Z".into()),
+        }
+    }
+
+    fn sample_phase_timing_entry() -> PhaseTimingEntry {
+        PhaseTimingEntry {
+            phase: "implement".into(),
+            start_ts: Some("2025-01-15T10:30:00Z".into()),
+            end_ts: Some("2025-01-15T10:32:15Z".into()),
+            input_tokens: 8200,
+            output_tokens: 3100,
+            cost_usd: 0.0281,
+        }
+    }
+
+    fn sample_session_event() -> SessionEvent {
+        SessionEvent {
+            seq: 7,
+            timestamp: "2025-01-15T10:30:05.123Z".into(),
+            event_kind: "fire".into(),
+            place: Some("ready".into()),
+            transition: Some("plan_to_implement".into()),
+            token_id: "tok-42".into(),
+            token_kind: "intent".into(),
+            token_data: r#"{"goal":"fix auth"}"#.into(),
+            record_type: Some("transition_fire".into()),
+        }
+    }
+
+    // -- Roundtrip tests --
+
+    #[test]
+    fn test_intent_entry_roundtrip() {
+        let original = sample_intent_entry();
+        let bytes = original.to_bytes();
+        let recovered = IntentEntry::from_bytes(&bytes).unwrap();
+
+        assert_eq!(original, recovered);
+        assert_eq!(recovered.title, "Fix authentication bug");
+        assert_eq!(recovered.turn_id, 3);
+        assert_eq!(recovered.total_tokens, 15420);
+        assert!((recovered.total_cost_usd - 0.0462).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_todo_snapshot_roundtrip() {
+        let original = sample_todo_snapshot();
+        let bytes = original.to_bytes();
+        let recovered = TodoSnapshot::from_bytes(&bytes).unwrap();
+
+        assert_eq!(original, recovered);
+        assert_eq!(recovered.todo_id, "todo-001");
+        assert_eq!(recovered.file, Some("src/auth/token.rs".into()));
+        assert_eq!(recovered.start_line, Some(42));
+        assert_eq!(recovered.end_line, Some(87));
+        assert_eq!(recovered.completed_at, Some("2025-01-15T10:32:15Z".into()));
+    }
+
+    #[test]
+    fn test_phase_timing_entry_roundtrip() {
+        let original = sample_phase_timing_entry();
+        let bytes = original.to_bytes();
+        let recovered = PhaseTimingEntry::from_bytes(&bytes).unwrap();
+
+        assert_eq!(original, recovered);
+        assert_eq!(recovered.phase, "implement");
+        assert_eq!(recovered.input_tokens, 8200);
+        assert_eq!(recovered.output_tokens, 3100);
+        assert!((recovered.cost_usd - 0.0281).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_session_event_roundtrip() {
+        let original = sample_session_event();
+        let bytes = original.to_bytes();
+        let recovered = SessionEvent::from_bytes(&bytes).unwrap();
+
+        assert_eq!(original, recovered);
+        assert_eq!(recovered.seq, 7);
+        assert_eq!(recovered.event_kind, "fire");
+        assert_eq!(recovered.place, Some("ready".into()));
+        assert_eq!(recovered.transition, Some("plan_to_implement".into()));
+        assert_eq!(recovered.record_type, Some("transition_fire".into()));
+    }
+
+    // -- Edge cases --
+
+    #[test]
+    fn test_intent_entry_with_empty_fields() {
+        let entry = IntentEntry {
+            title: String::new(),
+            description: String::new(),
+            turn_id: 0,
+            model: String::new(),
+            session_id: String::new(),
+            outcome: String::new(),
+            total_tokens: 0,
+            total_cost_usd: 0.0,
+        };
+
+        let bytes = entry.to_bytes();
+        let recovered = IntentEntry::from_bytes(&bytes).unwrap();
+
+        assert_eq!(entry, recovered);
+        assert!(recovered.title.is_empty());
+        assert_eq!(recovered.total_tokens, 0);
+        assert!((recovered.total_cost_usd).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_todo_snapshot_with_no_optional_fields() {
+        let snapshot = TodoSnapshot {
+            todo_id: "bare".into(),
+            content: "minimal".into(),
+            owner: "agent".into(),
+            final_status: "pending".into(),
+            priority: "low".into(),
+            file: None,
+            start_line: None,
+            end_line: None,
+            started_at: None,
+            completed_at: None,
+        };
+
+        let bytes = snapshot.to_bytes();
+        let recovered = TodoSnapshot::from_bytes(&bytes).unwrap();
+
+        assert_eq!(snapshot, recovered);
+        assert!(recovered.file.is_none());
+        assert!(recovered.start_line.is_none());
+        assert!(recovered.completed_at.is_none());
+    }
+
+    #[test]
+    fn test_phase_timing_entry_with_no_timestamps() {
+        let entry = PhaseTimingEntry {
+            phase: "unknown".into(),
+            start_ts: None,
+            end_ts: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            cost_usd: 0.0,
+        };
+
+        let bytes = entry.to_bytes();
+        let recovered = PhaseTimingEntry::from_bytes(&bytes).unwrap();
+
+        assert_eq!(entry, recovered);
+        assert!(recovered.start_ts.is_none());
+        assert!(recovered.end_ts.is_none());
+    }
+
+    #[test]
+    fn test_session_event_with_no_optional_fields() {
+        let event = SessionEvent {
+            seq: 0,
+            timestamp: "2025-01-01T00:00:00Z".into(),
+            event_kind: "init".into(),
+            place: None,
+            transition: None,
+            token_id: "tok-0".into(),
+            token_kind: "system".into(),
+            token_data: "{}".into(),
+            record_type: None,
+        };
+
+        let bytes = event.to_bytes();
+        let recovered = SessionEvent::from_bytes(&bytes).unwrap();
+
+        assert_eq!(event, recovered);
+        assert!(recovered.place.is_none());
+        assert!(recovered.transition.is_none());
+        assert!(recovered.record_type.is_none());
+    }
+
+    #[test]
+    fn test_intent_entry_unicode() {
+        let entry = IntentEntry {
+            title: "修复认证错误".into(),
+            description: "ログインフローの修正".into(),
+            turn_id: 1,
+            model: "模型-v1".into(),
+            session_id: "세션-αβγ".into(),
+            outcome: "réussite".into(),
+            total_tokens: 999,
+            total_cost_usd: 1.23,
+        };
+
+        let bytes = entry.to_bytes();
+        let recovered = IntentEntry::from_bytes(&bytes).unwrap();
+
+        assert_eq!(entry, recovered);
+    }
+
+    #[test]
+    fn test_invalid_bytes_returns_error() {
+        let garbage = &[0xFF, 0xFE, 0xFD, 0xFC, 0xFB];
+
+        assert!(IntentEntry::from_bytes(garbage).is_err());
+        assert!(TodoSnapshot::from_bytes(garbage).is_err());
+        assert!(PhaseTimingEntry::from_bytes(garbage).is_err());
+        assert!(SessionEvent::from_bytes(garbage).is_err());
+    }
+
+    #[test]
+    fn test_empty_bytes_returns_error() {
+        assert!(IntentEntry::from_bytes(&[]).is_err());
+        assert!(TodoSnapshot::from_bytes(&[]).is_err());
+        assert!(PhaseTimingEntry::from_bytes(&[]).is_err());
+        assert!(SessionEvent::from_bytes(&[]).is_err());
+    }
+
+    // -- Composite key encoding tests --
+
+    #[test]
+    fn test_session_event_key_roundtrip() {
+        let prov_id = 42u64;
+        let seq = 1337u64;
+
+        let key = encode_session_event_key(prov_id, seq);
+        let (dec_prov, dec_seq) = decode_session_event_key(&key);
+
+        assert_eq!(dec_prov, prov_id);
+        assert_eq!(dec_seq, seq);
+    }
+
+    #[test]
+    fn test_session_event_key_ordering() {
+        // Keys for the same provenance_id should sort by seq
+        let k1 = encode_session_event_key(5, 0);
+        let k2 = encode_session_event_key(5, 1);
+        let k3 = encode_session_event_key(5, 100);
+        let k4 = encode_session_event_key(6, 0);
+
+        assert!(k1 < k2);
+        assert!(k2 < k3);
+        assert!(k3 < k4, "different provenance_id sorts after");
+    }
+
+    #[test]
+    fn test_session_todo_key_deterministic() {
+        let k1 = encode_session_todo_key(10, "todo-abc");
+        let k2 = encode_session_todo_key(10, "todo-abc");
+
+        assert_eq!(k1, k2, "same inputs produce same key");
+    }
+
+    #[test]
+    fn test_session_todo_key_different_ids() {
+        let k1 = encode_session_todo_key(10, "todo-abc");
+        let k2 = encode_session_todo_key(10, "todo-xyz");
+
+        // Same provenance_id, different todo_id → different key
+        assert_ne!(k1, k2);
+        // First 8 bytes (provenance_id) should be the same
+        assert_eq!(k1[0..8], k2[0..8]);
+    }
+
+    #[test]
+    fn test_session_todo_key_provenance_id_decode() {
+        let key = encode_session_todo_key(77, "some-todo");
+        assert_eq!(decode_session_todo_key_provenance_id(&key), 77);
+    }
+
+    #[test]
+    fn test_session_phase_key_deterministic() {
+        let k1 = encode_session_phase_key(10, "plan");
+        let k2 = encode_session_phase_key(10, "plan");
+
+        assert_eq!(k1, k2);
+    }
+
+    #[test]
+    fn test_session_phase_key_different_phases() {
+        let k1 = encode_session_phase_key(10, "plan");
+        let k2 = encode_session_phase_key(10, "implement");
+
+        assert_ne!(k1, k2);
+        assert_eq!(k1[0..8], k2[0..8]);
+    }
+
+    #[test]
+    fn test_session_phase_key_provenance_id_decode() {
+        let key = encode_session_phase_key(88, "verify");
+        assert_eq!(decode_session_phase_key_provenance_id(&key), 88);
+    }
+
+    #[test]
+    fn test_session_prefix() {
+        let prefix = encode_session_prefix(42);
+        let (prov_id, secondary) = decode_session_event_key(&prefix);
+
+        assert_eq!(prov_id, 42);
+        assert_eq!(secondary, 0);
+    }
+
+    #[test]
+    fn test_session_prefix_ordering() {
+        // All keys for provenance_id=5 should be >= prefix(5) and < prefix(6)
+        let prefix_5 = encode_session_prefix(5);
+        let key_5_0 = encode_session_event_key(5, 0);
+        let key_5_max = encode_session_event_key(5, u64::MAX);
+        let prefix_6 = encode_session_prefix(6);
+
+        assert_eq!(prefix_5, key_5_0);
+        assert!(key_5_max < prefix_6);
+    }
+
+    #[test]
+    fn test_session_event_key_boundary_values() {
+        // Min values
+        let key_min = encode_session_event_key(0, 0);
+        let (p, s) = decode_session_event_key(&key_min);
+        assert_eq!(p, 0);
+        assert_eq!(s, 0);
+
+        // Max values
+        let key_max = encode_session_event_key(u64::MAX, u64::MAX);
+        let (p, s) = decode_session_event_key(&key_max);
+        assert_eq!(p, u64::MAX);
+        assert_eq!(s, u64::MAX);
+    }
+
+    #[test]
+    fn test_postcard_is_compact() {
+        // Verify that postcard produces reasonably compact output.
+        // An IntentEntry with short strings should fit in well under 200 bytes.
+        let entry = sample_intent_entry();
+        let bytes = entry.to_bytes();
+
+        assert!(
+            bytes.len() < 200,
+            "expected compact serialization, got {} bytes",
+            bytes.len()
+        );
+    }
+}

--- a/atomic-core/src/change/session.rs
+++ b/atomic-core/src/change/session.rs
@@ -20,9 +20,10 @@
 //! | `SESSION_PHASES` | `(provenance_id, phase_hash): [u8; 16]` | `PhaseTimingEntry` |
 //! | `SESSION_EVENTS` | `(provenance_id, seq): [u8; 16]` | `SessionEvent` |
 //!
-//! Composite keys are 16-byte arrays following the same pattern as
-//! `STACK_CHANGES`: first 8 bytes = discriminant (u64 LE), second 8 bytes =
-//! secondary key (u64 LE or first-8-bytes-of-blake3).
+//! Composite keys are 16-byte arrays where:
+//! first 8 bytes = discriminant (`u64` BE, for correct numeric ordering in
+//! lexicographic range scans), second 8 bytes = secondary key (`u64` BE or
+//! first 8 bytes of a BLAKE3 hash).
 
 use serde::{Deserialize, Serialize};
 

--- a/atomic-core/src/diff/mod.rs
+++ b/atomic-core/src/diff/mod.rs
@@ -505,6 +505,180 @@ pub fn diff_with_separator<'a>(
     diff(&old_lines, &new_lines, algorithm)
 }
 
+/// Three-way merge of byte content.
+///
+/// Given three versions of a file:
+/// - `base`   — the common ancestor (A's original content)
+/// - `ours`   — our modified version (A' after revise)
+/// - `theirs` — their modified version (A+B content after B was applied to A)
+///
+/// This computes B's delta via `diff(base, theirs)`, then applies that
+/// delta to `ours`.  For each region:
+///
+/// - **Equal** (B didn't change): keep whatever `ours` has (which may
+///   differ from base if A' modified it).
+/// - **Insert** (B added lines): insert them into the output.
+/// - **Delete** (B removed lines): if `ours` still has the same lines,
+///   remove them.  If `ours` already changed them → conflict.
+/// - **Replace** (B replaced lines): if `ours` still has the originals,
+///   apply B's replacement.  If `ours` already changed them → conflict.
+///
+/// # Returns
+///
+/// `Ok(merged_bytes)` on clean merge, `Err(description)` on conflict.
+///
+/// # Example
+///
+/// ```rust
+/// use atomic_core::diff::merge_text;
+///
+/// let base   = b"line alpha\n";
+/// let ours   = b"line alpha revised\n";
+/// let theirs = b"line alpha\nline beta\n";
+///
+/// let merged = merge_text(base, ours, theirs).unwrap();
+/// assert_eq!(merged, b"line alpha revised\nline beta\n");
+/// ```
+pub fn merge_text(base: &[u8], ours: &[u8], theirs: &[u8]) -> Result<Vec<u8>, String> {
+    let base_lines: Vec<Line> = Line::from_bytes(base);
+    let ours_lines: Vec<Line> = Line::from_bytes(ours);
+    let theirs_lines: Vec<Line> = Line::from_bytes(theirs);
+
+    // Compute what "they" changed relative to the common base.
+    let b_delta = diff(&base_lines, &theirs_lines, Algorithm::Myers);
+
+    // Compute what "we" changed relative to the common base.
+    let a_delta = diff(&base_lines, &ours_lines, Algorithm::Myers);
+
+    // Build a set of base line indices that "we" modified (deleted or replaced).
+    // If B also touches any of these lines, that's a conflict.
+    let mut our_changed: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    for op in a_delta.ops() {
+        match op {
+            DiffOp::Delete { old_pos, len, .. }
+            | DiffOp::Replace {
+                old_pos,
+                old_len: len,
+                ..
+            } => {
+                for i in *old_pos..(*old_pos + *len) {
+                    our_changed.insert(i);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Walk B's delta and build the merged output.
+    //
+    // We track our position in `ours_lines` via `ours_idx`.  For Equal
+    // regions we advance ours_idx by the number of base lines consumed
+    // (which maps 1:1 to ours lines in unchanged regions).  For regions
+    // B changed, we check for conflicts against our_changed.
+    let mut output: Vec<u8> = Vec::new();
+    let mut base_idx: usize = 0; // current position in base
+    let mut ours_idx: usize = 0; // current position in ours
+
+    for op in b_delta.ops() {
+        match op {
+            DiffOp::Equal { old_pos, len, .. } => {
+                // B didn't change this region.  Emit from ours (which may
+                // have A' modifications for these lines).
+                // First, advance to old_pos in base.
+                let skip = old_pos - base_idx;
+                // ours_idx should already be aligned; advance by the
+                // same number of lines we skip in base.
+                ours_idx += skip;
+                base_idx = *old_pos;
+
+                // Emit `len` lines from ours at ours_idx.
+                for i in 0..*len {
+                    if ours_idx + i < ours_lines.len() {
+                        output.extend_from_slice(ours_lines[ours_idx + i].content());
+                    }
+                }
+                ours_idx += len;
+                base_idx += len;
+            }
+
+            DiffOp::Insert {
+                old_pos,
+                new_pos,
+                len,
+            } => {
+                // B inserted lines here.  Advance ours to this point,
+                // then emit B's inserted lines from theirs.
+                let skip = old_pos - base_idx;
+                ours_idx += skip;
+                base_idx = *old_pos;
+
+                for i in 0..*len {
+                    if new_pos + i < theirs_lines.len() {
+                        output.extend_from_slice(theirs_lines[new_pos + i].content());
+                    }
+                }
+                // base_idx and ours_idx don't advance (insert is between lines)
+            }
+
+            DiffOp::Delete { old_pos, len, .. } => {
+                // B deleted lines from base.  Check if ours also changed them.
+                let skip = old_pos - base_idx;
+                ours_idx += skip;
+                base_idx = *old_pos;
+
+                for i in 0..*len {
+                    if our_changed.contains(&(old_pos + i)) {
+                        return Err(format!(
+                            "Conflict at base line {}: both sides modified",
+                            old_pos + i + 1
+                        ));
+                    }
+                }
+                // Skip these lines in both base and ours (B deleted them).
+                ours_idx += len;
+                base_idx += len;
+            }
+
+            DiffOp::Replace {
+                old_pos,
+                old_len,
+                new_pos,
+                new_len,
+            } => {
+                // B replaced lines.  Check for conflict.
+                let skip = old_pos - base_idx;
+                ours_idx += skip;
+                base_idx = *old_pos;
+
+                for i in 0..*old_len {
+                    if our_changed.contains(&(old_pos + i)) {
+                        return Err(format!(
+                            "Conflict at base line {}: both sides modified",
+                            old_pos + i + 1
+                        ));
+                    }
+                }
+                // Emit B's replacement lines from theirs.
+                for i in 0..*new_len {
+                    if new_pos + i < theirs_lines.len() {
+                        output.extend_from_slice(theirs_lines[new_pos + i].content());
+                    }
+                }
+                ours_idx += old_len;
+                base_idx += old_len;
+            }
+        }
+    }
+
+    // Emit any remaining lines from ours (after the last B delta op).
+    while ours_idx < ours_lines.len() {
+        output.extend_from_slice(ours_lines[ours_idx].content());
+        ours_idx += 1;
+    }
+
+    Ok(output)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/atomic-core/src/pristine/tables.rs
+++ b/atomic-core/src/pristine/tables.rs
@@ -446,18 +446,19 @@ pub const CHANGE_UNHASHED: TableDefinition<&[u8; 32], &[u8]> =
 // replay log. Values are postcard-encoded session structs from
 // `atomic_core::change::session`.
 //
-// Composite keys use the same `[u8; 16]` pattern as `STACK_CHANGES`:
-// first 8 bytes = provenance_id (u64 LE), second 8 bytes = secondary
-// component (seq, or first-8-bytes-of-blake3 for string IDs).
+// Composite keys use the same `[u8; 16]` shape as `STACK_CHANGES`:
+// first 8 bytes = provenance_id (u64, big-endian), second 8 bytes = secondary
+// component (u64, big-endian: seq, or first-8-bytes-of-blake3 for string IDs).
 
 /// Session events: (provenance_id, seq) → SessionEvent
 ///
 /// The full ordered Petri net replay log for a turn. Each row is one
 /// NetEvent from the JSONL trace file. Keys are composite `[u8; 16]`
-/// values `(provenance_id_le, seq_le)` and are ordered lexicographically
-/// by their little-endian byte representation. This groups events by
-/// `provenance_id` for efficient prefix scans, but does *not* guarantee
-/// numeric ordering by `seq` within a provenance.
+/// values `(provenance_id_be, seq_be)` as produced by
+/// `atomic_core::change::session::encode_session_*`. They are ordered
+/// lexicographically by their big-endian byte representation, so the
+/// key order matches numeric order: first by `provenance_id`, then by
+/// `seq` within each provenance, enabling efficient prefix and range scans.
 pub const SESSION_EVENTS: TableDefinition<&[u8; 16], &[u8]> =
     TableDefinition::new("session_events");
 

--- a/atomic-core/src/pristine/tables.rs
+++ b/atomic-core/src/pristine/tables.rs
@@ -439,6 +439,43 @@ pub const CHANGE_CHUNKS: TableDefinition<&[u8; 36], &[u8; 32]> =
 pub const CHANGE_UNHASHED: TableDefinition<&[u8; 32], &[u8]> =
     TableDefinition::new("change_unhashed");
 
+// Session Tables (Sherpa-enriched provenance data)
+//
+// Populated when `ProvenanceGraph.profile == "sherpa-trace/1.0.0"`.
+// These tables store the structured turn data extracted from the Petri net
+// replay log. Values are postcard-encoded session structs from
+// `atomic_core::change::session`.
+//
+// Composite keys use the same `[u8; 16]` pattern as `STACK_CHANGES`:
+// first 8 bytes = provenance_id (u64 LE), second 8 bytes = secondary
+// component (seq, or first-8-bytes-of-blake3 for string IDs).
+
+/// Session events: (provenance_id, seq) → SessionEvent
+///
+/// The full ordered Petri net replay log for a turn. Each row is one
+/// NetEvent from the JSONL trace file. Keys sort by `(provenance_id, seq)`
+/// in little-endian byte order, enabling prefix scans per provenance graph.
+pub const SESSION_EVENTS: TableDefinition<&[u8; 16], &[u8]> =
+    TableDefinition::new("session_events");
+
+/// Session todos: (provenance_id, todo_id_hash) → TodoSnapshot
+///
+/// Final state of each todo item at the end of the turn. The `todo_id`
+/// string is hashed to a fixed-size key (first 8 bytes of Blake3).
+pub const SESSION_TODOS: TableDefinition<&[u8; 16], &[u8]> = TableDefinition::new("session_todos");
+
+/// Session phases: (provenance_id, phase_hash) → PhaseTimingEntry
+///
+/// Timing breakdown by phase for the turn. The phase name is hashed to
+/// a fixed-size key (first 8 bytes of Blake3).
+pub const SESSION_PHASES: TableDefinition<&[u8; 16], &[u8]> =
+    TableDefinition::new("session_phases");
+
+/// Session intents: provenance_id → IntentEntry
+///
+/// Intent metadata for the turn. One entry per provenance graph.
+pub const SESSION_INTENTS: TableDefinition<u64, &[u8]> = TableDefinition::new("session_intents");
+
 // V3 Change Storage Key Encoding
 
 /// Encode a change-hash + file-index as 36 bytes for CHANGE_GRAPH / CHANGE_SEMANTIC / CHANGE_CHUNKS keys.

--- a/atomic-core/src/pristine/tables.rs
+++ b/atomic-core/src/pristine/tables.rs
@@ -453,8 +453,11 @@ pub const CHANGE_UNHASHED: TableDefinition<&[u8; 32], &[u8]> =
 /// Session events: (provenance_id, seq) → SessionEvent
 ///
 /// The full ordered Petri net replay log for a turn. Each row is one
-/// NetEvent from the JSONL trace file. Keys sort by `(provenance_id, seq)`
-/// in little-endian byte order, enabling prefix scans per provenance graph.
+/// NetEvent from the JSONL trace file. Keys are composite `[u8; 16]`
+/// values `(provenance_id_le, seq_le)` and are ordered lexicographically
+/// by their little-endian byte representation. This groups events by
+/// `provenance_id` for efficient prefix scans, but does *not* guarantee
+/// numeric ordering by `seq` within a provenance.
 pub const SESSION_EVENTS: TableDefinition<&[u8; 16], &[u8]> =
     TableDefinition::new("session_events");
 

--- a/atomic-core/src/pristine/txn/pristine.rs
+++ b/atomic-core/src/pristine/txn/pristine.rs
@@ -101,6 +101,12 @@ impl Pristine {
             // State tables
             write_txn.open_table(STATES)?;
             write_txn.open_table(TAGS)?;
+
+            // Session tables (Sherpa-enriched provenance data)
+            write_txn.open_table(SESSION_EVENTS)?;
+            write_txn.open_table(SESSION_TODOS)?;
+            write_txn.open_table(SESSION_PHASES)?;
+            write_txn.open_table(SESSION_INTENTS)?;
         }
         write_txn.commit()?;
 

--- a/atomic-core/src/pristine/txn/read.rs
+++ b/atomic-core/src/pristine/txn/read.rs
@@ -536,17 +536,17 @@ impl ReadTxn {
         &self,
         provenance_id: u64,
     ) -> PristineResult<Vec<crate::change::session::SessionEvent>> {
-        use crate::change::session::{decode_session_event_key, SessionEvent};
+        use crate::change::session::{encode_session_prefix, SessionEvent};
 
         let table = self.txn.open_table(SESSION_EVENTS)?;
         let mut events = Vec::new();
 
-        for result in table.iter()? {
-            let (key, value) = result?;
-            let (prov_id, _seq) = decode_session_event_key(key.value());
-            if prov_id != provenance_id {
-                continue;
-            }
+        // Use a bounded prefix range instead of a full-table scan.
+        // All keys for `provenance_id` lie in [prefix(id), prefix(id+1)).
+        let start = encode_session_prefix(provenance_id);
+        let end = encode_session_prefix(provenance_id.saturating_add(1));
+        for result in table.range::<&[u8; 16]>(&start..&end)? {
+            let (_key, value) = result?;
             match SessionEvent::from_bytes(value.value()) {
                 Ok(event) => events.push(event),
                 Err(e) => {
@@ -555,6 +555,8 @@ impl ReadTxn {
             }
         }
 
+        // Events are already in seq order because keys encode (provenance_id,
+        // seq) with the same byte layout, but sort explicitly to be safe.
         events.sort_by_key(|e| e.seq);
         Ok(events)
     }
@@ -567,17 +569,17 @@ impl ReadTxn {
         &self,
         provenance_id: u64,
     ) -> PristineResult<Vec<crate::change::session::TodoSnapshot>> {
-        use crate::change::session::{decode_session_todo_key_provenance_id, TodoSnapshot};
+        use crate::change::session::{encode_session_prefix, TodoSnapshot};
 
         let table = self.txn.open_table(SESSION_TODOS)?;
         let mut todos = Vec::new();
 
-        for result in table.iter()? {
-            let (key, value) = result?;
-            let prov_id = decode_session_todo_key_provenance_id(key.value());
-            if prov_id != provenance_id {
-                continue;
-            }
+        // Bounded prefix scan: all todo keys for this provenance_id lie in
+        // [prefix(id), prefix(id+1)).
+        let start = encode_session_prefix(provenance_id);
+        let end = encode_session_prefix(provenance_id.saturating_add(1));
+        for result in table.range::<&[u8; 16]>(&start..&end)? {
+            let (_key, value) = result?;
             match TodoSnapshot::from_bytes(value.value()) {
                 Ok(snapshot) => todos.push(snapshot),
                 Err(e) => {
@@ -597,17 +599,17 @@ impl ReadTxn {
         &self,
         provenance_id: u64,
     ) -> PristineResult<Vec<crate::change::session::PhaseTimingEntry>> {
-        use crate::change::session::{decode_session_phase_key_provenance_id, PhaseTimingEntry};
+        use crate::change::session::{encode_session_prefix, PhaseTimingEntry};
 
         let table = self.txn.open_table(SESSION_PHASES)?;
         let mut phases = Vec::new();
 
-        for result in table.iter()? {
-            let (key, value) = result?;
-            let prov_id = decode_session_phase_key_provenance_id(key.value());
-            if prov_id != provenance_id {
-                continue;
-            }
+        // Bounded prefix scan: all phase keys for this provenance_id lie in
+        // [prefix(id), prefix(id+1)).
+        let start = encode_session_prefix(provenance_id);
+        let end = encode_session_prefix(provenance_id.saturating_add(1));
+        for result in table.range::<&[u8; 16]>(&start..&end)? {
+            let (_key, value) = result?;
             match PhaseTimingEntry::from_bytes(value.value()) {
                 Ok(entry) => phases.push(entry),
                 Err(e) => {

--- a/atomic-core/src/pristine/txn/read.rs
+++ b/atomic-core/src/pristine/txn/read.rs
@@ -525,6 +525,124 @@ impl TreeTxnT for ReadTxn {
     }
 }
 
+// Session data queries
+
+impl ReadTxn {
+    /// Get all session events for a provenance graph.
+    ///
+    /// Returns events in sequence order. Empty if the provenance is not Sherpa
+    /// or has no session data.
+    pub fn get_session_events(
+        &self,
+        provenance_id: u64,
+    ) -> PristineResult<Vec<crate::change::session::SessionEvent>> {
+        use crate::change::session::{decode_session_event_key, SessionEvent};
+
+        let table = self.txn.open_table(SESSION_EVENTS)?;
+        let mut events = Vec::new();
+
+        for result in table.iter()? {
+            let (key, value) = result?;
+            let (prov_id, _seq) = decode_session_event_key(key.value());
+            if prov_id != provenance_id {
+                continue;
+            }
+            match SessionEvent::from_bytes(value.value()) {
+                Ok(event) => events.push(event),
+                Err(e) => {
+                    log::warn!("Failed to deserialize session event: {}", e);
+                }
+            }
+        }
+
+        events.sort_by_key(|e| e.seq);
+        Ok(events)
+    }
+
+    /// Get all todos for a provenance graph.
+    ///
+    /// Returns snapshots of all todo items from the turn.
+    /// Empty if the provenance is not Sherpa or has no session data.
+    pub fn get_session_todos(
+        &self,
+        provenance_id: u64,
+    ) -> PristineResult<Vec<crate::change::session::TodoSnapshot>> {
+        use crate::change::session::{decode_session_todo_key_provenance_id, TodoSnapshot};
+
+        let table = self.txn.open_table(SESSION_TODOS)?;
+        let mut todos = Vec::new();
+
+        for result in table.iter()? {
+            let (key, value) = result?;
+            let prov_id = decode_session_todo_key_provenance_id(key.value());
+            if prov_id != provenance_id {
+                continue;
+            }
+            match TodoSnapshot::from_bytes(value.value()) {
+                Ok(snapshot) => todos.push(snapshot),
+                Err(e) => {
+                    log::warn!("Failed to deserialize todo snapshot: {}", e);
+                }
+            }
+        }
+
+        Ok(todos)
+    }
+
+    /// Get phase timing breakdown for a provenance graph.
+    ///
+    /// Returns timing data for each phase in the turn.
+    /// Empty if the provenance is not Sherpa or has no session data.
+    pub fn get_session_phases(
+        &self,
+        provenance_id: u64,
+    ) -> PristineResult<Vec<crate::change::session::PhaseTimingEntry>> {
+        use crate::change::session::{decode_session_phase_key_provenance_id, PhaseTimingEntry};
+
+        let table = self.txn.open_table(SESSION_PHASES)?;
+        let mut phases = Vec::new();
+
+        for result in table.iter()? {
+            let (key, value) = result?;
+            let prov_id = decode_session_phase_key_provenance_id(key.value());
+            if prov_id != provenance_id {
+                continue;
+            }
+            match PhaseTimingEntry::from_bytes(value.value()) {
+                Ok(entry) => phases.push(entry),
+                Err(e) => {
+                    log::warn!("Failed to deserialize phase timing entry: {}", e);
+                }
+            }
+        }
+
+        Ok(phases)
+    }
+
+    /// Get intent metadata for a provenance graph.
+    ///
+    /// Returns the intent entry if this is a Sherpa provenance, `None` otherwise.
+    pub fn get_session_intent(
+        &self,
+        provenance_id: u64,
+    ) -> PristineResult<Option<crate::change::session::IntentEntry>> {
+        use crate::change::session::IntentEntry;
+
+        let table = self.txn.open_table(SESSION_INTENTS)?;
+
+        match table.get(provenance_id)? {
+            Some(guard) => match IntentEntry::from_bytes(guard.value()) {
+                Ok(entry) => Ok(Some(entry)),
+                Err(e) => {
+                    log::warn!("Failed to deserialize intent entry: {}", e);
+                    Ok(None)
+                }
+            },
+            None => Ok(None),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/atomic-core/src/pristine/txn/write/mod.rs
+++ b/atomic-core/src/pristine/txn/write/mod.rs
@@ -71,7 +71,7 @@ impl<'a> WriteTxn<'a> {
 
         // Gate on profile — only populate for Sherpa graphs.
         match graph.profile.as_deref() {
-            Some(p) if p.starts_with("sherpa-trace") => {}
+            Some("sherpa-trace/1.0.0") => {}
             _ => return Ok(()),
         }
 

--- a/atomic-core/src/pristine/txn/write/mod.rs
+++ b/atomic-core/src/pristine/txn/write/mod.rs
@@ -88,7 +88,7 @@ impl<'a> WriteTxn<'a> {
                 match serde_json::from_str(s) {
                     Ok(v) => Some(v),
                     Err(e) => {
-                        eprintln!(
+                        log::warn!(
                             "Warning: failed to parse provenance node detail JSON (node id={}, kind={}): {}",
                             node.id,
                             node.kind.label(),

--- a/atomic-core/src/pristine/txn/write/mod.rs
+++ b/atomic-core/src/pristine/txn/write/mod.rs
@@ -858,6 +858,17 @@ impl<'a> MutTxnT for WriteTxn<'a> {
         Ok(pos)
     }
 
+    fn get_deps(&self, change_id: NodeId) -> PristineResult<Vec<NodeId>> {
+        let table = self.txn.open_multimap_table(DEPS)?;
+        let mut result = Vec::new();
+        let iter = table.get(change_id.get())?;
+        for item in iter {
+            let value = item?;
+            result.push(NodeId::new(value.value()));
+        }
+        Ok(result)
+    }
+
     fn put_dep(&mut self, change_id: NodeId, dep_id: NodeId) -> PristineResult<()> {
         {
             let mut table = self.txn.open_multimap_table(DEPS)?;

--- a/atomic-core/src/pristine/txn/write/mod.rs
+++ b/atomic-core/src/pristine/txn/write/mod.rs
@@ -84,10 +84,22 @@ impl<'a> WriteTxn<'a> {
         let mut seq: u64 = 0;
 
         for node in &graph.nodes {
-            let detail: Option<serde_json::Value> = node
-                .detail
-                .as_deref()
-                .and_then(|s| serde_json::from_str(s).ok());
+            let detail: Option<serde_json::Value> = if let Some(s) = node.detail.as_deref() {
+                match serde_json::from_str(s) {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        eprintln!(
+                            "Warning: failed to parse provenance node detail JSON (node id={}, kind={}): {}",
+                            node.id,
+                            node.kind.label(),
+                            e
+                        );
+                        None
+                    }
+                }
+            } else {
+                None
+            };
 
             // Write every node as a SessionEvent regardless of kind.
             let event = SessionEvent {

--- a/atomic-core/src/pristine/txn/write/mod.rs
+++ b/atomic-core/src/pristine/txn/write/mod.rs
@@ -90,10 +90,23 @@ impl<'a> WriteTxn<'a> {
                 .and_then(|s| serde_json::from_str(s).ok());
 
             // Write every node as a SessionEvent regardless of kind.
+            //
+            // `event_kind` and `record_type` are populated from the original
+            // Sherpa/agent-trace `record_type` field stored in the detail JSON
+            // (e.g. "intent", "todo_status", "phase_transition").  We fall back
+            // to `node.kind.label()` only when no such field is present so that
+            // non-Sherpa nodes still get a meaningful discriminant.
+            let sherpa_record_type = detail
+                .as_ref()
+                .and_then(|d| d["record_type"].as_str())
+                .map(|s| s.to_string());
+            let event_kind = sherpa_record_type
+                .clone()
+                .unwrap_or_else(|| node.kind.label().to_string());
             let event = SessionEvent {
                 seq,
                 timestamp: format_timestamp_ms(node.timestamp),
-                event_kind: node.kind.label().to_string(),
+                event_kind,
                 place: None,
                 transition: None,
                 token_id: node.id.clone(),
@@ -102,7 +115,9 @@ impl<'a> WriteTxn<'a> {
                     _ => "todo".to_string(),
                 },
                 token_data: node.detail.clone().unwrap_or_default(),
-                record_type: Some(node.kind.label().to_string()),
+                record_type: Some(
+                    sherpa_record_type.unwrap_or_else(|| node.kind.label().to_string()),
+                ),
             };
 
             let event_key = encode_session_event_key(provenance_id, seq);

--- a/atomic-core/src/pristine/txn/write/mod.rs
+++ b/atomic-core/src/pristine/txn/write/mod.rs
@@ -52,6 +52,212 @@ impl<'a> WriteTxn<'a> {
             next_inode,
         }
     }
+
+    /// Populate the session tables from a Sherpa provenance graph.
+    ///
+    /// Called during `save_provenance_graph` when the graph has
+    /// `profile == "sherpa-trace/1.0.0"`. Extracts session data from
+    /// the provenance nodes' `detail` fields and writes to the four
+    /// session tables.
+    ///
+    /// Best-effort: parse errors on individual nodes are logged and skipped.
+    pub fn populate_session_tables(
+        &mut self,
+        provenance_id: u64,
+        graph: &crate::change::ProvenanceGraph,
+    ) -> PristineResult<()> {
+        use crate::change::provenance_graph::ProvenanceNodeKind;
+        use crate::change::session::*;
+
+        // Gate on profile — only populate for Sherpa graphs.
+        match graph.profile.as_deref() {
+            Some(p) if p.starts_with("sherpa-trace") => {}
+            _ => return Ok(()),
+        }
+
+        // Open all four tables.
+        let mut events_table = self.txn.open_table(SESSION_EVENTS)?;
+        let mut todos_table = self.txn.open_table(SESSION_TODOS)?;
+        let mut phases_table = self.txn.open_table(SESSION_PHASES)?;
+        let mut intents_table = self.txn.open_table(SESSION_INTENTS)?;
+
+        let mut seq: u64 = 0;
+
+        for node in &graph.nodes {
+            let detail: Option<serde_json::Value> = node
+                .detail
+                .as_deref()
+                .and_then(|s| serde_json::from_str(s).ok());
+
+            // Write every node as a SessionEvent regardless of kind.
+            let event = SessionEvent {
+                seq,
+                timestamp: format_timestamp_ms(node.timestamp),
+                event_kind: node.kind.label().to_string(),
+                place: None,
+                transition: None,
+                token_id: node.id.clone(),
+                token_kind: match node.kind {
+                    ProvenanceNodeKind::Goal => "turn".to_string(),
+                    _ => "todo".to_string(),
+                },
+                token_data: node.detail.clone().unwrap_or_default(),
+                record_type: Some(node.kind.label().to_string()),
+            };
+
+            let event_key = encode_session_event_key(provenance_id, seq);
+            let event_bytes = event.to_bytes();
+            events_table.insert(&event_key, event_bytes.as_slice())?;
+            seq += 1;
+
+            // Extract structured data by node kind.
+            match node.kind {
+                ProvenanceNodeKind::Goal => {
+                    if let Some(ref detail) = detail {
+                        let intent = IntentEntry {
+                            title: detail["intent_title"]
+                                .as_str()
+                                .unwrap_or(&node.summary)
+                                .to_string(),
+                            description: detail["intent_description"]
+                                .as_str()
+                                .unwrap_or("")
+                                .to_string(),
+                            turn_id: detail["intent_turn_id"].as_u64().unwrap_or(0) as u32,
+                            model: detail["model"].as_str().unwrap_or("").to_string(),
+                            session_id: detail["session_id"]
+                                .as_str()
+                                .unwrap_or(&graph.session_id)
+                                .to_string(),
+                            outcome: String::new(),
+                            total_tokens: detail["turn_totals"]["total"].as_u64().unwrap_or(0),
+                            total_cost_usd: detail["turn_totals"]["cost_usd"]
+                                .as_f64()
+                                .unwrap_or(0.0),
+                        };
+                        let intent_bytes = intent.to_bytes();
+                        intents_table.insert(provenance_id, intent_bytes.as_slice())?;
+
+                        // Extract phase timing from GoalDetail.phases
+                        if let Some(phases) = detail["phases"].as_object() {
+                            for (phase_name, phase_data) in phases {
+                                let entry = PhaseTimingEntry {
+                                    phase: phase_name.clone(),
+                                    start_ts: None,
+                                    end_ts: None,
+                                    input_tokens: phase_data["input"].as_u64().unwrap_or(0),
+                                    output_tokens: phase_data["output"].as_u64().unwrap_or(0),
+                                    cost_usd: phase_data["cost_usd"].as_f64().unwrap_or(0.0),
+                                };
+                                let phase_key = encode_session_phase_key(provenance_id, phase_name);
+                                let phase_bytes = entry.to_bytes();
+                                phases_table.insert(&phase_key, phase_bytes.as_slice())?;
+                            }
+                        }
+                    }
+                }
+
+                ProvenanceNodeKind::Commitment => {
+                    if let Some(ref detail) = detail {
+                        let todo_id = detail["todo_id"].as_str().unwrap_or(&node.id).to_string();
+
+                        let snapshot = TodoSnapshot {
+                            todo_id: todo_id.clone(),
+                            content: detail["todo_content"]
+                                .as_str()
+                                .unwrap_or(&node.summary)
+                                .to_string(),
+                            owner: detail["contributor"].as_str().unwrap_or("ai").to_string(),
+                            final_status: "completed".to_string(),
+                            priority: detail["priority"].as_str().unwrap_or("").to_string(),
+                            file: detail["file"].as_str().map(|s| s.to_string()),
+                            start_line: detail["start_line"].as_u64().map(|n| n as u32),
+                            end_line: detail["end_line"].as_u64().map(|n| n as u32),
+                            started_at: None,
+                            completed_at: None,
+                        };
+                        let todo_key = encode_session_todo_key(provenance_id, &todo_id);
+                        let todo_bytes = snapshot.to_bytes();
+                        todos_table.insert(&todo_key, todo_bytes.as_slice())?;
+                    }
+                }
+
+                ProvenanceNodeKind::Verification => {
+                    if let Some(ref detail) = detail {
+                        // Update the intent entry with outcome and totals.
+                        // Read existing bytes in a separate scope so the
+                        // immutable borrow on `intents_table` is released
+                        // before we call `.insert()`.
+                        let existing_bytes: Option<Vec<u8>> = {
+                            match intents_table.get(provenance_id) {
+                                Ok(Some(guard)) => Some(guard.value().to_vec()),
+                                _ => None,
+                            }
+                        };
+
+                        if let Some(bytes) = existing_bytes {
+                            if let Ok(mut intent) = IntentEntry::from_bytes(&bytes) {
+                                intent.outcome = detail["outcome"]
+                                    .as_str()
+                                    .unwrap_or("completed")
+                                    .to_string();
+                                if let Some(t) = detail["turn_tokens_total"].as_u64() {
+                                    intent.total_tokens = t;
+                                }
+                                if let Some(c) = detail["turn_cost_usd"].as_f64() {
+                                    intent.total_cost_usd = c;
+                                }
+                                let intent_bytes = intent.to_bytes();
+                                intents_table.insert(provenance_id, intent_bytes.as_slice())?;
+                            }
+                        }
+                    }
+                }
+
+                ProvenanceNodeKind::Todo => {
+                    if let Some(ref detail) = detail {
+                        let todo_id = detail["todo_id"].as_str().unwrap_or(&node.id).to_string();
+
+                        let snapshot = TodoSnapshot {
+                            todo_id: todo_id.clone(),
+                            content: detail["content"]
+                                .as_str()
+                                .unwrap_or(&node.summary)
+                                .to_string(),
+                            owner: detail["owner"].as_str().unwrap_or("ai").to_string(),
+                            final_status: detail["status"]
+                                .as_str()
+                                .unwrap_or("pending")
+                                .to_string(),
+                            priority: detail["priority"].as_str().unwrap_or("").to_string(),
+                            file: None,
+                            start_line: None,
+                            end_line: None,
+                            started_at: None,
+                            completed_at: None,
+                        };
+                        let todo_key = encode_session_todo_key(provenance_id, &todo_id);
+                        let todo_bytes = snapshot.to_bytes();
+                        todos_table.insert(&todo_key, todo_bytes.as_slice())?;
+                    }
+                }
+
+                _ => {
+                    // Exploration, Execution, Decision, etc. —
+                    // already captured as SessionEvent above.
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Format a Unix epoch milliseconds timestamp to RFC-3339 string.
+fn format_timestamp_ms(epoch_ms: i64) -> String {
+    chrono::DateTime::from_timestamp_millis(epoch_ms)
+        .map(|dt| dt.to_rfc3339())
+        .unwrap_or_else(|| format!("{}", epoch_ms))
 }
 
 mod graph;

--- a/atomic-core/src/pristine/txn/write/mod.rs
+++ b/atomic-core/src/pristine/txn/write/mod.rs
@@ -117,7 +117,7 @@ impl<'a> WriteTxn<'a> {
                 .unwrap_or_else(|| node.kind.label().to_string());
             let event = SessionEvent {
                 seq,
-                timestamp: format_timestamp_ms(node.timestamp * 1000),
+                timestamp: format_timestamp_ms(node.timestamp),
                 event_kind: node.kind.label().to_string(),
                 place: None,
                 transition: None,

--- a/atomic-core/src/pristine/txn/write/mod.rs
+++ b/atomic-core/src/pristine/txn/write/mod.rs
@@ -71,7 +71,7 @@ impl<'a> WriteTxn<'a> {
 
         // Gate on profile — only populate for Sherpa graphs.
         match graph.profile.as_deref() {
-            Some("sherpa-trace/1.0.0") => {}
+            Some(crate::SHERPA_PROFILE) => {}
             _ => return Ok(()),
         }
 

--- a/atomic-core/src/pristine/txn/write/mod.rs
+++ b/atomic-core/src/pristine/txn/write/mod.rs
@@ -870,17 +870,6 @@ impl<'a> MutTxnT for WriteTxn<'a> {
         Ok(())
     }
 
-    fn get_deps(&self, change_id: NodeId) -> PristineResult<Vec<NodeId>> {
-        let table = self.txn.open_multimap_table(DEPS)?;
-        let mut deps = Vec::new();
-        for result in table.get(change_id.get())? {
-            if let Ok(v) = result {
-                deps.push(NodeId::new(v.value()));
-            }
-        }
-        Ok(deps)
-    }
-
     fn alloc_inode(&mut self) -> PristineResult<Inode> {
         let id = self.next_inode.fetch_add(1, Ordering::SeqCst);
         Ok(Inode::new(id))

--- a/atomic-core/src/pristine/txn/write/mod.rs
+++ b/atomic-core/src/pristine/txn/write/mod.rs
@@ -118,7 +118,7 @@ impl<'a> WriteTxn<'a> {
             let event = SessionEvent {
                 seq,
                 timestamp: format_timestamp_ms(node.timestamp),
-                event_kind: node.kind.label().to_string(),
+                event_kind,
                 place: None,
                 transition: None,
                 token_id: node.id.clone(),

--- a/atomic-core/src/pristine/txn/write/mod.rs
+++ b/atomic-core/src/pristine/txn/write/mod.rs
@@ -104,7 +104,7 @@ impl<'a> WriteTxn<'a> {
             // Write every node as a SessionEvent regardless of kind.
             let event = SessionEvent {
                 seq,
-                timestamp: format_timestamp_ms(node.timestamp),
+                timestamp: format_timestamp_ms(node.timestamp * 1000),
                 event_kind: node.kind.label().to_string(),
                 place: None,
                 transition: None,

--- a/atomic-core/src/pristine/txn/write/tests.rs
+++ b/atomic-core/src/pristine/txn/write/tests.rs
@@ -725,4 +725,207 @@ mod tests {
 
         txn.commit().unwrap();
     }
+
+    #[test]
+    fn test_populate_session_tables_sherpa_graph() {
+        use crate::change::provenance_graph::ProvenanceNode;
+        use crate::change::provenance_graph::{
+            ProvenanceGraph, ProvenanceNodeKind, SHERPA_PROFILE,
+        };
+        use crate::change::session::*;
+
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("pristine");
+        let pristine = Pristine::open(&db_path).unwrap();
+
+        let mut txn = pristine.write_txn().unwrap();
+
+        // Build a Sherpa provenance graph with Goal, Commitment, and Verification nodes.
+        let goal_detail = serde_json::json!({
+            "intent_title": "Add login feature",
+            "intent_description": "Implement OAuth2 login flow",
+            "intent_turn_id": 1,
+            "model": "claude-sonnet-4-20250514",
+            "session_id": "sess-abc",
+            "turn_totals": { "total": 5000, "cost_usd": 0.05 },
+            "phases": {
+                "plan": { "input": 1000, "output": 500, "cost_usd": 0.01 },
+                "implement": { "input": 2000, "output": 1500, "cost_usd": 0.03 }
+            }
+        });
+
+        let commitment_detail = serde_json::json!({
+            "todo_id": "todo-42",
+            "todo_content": "Create login endpoint",
+            "contributor": "sherpa",
+            "priority": "high",
+            "file": "src/auth.rs",
+            "start_line": 10,
+            "end_line": 50
+        });
+
+        let verification_detail = serde_json::json!({
+            "outcome": "success",
+            "turn_tokens_total": 6000,
+            "turn_cost_usd": 0.06
+        });
+
+        let graph = ProvenanceGraph::builder("sess-abc", "sherpa")
+            .timestamp(1_700_000_000)
+            .profile(SHERPA_PROFILE)
+            .add_node(ProvenanceNode {
+                id: "node-goal".to_string(),
+                kind: ProvenanceNodeKind::Goal,
+                timestamp: 1_700_000_000_000,
+                summary: "Add login feature".to_string(),
+                detail: Some(goal_detail.to_string()),
+                change_hash: None,
+                tool_name: None,
+                tool_call_id: None,
+                duration_ms: None,
+                classified: false,
+                confidence: None,
+                consolidated_from: vec![],
+            })
+            .add_node(ProvenanceNode {
+                id: "node-commit".to_string(),
+                kind: ProvenanceNodeKind::Commitment,
+                timestamp: 1_700_000_001_000,
+                summary: "Create login endpoint".to_string(),
+                detail: Some(commitment_detail.to_string()),
+                change_hash: None,
+                tool_name: None,
+                tool_call_id: None,
+                duration_ms: None,
+                classified: false,
+                confidence: None,
+                consolidated_from: vec![],
+            })
+            .add_node(ProvenanceNode {
+                id: "node-verify".to_string(),
+                kind: ProvenanceNodeKind::Verification,
+                timestamp: 1_700_000_002_000,
+                summary: "All tests pass".to_string(),
+                detail: Some(verification_detail.to_string()),
+                change_hash: None,
+                tool_name: None,
+                tool_call_id: None,
+                duration_ms: None,
+                classified: false,
+                confidence: None,
+                consolidated_from: vec![],
+            })
+            .build();
+
+        let provenance_id: u64 = 42;
+
+        txn.populate_session_tables(provenance_id, &graph).unwrap();
+
+        // ---- Verify SESSION_EVENTS: 3 events (one per node) ----
+        {
+            let events_table = txn.txn.open_table(SESSION_EVENTS).unwrap();
+            for seq in 0u64..3 {
+                let key = encode_session_event_key(provenance_id, seq);
+                let guard = events_table.get(&key).unwrap().expect("event must exist");
+                let event = SessionEvent::from_bytes(guard.value()).unwrap();
+                assert_eq!(event.seq, seq);
+                assert!(!event.timestamp.is_empty());
+            }
+            // seq 3 should not exist
+            let key3 = encode_session_event_key(provenance_id, 3);
+            assert!(events_table.get(&key3).unwrap().is_none());
+        }
+
+        // ---- Verify SESSION_INTENTS: updated by Verification node ----
+        {
+            let intents_table = txn.txn.open_table(SESSION_INTENTS).unwrap();
+            let guard = intents_table
+                .get(provenance_id)
+                .unwrap()
+                .expect("intent must exist");
+            let intent = IntentEntry::from_bytes(guard.value()).unwrap();
+            assert_eq!(intent.title, "Add login feature");
+            assert_eq!(intent.description, "Implement OAuth2 login flow");
+            assert_eq!(intent.turn_id, 1);
+            assert_eq!(intent.model, "claude-sonnet-4-20250514");
+            assert_eq!(intent.session_id, "sess-abc");
+            // Verification node should have updated outcome and totals
+            assert_eq!(intent.outcome, "success");
+            assert_eq!(intent.total_tokens, 6000);
+            assert!((intent.total_cost_usd - 0.06).abs() < 1e-9);
+        }
+
+        // ---- Verify SESSION_TODOS ----
+        {
+            let todos_table = txn.txn.open_table(SESSION_TODOS).unwrap();
+            let key = encode_session_todo_key(provenance_id, "todo-42");
+            let guard = todos_table.get(&key).unwrap().expect("todo must exist");
+            let todo = TodoSnapshot::from_bytes(guard.value()).unwrap();
+            assert_eq!(todo.todo_id, "todo-42");
+            assert_eq!(todo.content, "Create login endpoint");
+            assert_eq!(todo.owner, "sherpa");
+            assert_eq!(todo.priority, "high");
+            assert_eq!(todo.file, Some("src/auth.rs".to_string()));
+            assert_eq!(todo.start_line, Some(10));
+            assert_eq!(todo.end_line, Some(50));
+        }
+
+        // ---- Verify SESSION_PHASES: two phases from the Goal node ----
+        {
+            let phases_table = txn.txn.open_table(SESSION_PHASES).unwrap();
+
+            let plan_key = encode_session_phase_key(provenance_id, "plan");
+            let guard = phases_table
+                .get(&plan_key)
+                .unwrap()
+                .expect("plan phase must exist");
+            let plan = PhaseTimingEntry::from_bytes(guard.value()).unwrap();
+            assert_eq!(plan.phase, "plan");
+            assert_eq!(plan.input_tokens, 1000);
+            assert_eq!(plan.output_tokens, 500);
+            assert!((plan.cost_usd - 0.01).abs() < 1e-9);
+
+            let impl_key = encode_session_phase_key(provenance_id, "implement");
+            let guard = phases_table
+                .get(&impl_key)
+                .unwrap()
+                .expect("implement phase must exist");
+            let imp = PhaseTimingEntry::from_bytes(guard.value()).unwrap();
+            assert_eq!(imp.phase, "implement");
+            assert_eq!(imp.input_tokens, 2000);
+            assert_eq!(imp.output_tokens, 1500);
+            assert!((imp.cost_usd - 0.03).abs() < 1e-9);
+        }
+
+        txn.commit().unwrap();
+    }
+
+    #[test]
+    fn test_populate_session_tables_skips_non_sherpa() {
+        use crate::change::provenance_graph::ProvenanceGraph;
+
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("pristine");
+        let pristine = Pristine::open(&db_path).unwrap();
+
+        let mut txn = pristine.write_txn().unwrap();
+
+        // Generic graph (no profile) — should be a no-op.
+        let graph = ProvenanceGraph::builder("sess-xyz", "claude-code")
+            .timestamp(1_700_000_000)
+            .build();
+
+        assert!(graph.profile.is_none());
+        txn.populate_session_tables(99, &graph).unwrap();
+
+        // SESSION_EVENTS should be empty for this provenance_id.
+        {
+            use crate::change::session::encode_session_event_key;
+            let events_table = txn.txn.open_table(SESSION_EVENTS).unwrap();
+            let key = encode_session_event_key(99, 0);
+            assert!(events_table.get(&key).unwrap().is_none());
+        }
+
+        txn.commit().unwrap();
+    }
 }

--- a/atomic-core/src/record/context.rs
+++ b/atomic-core/src/record/context.rs
@@ -832,10 +832,6 @@ mod tests {
             Ok(None)
         }
 
-        fn get_deps(&self, _change_id: NodeId) -> Result<Vec<NodeId>, PristineError> {
-            Ok(Vec::new())
-        }
-
         fn get_rev_deps(&self, _dep_id: NodeId) -> Result<Vec<NodeId>, PristineError> {
             Ok(Vec::new())
         }

--- a/atomic-core/src/record/context.rs
+++ b/atomic-core/src/record/context.rs
@@ -832,6 +832,10 @@ mod tests {
             Ok(None)
         }
 
+        fn get_deps(&self, _change_id: NodeId) -> Result<Vec<NodeId>, PristineError> {
+            Ok(Vec::new())
+        }
+
         fn get_rev_deps(&self, _dep_id: NodeId) -> Result<Vec<NodeId>, PristineError> {
             Ok(Vec::new())
         }

--- a/atomic-core/src/record/workflow/globalize/options.rs
+++ b/atomic-core/src/record/workflow/globalize/options.rs
@@ -1,6 +1,5 @@
 use super::*;
 
-
 // CONFIGURATION
 
 /// Configuration options for globalization.
@@ -112,7 +111,7 @@ impl GlobalizeOptions {
     /// ```rust
     /// use atomic_core::record::workflow::globalize::GlobalizeOptions;
     ///
-    /// let options = GlobalizeOptions::new().max_hunk_size(1024 * 1024);
+    /// let options = GlobalizeOptions::new().with_max_hunk_size(1024 * 1024);
     /// assert_eq!(options.max_hunk_size(), 1024 * 1024);
     /// ```
     #[must_use]
@@ -133,7 +132,7 @@ impl GlobalizeOptions {
     /// use atomic_core::record::workflow::globalize::GlobalizeOptions;
     /// use atomic_core::change::Encoding;
     ///
-    /// let options = GlobalizeOptions::new().default_encoding(Encoding::Binary);
+    /// let options = GlobalizeOptions::new().with_default_encoding(Encoding::Binary);
     /// assert_eq!(options.default_encoding(), Encoding::Binary);
     /// ```
     #[must_use]

--- a/atomic-repository/src/apply.rs
+++ b/atomic-repository/src/apply.rs
@@ -234,6 +234,14 @@ pub struct ApplyOptions {
     /// When `true`, detailed conflict tracking is performed.
     /// Default: `true`
     pub track_conflicts: bool,
+
+    /// Skip the "already applied" validation check.
+    ///
+    /// When `true`, `validate_can_apply` is bypassed.  This is used by
+    /// `rebuild_change_graph` which intentionally re-applies a change
+    /// that is already in the stack log (same NodeId, new hunks).
+    /// Default: `false`
+    pub skip_validation: bool,
 }
 
 impl Default for ApplyOptions {
@@ -244,6 +252,7 @@ impl Default for ApplyOptions {
             allow_conflicts: true,
             max_depth: 100,
             track_conflicts: true,
+            skip_validation: false,
         }
     }
 }
@@ -280,6 +289,15 @@ impl ApplyOptions {
     /// Set whether to allow conflicts.
     pub fn allow_conflict(mut self, allow: bool) -> Self {
         self.allow_conflicts = allow;
+        self
+    }
+
+    /// Skip the "already applied" validation check.
+    ///
+    /// Used by `rebuild_change_graph` which re-applies a change that is
+    /// already in the stack log (same NodeId, new hunks after revise).
+    pub fn skip_validation(mut self, skip: bool) -> Self {
+        self.skip_validation = skip;
         self
     }
 
@@ -500,8 +518,11 @@ pub fn apply_change_to_graph<T: MutTxnT + StackTxnT>(
         .open_or_create_stack(stack_name)
         .map_err(|e| ApplyError::Database(e.to_string()))?;
 
-    // Validate we can apply
-    validate_can_apply(txn, &stack, change_id, change_hash, change)?;
+    // Validate we can apply (unless caller explicitly skipped validation,
+    // e.g. rebuild_change_graph re-applying an existing change with new hunks).
+    if !options.skip_validation {
+        validate_can_apply(txn, &stack, change_id, change_hash, change)?;
+    }
 
     // Determine where edges should be written based on the stack kind.
     // Shared stacks → global GRAPH; Local workspaces → STACK_GRAPH[(stack_id, vertex)].

--- a/atomic-repository/src/repository/changes.rs
+++ b/atomic-repository/src/repository/changes.rs
@@ -605,6 +605,12 @@ impl Repository {
             }
         }
 
+        // Populate session tables if this is a Sherpa provenance graph.
+        // The write transaction is still open, so this is atomic with
+        // the provenance registration above.
+        txn.populate_session_tables(prov_id.get(), graph)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
         txn.commit()
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
@@ -729,5 +735,118 @@ impl Repository {
         graphs.sort_by_key(|(_, g)| g.timestamp);
 
         Ok(graphs)
+    }
+
+    // =========================================================================
+    // Session Data Queries (Sherpa-enriched provenance)
+    // =========================================================================
+
+    /// Get the full ordered replay log for a provenance graph.
+    ///
+    /// Returns all session events ordered by sequence number.
+    /// Empty if the provenance is not Sherpa or has no session data.
+    pub fn get_session_events(
+        &self,
+        provenance_hash: &Hash,
+    ) -> Result<Vec<atomic_core::change::session::SessionEvent>, RepositoryError> {
+        let txn = self
+            .pristine
+            .read_txn()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        let provenance_id = txn
+            .get_internal(provenance_hash)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+            .ok_or_else(|| RepositoryError::ChangeNotFound {
+                hash: provenance_hash.to_base32(),
+            })?;
+        txn.get_session_events(provenance_id.get())
+            .map_err(|e| RepositoryError::Database(e.to_string()))
+    }
+
+    /// Get all todos for a provenance graph.
+    ///
+    /// Returns snapshots of all todo items from the turn.
+    /// Empty if the provenance is not Sherpa or has no session data.
+    pub fn get_session_todos(
+        &self,
+        provenance_hash: &Hash,
+    ) -> Result<Vec<atomic_core::change::session::TodoSnapshot>, RepositoryError> {
+        let txn = self
+            .pristine
+            .read_txn()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        let provenance_id = txn
+            .get_internal(provenance_hash)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+            .ok_or_else(|| RepositoryError::ChangeNotFound {
+                hash: provenance_hash.to_base32(),
+            })?;
+        txn.get_session_todos(provenance_id.get())
+            .map_err(|e| RepositoryError::Database(e.to_string()))
+    }
+
+    /// Get phase timing breakdown for a provenance graph.
+    ///
+    /// Returns timing data for each phase in the turn.
+    /// Empty if the provenance is not Sherpa or has no session data.
+    pub fn get_session_phases(
+        &self,
+        provenance_hash: &Hash,
+    ) -> Result<Vec<atomic_core::change::session::PhaseTimingEntry>, RepositoryError> {
+        let txn = self
+            .pristine
+            .read_txn()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        let provenance_id = txn
+            .get_internal(provenance_hash)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+            .ok_or_else(|| RepositoryError::ChangeNotFound {
+                hash: provenance_hash.to_base32(),
+            })?;
+        txn.get_session_phases(provenance_id.get())
+            .map_err(|e| RepositoryError::Database(e.to_string()))
+    }
+
+    /// Get intent metadata for a provenance graph.
+    ///
+    /// Returns the intent entry if this is a Sherpa provenance, `None` otherwise.
+    pub fn get_session_intent(
+        &self,
+        provenance_hash: &Hash,
+    ) -> Result<Option<atomic_core::change::session::IntentEntry>, RepositoryError> {
+        let txn = self
+            .pristine
+            .read_txn()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        let provenance_id = txn
+            .get_internal(provenance_hash)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+            .ok_or_else(|| RepositoryError::ChangeNotFound {
+                hash: provenance_hash.to_base32(),
+            })?;
+        txn.get_session_intent(provenance_id.get())
+            .map_err(|e| RepositoryError::Database(e.to_string()))
+    }
+
+    /// Check if a provenance graph has session data.
+    ///
+    /// Returns `true` if the graph is a Sherpa provenance with populated
+    /// session tables. This is a fast gate for the UI — checking this first
+    /// avoids hitting the session tables for non-Sherpa provenance.
+    pub fn has_session_data(&self, provenance_hash: &Hash) -> bool {
+        let txn = match self.pristine.read_txn() {
+            Ok(t) => t,
+            Err(_) => return false,
+        };
+
+        let provenance_id = match txn.get_internal(provenance_hash) {
+            Ok(Some(id)) => id.get(),
+            _ => return false,
+        };
+
+        txn.get_session_intent(provenance_id)
+            .ok()
+            .flatten()
+            .is_some()
     }
 }

--- a/atomic-repository/src/repository/content.rs
+++ b/atomic-repository/src/repository/content.rs
@@ -75,8 +75,30 @@ impl Repository {
             Err(e) => return Err(RepositoryError::Database(e.to_string())),
         };
 
-        // Build a change filter starting from this stack's own changes.
+        // Build a change filter starting from this stack's own changes,
+        // then expand with their dependencies (from the change FILES,
+        // not the DEPS table which is for attestations).
+        //
+        // After a content revise, the stack has A' but not A.  A' depends
+        // on A (its hunks modify A's vertices).  Without including A's
+        // NodeId in the filter, the alive-graph traversal would exclude
+        // A's vertices and fail to produce content.
         let mut change_filter = collect_stack_change_ids(&txn, &stack)?;
+
+        // Expand: for each stack change, load its change file, resolve
+        // each dependency hash to a NodeId, and add to the filter.
+        let direct_ids: Vec<NodeId> = change_filter.iter().copied().collect();
+        for node_id in direct_ids {
+            if let Ok(Some(hash)) = txn.get_external(node_id) {
+                if let Ok(change) = self.load_change(&hash) {
+                    for dep_hash in change.dependencies() {
+                        if let Ok(Some(dep_id)) = txn.get_internal(dep_hash) {
+                            change_filter.insert(dep_id);
+                        }
+                    }
+                }
+            }
+        }
 
         // For local workspaces, also include changes from parent stacks in the
         // overlay chain, since those changes' vertices should be visible too.

--- a/atomic-repository/src/repository/status.rs
+++ b/atomic-repository/src/repository/status.rs
@@ -57,15 +57,42 @@ impl Repository {
         let mut status = RepositoryStatus::new(self.current_stack.clone(), stack_state);
 
         // ── Stack-aware filtering ──────────────────────────────────────
-        // Collect every change NodeId that belongs to the current stack.
-        // We use this below to decide whether a recorded file is "ours"
-        // (its creating change is on this stack) or "foreign" (recorded
-        // on a different stack and should be invisible here).
+        // Collect every change NodeId that belongs to the current stack,
+        // PLUS all of their transitive dependencies (via the DEPS table).
+        //
+        // Why dependencies?  After a content revise, the stack log has A'
+        // (the revised change) but NOT A (the original).  A' depends on A
+        // because its hunks reference A's graph vertices.  The INODES
+        // position for the file still points to A's NodeId (which created
+        // the inode vertex).  Without including dependencies, the status
+        // stack filter would see A's NodeId as "not on this stack" and
+        // hide the file — even though A' (which superseded A) IS on the
+        // stack.
         let current_stack_change_ids: HashSet<NodeId> = if let Some(ref stack) = txn
             .get_stack(&self.current_stack)
             .map_err(|e| RepositoryError::Database(e.to_string()))?
         {
-            collect_stack_change_ids(&txn, stack)?
+            let mut ids = collect_stack_change_ids(&txn, stack)?;
+
+            // Expand with dependencies from change FILES (not the DEPS
+            // table, which is for attestations).  After a content revise,
+            // the stack has A' but not A.  A' depends on A (its hunks
+            // reference A's vertices).  Without including A's NodeId,
+            // the status filter would hide files introduced by A.
+            let direct_ids: Vec<NodeId> = ids.iter().copied().collect();
+            for node_id in direct_ids {
+                if let Ok(Some(hash)) = txn.get_external(node_id) {
+                    if let Ok(change) = self.load_change(&hash) {
+                        for dep_hash in change.dependencies() {
+                            if let Ok(Some(dep_id)) = txn.get_internal(dep_hash) {
+                                ids.insert(dep_id);
+                            }
+                        }
+                    }
+                }
+            }
+
+            ids
         } else {
             HashSet::new()
         };


### PR DESCRIPTION
This pull request adds comprehensive support for ingesting and representing Sherpa agent provenance traces in the atomic-agent system. It introduces new node kinds and detail types to capture Sherpa-specific events, enables JSONL trace import, and marks Sherpa sessions in the provenance graph for downstream consumers. The changes also extend the statistics and node handling logic to work seamlessly with these new node types.

**Sherpa provenance trace ingestion and node representation:**

* Added a new `sherpa` hook and registered it in the agent registry to enable Sherpa-specific event handling (`atomic-agent/src/hooks/mod.rs`) [[1]](diffhunk://#diff-60222d3408ef163416c11ca7c7f0e439ec888d20693d1fe8e40e78f99230506dR62) [[2]](diffhunk://#diff-60222d3408ef163416c11ca7c7f0e439ec888d20693d1fe8e40e78f99230506dR250).
* Implemented the `ingest_sherpa_trace` method in `TurnOrchestrator`, which reads Sherpa JSONL trace files and creates typed provenance nodes for each record, preserving all structured details for advanced querying (`atomic-agent/src/turn/orchestrator.rs`) [[1]](diffhunk://#diff-14a88fa2d761bbc5f65378a2b5122fccbc7796d81198288da6aaffd2cd955b09R626-R637) [[2]](diffhunk://#diff-14a88fa2d761bbc5f65378a2b5122fccbc7796d81198288da6aaffd2cd955b09R1036-R1179).
* Added a new `append_raw_node` method to `ProvenanceAccumulator` for inserting nodes with arbitrary fields, bypassing usual edge inference, to support external trace formats like Sherpa (`atomic-agent/src/provenance/accumulator.rs`).

**New Sherpa node kinds and detail types:**

* Introduced multiple new `NodeKind` variants for Sherpa events, including `Todo`, `TodoStatusChange`, `PhaseTransition`, `Lesson`, `LlmResponse`, and `HumanGateResolution`, with all associated serialization, statistics, and string representation logic (`atomic-agent/src/provenance/types.rs`) [[1]](diffhunk://#diff-a928f9278295f17b8f5106f6ae34630eaaeaea1a9b24425ff1ac0923e2a4b33dR79-R96) [[2]](diffhunk://#diff-a928f9278295f17b8f5106f6ae34630eaaeaea1a9b24425ff1ac0923e2a4b33dR129-R134) [[3]](diffhunk://#diff-a928f9278295f17b8f5106f6ae34630eaaeaea1a9b24425ff1ac0923e2a4b33dR399-R410) [[4]](diffhunk://#diff-a928f9278295f17b8f5106f6ae34630eaaeaea1a9b24425ff1ac0923e2a4b33dR425-R430) [[5]](diffhunk://#diff-a928f9278295f17b8f5106f6ae34630eaaeaea1a9b24425ff1ac0923e2a4b33dR445-R450).
* Added a new `detail` module for typed JSON payloads specific to Sherpa provenance nodes and re-exported these types for use elsewhere (`atomic-agent/src/provenance/mod.rs`) [[1]](diffhunk://#diff-4ec5ae6261ca4bc9ee5ab499d5d2bf1af799b944ca2b369d7d96ccc476496fedR33) [[2]](diffhunk://#diff-4ec5ae6261ca4bc9ee5ab499d5d2bf1af799b944ca2b369d7d96ccc476496fedR61-R71).

**Provenance graph schema and profile support:**

* Bumped the provenance graph schema version to 2 and added an optional `profile` field; introduced the `SHERPA_PROFILE` constant to identify Sherpa-structured provenance graphs for downstream consumers (`atomic-core/src/change/provenance_graph.rs`).

**Event and hook handling improvements:**

* Updated hook type mapping to recognize Sherpa-specific verbs and session boundaries, ensuring correct event routing (`atomic-agent/src/event.rs`) [[1]](diffhunk://#diff-157d98db3b12fdfd224cd1af3fe5a3e451e68cf75a31fb93ee3aac7ea80855d2L156-R156) [[2]](diffhunk://#diff-157d98db3b12fdfd224cd1af3fe5a3e451e68cf75a31fb93ee3aac7ea80855d2R172-R177).

**Miscellaneous:**

* Added a string truncation helper for summarizing LLM responses in provenance nodes (`atomic-agent/src/turn/orchestrator.rs`).
* Added the `export` and `session` modules to the public API for broader functionality (`atomic-agent/src/lib.rs`, `atomic-core/src/change/mod.rs`) [[1]](diffhunk://#diff-7d22ac194aeecd0a07fd234a60c828e53858f9afffd244eff93a334e71d1d55fR89) [[2]](diffhunk://#diff-c1b936d7522cac997cc2c94536d734e292898f89ae6c8f8851227a400fbf265eR103).

These changes enable the system to fully ingest, represent, and distinguish Sherpa agent traces, supporting richer provenance and downstream analytics.