### PR TITLE
fix: server-side push — shared stacks, Arc<Pristine> caching, and apply debug logging

### DIFF
--- a/atomic-repository/src/apply.rs
+++ b/atomic-repository/src/apply.rs
@@ -563,6 +563,11 @@ pub fn apply_change_to_graph<T: MutTxnT + StackTxnT>(
         true
     };
 
+    log::debug!(
+        "apply_change_to_graph: change_id={:?} hash={} should_apply_hunks={} target={:?} stack_kind={:?}",
+        change_id, change_hash.to_base32(), should_apply_hunks, apply_target, stack.kind
+    );
+
     if should_apply_hunks {
         // Process each graph_op (graph layer)
         for graph_op in change.hunks() {

--- a/atomic-repository/src/repository/apply.rs
+++ b/atomic-repository/src/repository/apply.rs
@@ -125,9 +125,21 @@ impl Repository {
             .get_internal(hash)
             .map_err(|e| RepositoryError::Database(e.to_string()))?
         {
-            txn.has_change_in_graph(node_id)
-                .map_err(|e| RepositoryError::Database(e.to_string()))?
+            let in_graph = txn
+                .has_change_in_graph(node_id)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+            log::debug!(
+                "apply_change: hash={} node_id={:?} already_in_graph={}",
+                hash.to_base32(),
+                node_id,
+                in_graph
+            );
+            in_graph
         } else {
+            log::debug!(
+                "apply_change: hash={} not in INTERNAL (new change)",
+                hash.to_base32()
+            );
             false
         };
 
@@ -140,6 +152,13 @@ impl Repository {
 
         // Determine which stack to use
         let stack_name = options.stack.as_deref().unwrap_or(&self.current_stack);
+        log::debug!(
+            "apply_change: change_id={:?} stack={} already_in_graph={} hunks={}",
+            change_id,
+            stack_name,
+            already_in_graph,
+            change.hunks().len()
+        );
 
         // Populate tree tables for FileAdd/DirAdd/FileDel hunks.
         // This creates the path→inode→position mappings that output_working_copy

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -327,9 +327,13 @@ pub struct Repository {
     dot_dir: PathBuf,
     /// Current stack name
     current_stack: String,
-    /// The pristine database handle (shared via Arc so that multiple
-    /// `Repository` instances for the same project reuse the same redb
-    /// `Database`, avoiding stale-snapshot bugs).
+    /// The pristine database handle.
+    ///
+    /// Wrapped in `Arc` so that multiple `Repository` instances _can_
+    /// share the same underlying redb `Database` and avoid stale-snapshot
+    /// bugs. In practice, sharing only happens when constructing via
+    /// `open_with_pristine`; `open` / `open_readonly` create a fresh
+    /// `Pristine` for each `Repository`.
     pristine: Arc<Pristine>,
     /// The change store for persisting changes
     change_store: ChangeStore,
@@ -529,6 +533,14 @@ default = "{}"
     /// the same project.  Sharing the handle ensures every write transaction
     /// sees the committed state of prior transactions — opening a fresh
     /// `Database` per request can see stale snapshots.
+    ///
+    /// # Requirements
+    ///
+    /// The provided `pristine` **must** have been opened from
+    /// `<path>/.atomic/pristine.redb` (i.e. the same repository that
+    /// `path` resolves to). Passing a `Pristine` from a different
+    /// repository will silently couple one repo's configuration and
+    /// change store with another repo's database, leading to corruption.
     pub fn open_with_pristine<P: AsRef<Path>>(
         path: P,
         pristine: Arc<Pristine>,

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -1109,6 +1109,41 @@ default = "{}"
         Ok(())
     }
 
+    /// Create a new Shared stack with no parent.
+    ///
+    /// Edges written to a Shared stack go into the global `GRAPH` table and
+    /// are permanently visible to all stacks. This is the correct kind to use
+    /// for server-side push targets, where changes must be universally visible
+    /// regardless of which run or request applies them.
+    ///
+    /// Returns `StackAlreadyExists` if the stack already exists.
+    pub fn create_shared_stack(&mut self, name: &str) -> Result<(), RepositoryError> {
+        ensure_workspace_dir(&self.dot_dir, name)?;
+
+        let mut txn = self
+            .pristine
+            .write_txn()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        if txn
+            .get_stack(name)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+            .is_some()
+        {
+            return Err(RepositoryError::StackAlreadyExists {
+                name: name.to_string(),
+            });
+        }
+
+        txn.create_stack(name, StackKind::Shared, None)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        txn.commit()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        Ok(())
+    }
+
     /// Walk the parent chain from `stack_name` and return the name of the
     /// first Shared stack encountered.  If `stack_name` is itself Shared,
     /// it is returned immediately.  This is used to determine the correct

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -39,6 +39,7 @@
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use atomic_core::change::{Author, Change, ChangeHeader, GraphOp};
 use atomic_core::output::repo::{
@@ -326,8 +327,10 @@ pub struct Repository {
     dot_dir: PathBuf,
     /// Current stack name
     current_stack: String,
-    /// The pristine database handle
-    pristine: Pristine,
+    /// The pristine database handle (shared via Arc so that multiple
+    /// `Repository` instances for the same project reuse the same redb
+    /// `Database`, avoiding stale-snapshot bugs).
+    pristine: Arc<Pristine>,
     /// The change store for persisting changes
     change_store: ChangeStore,
 }
@@ -393,8 +396,10 @@ default = "{}"
         std::fs::write(&wc_id_path, "")?;
 
         // Initialize the pristine database (redb creates the file)
-        let pristine = Pristine::open(dot_dir.join("pristine.redb"))
-            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        let pristine = Arc::new(
+            Pristine::open(dot_dir.join("pristine.redb"))
+                .map_err(|e| RepositoryError::Database(e.to_string()))?,
+        );
 
         // Create the default stack and its workspace directory
         {
@@ -438,8 +443,10 @@ default = "{}"
         let dot_dir = root.join(DOT_DIR);
 
         // Open the pristine database
-        let pristine = Pristine::open(dot_dir.join("pristine.redb"))
-            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        let pristine = Arc::new(
+            Pristine::open(dot_dir.join("pristine.redb"))
+                .map_err(|e| RepositoryError::Database(e.to_string()))?,
+        );
 
         // Read current stack from config or use default
         let current_stack =
@@ -493,14 +500,45 @@ default = "{}"
         let dot_dir = root.join(DOT_DIR);
 
         // Open the pristine database in read-only mode
-        let pristine = Pristine::open_readonly(dot_dir.join("pristine.redb"))
-            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        let pristine = Arc::new(
+            Pristine::open_readonly(dot_dir.join("pristine.redb"))
+                .map_err(|e| RepositoryError::Database(e.to_string()))?,
+        );
 
         // Read current stack from config or use default
         let current_stack =
             Self::read_current_stack(&dot_dir).unwrap_or_else(|_| DEFAULT_STACK.to_string());
 
         // Open the change store
+        let change_store = ChangeStore::new(dot_dir.join("changes"), DEFAULT_CACHE_CAPACITY)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        Ok(Self {
+            root,
+            dot_dir,
+            current_stack,
+            pristine,
+            change_store,
+        })
+    }
+
+    /// Open an existing repository using a pre-opened `Pristine`.
+    ///
+    /// This constructor is used by the storage server to share a single
+    /// `Pristine` (redb `Database`) handle across concurrent requests to
+    /// the same project.  Sharing the handle ensures every write transaction
+    /// sees the committed state of prior transactions — opening a fresh
+    /// `Database` per request can see stale snapshots.
+    pub fn open_with_pristine<P: AsRef<Path>>(
+        path: P,
+        pristine: Arc<Pristine>,
+    ) -> Result<Self, RepositoryError> {
+        let root = Self::find_root(path.as_ref())?;
+        let dot_dir = root.join(DOT_DIR);
+
+        let current_stack =
+            Self::read_current_stack(&dot_dir).unwrap_or_else(|_| DEFAULT_STACK.to_string());
+
         let change_store = ChangeStore::new(dot_dir.join("changes"), DEFAULT_CACHE_CAPACITY)
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
 


### PR DESCRIPTION
## Summary

- Add `Repository::create_shared_stack(name)` for server-side push targets that need edges in the global `GRAPH`
- Wrap `Pristine` in `Arc` so multiple `Repository` instances can share a single redb `Database` handle
- Add `Repository::open_with_pristine(path, Arc<Pristine>)` constructor for server-side pristine caching
- Add `log::debug!` statements in the apply path for diagnosing dependency resolution

## Problem

Server-side push handlers (`atomic-storage`, `atomic-api`) call `create_stack()` when a client pushes to a new stack. This creates the stack as `StackKind::Local`, routing all vertices/edges to `STACK_GRAPH[stack_id]` — an isolated per-stack overlay.

This causes failures when:
1. The same change hash is pushed across multiple runs (retries, multi-client scenarios, load tests)
2. A prior run applied the change to a different Local stack (different `stack_id`)
3. The new run's apply finds the change registered in INTERNAL but can't locate its vertices — they're in the old stack's `STACK_GRAPH`, not the global `GRAPH`
4. Result: `Block not found at position` → cascading `Missing dependencies` errors

Additionally, opening a fresh `Pristine` (redb `Database`) per HTTP request means each request gets an independent database handle. Sharing a single handle via `Arc<Pristine>` ensures write transactions are properly serialized and reads always see the latest committed state.

## Changes

### Commit 1: `create_shared_stack()`

New method on `Repository` that creates a `StackKind::Shared` stack with no parent. Shared stacks write edges to the global `GRAPH` table, making changes permanently visible to all stacks — the correct behavior for server-side push targets.

### Commit 2: `Arc<Pristine>` + `open_with_pristine()` + debug logging

- `pristine` field changed from `Pristine` to `Arc<Pristine>` — allows multiple `Repository` instances for the same project to share one redb `Database`
- `open_with_pristine(path, Arc<Pristine>)` — new constructor for server-side use where a shared pristine cache is maintained across requests
- Debug log statements in `apply_change` and `apply_change_to_graph` showing `already_in_graph`, `should_apply_hunks`, stack kind, and dependency resolution state
