### PR TITLE
feat: scalable git import with zero filesystem I/O

### DIFF
--- a/atomic-cli/src/commands/git/import.rs
+++ b/atomic-cli/src/commands/git/import.rs
@@ -67,6 +67,13 @@ pub struct Import {
     /// Compares Git commit SHAs with existing change metadata to skip already-imported commits.
     #[arg(long)]
     pub incremental: bool,
+
+    /// Number of commits to process per batch.
+    ///
+    /// Larger batches use slightly more memory but reduce checkpoint overhead.
+    /// The default works well for most repositories including very large ones.
+    #[arg(long, default_value = "5000")]
+    pub batch_size: usize,
 }
 
 impl Import {
@@ -77,6 +84,7 @@ impl Import {
         branch_name: &str,
         repo: &mut Repository,
         imported_shas: &HashSet<String>,
+        repo_root: &std::path::Path,
     ) -> CliResult<usize> {
         // Get repository name from remote URL or working directory
         let repo_name = self.get_repo_name(git_repo);
@@ -86,12 +94,13 @@ impl Import {
             incremental: self.incremental,
             imported_shas: imported_shas.clone(),
             repo_name,
+            batch_size: self.batch_size,
         };
 
         let importer = ParallelImporter::new(git_repo, options);
 
-        // Run the three-phase parallel import
-        let stats = importer.import_branch(branch_name, repo)?;
+        // Run the batched parallel import
+        let stats = importer.import_branch(branch_name, repo, repo_root)?;
 
         // Return total changes created (written + empty + merge)
         Ok(stats.changes_written + stats.empty_commits + stats.merge_commits)
@@ -307,7 +316,7 @@ impl Command for Import {
 
                 // Import the branch
                 let count =
-                    self.import_branch(&git_repo, &branch_name, &mut repo, &imported_shas)?;
+                    self.import_branch(&git_repo, &branch_name, &mut repo, &imported_shas, workdir)?;
                 total_imported += count;
             }
 
@@ -340,7 +349,7 @@ impl Command for Import {
                 .map_err(|e| CliError::Internal(e.into()))?;
 
             // Import
-            let count = self.import_branch(&git_repo, &branch_name, &mut repo, &imported_shas)?;
+            let count = self.import_branch(&git_repo, &branch_name, &mut repo, &imported_shas, workdir)?;
 
             print_success(&format!(
                 "Imported {} changes from branch '{}'",
@@ -363,5 +372,6 @@ mod tests {
         assert!(!import.all_branches);
         assert!(!import.incremental);
         assert!(import.branch.is_none());
+        assert_eq!(import.batch_size, 0);
     }
 }

--- a/atomic-cli/src/commands/git/parallel.rs
+++ b/atomic-cli/src/commands/git/parallel.rs
@@ -54,16 +54,16 @@
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
 use std::time::Instant;
 
 use chrono::{DateTime, TimeZone, Utc};
-use git2::{Delta, Diff, DiffOptions, ObjectType, Oid, Repository as GitRepository, Tree};
+use git2::{Delta, Diff, DiffOptions, Oid, Repository as GitRepository};
+use indicatif::{ProgressBar, ProgressStyle};
 use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
 
 use atomic_core::change::{Author, Change, ChangeHeader};
-use atomic_repository::Repository;
+use atomic_repository::{DirectFileChange, DirectFileOp, RecordOptions, Repository};
 
 use crate::error::{CliError, CliResult};
 use crate::output::{print_info, print_warning};
@@ -134,8 +134,6 @@ pub struct ParsedFile {
     pub path: String,
     /// Type of change.
     pub operation: FileOperation,
-    /// New content (for added/modified files).
-    pub new_content: Option<Vec<u8>>,
     /// Old path (for renames).
     pub old_path: Option<String>,
 }
@@ -164,6 +162,8 @@ pub struct ParallelImportOptions {
     pub imported_shas: HashSet<String>,
     /// Repository name (from remote URL or directory).
     pub repo_name: String,
+    /// Number of commits to process per batch.
+    pub batch_size: usize,
 }
 
 impl Default for ParallelImportOptions {
@@ -172,7 +172,55 @@ impl Default for ParallelImportOptions {
             incremental: false,
             imported_shas: HashSet::new(),
             repo_name: "unknown".to_string(),
+            batch_size: 5000,
         }
+    }
+}
+
+/// Checkpoint for resumable imports.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImportCheckpoint {
+    /// Branch being imported.
+    pub branch: String,
+    /// Index of the last imported commit in the OID list.
+    pub last_imported_index: usize,
+    /// Git SHA of the last imported commit.
+    pub last_imported_sha: String,
+    /// Total number of OIDs collected for this import.
+    pub total_oids: usize,
+    /// Cumulative number of commits written so far.
+    pub commits_written: usize,
+}
+
+impl ImportCheckpoint {
+    /// Path to the checkpoint file within an Atomic repository.
+    fn path(repo_root: &Path) -> PathBuf {
+        repo_root.join(".atomic").join("git-import-checkpoint.json")
+    }
+
+    /// Load a checkpoint from disk, if one exists and is valid JSON.
+    pub fn load(repo_root: &Path) -> Option<Self> {
+        let data = std::fs::read_to_string(Self::path(repo_root)).ok()?;
+        serde_json::from_str(&data).ok()
+    }
+
+    /// Save the checkpoint to disk.
+    pub fn save(&self, repo_root: &Path) -> CliResult<()> {
+        let path = Self::path(repo_root);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| CliError::Internal(e.into()))?;
+        }
+        let data = serde_json::to_string_pretty(self)
+            .map_err(|e| CliError::Internal(e.into()))?;
+        std::fs::write(&path, data)
+            .map_err(|e| CliError::Internal(e.into()))?;
+        Ok(())
+    }
+
+    /// Remove the checkpoint file.
+    pub fn remove(repo_root: &Path) {
+        let _ = std::fs::remove_file(Self::path(repo_root));
     }
 }
 
