### PR TITLE
Add tenant support and authorized push functionality

### DIFF
--- a/atomic-cli/src/commands/auth.rs
+++ b/atomic-cli/src/commands/auth.rs
@@ -1,0 +1,151 @@
+//! Shared authentication helpers for remote commands.
+//!
+//! Resolves the caller's identity from the remote URL and builds
+//! the `Authorization: Bearer` header for authenticated requests.
+//!
+//! Identity resolution order:
+//! 1. URL userinfo — `http://bob@alice.localhost:8080/...` → identity "bob"
+//! 2. Subdomain — `http://alice.localhost:8080/...` → identity "alice"
+
+use atomic_identity::IdentityStore;
+use atomic_remote::HttpRemoteConfig;
+use url::Url;
+
+/// Attach a Bearer auth header to the remote config by resolving the
+/// identity from the URL.
+///
+/// If the identity cannot be resolved (no userinfo, no subdomain, or
+/// identity not found in the store), the config is returned unmodified
+/// and a debug log is emitted. This keeps push/pull/clone working
+/// against servers that don't require auth.
+pub fn attach_identity(config: HttpRemoteConfig, remote_url: &str) -> HttpRemoteConfig {
+    let identity_name = match resolve_identity_name(remote_url) {
+        Some(name) => name,
+        None => {
+            log::debug!("No identity resolvable from URL: {}", remote_url);
+            return config;
+        }
+    };
+
+    log::debug!("Resolved identity name: {}", identity_name);
+
+    let store = match IdentityStore::open_default() {
+        Ok(s) => s,
+        Err(e) => {
+            log::debug!("Failed to open identity store: {}", e);
+            return config;
+        }
+    };
+
+    let identity = match store.load_by_name(&identity_name) {
+        Ok(id) => id,
+        Err(e) => {
+            log::debug!("Identity '{}' not found in store: {}", identity_name, e);
+            return config;
+        }
+    };
+
+    let public_key_b32 = identity.public_key_base32();
+    log::debug!("Attaching Bearer auth for identity '{}'", identity_name);
+
+    config.with_header("Authorization", format!("Bearer {}", public_key_b32))
+}
+
+/// Extract the identity name from a remote URL.
+///
+/// Tries URL userinfo first (`bob@host`), then the subdomain (`bob.host`).
+fn resolve_identity_name(remote_url: &str) -> Option<String> {
+    let url = Url::parse(remote_url).ok()?;
+
+    // 1. Explicit: http://bob@alice.localhost:8080/...
+    let username = url.username();
+    if !username.is_empty() {
+        return Some(username.to_string());
+    }
+
+    // 2. Implicit: http://alice.localhost:8080/... → "alice"
+    extract_subdomain(url.host_str()?)
+}
+
+/// Extract the first subdomain label from a host string.
+///
+/// `"alice.localhost"` → `Some("alice")`
+/// `"alice.atomic.storage"` → `Some("alice")`
+/// `"localhost"` → `None`
+fn extract_subdomain(host: &str) -> Option<String> {
+    // Strip port if somehow present (Url should have parsed it out, but be safe).
+    let host = host.split(':').next().unwrap_or(host);
+
+    let dot_pos = host.find('.')?;
+    let subdomain = &host[..dot_pos];
+
+    if subdomain.is_empty() {
+        return None;
+    }
+
+    Some(subdomain.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn userinfo_takes_priority() {
+        let name =
+            resolve_identity_name("http://bob@alice.localhost:8080/workspaces/w/projects/p/code");
+        assert_eq!(name.as_deref(), Some("bob"));
+    }
+
+    #[test]
+    fn subdomain_fallback() {
+        let name =
+            resolve_identity_name("http://alice.localhost:8080/workspaces/w/projects/p/code");
+        assert_eq!(name.as_deref(), Some("alice"));
+    }
+
+    #[test]
+    fn full_domain_subdomain() {
+        let name =
+            resolve_identity_name("https://alice.atomic.storage/workspaces/w/projects/p/code");
+        assert_eq!(name.as_deref(), Some("alice"));
+    }
+
+    #[test]
+    fn no_subdomain_returns_none() {
+        let name = resolve_identity_name("http://localhost:8080/workspaces/w/projects/p/code");
+        assert_eq!(name, None);
+    }
+
+    #[test]
+    fn invalid_url_returns_none() {
+        let name = resolve_identity_name("not a url");
+        assert_eq!(name, None);
+    }
+
+    #[test]
+    fn extract_subdomain_simple() {
+        assert_eq!(
+            extract_subdomain("alice.localhost"),
+            Some("alice".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_subdomain_nested() {
+        assert_eq!(
+            extract_subdomain("alice.atomic.storage"),
+            Some("alice".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_subdomain_bare() {
+        assert_eq!(extract_subdomain("localhost"), None);
+    }
+
+    #[test]
+    fn extract_subdomain_empty_label() {
+        assert_eq!(extract_subdomain(".localhost"), None);
+    }
+}

--- a/atomic-cli/src/commands/clone/command.rs
+++ b/atomic-cli/src/commands/clone/command.rs
@@ -201,9 +201,11 @@ impl Clone {
     /// Creates an `HttpRemoteConfig` with the timeout and security settings
     /// specified by the user.
     fn build_remote_config(&self) -> HttpRemoteConfig {
-        HttpRemoteConfig::new()
+        let config = HttpRemoteConfig::new()
             .with_timeout(Duration::from_secs(self.timeout))
-            .danger_accept_invalid_certs(self.insecure)
+            .danger_accept_invalid_certs(self.insecure);
+
+        crate::commands::auth::attach_identity(config, &self.url)
     }
 
     /// Get the display name for the repository.

--- a/atomic-cli/src/commands/identity/mod.rs
+++ b/atomic-cli/src/commands/identity/mod.rs
@@ -41,6 +41,7 @@
 pub mod delete;
 pub mod list;
 pub mod new;
+pub mod register;
 pub mod show;
 pub mod whoami;
 
@@ -48,6 +49,7 @@ pub mod whoami;
 pub use delete::Delete;
 pub use list::List;
 pub use new::New;
+pub use register::Register;
 pub use show::Show;
 pub use whoami::WhoAmI;
 
@@ -178,6 +180,23 @@ pub enum IdentityCommands {
     /// ```
     #[command(name = "whoami")]
     WhoAmI(WhoAmI),
+
+    /// Register an identity with a remote atomic-storage server.
+    ///
+    /// Pushes the local identity to a server, creating a tenant whose
+    /// slug is derived from the username. Authentication is Ed25519
+    /// signature-based — no passwords required.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// # Register with the default identity
+    /// atomic identity register https://atomic.storage
+    ///
+    /// # Register a specific identity
+    /// atomic identity register https://atomic.storage --identity alice-work
+    /// ```
+    Register(Register),
 }
 
 impl Command for Identity {
@@ -189,6 +208,7 @@ impl Command for Identity {
             IdentityCommands::Default(cmd) => cmd.run(),
             IdentityCommands::Delete(cmd) => cmd.run(),
             IdentityCommands::WhoAmI(cmd) => cmd.run(),
+            IdentityCommands::Register(cmd) => cmd.run(),
         }
     }
 }

--- a/atomic-cli/src/commands/identity/register.rs
+++ b/atomic-cli/src/commands/identity/register.rs
@@ -68,8 +68,8 @@ pub struct Register {
     /// will be called automatically.
     ///
     /// Examples:
-    ///   https://atomic.storage
-    ///   http://localhost:8080
+    ///   <https://atomic.storage>
+    ///   <http://localhost:8080>
     #[arg(required = true)]
     pub server_url: String,
 

--- a/atomic-cli/src/commands/identity/register.rs
+++ b/atomic-cli/src/commands/identity/register.rs
@@ -174,6 +174,10 @@ impl Register {
             // The server wraps the response in ApiResponse { success, data, ... }
             let data = result.get("data").unwrap_or(&result);
 
+            let tenant_id = data
+                .get("tenant_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("(unknown)");
             let slug = data
                 .get("slug")
                 .and_then(|v| v.as_str())
@@ -185,9 +189,10 @@ impl Register {
 
             print_success(&format!("Registered as {slug}"));
             println!();
-            println!("  Tenant:   {slug}");
-            println!("  URL:      {base_url}");
-            println!("  Identity: {} ({})", identity.name, identity.id.short());
+            println!("  Tenant ID: {tenant_id}");
+            println!("  Slug:      {slug}");
+            println!("  URL:       {base_url}");
+            println!("  Identity:  {} ({})", identity.name, identity.id.short());
 
             if slug != username {
                 println!();

--- a/atomic-cli/src/commands/identity/register.rs
+++ b/atomic-cli/src/commands/identity/register.rs
@@ -1,0 +1,304 @@
+//! The `identity register` command for registering with an atomic-storage server.
+//!
+//! This module implements the `atomic identity register` command, which pushes
+//! the user's local identity to a remote atomic-storage server to create a
+//! tenant. The server verifies the Ed25519 signature and creates a tenant
+//! whose slug is derived from the identity's username.
+//!
+//! # Usage
+//!
+//! ```text
+//! atomic identity register <SERVER_URL> [OPTIONS]
+//!
+//! Arguments:
+//!   <SERVER_URL>  URL of the atomic-storage server (e.g. https://atomic.storage)
+//!
+//! Options:
+//!   -i, --identity <NAME>  Identity to register (defaults to current default)
+//!   -h, --help             Print help information
+//! ```
+//!
+//! # Examples
+//!
+//! ```text
+//! # Register with the default identity
+//! $ atomic identity register https://atomic.storage
+//! ✓ Registered as alice
+//!   Tenant:   alice
+//!   URL:      https://alice.atomic.storage
+//!
+//! # Register a specific identity
+//! $ atomic identity register https://atomic.storage --identity alice-work
+//! ```
+//!
+//! # Protocol
+//!
+//! The command constructs a signed registration payload:
+//!
+//! 1. Loads the identity and its Ed25519 keypair from local storage
+//! 2. Builds a canonical signing payload:
+//!    `atomic-storage:register\n{username}\n{public_key_base32}\n{timestamp}`
+//! 3. Signs the payload with the identity's secret key
+//! 4. POSTs the request to `{server_url}/register`
+//! 5. Displays the server's response (tenant slug, base URL)
+
+use chrono::Utc;
+use clap::Parser;
+use data_encoding::BASE32_NOPAD;
+
+use atomic_identity::IdentityStore;
+
+use crate::commands::Command;
+use crate::error::{CliError, CliResult};
+use crate::output::{print_error, print_success};
+
+/// Signing domain prefix — must match the server's `registration.rs`.
+const SIGNING_DOMAIN: &str = "atomic-storage:register";
+
+/// Register an identity with a remote atomic-storage server.
+///
+/// Pushes the local identity to the server, which creates a tenant
+/// whose slug is derived from the identity's username. Authentication
+/// is Ed25519 signature-based — no passwords required.
+#[derive(Debug, Parser)]
+pub struct Register {
+    /// URL of the atomic-storage server.
+    ///
+    /// The server must be running and reachable. The `/register` endpoint
+    /// will be called automatically.
+    ///
+    /// Examples:
+    ///   https://atomic.storage
+    ///   http://localhost:8080
+    #[arg(required = true)]
+    pub server_url: String,
+
+    /// Name of the identity to register.
+    ///
+    /// If not specified, the current default identity is used.
+    #[arg(short, long)]
+    pub identity: Option<String>,
+}
+
+impl Command for Register {
+    fn run(&self) -> CliResult<()> {
+        // We need async for the HTTP request. Build a one-shot runtime
+        // rather than depending on the caller being inside tokio.
+        let rt = tokio::runtime::Runtime::new().map_err(|e| {
+            CliError::Internal(anyhow::anyhow!("Failed to create async runtime: {e}"))
+        })?;
+
+        rt.block_on(self.execute())
+    }
+}
+
+impl Register {
+    async fn execute(&self) -> CliResult<()> {
+        // 1. Open the identity store.
+        let store = IdentityStore::open_default().map_err(|e| {
+            CliError::Internal(anyhow::anyhow!("Failed to open identity store: {e}"))
+        })?;
+
+        // 2. Load the identity.
+        let identity = if let Some(name) = &self.identity {
+            store
+                .load_by_name(name)
+                .map_err(|_| CliError::IdentityNotFound(name.clone()))?
+        } else {
+            store
+                .get_default()
+                .map_err(|e| {
+                    CliError::Internal(anyhow::anyhow!("Failed to load default identity: {e}"))
+                })?
+                .ok_or_else(|| {
+                    CliError::Internal(anyhow::anyhow!(
+                        "No default identity set. Create one first:\n  \
+                         atomic identity new <name> --email <email> --set-default"
+                    ))
+                })?
+        };
+
+        // 3. Load the keypair (needs the secret key for signing).
+        let keypair = store.load_keypair(&identity.id, None).map_err(|e| {
+            CliError::Internal(anyhow::anyhow!(
+                "Failed to load keypair for '{}': {e}",
+                identity.name
+            ))
+        })?;
+
+        // 4. Build the registration payload.
+        let username = &identity.name;
+        let public_key_b32 = identity.public_key_base32();
+        let timestamp = Utc::now();
+        let timestamp_str = timestamp.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+
+        // 5. Build and sign the canonical payload.
+        let payload = format!("{SIGNING_DOMAIN}\n{username}\n{public_key_b32}\n{timestamp_str}");
+        let signature_bytes = keypair.sign(payload.as_bytes());
+        let signature_b32 = BASE32_NOPAD.encode(&signature_bytes);
+
+        // 6. Construct the JSON request body.
+        let body = serde_json::json!({
+            "username": username,
+            "email": identity.email,
+            "public_key": public_key_b32,
+            "timestamp": timestamp_str,
+            "signature": signature_b32,
+        });
+
+        // 7. POST to the server.
+        let url = format!("{}/register", self.server_url.trim_end_matches('/'));
+
+        let client = reqwest::Client::new();
+        let response = client
+            .post(&url)
+            .json(&body)
+            .header("Content-Type", "application/json")
+            .send()
+            .await
+            .map_err(|e| CliError::RemoteError {
+                message: format!("Failed to connect to server: {e}"),
+                url: Some(url.clone()),
+            })?;
+
+        let status = response.status();
+        let response_text = response.text().await.map_err(|e| {
+            CliError::Internal(anyhow::anyhow!("Failed to read response body: {e}"))
+        })?;
+
+        // 8. Handle the response.
+        if status.is_success() {
+            let result: serde_json::Value = serde_json::from_str(&response_text)
+                .map_err(|e| CliError::Internal(anyhow::anyhow!("Invalid server response: {e}")))?;
+
+            // The server wraps the response in ApiResponse { success, data, ... }
+            let data = result.get("data").unwrap_or(&result);
+
+            let slug = data
+                .get("slug")
+                .and_then(|v| v.as_str())
+                .unwrap_or(username);
+            let base_url = data
+                .get("base_url")
+                .and_then(|v| v.as_str())
+                .unwrap_or("(unknown)");
+
+            print_success(&format!("Registered as {slug}"));
+            println!();
+            println!("  Tenant:   {slug}");
+            println!("  URL:      {base_url}");
+            println!("  Identity: {} ({})", identity.name, identity.id.short());
+
+            if slug != username {
+                println!();
+                println!(
+                    "  {}",
+                    crate::output::hint(format!(
+                        "Note: slug '{slug}' differs from username '{username}' \
+                         (normalized or collision-resolved)"
+                    ))
+                );
+            }
+
+            println!();
+            println!("{}", crate::output::hint("Next steps:"));
+            println!(
+                "  {}  Push a project",
+                crate::output::command("atomic push")
+            );
+            println!(
+                "  {}  Clone from the server",
+                crate::output::command(format!("atomic clone {base_url}/<project>"))
+            );
+        } else {
+            // Parse error response.
+            let error_msg = serde_json::from_str::<serde_json::Value>(&response_text)
+                .ok()
+                .and_then(|v| {
+                    // Try ApiError shape: { code, message }
+                    v.get("message")
+                        .and_then(|m| m.as_str())
+                        .map(String::from)
+                        .or_else(|| {
+                            // Try ApiResponse shape: { error: { message } }
+                            v.get("error")
+                                .and_then(|e| e.get("message"))
+                                .and_then(|m| m.as_str())
+                                .map(String::from)
+                        })
+                })
+                .unwrap_or_else(|| format!("Server returned {status}"));
+
+            print_error(&format!("Registration failed: {error_msg}"));
+
+            if status.as_u16() == 409 {
+                println!();
+                println!(
+                    "  {}",
+                    crate::output::hint(
+                        "This public key is already registered. \
+                         Use a different identity or contact support."
+                    )
+                );
+            }
+
+            return Err(CliError::RemoteError {
+                message: error_msg,
+                url: Some(url),
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signing_payload_format() {
+        let username = "alice";
+        let public_key = "ABCDEF1234567890";
+        let timestamp = "2025-03-26T17:00:00Z";
+
+        let payload = format!("{SIGNING_DOMAIN}\n{username}\n{public_key}\n{timestamp}");
+        assert_eq!(
+            payload,
+            "atomic-storage:register\nalice\nABCDEF1234567890\n2025-03-26T17:00:00Z"
+        );
+    }
+
+    #[test]
+    fn server_url_trailing_slash_stripped() {
+        let url_with_slash = "https://atomic.storage/";
+        let url_without_slash = "https://atomic.storage";
+
+        let endpoint_a = format!("{}/register", url_with_slash.trim_end_matches('/'));
+        let endpoint_b = format!("{}/register", url_without_slash.trim_end_matches('/'));
+
+        assert_eq!(endpoint_a, "https://atomic.storage/register");
+        assert_eq!(endpoint_b, "https://atomic.storage/register");
+    }
+
+    #[test]
+    fn command_fields() {
+        let cmd = Register {
+            server_url: "http://localhost:8080".to_string(),
+            identity: Some("alice".to_string()),
+        };
+
+        assert_eq!(cmd.server_url, "http://localhost:8080");
+        assert_eq!(cmd.identity, Some("alice".to_string()));
+    }
+
+    #[test]
+    fn command_default_identity() {
+        let cmd = Register {
+            server_url: "http://localhost:8080".to_string(),
+            identity: None,
+        };
+
+        assert!(cmd.identity.is_none());
+    }
+}

--- a/atomic-cli/src/commands/mod.rs
+++ b/atomic-cli/src/commands/mod.rs
@@ -89,6 +89,7 @@ pub mod unrecord;
 pub mod agent;
 
 // Phase 3: Remote Commands
+pub mod auth;
 pub mod clone;
 pub mod pull;
 pub mod push;

--- a/atomic-cli/src/commands/pull/command.rs
+++ b/atomic-cli/src/commands/pull/command.rs
@@ -275,10 +275,12 @@ impl Pull {
     ///
     /// Creates an `HttpRemoteConfig` with the timeout and security settings
     /// specified by the user.
-    fn build_remote_config(&self) -> HttpRemoteConfig {
-        HttpRemoteConfig::new()
+    fn build_remote_config(&self, remote_url: &str) -> HttpRemoteConfig {
+        let config = HttpRemoteConfig::new()
             .with_timeout(Duration::from_secs(self.timeout))
-            .danger_accept_invalid_certs(self.insecure)
+            .danger_accept_invalid_certs(self.insecure);
+
+        crate::commands::auth::attach_identity(config, remote_url)
     }
 
     /// Display the dry run preview.
@@ -366,7 +368,7 @@ impl Pull {
 
         // Connect to remote
         let spinner = create_spinner("Connecting to remote...");
-        let config = self.build_remote_config();
+        let config = self.build_remote_config(&remote_url);
         let remote = HttpRemote::with_config(&remote_url, config).map_err(|e| {
             finish_error(&spinner, "Failed to connect");
             convert_remote_error(e, &remote_url)
@@ -756,7 +758,7 @@ mod tests {
     #[test]
     fn test_build_remote_config_default() {
         let pull = Pull::new();
-        let config = pull.build_remote_config();
+        let config = pull.build_remote_config("http://test.localhost:8080/code");
 
         // HttpRemoteConfig doesn't expose fields directly, so we just verify
         // it doesn't panic and returns something
@@ -767,7 +769,7 @@ mod tests {
     #[test]
     fn test_build_remote_config_custom_timeout() {
         let pull = Pull::new().with_timeout(120);
-        let config = pull.build_remote_config();
+        let config = pull.build_remote_config("http://test.localhost:8080/code");
         assert!(std::mem::size_of_val(&config) > 0);
     }
 
@@ -775,7 +777,7 @@ mod tests {
     #[test]
     fn test_build_remote_config_insecure() {
         let pull = Pull::new().with_insecure(true);
-        let config = pull.build_remote_config();
+        let config = pull.build_remote_config("http://test.localhost:8080/code");
         assert!(std::mem::size_of_val(&config) > 0);
     }
 

--- a/atomic-cli/src/commands/push/command.rs
+++ b/atomic-cli/src/commands/push/command.rs
@@ -249,10 +249,12 @@ impl Push {
     }
 
     /// Build the HTTP remote configuration.
-    fn build_remote_config(&self) -> HttpRemoteConfig {
-        HttpRemoteConfig::new()
+    fn build_remote_config(&self, remote_url: &str) -> HttpRemoteConfig {
+        let config = HttpRemoteConfig::new()
             .with_timeout(Duration::from_secs(self.timeout))
-            .danger_accept_invalid_certs(self.insecure)
+            .danger_accept_invalid_certs(self.insecure);
+
+        crate::commands::auth::attach_identity(config, remote_url)
     }
 
     /// Display the dry run preview.
@@ -310,7 +312,7 @@ impl Push {
 
         // Connect to remote
         let spinner = create_spinner("Connecting to remote...");
-        let config = self.build_remote_config();
+        let config = self.build_remote_config(&remote_url);
         let remote = HttpRemote::with_config(&remote_url, config).map_err(|e| {
             finish_error(&spinner, "Failed to connect");
             convert_remote_error(e, &remote_url)
@@ -871,7 +873,7 @@ mod tests {
     #[test]
     fn test_build_remote_config_default() {
         let push = Push::new();
-        let config = push.build_remote_config();
+        let config = push.build_remote_config("http://test.localhost:8080/code");
 
         assert_eq!(config.timeout, Duration::from_secs(DEFAULT_TIMEOUT_SECS));
         assert!(!config.danger_accept_invalid_certs);
@@ -880,7 +882,7 @@ mod tests {
     #[test]
     fn test_build_remote_config_custom_timeout() {
         let push = Push::new().with_timeout(120);
-        let config = push.build_remote_config();
+        let config = push.build_remote_config("http://test.localhost:8080/code");
 
         assert_eq!(config.timeout, Duration::from_secs(120));
     }
@@ -888,7 +890,7 @@ mod tests {
     #[test]
     fn test_build_remote_config_insecure() {
         let push = Push::new().with_insecure(true);
-        let config = push.build_remote_config();
+        let config = push.build_remote_config("http://test.localhost:8080/code");
 
         assert!(config.danger_accept_invalid_certs);
     }


### PR DESCRIPTION
This pull request adds support for registering user identities with a remote atomic-storage server and introduces shared authentication helpers for remote commands. It also refactors the way authentication is attached to remote configs for clone, pull, and push commands, ensuring that identity-based Bearer authentication is consistently applied when possible. The most important changes are summarized below:

**New Feature: Identity Registration**

* Adds the `identity register` command, allowing users to register their local identity with a remote atomic-storage server via a signed Ed25519 payload. This includes the new `register.rs` implementation, command wiring, and documentation. [[1]](diffhunk://#diff-04cdcbe4dc98ba8c71a5c416d646a63ffee67e29426c3187d88139b120d79f74R1-R309) [[2]](diffhunk://#diff-4ba7352b14988bfa4199b1c70ed2ea6cb61501f1b2073b5acebf2764ed737f43R44-R52) [[3]](diffhunk://#diff-4ba7352b14988bfa4199b1c70ed2ea6cb61501f1b2073b5acebf2764ed737f43R183-R199) [[4]](diffhunk://#diff-4ba7352b14988bfa4199b1c70ed2ea6cb61501f1b2073b5acebf2764ed737f43R211)

**Authentication Infrastructure**

* Introduces a shared `auth` module containing helpers to resolve the user's identity from a remote URL (via userinfo or subdomain) and attach a Bearer token to HTTP requests. This logic is now used by clone, pull, and push commands to automatically authenticate when possible. [[1]](diffhunk://#diff-6e778c8402ecf160cc321f78f454a85e612b9d4372c475e257932c6aa7001e33R1-R151) [[2]](diffhunk://#diff-20c162e1185710242f9838bee1a8985cd4ac31c015572d29f6c1013b08065d77R92)

**Remote Command Refactoring**

* Refactors the `build_remote_config` methods in `clone`, `pull`, and `push` commands to use the new authentication helpers, ensuring Bearer authentication is attached based on the URL and available identities. Updates related tests to pass the remote URL as a parameter. [[1]](diffhunk://#diff-8ace27124ebe2af933665aa1062ab2b4e8c5ff0edfdff2aff739aa4622e7b120L204-R208) [[2]](diffhunk://#diff-200a6dea863b546486d79cf44cb84ea3c903204775b9853397bb84c2674d9fa7L278-R283) [[3]](diffhunk://#diff-200a6dea863b546486d79cf44cb84ea3c903204775b9853397bb84c2674d9fa7L369-R371) [[4]](diffhunk://#diff-200a6dea863b546486d79cf44cb84ea3c903204775b9853397bb84c2674d9fa7L759-R761) [[5]](diffhunk://#diff-200a6dea863b546486d79cf44cb84ea3c903204775b9853397bb84c2674d9fa7L770-R780) [[6]](diffhunk://#diff-4c5fd7eff477f720945af550bcc28b407a7f53637260fd9d5642ccb94edb9cc3L252-R257) [[7]](diffhunk://#diff-4c5fd7eff477f720945af550bcc28b407a7f53637260fd9d5642ccb94edb9cc3L313-R315) [[8]](diffhunk://#diff-4c5fd7eff477f720945af550bcc28b407a7f53637260fd9d5642ccb94edb9cc3L874-R876)