@@ -213,67 +261,144 @@ impl ParallelImporter {
 
     /// Import commits from a branch into an Atomic repository.
     ///
-    /// This is the main entry point for the three-phase import.
+    /// Uses a batched pipeline: commits are split into chunks of `batch_size`,
+    /// and each chunk is parsed in parallel (Phase 1) then written sequentially
+    /// (Phase 2). This keeps memory bounded regardless of repository size.
+    ///
+    /// A checkpoint file is written after each batch so the import can resume
+    /// from where it left off if interrupted.
     pub fn import_branch(
         &self,
         branch_name: &str,
         repo: &mut Repository,
+        repo_root: &Path,
     ) -> CliResult<ImportStats> {
         let mut stats = ImportStats::default();
 
-        // Open git repo for this thread
+        // Open git repo
         let git_repo = self.open_git_repo()?;
 
-        // Collect commit OIDs in topological order
-        let commit_oids = self.collect_commit_oids(&git_repo, branch_name)?;
+        // Collect commit OIDs in topological order (shows spinner for large repos)
+        let collect_spinner = ProgressBar::new_spinner();
+        collect_spinner.set_style(
+            ProgressStyle::with_template("{spinner:.green} {msg}")
+                .unwrap(),
+        );
+        collect_spinner.set_message("Collecting commits...");
+        collect_spinner.enable_steady_tick(std::time::Duration::from_millis(100));
+
+        let commit_oids = self.collect_commit_oids(&git_repo, branch_name, &collect_spinner)?;
         stats.commits_found = commit_oids.len();
+
+        collect_spinner.finish_and_clear();
 
         if commit_oids.is_empty() {
             return Ok(stats);
         }
 
-        print_info(&format!(
-            "Phase 1: Parsing {} commits in parallel...",
-            commit_oids.len()
-        ));
+        // Determine resume point from checkpoint
+        let start_index = if let Some(checkpoint) = ImportCheckpoint::load(repo_root) {
+            if checkpoint.branch == branch_name && checkpoint.total_oids == commit_oids.len() {
+                // Validate the SHA matches at the checkpoint index
+                if commit_oids
+                    .get(checkpoint.last_imported_index)
+                    .map(|oid| oid.to_string() == checkpoint.last_imported_sha)
+                    .unwrap_or(false)
+                {
+                    let resume_from = checkpoint.last_imported_index + 1;
+                    print_info(&format!(
+                        "Resuming from checkpoint: {}/{} commits already imported",
+                        resume_from, commit_oids.len()
+                    ));
+                    stats.changes_written = checkpoint.commits_written;
+                    resume_from
+                } else {
+                    print_warning("Checkpoint SHA mismatch, starting from beginning");
+                    0
+                }
+            } else {
+                0
+            }
+        } else {
+            0
+        };
 
-        // Phase 1: Parallel git parsing
-        let phase1_start = Instant::now();
-        let parsed_commits = self.phase1_parse(&commit_oids)?;
-        stats.phase1_duration = phase1_start.elapsed();
-        stats.commits_parsed = parsed_commits.len();
-
-        print_info(&format!(
-            "Phase 1 complete: {} commits parsed in {:.2}s",
-            stats.commits_parsed,
-            stats.phase1_duration.as_secs_f64()
-        ));
-
-        if parsed_commits.is_empty() {
+        let remaining_oids = &commit_oids[start_index..];
+        if remaining_oids.is_empty() {
+            ImportCheckpoint::remove(repo_root);
             return Ok(stats);
         }
 
-        print_info(&format!(
-            "Phase 2: Writing {} changes sequentially...",
-            parsed_commits.len()
-        ));
-
-        // Phase 2: Sequential write with hash chaining
-        let phase2_start = Instant::now();
-        let write_stats = self.phase2_write(repo, &parsed_commits)?;
-        stats.phase2_duration = phase2_start.elapsed();
-        stats.changes_written = write_stats.changes_written;
-        stats.empty_commits = write_stats.empty_commits;
-        stats.merge_commits = write_stats.merge_commits;
-        stats.files_processed = write_stats.files_processed;
+        let total_remaining = remaining_oids.len();
+        let batch_size = self.options.batch_size;
+        let total_batches = (total_remaining + batch_size - 1) / batch_size;
 
         print_info(&format!(
-            "Phase 2 complete: {} changes written in {:.2}s",
-            stats.changes_written,
-            stats.phase2_duration.as_secs_f64()
+            "Importing {} commits in {} batches of {}",
+            total_remaining, total_batches, batch_size
         ));
 
-        // Phase 3: Finalization (just verification for now)
+        // Set up progress bar
+        let pb = ProgressBar::new(commit_oids.len() as u64);
+        pb.set_style(
+            ProgressStyle::with_template(
+                "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({per_sec}, ETA: {eta}) {msg}"
+            )
+            .unwrap()
+            .progress_chars("#>-"),
+        );
+        pb.set_position(start_index as u64);
+
+        // Process in batches
+        let overall_start = Instant::now();
+
+        for (batch_idx, batch_oids) in remaining_oids.chunks(batch_size).enumerate() {
+            let batch_start = start_index + batch_idx * batch_size;
+
+            // Phase 1: parallel parse (metadata only, no file content)
+            pb.set_message(format!("batch {}/{} — parsing", batch_idx + 1, total_batches));
+            let phase1_start = Instant::now();
+            let parsed_commits = self.phase1_parse(batch_oids, &pb)?;
+            stats.phase1_duration += phase1_start.elapsed();
+            stats.commits_parsed += parsed_commits.len();
+
+            // Phase 2: sequential write
+            pb.set_message(format!("batch {}/{} — writing", batch_idx + 1, total_batches));
+            let phase2_start = Instant::now();
+            let write_stats = self.phase2_write(repo, &parsed_commits, &pb)?;
+            stats.phase2_duration += phase2_start.elapsed();
+            stats.changes_written += write_stats.changes_written;
+            stats.empty_commits += write_stats.empty_commits;
+            stats.merge_commits += write_stats.merge_commits;
+            stats.files_processed += write_stats.files_processed;
+
+            // Write checkpoint
+            let last_idx = batch_start + batch_oids.len() - 1;
+            let checkpoint = ImportCheckpoint {
+                branch: branch_name.to_string(),
+                last_imported_index: last_idx,
+                last_imported_sha: commit_oids[last_idx].to_string(),
+                total_oids: commit_oids.len(),
+                commits_written: stats.changes_written + stats.empty_commits + stats.merge_commits,
+            };
+            checkpoint.save(repo_root)?;
+        }
+
+        pb.finish_with_message("Import complete");
+
+        let total_elapsed = overall_start.elapsed();
+        print_info(&format!(
+            "Imported {} commits in {:.1}s (parse: {:.1}s, write: {:.1}s)",
+            stats.changes_written + stats.empty_commits + stats.merge_commits,
+            total_elapsed.as_secs_f64(),
+            stats.phase1_duration.as_secs_f64(),
+            stats.phase2_duration.as_secs_f64(),
+        ));
+
+        // Clean up checkpoint on success
+        ImportCheckpoint::remove(repo_root);
+
+        // Phase 3: verification
         self.phase3_finalize(&stats)?;
 
         Ok(stats)
@@ -284,6 +409,7 @@ impl ParallelImporter {
         &self,
         git_repo: &GitRepository,
         branch_name: &str,
+        spinner: &ProgressBar,
     ) -> CliResult<Vec<Oid>> {
         let reference = git_repo
             .find_branch(branch_name, git2::BranchType::Local)
@@ -322,7 +448,14 @@ impl ParallelImporter {
             }
 
             oids.push(oid);
+
+            // Update spinner every 10K commits
+            if oids.len() % 10_000 == 0 {
+                spinner.set_message(format!("Collecting commits... {}", oids.len()));
+            }
         }
+
+        spinner.set_message(format!("Collected {} commits", oids.len()));
 
         Ok(oids)
     }
@@ -331,8 +464,12 @@ impl ParallelImporter {
     // Phase 1: Parallel Git Parsing
     // ═══════════════════════════════════════════════════════════════════════
 
-    /// Phase 1: Parse all commits in parallel using rayon.
-    fn phase1_parse(&self, commit_oids: &[Oid]) -> CliResult<Vec<ParsedCommit>> {
+    /// Phase 1: Parse a batch of commits in parallel using rayon.
+    fn phase1_parse(
+        &self,
+        commit_oids: &[Oid],
+        _pb: &ProgressBar,
+    ) -> CliResult<Vec<ParsedCommit>> {
         // Build a map from OID to index for parent lookups
         let oid_to_index: std::collections::HashMap<Oid, usize> = commit_oids
             .iter()
@@ -340,38 +477,48 @@ impl ParallelImporter {
             .map(|(i, oid)| (*oid, i))
             .collect();
 
-        // Progress counter for large repos
-        let progress = Arc::new(AtomicUsize::new(0));
-        let total = commit_oids.len();
-
         // Share the repo path for thread-local repo opening
         let repo_path = self.git_repo_path.clone();
 
-        // Parse commits in parallel - each thread opens its own git repo
-        let results: Vec<CliResult<ParsedCommit>> = commit_oids
+        // Thread-local counter for repo reuse
+        use std::cell::RefCell;
+        thread_local! {
+            static THREAD_GIT_REPO: RefCell<Option<(PathBuf, GitRepository)>> = const { RefCell::new(None) };
+        }
+
+        // Parse commits in parallel - each thread reuses its git repo
+        let results: Vec<(usize, CliResult<ParsedCommit>)> = commit_oids
             .par_iter()
             .enumerate()
             .map(|(idx, oid)| {
-                // Progress reporting (every 100 commits)
-                let count = progress.fetch_add(1, Ordering::Relaxed);
-                if total > 100 && count % 100 == 0 {
-                    print_info(&format!("  Parsed {}/{} commits...", count, total));
-                }
-
-                // Open a thread-local git repo
-                let git_repo = GitRepository::open(&repo_path).map_err(|e| CliError::GitError {
-                    message: format!("Failed to open git repository: {}", e),
-                })?;
-
-                parse_commit(&git_repo, *oid, idx, &oid_to_index)
+                let result = THREAD_GIT_REPO.with(|cell| {
+                    let mut slot = cell.borrow_mut();
+                    // Reuse repo if path matches, otherwise open a new one
+                    let git_repo = match slot.as_ref() {
+                        Some((path, _)) if path == &repo_path => {
+                            &slot.as_ref().unwrap().1
+                        }
+                        _ => {
+                            let repo = GitRepository::open(&repo_path).map_err(|e| {
+                                CliError::GitError {
+                                    message: format!("Failed to open git repository: {}", e),
+                                }
+                            })?;
+                            *slot = Some((repo_path.clone(), repo));
+                            &slot.as_ref().unwrap().1
+                        }
+                    };
+                    parse_commit(git_repo, *oid, idx, &oid_to_index)
+                });
+                (idx, result)
             })
             .collect();
 
-        // Collect results, filtering out errors (with warnings)
-        let mut parsed = Vec::with_capacity(results.len());
-        for (idx, result) in results.into_iter().enumerate() {
+        // Collect results in original order, filtering out errors
+        let mut parsed: Vec<(usize, ParsedCommit)> = Vec::with_capacity(results.len());
+        for (idx, result) in results {
             match result {
-                Ok(commit) => parsed.push(commit),
+                Ok(commit) => parsed.push((idx, commit)),
                 Err(e) => {
                     print_warning(&format!("Skipping commit {}: {}", idx, e));
                 }
@@ -379,15 +526,9 @@ impl ParallelImporter {
         }
 
         // Sort by original index to restore topological order
-        // (rayon may have processed them out of order)
-        parsed.sort_by_key(|c| {
-            commit_oids
-                .iter()
-                .position(|oid| oid.to_string() == c.git_sha)
-                .unwrap_or(usize::MAX)
-        });
+        parsed.sort_by_key(|(idx, _)| *idx);
 
-        Ok(parsed)
+        Ok(parsed.into_iter().map(|(_, c)| c).collect())
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -399,17 +540,23 @@ impl ParallelImporter {
         &self,
         repo: &mut Repository,
         commits: &[ParsedCommit],
+        pb: &ProgressBar,
     ) -> CliResult<WriteStats> {
         let mut stats = WriteStats::default();
-        let total = commits.len();
 
         // Open git repo for Phase 2 (single-threaded, so one instance is fine)
         let git_repo = self.open_git_repo()?;
 
-        for (idx, parsed) in commits.iter().enumerate() {
-            // Progress reporting
-            if total > 100 && idx % 100 == 0 {
-                print_info(&format!("  Writing {}/{}...", idx, total));
+        for parsed in commits.iter() {
+            // Log large commits so the user knows why it's slow
+            if parsed.files.len() > 1000 {
+                pb.suspend(|| {
+                    print_info(&format!(
+                        "Processing large commit {} ({} files)...",
+                        parsed.short_sha,
+                        parsed.files.len()
+                    ));
+                });
             }
 
             // Write the change
@@ -428,12 +575,19 @@ impl ParallelImporter {
                     print_warning(&format!("Failed to write {}: {}", parsed.short_sha, e));
                 }
             }
+            pb.inc(1);
         }
 
         Ok(stats)
     }
 
     /// Write a single commit to the repository.
+    ///
+    /// Write a single commit using direct recording (zero filesystem I/O).
+    ///
+    /// Content is read from git's object store (compressed packfiles) and fed
+    /// directly to `record_direct()`, bypassing the working directory entirely.
+    /// No `checkout_tree`, no `status()`, no `std::fs::read()`.
     fn write_commit(
         &self,
         git_repo: &GitRepository,
@@ -460,7 +614,7 @@ impl ParallelImporter {
             return self.write_empty_commit(repo, parsed, header);
         }
 
-        // Checkout the commit's tree to set working copy state
+        // Get the commit's tree (for reading blob content from git object store)
         let commit = git_repo
             .find_commit(
                 Oid::from_str(&parsed.git_sha).map_err(|e| CliError::GitError {
@@ -475,32 +629,69 @@ impl ParallelImporter {
             message: format!("Failed to get tree: {}", e),
         })?;
 
-        git_repo
-            .checkout_tree(
-                tree.as_object(),
-                Some(git2::build::CheckoutBuilder::new().force()),
-            )
-            .map_err(|e| CliError::GitError {
-                message: format!("Failed to checkout tree: {}", e),
-            })?;
+        // Get parent tree for reading old content of modified files.
+        // This avoids the expensive get_file_content_via_overlay() graph traversal.
+        let parent_tree = if commit.parent_count() > 0 {
+            commit.parent(0).ok().and_then(|p| p.tree().ok())
+        } else {
+            None
+        };
 
-        // Track new files
+        // Build DirectFileChange list from git blobs — no filesystem writes
+        let mut changes = Vec::with_capacity(parsed.files.len());
         for file in &parsed.files {
-            if file.operation == FileOperation::Added
-                || file.operation == FileOperation::Renamed
-                || file.operation == FileOperation::Copied
-            {
-                let _ = repo.add(&file.path, atomic_repository::TrackingOptions::default());
+            match file.operation {
+                FileOperation::Added | FileOperation::Copied => {
+                    let content = read_blob_from_tree(git_repo, &tree, &file.path)
+                        .unwrap_or_default();
+                    changes.push(DirectFileChange {
+                        path: file.path.clone(),
+                        operation: DirectFileOp::Added { content },
+                    });
+                }
+                FileOperation::Modified => {
+                    let content = read_blob_from_tree(git_repo, &tree, &file.path)
+                        .unwrap_or_default();
+                    // Read old content from git parent tree (fast mmap read)
+                    // instead of reconstructing from the pristine graph (slow traversal)
+                    let old_content = parent_tree.as_ref()
+                        .and_then(|pt| read_blob_from_tree(git_repo, pt, &file.path));
+                    changes.push(DirectFileChange {
+                        path: file.path.clone(),
+                        operation: DirectFileOp::Modified { content, old_content },
+                    });
+                }
+                FileOperation::Deleted => {
+                    changes.push(DirectFileChange {
+                        path: file.path.clone(),
+                        operation: DirectFileOp::Deleted,
+                    });
+                }
+                FileOperation::Renamed => {
+                    // Decompose rename into delete + add
+                    if let Some(ref old_path) = file.old_path {
+                        changes.push(DirectFileChange {
+                            path: old_path.clone(),
+                            operation: DirectFileOp::Deleted,
+                        });
+                    }
+                    let content = read_blob_from_tree(git_repo, &tree, &file.path)
+                        .unwrap_or_default();
+                    changes.push(DirectFileChange {
+                        path: file.path.clone(),
+                        operation: DirectFileOp::Added { content },
+                    });
+                }
             }
         }
 
-        // Record the change
-        let options = atomic_repository::RecordOptions::new()
+        // Record directly — no filesystem writes, no status() walk, no repo.add()
+        let options = RecordOptions::new()
             .with_all(true)
             .save_to_store(false)
             .apply_after_record(false);
 
-        let (change, hash) = match repo.record(header.clone(), options) {
+        let (change, hash) = match repo.record_direct(header.clone(), &changes, options) {
             Ok(mut result) => {
                 let hash = *result.hash();
                 result.change_mut().unhashed = Some(self.build_git_metadata(parsed, false, false));
@@ -678,7 +869,7 @@ fn parse_commit(
     let is_empty = stats.files_changed() == 0;
 
     // Parse files
-    let files = parse_diff_files(git_repo, &diff, &tree)?;
+    let files = parse_diff_files(&diff)?;
 
     Ok(ParsedCommit {
         git_sha: sha,
@@ -717,9 +908,7 @@ fn extract_commit_metadata(commit: &git2::Commit) -> CliResult<CommitMetadata> {
 
 /// Parse files from a git diff.
 fn parse_diff_files(
-    git_repo: &GitRepository,
     diff: &Diff,
-    tree: &Tree,
 ) -> CliResult<Vec<ParsedFile>> {
     let mut files = Vec::new();
 
@@ -753,49 +942,14 @@ fn parse_diff_files(
             None
         };
 
-        // Get new content for added/modified files
-        let new_content = if operation == FileOperation::Added
-            || operation == FileOperation::Modified
-            || operation == FileOperation::Renamed
-            || operation == FileOperation::Copied
-        {
-            get_file_content(git_repo, tree, &path).ok()
-        } else {
-            None
-        };
-
         files.push(ParsedFile {
             path,
             operation,
-            new_content,
             old_path,
         });
     }
 
     Ok(files)
-}
-
-/// Get file content from a git tree.
-fn get_file_content(git_repo: &GitRepository, tree: &Tree, path: &str) -> CliResult<Vec<u8>> {
-    let entry = tree
-        .get_path(Path::new(path))
-        .map_err(|e| CliError::GitError {
-            message: format!("Path not found in tree: {}", e),
-        })?;
-
-    if entry.kind() != Some(ObjectType::Blob) {
-        return Err(CliError::GitError {
-            message: "Not a file".to_string(),
-        });
-    }
-
-    let blob = git_repo
-        .find_blob(entry.id())
-        .map_err(|e| CliError::GitError {
-            message: format!("Failed to find blob: {}", e),
-        })?;
-
-    Ok(blob.content().to_vec())
 }
 
 /// Parse a git commit message into subject and description.
@@ -822,6 +976,20 @@ fn parse_commit_message(message: &str) -> (String, Option<String>) {
     };
 
     (subject, description)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Incremental Working Directory Helpers
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Read a file's content directly from git's object store (no filesystem checkout).
+///
+/// This reads from packed objects / loose objects, which is much faster than
+/// checking out the entire tree to disk.
+fn read_blob_from_tree(git_repo: &GitRepository, tree: &git2::Tree, path: &str) -> Option<Vec<u8>> {
+    let entry = tree.get_path(Path::new(path)).ok()?;
+    let blob = git_repo.find_blob(entry.id()).ok()?;
+    Some(blob.content().to_vec())
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/atomic-repository/src/lib.rs
+++ b/atomic-repository/src/lib.rs
@@ -178,8 +178,8 @@ pub use remote::{RemoteConfig, RemoteEntry, RemoteError, RemoteResult};
 
 // Record exports
 pub use record::{
-    build_header, filter_files, RecordError, RecordOptions, RecordOutcome, RecordResult,
-    RecordStats,
+    build_header, filter_files, DirectFileChange, DirectFileOp, RecordError, RecordOptions,
+    RecordOutcome, RecordResult, RecordStats,
 };
 
 // Archive exports

--- a/atomic-repository/src/record.rs
+++ b/atomic-repository/src/record.rs
@@ -792,6 +792,42 @@ impl fmt::Display for RecordStats {
     }
 }
 
+// DIRECT FILE CHANGES
+
+/// A file change with content already provided (no filesystem access needed).
+///
+/// Used by [`Repository::record_direct()`] to bypass the filesystem entirely.
+/// Content is provided directly from an external source (e.g., git's object store).
+#[derive(Debug, Clone)]
+pub struct DirectFileChange {
+    /// Path relative to repository root.
+    pub path: String,
+    /// The type of change and associated content.
+    pub operation: DirectFileOp,
+}
+
+/// The type of direct file operation.
+#[derive(Debug, Clone)]
+pub enum DirectFileOp {
+    /// File was added. Content is the full file bytes.
+    Added {
+        /// Full content of the new file.
+        content: Vec<u8>,
+    },
+    /// File was modified. Content is the new full file bytes.
+    Modified {
+        /// Full content of the modified file.
+        content: Vec<u8>,
+        /// Old content from the previous version.
+        /// When provided, skips the expensive `get_file_content_via_overlay()` call.
+        /// For sequential imports (e.g., git), the caller can provide this from the
+        /// parent commit's tree, which is much faster than reconstructing from the graph.
+        old_content: Option<Vec<u8>>,
+    },
+    /// File was deleted.
+    Deleted,
+}
+
 // RESULT
 
 /// Result of recording changes.

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -63,7 +63,8 @@ use crate::changestore::{ChangeStore, ChangeStoreError, DEFAULT_CACHE_CAPACITY};
 use crate::history::{HistoryOptions, HistorySummary};
 use crate::ignore::IgnoreRules;
 use crate::record::{
-    build_header, filter_files, RecordError, RecordOptions, RecordOutcome, RecordStats,
+    build_header, filter_files, DirectFileChange, DirectFileOp, RecordError, RecordOptions,
+    RecordOutcome, RecordStats,
 };
 use crate::remote::{RemoteConfig, RemoteEntry};
 use crate::status::{

--- a/atomic-repository/src/repository/record.rs
+++ b/atomic-repository/src/repository/record.rs
@@ -624,6 +624,361 @@ impl Repository {
         Ok(outcome)
     }
 
+    /// Record pre-computed file changes without filesystem access.
+    ///
+    /// This method accepts file changes with content already provided (e.g., from
+    /// git's object store), bypassing `status()` and `std::fs::read()` entirely.
+    /// This is dramatically faster for bulk imports where the caller already knows
+    /// what changed and has the content in memory.
+    ///
+    /// # Arguments
+    ///
+    /// * `header` - Change metadata (author, message, timestamp)
+    /// * `changes` - Pre-computed file changes with content
+    /// * `options` - Recording options (save_to_store and apply_after_record are ignored;
+    ///               the caller handles persistence)
+    pub fn record_direct(
+        &self,
+        header: ChangeHeader,
+        changes: &[DirectFileChange],
+        options: RecordOptions,
+    ) -> Result<RecordOutcome, RecordError> {
+        use atomic_core::output::Memory;
+        use atomic_core::record::workflow::{
+            assemble_change, record_added_file, record_deleted_file, record_modified_file,
+            DetectedFile, RecordedFile,
+        };
+
+        if changes.is_empty() {
+            return Err(RecordError::NothingToRecord);
+        }
+
+        let final_header = build_header(header, &options);
+        let core_options = options.to_core_options();
+
+        // Create in-memory working copy (no filesystem access)
+        let memory_wc = Memory::new();
+
+        let mut stats = RecordStats::new();
+        let mut recorded_files: Vec<RecordedFile> = Vec::new();
+        let mut recorded_paths: Vec<String> = Vec::new();
+        let mut deleted_paths: Vec<String> = Vec::new();
+        let mut errors: Vec<(String, String)> = Vec::new();
+
+        for change in changes {
+            let path = &change.path;
+            stats.files_processed += 1;
+
+            match &change.operation {
+                DirectFileOp::Added { content } => {
+                    // Populate memory working copy with content
+                    memory_wc.add_file(path, content);
+
+                    let detected = DetectedFile::added(path);
+
+                    match record_added_file(&memory_wc, &detected, &core_options) {
+                        Ok(recorded) => {
+                            if !recorded.is_empty() {
+                                stats.files_recorded += 1;
+                                stats.hunks_created += recorded.hunk_count();
+                                stats.content_bytes += recorded.content_len() as u64;
+                                stats.vertices_added += 3;
+
+                                if let Some(crdt_stats) = recorded.crdt_stats() {
+                                    stats.lines_added += crdt_stats.lines_added;
+                                    stats.lines_deleted += crdt_stats.lines_deleted;
+                                    stats.lines_modified += crdt_stats.lines_modified;
+                                    stats.tokens_added += crdt_stats.tokens_added;
+                                    stats.tokens_deleted += crdt_stats.tokens_deleted;
+                                    stats.tokens_replaced += crdt_stats.tokens_replaced;
+                                }
+
+                                recorded_paths.push(path.clone());
+                                recorded_files.push(recorded);
+                            } else {
+                                stats.files_skipped += 1;
+                            }
+                        }
+                        Err(e) => {
+                            errors.push((path.clone(), format!("{:?}", e)));
+                            stats.errors += 1;
+                        }
+                    }
+                }
+
+                DirectFileOp::Modified { content, old_content } => {
+                    // Look up inode and position from pristine
+                    let (file_inode, file_position) = {
+                        let txn = self
+                            .pristine
+                            .read_txn()
+                            .map_err(|e| RecordError::Database(e.to_string()))?;
+
+                        let inode = match txn.get_inode(path) {
+                            Ok(Some(inode)) => inode,
+                            Ok(None) => {
+                                // File not tracked yet — treat as Added
+                                memory_wc.add_file(path, content);
+                                let detected = DetectedFile::added(path);
+                                match record_added_file(&memory_wc, &detected, &core_options) {
+                                    Ok(recorded) => {
+                                        if !recorded.is_empty() {
+                                            stats.files_recorded += 1;
+                                            stats.hunks_created += recorded.hunk_count();
+                                            stats.content_bytes += recorded.content_len() as u64;
+                                            stats.vertices_added += 3;
+                                            recorded_paths.push(path.clone());
+                                            recorded_files.push(recorded);
+                                        }
+                                    }
+                                    Err(e) => {
+                                        errors.push((path.clone(), format!("{:?}", e)));
+                                        stats.errors += 1;
+                                    }
+                                }
+                                continue;
+                            }
+                            Err(e) => {
+                                errors.push((path.clone(), format!("Failed to get inode: {}", e)));
+                                stats.errors += 1;
+                                continue;
+                            }
+                        };
+
+                        let position = match txn.inode_position(inode) {
+                            Ok(Some(pos)) => pos,
+                            Ok(None) => {
+                                errors.push((
+                                    path.clone(),
+                                    "File position not found in pristine".to_string(),
+                                ));
+                                stats.errors += 1;
+                                continue;
+                            }
+                            Err(e) => {
+                                errors.push((
+                                    path.clone(),
+                                    format!("Failed to get position: {}", e),
+                                ));
+                                stats.errors += 1;
+                                continue;
+                            }
+                        };
+
+                        (inode, position)
+                    };
+
+                    // Use caller-provided old content if available (fast path),
+                    // otherwise reconstruct from the pristine graph (slow path).
+                    let resolved_old_content = if let Some(ref provided) = old_content {
+                        provided.clone()
+                    } else {
+                        match self
+                            .get_file_content_via_overlay(path, &self.current_stack)
+                        {
+                            Ok(Some(content)) => content,
+                            Ok(None) => Vec::new(),
+                            Err(e) => {
+                                errors.push((
+                                    path.clone(),
+                                    format!("Failed to retrieve old content: {}", e),
+                                ));
+                                stats.errors += 1;
+                                continue;
+                            }
+                        }
+                    };
+
+                    // Skip if content unchanged
+                    if resolved_old_content == content.as_slice() {
+                        stats.files_skipped += 1;
+                        continue;
+                    }
+
+                    // Populate memory working copy
+                    memory_wc.add_file(path, content);
+
+                    let mut detected = DetectedFile::modified(path);
+                    detected.inode = Some(file_inode);
+                    detected.position = Some(file_position);
+
+                    match record_modified_file(&memory_wc, &detected, &resolved_old_content, &core_options) {
+                        Ok(recorded) => {
+                            if !recorded.is_empty() {
+                                stats.files_recorded += 1;
+                                stats.hunks_created += recorded.hunk_count();
+                                stats.content_bytes += recorded.content_len() as u64;
+
+                                for graph_op in recorded.hunks() {
+                                    if graph_op.is_edit() {
+                                        stats.vertices_added += 1;
+                                    } else if graph_op.is_replace() {
+                                        stats.vertices_added += 1;
+                                        stats.edges_modified += 1;
+                                    } else if graph_op.is_delete() {
+                                        stats.edges_modified += 1;
+                                    }
+                                }
+
+                                if let Some(crdt_stats) = recorded.crdt_stats() {
+                                    stats.lines_added += crdt_stats.lines_added;
+                                    stats.lines_deleted += crdt_stats.lines_deleted;
+                                    stats.lines_modified += crdt_stats.lines_modified;
+                                    stats.tokens_added += crdt_stats.tokens_added;
+                                    stats.tokens_deleted += crdt_stats.tokens_deleted;
+                                    stats.tokens_replaced += crdt_stats.tokens_replaced;
+                                }
+
+                                recorded_paths.push(path.clone());
+                                recorded_files.push(recorded);
+                            } else {
+                                stats.files_skipped += 1;
+                            }
+                        }
+                        Err(e) => {
+                            errors.push((path.clone(), format!("{:?}", e)));
+                            stats.errors += 1;
+                        }
+                    }
+                }
+
+                DirectFileOp::Deleted => {
+                    // Look up inode and position from pristine
+                    let (file_inode, file_position) = {
+                        let txn = self
+                            .pristine
+                            .read_txn()
+                            .map_err(|e| RecordError::Database(e.to_string()))?;
+
+                        let inode = match txn.get_inode(path) {
+                            Ok(Some(inode)) => inode,
+                            Ok(None) => {
+                                // File was never tracked — skip silently
+                                continue;
+                            }
+                            Err(e) => {
+                                errors.push((path.clone(), format!("Failed to get inode: {}", e)));
+                                stats.errors += 1;
+                                continue;
+                            }
+                        };
+
+                        let position = match txn.inode_position(inode) {
+                            Ok(Some(pos)) => pos,
+                            Ok(None) => {
+                                errors.push((
+                                    path.clone(),
+                                    "File position not found in pristine".to_string(),
+                                ));
+                                stats.errors += 1;
+                                continue;
+                            }
+                            Err(e) => {
+                                errors.push((
+                                    path.clone(),
+                                    format!("Failed to get position: {}", e),
+                                ));
+                                stats.errors += 1;
+                                continue;
+                            }
+                        };
+
+                        (inode, position)
+                    };
+
+                    let mut detected = DetectedFile::deleted(path);
+                    detected.inode = Some(file_inode);
+                    detected.position = Some(file_position);
+
+                    match record_deleted_file(&detected, &core_options) {
+                        Ok(recorded) => {
+                            stats.files_recorded += 1;
+                            stats.hunks_created += recorded.hunk_count();
+                            stats.edges_modified += 1;
+
+                            if let Some(crdt_stats) = recorded.crdt_stats() {
+                                stats.lines_added += crdt_stats.lines_added;
+                                stats.lines_deleted += crdt_stats.lines_deleted;
+                                stats.lines_modified += crdt_stats.lines_modified;
+                                stats.tokens_added += crdt_stats.tokens_added;
+                                stats.tokens_deleted += crdt_stats.tokens_deleted;
+                                stats.tokens_replaced += crdt_stats.tokens_replaced;
+                            }
+
+                            deleted_paths.push(path.clone());
+                            recorded_paths.push(path.clone());
+                            recorded_files.push(recorded);
+                        }
+                        Err(e) => {
+                            errors.push((path.clone(), format!("{:?}", e)));
+                            stats.errors += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        if recorded_files.is_empty() {
+            return Err(RecordError::NothingToRecord);
+        }
+
+        // Assemble the change using OverlayTxn (same as record())
+        let txn = self
+            .pristine
+            .read_txn()
+            .map_err(|e| RecordError::Database(e.to_string()))?;
+
+        let stack = txn
+            .get_stack(&self.current_stack)
+            .map_err(|e| RecordError::Database(e.to_string()))?
+            .ok_or_else(|| {
+                RecordError::Database(format!(
+                    "Stack '{}' not found during record assembly",
+                    self.current_stack
+                ))
+            })?;
+
+        let overlay_txn = OverlayTxn::from_stack(&txn, &stack)
+            .map_err(|e| RecordError::Database(e.to_string()))?;
+
+        let assembly_options = options.to_assembly_options();
+
+        let assembly_result = assemble_change(
+            &overlay_txn,
+            &recorded_files,
+            final_header,
+            &assembly_options,
+        )?;
+
+        let change = assembly_result.into_change();
+        stats.dependency_count = change.dependencies().len();
+
+        // Serialize to V3 format
+        let mut v3_bytes = Vec::new();
+        let computed_hash = change
+            .serialize(&mut v3_bytes)
+            .map_err(|e| RecordError::ChangeStore(e.to_string()))?;
+
+        let (final_change, verified_hash) = Change::deserialize(&mut v3_bytes.as_slice())
+            .map_err(|e| RecordError::ChangeStore(e.to_string()))?;
+        debug_assert_eq!(computed_hash, verified_hash);
+
+        let mut outcome = RecordOutcome::new(final_change, computed_hash, stats);
+        outcome.set_v3_bytes(v3_bytes);
+
+        for path in recorded_paths {
+            outcome.add_recorded_file(path);
+        }
+        for path in deleted_paths {
+            outcome.add_deleted_file(path);
+        }
+        for (path, error) in errors {
+            outcome.add_error(path, error);
+        }
+
+        Ok(outcome)
+    }
+
     /// Record changes with a simple message.
     ///
     /// This is a convenience method that creates a change header with just

--- a/tests/harness/10_git_import.sh
+++ b/tests/harness/10_git_import.sh
@@ -93,17 +93,15 @@ init_git_repo
 git_commit "Initial commit" "main.txt" "main content"
 git_commit "Second commit" "main.txt" "updated main"
 
+# Capture main branch name before switching away
+main_branch="$(git symbolic-ref --short HEAD 2>/dev/null || echo "main")"
+
 # Create feature branch with additional commits
 git checkout -b feature --quiet
 git_commit "Feature commit" "feature.txt" "feature content"
 
-# Switch back to main (or master, depending on git version)
-main_branch="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|origin/||')"
-# For local repos without origin, fall back to the currently checked-out branch
-if [ -z "$main_branch" ]; then
-    main_branch="$(git symbolic-ref --short HEAD 2>/dev/null || echo "main")"
-fi
-git checkout "$main_branch" --quiet 2>/dev/null || true
+# Switch back to main
+git checkout "$main_branch" --quiet
 
 # Import main branch
 atomic init >/dev/null 2>&1
@@ -240,8 +238,7 @@ make_temp_repo "git-import-errors"
 atomic init >/dev/null 2>&1
 
 # Should fail with clear error about not being a git repo
-out="$(atomic git import 2>&1)"
-status=$?
+out="$(atomic git import 2>&1)" && status=0 || status=$?
 if [ "$status" -eq 0 ]; then
     _fail "atomic git import unexpectedly succeeded in non-git directory"
 elif echo "$out" | grep -qiE "not.*git|no.*repository|git.*not found"; then
@@ -253,8 +250,7 @@ fi
 # Now make it a git repo and test invalid branch
 init_git_repo
 git_commit "test" "test.txt" "test"
-out="$(atomic git import --branch nonexistent 2>&1)"
-status=$?
+out="$(atomic git import --branch nonexistent 2>&1)" && status=0 || status=$?
 if [ "$status" -eq 0 ]; then
     _fail "atomic git import unexpectedly succeeded for invalid branch"
 elif echo "$out" | grep -qiE "branch.*not found|no.*branch|invalid.*branch|unknown.*branch"; then

--- a/tests/harness/10_git_import.sh
+++ b/tests/harness/10_git_import.sh
@@ -6,6 +6,7 @@
 #   - Tiny:   hashicorp/go-uuid (~50 commits)
 #   - Medium: holman/spark (~104 commits)
 #   - Large:  sharkdp/hyperfine (~1,017 commits)
+#   - XL:     rails/rails (~97,000 commits)
 #
 # This harness requires network access to clone repositories from GitHub.
 
@@ -224,6 +225,53 @@ if [[ $actual -ge $((expected_commits - 50)) ]] && [[ $actual -le $((expected_co
     _pass "change count roughly matches ($actual vs $expected_commits)"
 else
     _fail "change count matches" "expected ~$expected_commits, got $actual"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+# Section 8b: Extra Large Repo Performance (rails/rails ~97k commits)
+# ════════════════════════════════════════════════════════════════════════════
+
+begin_section "Git Import: XL Repo Performance (rails — ~97k commits)"
+
+make_temp_repo "git-import-xl"
+
+echo "  Cloning rails/rails (this may take a few minutes)..."
+clone_git_repo "https://github.com/rails/rails.git"
+cd "$GIT_REPO_DIR"
+
+expected_commits="$(git_commit_count)"
+echo "  Found $expected_commits commits"
+
+start_time=$(date +%s)
+atomic git import >/dev/null 2>&1
+end_time=$(date +%s)
+duration=$((end_time - start_time))
+
+assert_success "import completed" true
+echo "  Import took ${duration}s"
+
+# Should complete in reasonable time (< 30 minutes)
+if [[ $duration -lt 1800 ]]; then
+    _pass "import completed in reasonable time (<30min)"
+else
+    _fail "import completed in reasonable time" "took ${duration}s"
+fi
+
+# Verify counts match (with tolerance for merge handling)
+actual="$(atomic log 2>/dev/null | grep -cE '^\s*#[0-9]+|^[0-9a-f]{8,}' 2>/dev/null || true)"
+actual="${actual:-0}"
+actual="$(echo "$actual" | tr -d '[:space:]')"
+[[ -z "$actual" ]] && actual=0
+if [[ $actual -ge $((expected_commits - 500)) ]] && [[ $actual -le $((expected_commits + 500)) ]]; then
+    _pass "change count roughly matches ($actual vs $expected_commits)"
+else
+    _fail "change count matches" "expected ~$expected_commits, got $actual"
+fi
+
+# Report throughput
+if [[ $duration -gt 0 ]]; then
+    throughput=$((expected_commits / duration))
+    echo "  Throughput: ~${throughput} commits/s"
 fi
 
 # ════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Key changes:
- Add `record_direct()` to Repository: bypasses `status()` and filesystem reads entirely. Content is fed from an in-memory `Memory` working copy, with old content optionally provided by the caller (avoiding expensive graph traversal via `get_file_content_via_overlay()`).

- Add `DirectFileChange`/`DirectFileOp` types for pre-computed file changes.

- Rewrite `write_commit()` to read content from git's object store (mmap'd packfiles) and feed directly to `record_direct()`. No `checkout_tree`, no `status()`, no `std::fs::read/write`.

- Add batched processing with configurable `--batch-size` (default 5000). Memory is bounded to one batch of metadata regardless of repo size.

- Add checkpoint-based resumability via `.atomic/git-import-checkpoint.json`. Interrupted imports resume from the last completed batch.

- Add `indicatif` progress bar with ETA, batch indicators, and large commit warnings. Spinner during initial commit collection.

- Thread-local `git2::Repository` reuse in Phase 1 rayon workers.

- Fix pre-existing test harness bugs: branch name resolution before checkout, and `set -e` compatibility for expected-failure tests.