### PR TITLE
Improve roundtrip fidelity and optimize Git import process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-agent"
-version = "0.5.1"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "atomic-core",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-cli"
-version = "0.5.1"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "atomic-agent",
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-config"
-version = "0.5.1"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "dirs",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-core"
-version = "0.5.1"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -206,7 +206,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-identity"
-version = "0.5.1"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "atomic-config",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-remote"
-version = "0.5.1"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-repository"
-version = "0.5.1"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "atomic-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.3"
 edition = "2021"
 authors = ["Atomic Contributors"]
 license = "Apache-2.0"

--- a/atomic-cli/src/commands/git/parallel.rs
+++ b/atomic-cli/src/commands/git/parallel.rs
@@ -224,7 +224,17 @@ impl ParallelImporter {
 
     /// Import commits from a branch into an Atomic repository.
     ///
-    /// This is the main entry point for the three-phase import.
+    /// Commits are processed in **batches** to keep memory bounded and show
+    /// progress sooner. Each batch: parse in parallel → write sequentially.
+    ///
+    /// Batch sizes are tiered by total commit count:
+    ///
+    /// | Total commits | Batch size |
+    /// |---------------|------------|
+    /// | < 5,000       | 250        |
+    /// | 5,000–9,999   | 500        |
+    /// | 10,000–19,999 | 1,000      |
+    /// | ≥ 20,000      | 2,500      |
     pub fn import_branch(
         &self,
         branch_name: &str,
@@ -243,51 +253,98 @@ impl ParallelImporter {
             return Ok(stats);
         }
 
-        print_info(&format!(
-            "Phase 1: Parsing {} commits in parallel...",
-            commit_oids.len()
-        ));
-
-        // Phase 1: Parallel git parsing
-        let phase1_start = Instant::now();
-        let parsed_commits = self.phase1_parse(&commit_oids)?;
-        stats.phase1_duration = phase1_start.elapsed();
-        stats.commits_parsed = parsed_commits.len();
+        let total = commit_oids.len();
+        let batch_size = Self::batch_size_for(total);
 
         print_info(&format!(
-            "Phase 1 complete: {} commits parsed in {:.2}s",
-            stats.commits_parsed,
-            stats.phase1_duration.as_secs_f64()
+            "Importing {} commits in batches of {}...",
+            total, batch_size
         ));
 
-        if parsed_commits.is_empty() {
-            return Ok(stats);
+        let import_start = Instant::now();
+        let mut commits_written = 0usize;
+
+        for (batch_idx, chunk) in commit_oids.chunks(batch_size).enumerate() {
+            let batch_start = batch_idx * batch_size;
+            let batch_end = (batch_start + chunk.len()).min(total);
+
+            print_info(&format!(
+                "Batch {}: parsing commits {}-{} of {}...",
+                batch_idx + 1,
+                batch_start,
+                batch_end,
+                total
+            ));
+
+            // Phase 1: Parallel git parsing for this batch
+            let parse_start = Instant::now();
+            let parsed_commits = self.phase1_parse(chunk)?;
+            let parse_elapsed = parse_start.elapsed();
+
+            stats.phase1_duration += parse_elapsed;
+            stats.commits_parsed += parsed_commits.len();
+
+            if parsed_commits.is_empty() {
+                continue;
+            }
+
+            // Phase 2: Sequential write for this batch
+            let write_start = Instant::now();
+            let write_stats = self.phase2_write(repo, &parsed_commits)?;
+            let write_elapsed = write_start.elapsed();
+
+            stats.phase2_duration += write_elapsed;
+            stats.changes_written += write_stats.changes_written;
+            stats.empty_commits += write_stats.empty_commits;
+            stats.merge_commits += write_stats.merge_commits;
+            stats.files_processed += write_stats.files_processed;
+
+            commits_written +=
+                write_stats.changes_written + write_stats.empty_commits + write_stats.merge_commits;
+
+            let total_elapsed = import_start.elapsed();
+            let avg_ms = if commits_written > 0 {
+                total_elapsed.as_secs_f64() * 1000.0 / commits_written as f64
+            } else {
+                0.0
+            };
+
+            print_info(&format!(
+                "Batch {} done: parsed {:.1}s, wrote {:.1}s ({} changes, avg {:.1}ms/commit)",
+                batch_idx + 1,
+                parse_elapsed.as_secs_f64(),
+                write_elapsed.as_secs_f64(),
+                write_stats.changes_written,
+                avg_ms,
+            ));
         }
 
+        let total_elapsed = import_start.elapsed();
         print_info(&format!(
-            "Phase 2: Writing {} changes sequentially...",
-            parsed_commits.len()
-        ));
-
-        // Phase 2: Sequential write with hash chaining
-        let phase2_start = Instant::now();
-        let write_stats = self.phase2_write(repo, &parsed_commits)?;
-        stats.phase2_duration = phase2_start.elapsed();
-        stats.changes_written = write_stats.changes_written;
-        stats.empty_commits = write_stats.empty_commits;
-        stats.merge_commits = write_stats.merge_commits;
-        stats.files_processed = write_stats.files_processed;
-
-        print_info(&format!(
-            "Phase 2 complete: {} changes written in {:.2}s",
+            "Import complete: {} changes written in {:.1}s ({:.1}ms/commit avg)",
             stats.changes_written,
-            stats.phase2_duration.as_secs_f64()
+            total_elapsed.as_secs_f64(),
+            if stats.changes_written > 0 {
+                total_elapsed.as_secs_f64() * 1000.0 / stats.changes_written as f64
+            } else {
+                0.0
+            },
         ));
 
         // Phase 3: Finalization (just verification for now)
         self.phase3_finalize(&stats)?;
 
         Ok(stats)
+    }
+
+    /// Determine batch size based on total commit count.
+    fn batch_size_for(total: usize) -> usize {
+        match total {
+            0..5_000 => 250,
+            5_000..10_000 => 500,
+            10_000..20_000 => 1_000,
+            _ => 2_500,
+        }
     }
 
     /// Collect commit OIDs in topological order (oldest first).

--- a/atomic-cli/src/commands/git/parallel.rs
+++ b/atomic-cli/src/commands/git/parallel.rs
@@ -32,7 +32,7 @@
 //! │    - Globalize positions → graph vertices                                │
 //! │    - Write change to RedbChangeStore                                     │
 //! │    - Apply to graph (GRAPH, TREE, INODES tables)                         │
-//! │    - Update view sequence                                               │
+//! │    - Update view sequence                                                │
 //! ├──────────────────────────────────────────────────────────────────────────┤
 //! │  Phase 3: FINALIZE  (verification)                                       │
 //! │                                                                          │
@@ -59,10 +59,13 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use chrono::{DateTime, TimeZone, Utc};
-use git2::{Delta, Diff, DiffOptions, ObjectType, Oid, Repository as GitRepository, Tree};
+use git2::{
+    Delta, Diff, DiffFindOptions, DiffOptions, ObjectType, Oid, Repository as GitRepository, Tree,
+};
 use rayon::prelude::*;
 
 use atomic_core::change::{Author, Change, ChangeHeader};
+use atomic_core::record::workflow::GitDiffLine;
 use atomic_repository::Repository;
 
 use crate::error::{CliError, CliResult};
@@ -136,6 +139,14 @@ pub struct ParsedFile {
     pub operation: FileOperation,
     /// New content (for added/modified files).
     pub new_content: Option<Vec<u8>>,
+    /// Old content at the parent commit (for modified/deleted files).
+    pub old_content: Option<Vec<u8>>,
+    /// Git diff lines for this file (populated in Phase 1).
+    ///
+    /// When `Some`, Phase 2 builds BranchOps directly from these lines
+    /// using git's own diff algorithm, rather than re-diffing with ours.
+    /// This guarantees that `atomic diff -c` output matches `git diff`.
+    pub diff_lines: Option<Vec<GitDiffLine>>,
     /// Old path (for renames).
     pub old_path: Option<String>,
 }
@@ -402,18 +413,31 @@ impl ParallelImporter {
     ) -> CliResult<WriteStats> {
         let mut stats = WriteStats::default();
         let total = commits.len();
-
-        // Open git repo for Phase 2 (single-threaded, so one instance is fine)
-        let git_repo = self.open_git_repo()?;
+        let phase2_start = Instant::now();
+        let mut batch_start = Instant::now();
 
         for (idx, parsed) in commits.iter().enumerate() {
-            // Progress reporting
+            // Progress reporting with per-batch timing
             if total > 100 && idx % 100 == 0 {
-                print_info(&format!("  Writing {}/{}...", idx, total));
+                if idx == 0 {
+                    print_info(&format!("  Writing {}/{}...", idx, total));
+                } else {
+                    let batch_elapsed = batch_start.elapsed();
+                    let total_elapsed = phase2_start.elapsed();
+                    let avg_per_commit = total_elapsed.as_secs_f64() / idx as f64;
+                    print_info(&format!(
+                        "  Writing {}/{}... (last 100: {:.2}s, avg: {:.1}ms/commit)",
+                        idx,
+                        total,
+                        batch_elapsed.as_secs_f64(),
+                        avg_per_commit * 1000.0,
+                    ));
+                }
+                batch_start = Instant::now();
             }
 
             // Write the change
-            match self.write_commit(&git_repo, repo, parsed) {
+            match self.write_commit(repo, parsed) {
                 Ok(written) => {
                     if written {
                         stats.changes_written += 1;
@@ -434,12 +458,13 @@ impl ParallelImporter {
     }
 
     /// Write a single commit to the repository.
-    fn write_commit(
-        &self,
-        git_repo: &GitRepository,
-        repo: &mut Repository,
-        parsed: &ParsedCommit,
-    ) -> CliResult<bool> {
+    fn write_commit(&self, repo: &mut Repository, parsed: &ParsedCommit) -> CliResult<bool> {
+        use atomic_core::output::memory::Memory;
+        use atomic_core::record::workflow::{
+            record_added_file, record_deleted_file, record_modified_file, DetectedFile,
+            RecordedFile, RecordingOptions,
+        };
+
         // Build change header
         let mut header_builder = ChangeHeader::builder()
             .message(&parsed.metadata.message)
@@ -460,68 +485,294 @@ impl ParallelImporter {
             return self.write_empty_commit(repo, parsed, header);
         }
 
-        // Checkout the commit's tree to set working copy state
-        let commit = git_repo
-            .find_commit(
-                Oid::from_str(&parsed.git_sha).map_err(|e| CliError::GitError {
-                    message: format!("Invalid SHA: {}", e),
-                })?,
-            )
-            .map_err(|e| CliError::GitError {
-                message: format!("Failed to find commit: {}", e),
-            })?;
-
-        let tree = commit.tree().map_err(|e| CliError::GitError {
-            message: format!("Failed to get tree: {}", e),
-        })?;
-
-        git_repo
-            .checkout_tree(
-                tree.as_object(),
-                Some(git2::build::CheckoutBuilder::new().force()),
-            )
-            .map_err(|e| CliError::GitError {
-                message: format!("Failed to checkout tree: {}", e),
-            })?;
-
-        // Track new files
+        // Track new files so the pristine knows about them before we record.
+        // Also collect deleted paths so we can remove them from TREE after insert.
+        let mut deleted_paths: Vec<String> = Vec::new();
         for file in &parsed.files {
-            if file.operation == FileOperation::Added
-                || file.operation == FileOperation::Renamed
-                || file.operation == FileOperation::Copied
-            {
+            if file.operation == FileOperation::Added || file.operation == FileOperation::Copied {
                 let _ = repo.add(&file.path, atomic_repository::TrackingOptions::default());
+            }
+            if file.operation == FileOperation::Deleted {
+                deleted_paths.push(file.path.clone());
             }
         }
 
-        // Record the change
-        let options = atomic_repository::RecordOptions::new()
-            .with_all(true)
-            .save_to_store(false)
-            .apply_after_record(false);
+        // ── Fast path: build RecordedFiles directly from parsed content ──
+        //
+        // Instead of checking out the git tree to disk and running the
+        // full record() pipeline (which does a filesystem scan + status),
+        // we feed the already-parsed content into record_added_file /
+        // record_modified_file via in-memory working copies.  This
+        // eliminates all filesystem I/O for Phase 2.
 
-        let (change, hash) = match repo.record(header.clone(), options) {
-            Ok(mut result) => {
-                let hash = *result.hash();
-                result.change_mut().unhashed = Some(self.build_git_metadata(parsed, false, false));
-                (result.into_change(), hash)
-            }
-            Err(atomic_repository::RecordError::NothingToRecord) => {
-                // This can happen with merge commits where content was already imported
-                let mut change = Change::empty(header);
-                change.unhashed = Some(self.build_git_metadata(parsed, false, true));
-                let hash = change.hash().map_err(|e| CliError::Internal(e.into()))?;
-                (change, hash)
-            }
-            Err(e) => return Err(CliError::Internal(e.into())),
-        };
+        // Use patience diff for both the CRDT line-op generation and the
+        // git2 capture (see parse_commit).  Both implementations produce the
+        // same output for patience, so `atomic diff -c` matches `git diff
+        // --patience` exactly.
+        let core_options =
+            RecordingOptions::new().algorithm(atomic_core::diff::Algorithm::Patience);
+        let mut recorded_files: Vec<RecordedFile> = Vec::new();
 
-        // Save and apply
+        for file in &parsed.files {
+            let memory_wc = Memory::new();
+
+            match file.operation {
+                FileOperation::Added | FileOperation::Copied => {
+                    let content = match &file.new_content {
+                        Some(c) => c.as_slice(),
+                        None => continue,
+                    };
+                    memory_wc.add_file(&file.path, content);
+                    let detected = DetectedFile::added(&file.path);
+                    match record_added_file(&memory_wc, &detected, &core_options) {
+                        Ok(rec) if !rec.is_empty() => recorded_files.push(rec),
+                        _ => {}
+                    }
+                }
+
+                FileOperation::Renamed => {
+                    // A rename is recorded as a GraphOp::FileMove, which:
+                    //   1. Marks the old name edge DELETED in the graph
+                    //   2. Inserts a new name edge pointing to the SAME inode
+                    //
+                    // We do NOT call repo.move_file() here — the TREE update
+                    // happens later when insert_change processes the FileMove op.
+                    let old_path = file.old_path.as_deref().unwrap_or(&file.path);
+
+                    // Look up the inode and position for the old path.
+                    // If the old file isn't tracked at all, fall back to
+                    // treating the rename as a plain addition.
+                    match repo.get_inode_and_position(old_path) {
+                        Ok(Some((inode, pos))) => {
+                            // Build the move RecordedFile. Globalization will
+                            // produce a GraphOp::FileMove from this.
+                            let mut move_rec = RecordedFile::new(&file.path);
+                            move_rec.set_kind(atomic_core::record::workflow::DetectionKind::Moved);
+                            move_rec.set_old_path(old_path.to_string());
+                            move_rec.set_inode(inode);
+                            move_rec.set_position(pos);
+                            recorded_files.push(move_rec);
+
+                            // If the content also changed during the rename,
+                            // record the modification on the new path separately.
+                            let new_content = match &file.new_content {
+                                Some(c) => c.as_slice(),
+                                None => &[],
+                            };
+
+                            // Use old content from Phase 1 (captured from git
+                            // parent tree) to avoid an O(N) graph scan.
+                            let old_content = file.old_content.as_deref().unwrap_or(&[]).to_vec();
+
+                            if !new_content.is_empty() && old_content != new_content {
+                                let memory_wc2 = Memory::new();
+                                memory_wc2.add_file(&file.path, new_content);
+
+                                let mut detected = DetectedFile::modified(&file.path);
+                                detected.inode = Some(inode);
+                                detected.position = Some(pos);
+
+                                match record_modified_file(
+                                    &memory_wc2,
+                                    &detected,
+                                    &old_content,
+                                    &core_options,
+                                ) {
+                                    Ok(mut rec) if !rec.is_empty() => {
+                                        if let Some(ref diff_lines) = file.diff_lines {
+                                            use atomic_core::record::workflow::build_crdt_ops_from_git_diff;
+                                            let (git_file_ops, _) = build_crdt_ops_from_git_diff(
+                                                &file.path, diff_lines,
+                                            );
+                                            rec.set_crdt_ops(git_file_ops);
+                                        }
+                                        recorded_files.push(rec);
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                        _ => {
+                            // Old path not tracked — treat rename as a plain addition.
+                            let content = match &file.new_content {
+                                Some(c) => c.as_slice(),
+                                None => continue,
+                            };
+                            memory_wc.add_file(&file.path, content);
+                            let detected = DetectedFile::added(&file.path);
+                            match record_added_file(&memory_wc, &detected, &core_options) {
+                                Ok(rec) if !rec.is_empty() => recorded_files.push(rec),
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+
+                FileOperation::Modified => {
+                    let new_content = match &file.new_content {
+                        Some(c) => c.as_slice(),
+                        None => continue,
+                    };
+                    memory_wc.add_file(&file.path, new_content);
+
+                    // Use old content from Phase 1 (captured from git parent
+                    // tree) to avoid an O(N) graph scan per commit.
+                    let old_content = file.old_content.as_deref().unwrap_or(&[]).to_vec();
+
+                    // Look up inode + position for this file
+                    let mut detected = DetectedFile::modified(&file.path);
+                    if let Ok(Some((inode, pos))) = repo.get_inode_and_position(&file.path) {
+                        detected.inode = Some(inode);
+                        detected.position = Some(pos);
+                    }
+
+                    match record_modified_file(&memory_wc, &detected, &old_content, &core_options) {
+                        Ok(mut rec) if !rec.is_empty() => {
+                            // Override CRDT ops with git's exact diff lines when available.
+                            // This guarantees `atomic diff -c` matches `git diff` line-for-line
+                            // instead of re-running our Myers algorithm which may differ.
+                            if let Some(ref diff_lines) = file.diff_lines {
+                                use atomic_core::record::workflow::build_crdt_ops_from_git_diff;
+                                let (git_file_ops, _) =
+                                    build_crdt_ops_from_git_diff(&file.path, diff_lines);
+                                rec.set_crdt_ops(git_file_ops);
+                            }
+                            recorded_files.push(rec);
+                        }
+                        _ => {}
+                    }
+                }
+
+                FileOperation::Deleted => {
+                    // Use old content from Phase 1 (captured from git parent
+                    // tree) so the diff can show deleted lines — avoids O(N)
+                    // graph scan.
+                    let old_content = file.old_content.as_deref().unwrap_or(&[]).to_vec();
+
+                    if !old_content.is_empty() {
+                        // Record as a modification that removes all content:
+                        // old_content = the file's current bytes, new_content = empty.
+                        // This produces proper BranchOp::Delete entries with line content
+                        // so that `atomic diff -c` can show what was deleted.
+                        let del_wc = Memory::new();
+                        // Empty new content — the file is being deleted.
+                        del_wc.add_file(&file.path, b"");
+
+                        if let Ok(Some((inode, pos))) = repo.get_inode_and_position(&file.path) {
+                            let mut detected = DetectedFile::modified(&file.path);
+                            detected.inode = Some(inode);
+                            detected.position = Some(pos);
+                            match record_modified_file(
+                                &del_wc,
+                                &detected,
+                                &old_content,
+                                &core_options,
+                            ) {
+                                Ok(mut rec) if !rec.is_empty() => {
+                                    // Override CRDT ops with git's exact diff lines
+                                    // so `atomic diff -c` shows what git shows.
+                                    if let Some(ref diff_lines) = file.diff_lines {
+                                        use atomic_core::record::workflow::build_crdt_ops_from_git_diff;
+                                        let (git_file_ops, _) =
+                                            build_crdt_ops_from_git_diff(&file.path, diff_lines);
+                                        rec.set_crdt_ops(git_file_ops);
+                                    }
+                                    recorded_files.push(rec);
+                                }
+                                _ => {
+                                    // Fall back to simple delete if modified recording fails
+                                    let mut det = DetectedFile::deleted(&file.path);
+                                    if let Ok(Some((inode, pos))) =
+                                        repo.get_inode_and_position(&file.path)
+                                    {
+                                        det.inode = Some(inode);
+                                        det.position = Some(pos);
+                                    }
+                                    if let Ok(rec) = record_deleted_file(&det, &core_options) {
+                                        if !rec.is_empty() {
+                                            recorded_files.push(rec);
+                                        }
+                                    }
+                                }
+                            }
+                        } else {
+                            // No inode — try simple delete
+                            let det = DetectedFile::deleted(&file.path);
+                            if let Ok(rec) = record_deleted_file(&det, &core_options) {
+                                if !rec.is_empty() {
+                                    recorded_files.push(rec);
+                                }
+                            }
+                        }
+                    } else {
+                        // Empty old content — just record a simple deletion
+                        let mut det = DetectedFile::deleted(&file.path);
+                        if let Ok(Some((inode, pos))) = repo.get_inode_and_position(&file.path) {
+                            det.inode = Some(inode);
+                            det.position = Some(pos);
+                        }
+                        if let Ok(rec) = record_deleted_file(&det, &core_options) {
+                            if !rec.is_empty() {
+                                recorded_files.push(rec);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Assemble the change from recorded files
+        if recorded_files.is_empty() {
+            let mut change = Change::empty(header);
+            change.unhashed = Some(self.build_git_metadata(parsed, false, true));
+            let hash = change.hash().map_err(|e| CliError::Internal(e.into()))?;
+            repo.save_change(&change)
+                .map_err(|e| CliError::Internal(e.into()))?;
+            repo.insert_change(&hash, Default::default())
+                .map_err(|e| CliError::Internal(e.into()))?;
+            return Ok(true);
+        }
+
+        let step_start = Instant::now();
+        let (mut change, hash) = repo
+            .assemble_and_hash(header, &recorded_files)
+            .map_err(|e| CliError::Internal(e.into()))?;
+        let assemble_ms = step_start.elapsed().as_millis();
+
+        change.unhashed = Some(self.build_git_metadata(parsed, false, false));
+
+        // Save and insert
+        let step_start = Instant::now();
         repo.save_change(&change)
             .map_err(|e| CliError::Internal(e.into()))?;
+        let save_ms = step_start.elapsed().as_millis();
 
+        let step_start = Instant::now();
         repo.insert_change(&hash, Default::default())
             .map_err(|e| CliError::Internal(e.into()))?;
+        let insert_ms = step_start.elapsed().as_millis();
+
+        // Log slow commits (>50ms total) so we can identify the bottleneck
+        let total_ms = assemble_ms + save_ms + insert_ms;
+        if total_ms > 50 {
+            log::info!(
+                "  SLOW commit {} ({} files): assemble={}ms save={}ms insert={}ms total={}ms",
+                parsed.short_sha,
+                parsed.files.len(),
+                assemble_ms,
+                save_ms,
+                insert_ms,
+                total_ms,
+            );
+        }
+
+        // Files deleted via record_modified_file (the "show diff lines" path)
+        // produce GraphOp::Replacement, not GraphOp::FileDel, so insert_change
+        // never removes their TREE entries.  Explicitly untrack them now so that
+        // `atomic status` after import matches the git working copy.
+        for del_path in &deleted_paths {
+            let _ = repo.remove(del_path, atomic_repository::TrackingOptions::forced());
+        }
 
         Ok(true)
     }
@@ -661,15 +912,36 @@ fn parse_commit(
         None
     };
 
-    // Compute diff
+    // Use patience diff for the git2 line capture.  We use patience for
+    // the atomic RecordingOptions too (see write_commit), so both produce
+    // the same line classification for the same file content.
     let mut diff_opts = DiffOptions::new();
     diff_opts.include_untracked(false);
+    diff_opts.patience(true);
 
-    let diff = git_repo
+    let mut diff = git_repo
         .diff_tree_to_tree(parent_tree.as_ref(), Some(&tree), Some(&mut diff_opts))
         .map_err(|e| CliError::GitError {
             message: format!("Failed to compute diff: {}", e),
         })?;
+
+    // Apply rename detection — mirrors what git CLI does after computing
+    // the initial diff.  This correctly classifies renamed files as R deltas
+    // so write_commit can produce GraphOp::FileMove instead of treating them
+    // as plain modifications.
+    //
+    // We enable renames(true) only — NOT renames_from_rewrites(true).
+    // renames_from_rewrites tells git2 to consider heavily-modified files
+    // as potential rename *sources*, which causes false positives: when a
+    // file is modified AND a new file is added with similar content, git2
+    // converts the (Modified + Added) pair into a Renamed delta — even
+    // though the original file still exists.  Example: modifying
+    // src/export/markdown.rs while adding src/export/tests.rs (52%
+    // similar) would be misclassified as a rename of markdown→tests,
+    // orphaning markdown.rs from the TREE.
+    let mut find_opts = DiffFindOptions::new();
+    find_opts.renames(true);
+    let _ = diff.find_similar(Some(&mut find_opts));
 
     let stats = diff.stats().map_err(|e| CliError::GitError {
         message: format!("Failed to get diff stats: {}", e),
@@ -678,7 +950,7 @@ fn parse_commit(
     let is_empty = stats.files_changed() == 0;
 
     // Parse files
-    let files = parse_diff_files(git_repo, &diff, &tree)?;
+    let files = parse_diff_files(git_repo, &diff, &tree, parent_tree.as_ref())?;
 
     Ok(ParsedCommit {
         git_sha: sha,
@@ -716,11 +988,59 @@ fn extract_commit_metadata(commit: &git2::Commit) -> CliResult<CommitMetadata> {
 }
 
 /// Parse files from a git diff.
+///
+/// For each changed file we capture:
+///   - The operation type (Added / Modified / Deleted / Renamed / Copied)
+///   - The new file content (for adds/modifies)
+///   - The old file content (for modifies/deletes)
+///   - The exact diff lines that git computed, so Phase 2 can build
+///     BranchOps directly from git's diff rather than re-diffing.
 fn parse_diff_files(
     git_repo: &GitRepository,
     diff: &Diff,
     tree: &Tree,
+    parent_tree: Option<&Tree>,
 ) -> CliResult<Vec<ParsedFile>> {
+    use std::collections::HashMap;
+
+    // ── Step 1: collect per-file diff lines via diff.foreach ────────────
+    //
+    // git2::Diff::foreach gives us each DiffLine with its origin (`+`/`-`/` `),
+    // raw bytes, and old/new line numbers — exactly what `git diff` outputs.
+    // We key by file path so we can attach them to the ParsedFile below.
+
+    // Map from file path → accumulated diff lines for that file.
+    let mut lines_by_path: HashMap<String, Vec<GitDiffLine>> = HashMap::new();
+
+    let _ = diff.foreach(
+        &mut |_delta, _progress| true, // file_cb  (no-op)
+        None,                          // binary_cb
+        None,                          // hunk_cb
+        Some(&mut |delta, _hunk, line| {
+            let origin = line.origin();
+            // We only keep `+`, `-`, and context (` `) lines.
+            if origin != '+' && origin != '-' && origin != ' ' {
+                return true;
+            }
+            let path = delta
+                .new_file()
+                .path()
+                .or_else(|| delta.old_file().path())
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_default();
+
+            lines_by_path.entry(path).or_default().push(GitDiffLine {
+                origin,
+                content: line.content().to_vec(),
+                old_lineno: line.old_lineno(),
+                new_lineno: line.new_lineno(),
+            });
+            true
+        }),
+    );
+
+    // ── Step 2: build ParsedFile entries from the delta list ─────────────
+
     let mut files = Vec::new();
 
     for delta in diff.deltas() {
@@ -753,7 +1073,7 @@ fn parse_diff_files(
             None
         };
 
-        // Get new content for added/modified files
+        // New content from the commit's tree
         let new_content = if operation == FileOperation::Added
             || operation == FileOperation::Modified
             || operation == FileOperation::Renamed
@@ -764,10 +1084,28 @@ fn parse_diff_files(
             None
         };
 
+        // Old content from the parent commit's tree (for modifies/deletes)
+        let old_content = if operation == FileOperation::Modified
+            || operation == FileOperation::Deleted
+            || operation == FileOperation::Renamed
+        {
+            parent_tree.and_then(|pt| {
+                let lookup_path = old_path.as_deref().unwrap_or(&path);
+                get_file_content(git_repo, pt, lookup_path).ok()
+            })
+        } else {
+            None
+        };
+
+        // Diff lines captured above
+        let diff_lines = lines_by_path.remove(&path);
+
         files.push(ParsedFile {
             path,
             operation,
             new_content,
+            old_content,
+            diff_lines,
             old_path,
         });
     }

--- a/atomic-core/src/apply/edge.rs
+++ b/atomic-core/src/apply/edge.rs
@@ -140,7 +140,7 @@ fn write_new_edge<T: MutTxnT>(
     change: &Change,
 ) -> Result<(), LocalApplyError> {
     // Resolve the introduced_by change
-    let _introduced_by = resolve_introduced_by(txn, &edge.introduced_by, change_id)?;
+    let introduced_by = resolve_introduced_by(txn, &edge.introduced_by, change_id)?;
 
     // Find source span — predecessor context (ending at position).
     let source_pos = resolve_position(txn, &edge.from, change_id)?;
@@ -179,18 +179,25 @@ fn write_new_edge<T: MutTxnT>(
         collect_pseudo_edges_for_reconnection(txn, workspace, target)?;
     }
 
-    // In the ambient graph model, we NEVER delete edges from GRAPH.
-    // The original edge (introduced by a prior change) stays in place.
-    // We only ADD the new edge alongside it.  The view filter determines
-    // which edge is "active" for any given view:
+    // Remove the old edge before adding the new one.
     //
-    //   - If the new edge's introducing change is IN the view's filter,
-    //     the new edge (e.g., BLOCK|DELETED) takes precedence.
-    //   - If the new edge's introducing change is OUTSIDE the filter,
-    //     the original edge remains visible.
-    //
-    // This is what makes views work as true projections over a single
-    // graph — no view can destroy information that another view depends on.
+    // The `previous` field records the flags of the edge being superseded
+    // (e.g., BLOCK for a live edge that is now being marked DELETED).
+    // Without this deletion the old alive edge remains in the B-tree
+    // multimap alongside the new DELETED edge, causing `is_vertex_alive`
+    // to find the stale alive parent and incorrectly report the vertex as
+    // alive — which breaks subsequent Replace operations on the same file.
+    del_edge_with_reverse(
+        txn,
+        resolved_inode,
+        edge.previous,
+        source,
+        target,
+        introduced_by,
+    )?;
+
+    // Add the new edge (e.g., BLOCK|DELETED to mark content as removed,
+    // or BLOCK to wire in new content).
     add_edge_with_reverse(txn, resolved_inode, edge.flag, source, target, change_id)?;
 
     // For non-folder deletions, check for zombie context
@@ -275,6 +282,34 @@ pub fn find_target_vertex<T: GraphTxnT>(
 
 // Edge Operations
 
+/// Remove a forward edge and its reverse (PARENT) counterpart from
+/// GRAPH and INODE_GRAPH.
+///
+/// Errors are silently ignored (the edge may not exist if this is the
+/// first time the graph is being written).
+fn del_edge_with_reverse<T: MutTxnT>(
+    txn: &mut T,
+    inode: Option<Inode>,
+    flag: EdgeFlags,
+    source: GraphNode<NodeId>,
+    dest: GraphNode<NodeId>,
+    introduced_by: NodeId,
+) -> Result<(), LocalApplyError> {
+    let forward_edge = SerializedGraphEdge::new(flag, dest.start_pos(), introduced_by);
+    let reverse_flag = flag | EdgeFlags::PARENT;
+    let reverse_edge = SerializedGraphEdge::new(reverse_flag, source.end_pos(), introduced_by);
+
+    let _ = txn.del_graph(source, forward_edge);
+    let _ = txn.del_graph(dest, reverse_edge);
+
+    if let Some(inode_val) = inode {
+        let _ = txn.del_inode_graph(inode_val, source, forward_edge);
+        let _ = txn.del_inode_graph(inode_val, dest, reverse_edge);
+    }
+
+    Ok(())
+}
+
 /// Write an edge and its reverse to the graph.
 ///
 /// In the Atomic graph model, edges come in pairs:
@@ -283,15 +318,6 @@ pub fn find_target_vertex<T: GraphTxnT>(
 ///
 /// Writes both edges to the global GRAPH table and, when an inode is
 /// provided, to the INODE_GRAPH secondary index.
-///
-/// # Arguments
-///
-/// * `txn` - Write transaction
-/// * `inode` - Optional inode for inode_graph indexing
-/// * `flag` - Edge flags for the forward edge
-/// * `source` - Source span
-/// * `dest` - Destination span
-/// * `introduced_by` - Change that introduced this edge
 fn add_edge_with_reverse<T: MutTxnT>(
     txn: &mut T,
     inode: Option<Inode>,

--- a/atomic-core/src/pristine/txn/pristine.rs
+++ b/atomic-core/src/pristine/txn/pristine.rs
@@ -244,8 +244,7 @@ impl Pristine {
     /// must be explicitly committed with `commit()` or it will be rolled back
     /// when dropped.
     pub fn write_txn(&self) -> PristineResult<WriteTxn<'_>> {
-        let mut txn = self.db.begin_write()?;
-        txn.set_durability(redb::Durability::Eventual);
+        let txn = self.db.begin_write()?;
         Ok(WriteTxn::new(
             txn,
             &self.next_node_id,

--- a/atomic-core/src/pristine/txn/pristine.rs
+++ b/atomic-core/src/pristine/txn/pristine.rs
@@ -244,7 +244,8 @@ impl Pristine {
     /// must be explicitly committed with `commit()` or it will be rolled back
     /// when dropped.
     pub fn write_txn(&self) -> PristineResult<WriteTxn<'_>> {
-        let txn = self.db.begin_write()?;
+        let mut txn = self.db.begin_write()?;
+        txn.set_durability(redb::Durability::Eventual);
         Ok(WriteTxn::new(
             txn,
             &self.next_node_id,

--- a/atomic-core/src/pristine/view_graph.rs
+++ b/atomic-core/src/pristine/view_graph.rs
@@ -15,7 +15,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use crate::pristine::{GraphTxnT, PristineError, TreeTxnT};
+use crate::pristine::{GraphTxnT, InodeAdjState, InodeGraphOps, PristineError, TreeTxnT};
 use crate::types::{EdgeFlags, GraphNode, Hash, Inode, NodeId, Position, SerializedGraphEdge};
 
 /// A view-scoped graph wrapper that filters edge traversal by visibility.
@@ -68,6 +68,47 @@ impl<'a, T> ViewGraph<'a, T> {
     #[cfg(test)]
     fn is_visible(&self, change_id: NodeId) -> bool {
         change_id == NodeId::ROOT || self.visible.contains(&change_id)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// InodeGraphOps — delegate to inner txn (INODE_GRAPH is unfiltered)
+// ─────────────────────────────────────────────────────────────────────────
+
+impl<'a, T: InodeGraphOps> InodeGraphOps for ViewGraph<'a, T> {
+    type InodeError = T::InodeError;
+
+    fn init_inode_adj(
+        &self,
+        inode: Inode,
+        node: GraphNode<NodeId>,
+        min_flag: EdgeFlags,
+        max_flag: EdgeFlags,
+    ) -> Result<InodeAdjState, Self::InodeError> {
+        self.inner.init_inode_adj(inode, node, min_flag, max_flag)
+    }
+
+    fn next_inode_adj(
+        &self,
+        adj: &mut InodeAdjState,
+    ) -> Option<Result<SerializedGraphEdge, Self::InodeError>> {
+        self.inner.next_inode_adj(adj)
+    }
+
+    fn find_block_in_inode(
+        &self,
+        inode: Inode,
+        pos: Position<NodeId>,
+    ) -> Result<Option<GraphNode<NodeId>>, Self::InodeError> {
+        self.inner.find_block_in_inode(inode, pos)
+    }
+
+    fn count_inode_vertices(&self, inode: Inode) -> Result<usize, Self::InodeError> {
+        self.inner.count_inode_vertices(inode)
+    }
+
+    fn inode_graph_is_populated(&self, inode: Inode) -> Result<bool, Self::InodeError> {
+        self.inner.inode_graph_is_populated(inode)
     }
 }
 

--- a/atomic-core/src/record/workflow/assembly/mod.rs
+++ b/atomic-core/src/record/workflow/assembly/mod.rs
@@ -321,7 +321,7 @@ pub fn assemble_change<T>(
     options: &AssemblyOptions,
 ) -> types::AssemblyResult<AssemblyResult_>
 where
-    T: GraphTxnT + TreeTxnT,
+    T: GraphTxnT + TreeTxnT + crate::pristine::InodeGraphOps,
 {
     // Validate input
     if files.is_empty() {

--- a/atomic-core/src/record/workflow/globalize/hunk.rs
+++ b/atomic-core/src/record/workflow/globalize/hunk.rs
@@ -307,30 +307,29 @@ where
     Ok(vertices)
 }
 
-/// Retrieve every alive content vertex for a file using the INODE_GRAPH
-/// secondary index.
+/// Retrieve every alive content vertex for a file.
 ///
-/// This is O(m) where m = edges for this file, instead of the O(n)
-/// `retrieve_graph` approach that scans the entire global GRAPH.
+/// This always uses `retrieve_graph` which traverses via the `GraphTxnT`
+/// implementation.  When the caller passes a `ViewGraph`, the traversal
+/// respects the view's change filter — only vertices from visible changes
+/// are returned.  When the caller passes a bare `ReadTxn`, all vertices
+/// are returned.
 ///
-/// Falls back to the global `retrieve_graph` if INODE_GRAPH is not
-/// populated for this inode.
+/// **Why not INODE_GRAPH?**  The `INODE_GRAPH` secondary index stores ALL
+/// edges regardless of view.  Using it directly would bypass the
+/// `ViewGraph` filter, returning vertices from changes that aren't visible
+/// in the current view — causing content duplication in the `record()`
+/// path.  The INODE_GRAPH optimisation is safe only when there is no
+/// filter (e.g. `assemble_and_hash` for git import, which passes a bare
+/// `&txn`).  For the general case we must go through `retrieve_graph`.
 fn find_content_vertices<T>(
     txn: &T,
-    inode: Inode,
+    _inode: Inode,
     inode_pos: Position<NodeId>,
 ) -> GlobalizeResult<Vec<GraphNode<NodeId>>>
 where
     T: GraphTxnT + InodeGraphOps,
 {
-    // Try the fast path: INODE_GRAPH secondary index
-    let populated = txn.inode_graph_is_populated(inode).unwrap_or(false);
-
-    if populated {
-        return find_content_vertices_via_inode(txn, inode, inode_pos);
-    }
-
-    // Fallback: global GRAPH scan (for repos where INODE_GRAPH wasn't populated)
     find_content_vertices_global(txn, inode_pos)
 }
 

--- a/atomic-core/src/record/workflow/globalize/hunk.rs
+++ b/atomic-core/src/record/workflow/globalize/hunk.rs
@@ -1,39 +1,54 @@
+//! Globalize a single built hunk into a graph operation.
+//!
+//! This module converts a local working-copy change (a [`BuiltHunk`]) into a
+//! graph-compatible [`GraphOp<Option<Hash>>`].
+//!
+//! # Design
+//!
+//! After the upstream consolidation in `record_modified_file`, every hunk that
+//! reaches this function belongs to exactly one of four operations:
+//!
+//! | Hunk kind | Condition | Graph operation |
+//! |-----------|-----------|-----------------|
+//! | `Insert`  | `old_start == 0` | **Prepend**: insert before first content |
+//! | `Insert`  | `old_start >= old_lines` | **Append**: insert after last content |
+//! | `Replace` | *(always)* | **Replace**: delete all old → insert new |
+//! | `Delete`  | *(always)* | **Delete**: delete all old content |
+//!
+//! Middle insertions (`0 < old_start < old_lines`) are collapsed into a
+//! single Replace by the upstream consolidation step. If one somehow
+//! reaches here (e.g. a future code path bypasses the consolidation), we
+//! return a clear error rather than silently duplicating content.
+//!
+//! Both `Replace` and `Delete` need the same "find every content vertex and
+//! build deletion edges" work, so that logic lives in one place:
+//! [`delete_all_content`].
+
 use super::*;
+use crate::change::Local;
 
-// MAIN GLOBALIZATION FUNCTIONS
+// ───────────────────────────────────────────────────────────────────────────
+// Public entry point
+// ───────────────────────────────────────────────────────────────────────────
 
-/// Globalize a single built graph_op into a graph graph_op.
-///
-/// This is the core function that converts a local working copy change
-/// (represented as a `BuiltHunk`) into a graph-compatible `GraphOp<Option<Hash>>`.
+/// Globalize a single built hunk into a graph operation.
 ///
 /// # Arguments
 ///
-/// * `ctx` - The globalization context
-/// * `built` - The built graph_op from the recording phase
-/// * `inode` - The file's inode
-/// * `inode_pos` - The graph position of the file's inode
-/// * `content` - The content slice for this graph_op
-/// * `full_content` - The full file content (needed for NeedsReplace case)
-/// * `old_line_count` - Number of lines in the old content (for precise insert detection)
-///
-/// # Returns
-///
-/// A graph-compatible graph_op, or an error if globalization fails.
-///
-/// # Example
-///
-/// ```rust,ignore
-/// let graph_op = globalize_hunk(&mut ctx, &built_hunk, inode, inode_pos, content)?;
-/// change.add_hunk(graph_op);
-/// ```
+/// * `ctx`            – globalization context (content buffer, dependencies, txn)
+/// * `built`          – the built hunk from the recording phase
+/// * `inode`          – the file's stable identifier
+/// * `inode_pos`      – the graph position of the file's inode vertex
+/// * `content`        – the content bytes this hunk should insert (the hunk's
+///                      own slice for Insert, the full new file for Replace)
+/// * `old_line_count` – number of lines in the old file (for insert-position
+///                      classification)
 pub fn globalize_hunk<T>(
     ctx: &mut GlobalizeContext<'_, T>,
     built: &BuiltHunk,
     inode: Inode,
     inode_pos: Position<NodeId>,
     content: &[u8],
-    full_content: &[u8],
     old_line_count: Option<usize>,
 ) -> GlobalizeResult<GraphOp<Option<Hash>>>
 where
@@ -42,363 +57,237 @@ where
     let local = built.local.clone();
     let encoding = built.encoding;
 
-    // For modifications to existing files, we need to find the correct context
-    // positions from the content graph. The predecessors should be the END of the
-    // span that comes before, and successors should be the START of the
-    // span that comes after.
-    //
-    // We use the line number information (old_start) to determine insertion position:
-    // - old_start == 0: Prepend (insert at beginning)
-    // - Otherwise: Check if we can insert in middle, or need to do a Replace
-    //
-    // The challenge is that without byte-to-span mapping (like original Atomic has),
-    // we can't reliably insert in the middle of a single span. So for middle insertions,
-    // we convert to Replace (delete all old content, insert all new content).
-
     match built.kind {
-        BuiltHunkKind::Insert => {
-            // Pure insertion - create a Insertion
-            // Determine predecessors and successors based on insertion position
-            // old_start tells us which line in the old content the insertion comes AFTER
-            let insert_result =
-                find_insert_context(ctx.txn(), inode_pos, built.old_start, old_line_count)?;
-
-            match insert_result {
-                InsertContext::Prepend { successors } => {
-                    // Prepend: connect to inode, with successors to first content
-                    let content_node = create_content_vertex(
-                        ctx,
-                        inode,
-                        inode_pos,
-                        vec![inode_pos],
-                        successors,
-                        content,
-                    )?;
-
-                    Ok(GraphOp::Edit {
-                        change: Atom::Insertion(content_node),
-                        local,
-                        encoding,
-                    })
-                }
-                InsertContext::Append { predecessors } => {
-                    // Append: connect after existing content
-                    let content_node = create_content_vertex(
-                        ctx,
-                        inode,
-                        inode_pos,
-                        predecessors,
-                        vec![],
-                        content,
-                    )?;
-
-                    Ok(GraphOp::Edit {
-                        change: Atom::Insertion(content_node),
-                        local,
-                        encoding,
-                    })
-                }
-                InsertContext::NeedsReplace => {
-                    // Middle insertion into a single span - we can't split it without
-                    // byte-to-span mapping. Convert this to a Replace operation:
-                    // 1. Delete all existing content
-                    // 2. Insert new content connected to the inode
-                    //
-                    // This is semantically correct: we're replacing the file content.
-                    let content_vertices = find_content_vertices(ctx.txn(), inode_pos)?;
-                    let deletion_edges =
-                        create_deletion_edges_for_vertices(ctx, &content_vertices)?;
-
-                    let deletion = EdgeUpdate {
-                        edges: deletion_edges,
-                        inode: position_to_option_hash(inode_pos),
-                    };
-
-                    // Insert the FULL file content connected to the inode (after deletion)
-                    // We use full_content because this is a complete file replacement
-                    let insertion = create_content_vertex(
-                        ctx,
-                        inode,
-                        inode_pos,
-                        vec![inode_pos], // predecessors: the inode span itself
-                        vec![],          // successors: nothing after
-                        full_content,
-                    )?;
-
-                    Ok(GraphOp::Replacement {
-                        change: deletion,
-                        replacement: insertion,
-                        local,
-                        encoding,
-                    })
-                }
-            }
-        }
-
-        BuiltHunkKind::Delete => {
-            // Pure deletion - create an EdgeUpdate
-            // Find all content vertices for this file and mark them as deleted
-            let content_vertices = find_content_vertices(ctx.txn(), inode_pos)?;
-            let deletion_edges = create_deletion_edges_for_vertices(ctx, &content_vertices)?;
-
-            let edge_update = EdgeUpdate {
-                edges: deletion_edges,
-                inode: position_to_option_hash(inode_pos),
-            };
-
-            Ok(GraphOp::Edit {
-                change: Atom::EdgeUpdate(edge_update),
-                local,
-                encoding,
-            })
-        }
-
+        BuiltHunkKind::Insert => globalize_insert(
+            ctx,
+            built,
+            inode,
+            inode_pos,
+            content,
+            old_line_count,
+            local,
+            encoding,
+        ),
         BuiltHunkKind::Replace => {
-            // Replacement - delete old content, insert new
-            // For a replacement, we need to:
-            // 1. Find and delete the old content vertices
-            // 2. Insert the FULL new file content connected to the inode span
-            //
-            // IMPORTANT: We must use `full_content` (the entire new file), not `content`
-            // (just the replacement portion). This is because we're deleting ALL old
-            // content vertices, so we need to replace with ALL new content.
-            //
-            // Bug fix: Previously this used `content` which only contained the changed
-            // lines, causing data loss of unchanged lines.
-            let content_vertices = find_content_vertices(ctx.txn(), inode_pos)?;
-            let deletion_edges = create_deletion_edges_for_vertices(ctx, &content_vertices)?;
-
-            let deletion = EdgeUpdate {
-                edges: deletion_edges,
-                inode: position_to_option_hash(inode_pos),
-            };
-
-            // For replacement, insert the FULL new file content connected to the inode
-            // (not just the graph_op content, since we're deleting ALL old content)
-            let insertion = create_content_vertex(
-                ctx,
-                inode,
-                inode_pos,
-                vec![inode_pos], // predecessors: the inode span itself
-                vec![],          // successors: nothing after
-                full_content,    // Use full file content, not just the graph_op portion
-            )?;
-
-            Ok(GraphOp::Replacement {
-                change: deletion,
-                replacement: insertion,
-                local,
-                encoding,
-            })
+            globalize_replace(ctx, inode, inode_pos, content, local, encoding)
         }
+        BuiltHunkKind::Delete => globalize_delete(ctx, inode_pos, local, encoding),
     }
 }
 
-/// Find the end position of the last content span in a file.
+// ───────────────────────────────────────────────────────────────────────────
+// Insert: prepend / append (the only two safe positions)
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Classify an Insert hunk and emit the corresponding graph operation.
 ///
-/// This traverses the file's content graph to find the span that represents
-/// the end of the current content. This position is used as predecessors when
-/// appending new content.
+/// Only two positions are supported:
 ///
-/// # Arguments
+/// * **Prepend** (`old_start == 0`): new content is wired between the inode
+///   vertex and the first existing content vertex.
+/// * **Append** (`old_start >= old_line_count`): new content is wired after
+///   the last existing content vertex.
 ///
-/// * `txn` - Transaction for graph lookups
-/// * `inode_pos` - The graph position of the file's inode
-///
-/// # Returns
-///
-/// The end position of the last content span, or the inode position if
-/// the file has no content.
-/// Result of finding insert context - determines how to handle the insertion.
-#[derive(Debug)]
-enum InsertContext {
-    /// Prepend: insert at the very beginning of the file.
-    /// predecessors should be the inode, successors is the start of first content.
-    Prepend { successors: Vec<Position<NodeId>> },
-    /// Append: insert at the end of the file.
-    /// predecessors is the end of last content, successors is empty.
-    Append { predecessors: Vec<Position<NodeId>> },
-    /// Middle insertion that requires a Replace operation.
-    /// This happens when we need to insert within a single span but don't have
-    /// byte-to-span mapping to find the exact position.
-    NeedsReplace,
+/// Any other position means the upstream consolidation was bypassed, and we
+/// return an error instead of silently producing duplicate content.
+fn globalize_insert<T>(
+    ctx: &mut GlobalizeContext<'_, T>,
+    built: &BuiltHunk,
+    inode: Inode,
+    inode_pos: Position<NodeId>,
+    content: &[u8],
+    old_line_count: Option<usize>,
+    local: Local,
+    encoding: Option<Encoding>,
+) -> GlobalizeResult<GraphOp<Option<Hash>>>
+where
+    T: GraphTxnT + TreeTxnT,
+{
+    let position = classify_insert(ctx.txn(), inode_pos, built.old_start, old_line_count)?;
+
+    let (predecessors, successors) = match position {
+        InsertPosition::Prepend { first_content } => (vec![inode_pos], vec![first_content]),
+        InsertPosition::Append { last_content_end } => (vec![last_content_end], vec![]),
+    };
+
+    let vertex = create_content_vertex(ctx, inode, inode_pos, predecessors, successors, content)?;
+
+    Ok(GraphOp::Edit {
+        change: Atom::Insertion(vertex),
+        local,
+        encoding,
+    })
 }
 
-/// Find the appropriate context for an insertion based on old_start line number.
+// ───────────────────────────────────────────────────────────────────────────
+// Replace: delete all old content, insert full new content
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Delete every existing content vertex and insert `content` (the full new
+/// file) as a single vertex connected to the inode.
+fn globalize_replace<T>(
+    ctx: &mut GlobalizeContext<'_, T>,
+    inode: Inode,
+    inode_pos: Position<NodeId>,
+    content: &[u8],
+    local: Local,
+    encoding: Option<Encoding>,
+) -> GlobalizeResult<GraphOp<Option<Hash>>>
+where
+    T: GraphTxnT + TreeTxnT,
+{
+    let deletion = delete_all_content(ctx, inode_pos)?;
+
+    let insertion = create_content_vertex(ctx, inode, inode_pos, vec![inode_pos], vec![], content)?;
+
+    Ok(GraphOp::Replacement {
+        change: deletion,
+        replacement: insertion,
+        local,
+        encoding,
+    })
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Delete: mark every content vertex as deleted
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Mark every content vertex for this file as deleted.
+fn globalize_delete<T>(
+    ctx: &mut GlobalizeContext<'_, T>,
+    inode_pos: Position<NodeId>,
+    local: Local,
+    encoding: Option<Encoding>,
+) -> GlobalizeResult<GraphOp<Option<Hash>>>
+where
+    T: GraphTxnT + TreeTxnT,
+{
+    let deletion = delete_all_content(ctx, inode_pos)?;
+
+    Ok(GraphOp::Edit {
+        change: Atom::EdgeUpdate(deletion),
+        local,
+        encoding,
+    })
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Shared helpers
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Build an [`EdgeUpdate`] that marks every content vertex in the file as
+/// deleted.
 ///
-/// This determines where new content should be inserted:
-/// - old_start == 0: Prepend (insert before all existing content)
-/// - old_start >= total_lines: Append (insert after all existing content)
-/// - Otherwise: Middle insertion (needs Replace because we can't split vertices)
+/// This is the single place where "find all content vertices → create
+/// deletion edges" happens. Both [`globalize_replace`] and
+/// [`globalize_delete`] delegate here.
+fn delete_all_content<T>(
+    ctx: &mut GlobalizeContext<'_, T>,
+    inode_pos: Position<NodeId>,
+) -> GlobalizeResult<EdgeUpdate<Option<Hash>>>
+where
+    T: GraphTxnT + TreeTxnT,
+{
+    let vertices = find_content_vertices(ctx.txn(), inode_pos)?;
+    let edges = build_deletion_edges(ctx, &vertices)?;
+
+    Ok(EdgeUpdate {
+        edges,
+        inode: position_to_option_hash(inode_pos),
+    })
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Insert position classification
+// ───────────────────────────────────────────────────────────────────────────
+
+/// The two valid positions for an Insert hunk.
+#[derive(Debug)]
+enum InsertPosition {
+    /// Insert before all existing content.
+    ///
+    /// `first_content` is the start position of the first content vertex —
+    /// used as the successor of the new vertex.
+    Prepend { first_content: Position<NodeId> },
+
+    /// Insert after all existing content.
+    ///
+    /// `last_content_end` is the end position of the last content vertex —
+    /// used as the predecessor of the new vertex.
+    Append { last_content_end: Position<NodeId> },
+}
+
+/// Determine whether an Insert hunk is a Prepend or Append.
 ///
-/// # Arguments
-///
-/// * `txn` - Transaction for graph lookups
-/// * `inode_pos` - The graph position of the file's inode
-/// * `old_start` - The line number in old content AFTER which to insert (0 = prepend)
-///
-/// # Returns
-///
-/// An `InsertContext` indicating how to handle the insertion.
-fn find_insert_context<T>(
+/// Returns an error if `old_start` falls in the middle of the file — that
+/// case should have been consolidated into a Replace upstream.
+fn classify_insert<T>(
     txn: &T,
     inode_pos: Position<NodeId>,
     old_start: usize,
     old_line_count: Option<usize>,
-) -> GlobalizeResult<InsertContext>
+) -> GlobalizeResult<InsertPosition>
 where
     T: GraphTxnT,
 {
-    // Retrieve the file's content graph
-    let result = match retrieve_graph(txn, inode_pos, RetrieveOptions::default()) {
-        Ok(r) => r,
-        Err(_) => {
-            // Empty file - treat as append (will connect to inode)
-            return Ok(InsertContext::Append {
-                predecessors: vec![inode_pos],
-            });
-        }
-    };
+    let vertices = collect_sorted_content_vertices(txn, inode_pos)?;
 
-    // Collect content vertices with their positions
-    let mut content_vertices: Vec<(GraphNode<NodeId>, Position<NodeId>, Position<NodeId>)> =
-        Vec::new();
-
-    for vertex_id in 0..result.graph.len_vertices() {
-        if let Some(alive_vertex) = result.graph.try_get_vertex(vertex_id.into()) {
-            let alive_node = alive_vertex.node;
-
-            // Skip DUMMY and empty vertices
-            if alive_node.change.is_root() || alive_node.start == alive_node.end {
-                continue;
-            }
-
-            let start_pos = Position::new(alive_node.change, alive_node.start);
-            let end_pos = Position::new(alive_node.change, alive_node.end);
-            content_vertices.push((alive_node, start_pos, end_pos));
-        }
-    }
-
-    // If no content vertices, this is an empty file - append
-    if content_vertices.is_empty() {
-        return Ok(InsertContext::Append {
-            predecessors: vec![inode_pos],
+    // Empty file → append (predecessor is the inode itself).
+    if vertices.is_empty() {
+        return Ok(InsertPosition::Append {
+            last_content_end: inode_pos,
         });
     }
 
-    // Sort by start position to get proper ordering
-    content_vertices.sort_by(|a, b| a.1.pos.cmp(&b.1.pos));
-
-    // old_start == 0 means prepend (insert BEFORE line 0, i.e., at the very beginning)
+    // Prepend: insert before the very first line.
     if old_start == 0 {
-        let first_start = content_vertices[0].1;
-        return Ok(InsertContext::Prepend {
-            successors: vec![first_start],
+        let first_start = Position::new(vertices[0].change, vertices[0].start);
+        return Ok(InsertPosition::Prepend {
+            first_content: first_start,
         });
     }
 
-    // Determine if this is an append or middle insertion using the actual old line count.
-    //
-    // old_start indicates which line of OLD content the insertion comes AFTER.
-    // If old_start >= total_old_lines, it's an append (insert at end).
-    // If old_start < total_old_lines and we have a single span, we need Replace
-    // because we can't split a span without byte-to-span mapping.
-
-    // Use the actual old line count if available, otherwise fall back to span count
-    let total_old_lines = old_line_count.unwrap_or(content_vertices.len());
-
-    // If old_start >= total lines, it's an append
+    // Append: insert after the very last line.
+    let total_old_lines = old_line_count.unwrap_or(vertices.len());
     if old_start >= total_old_lines {
-        let last_end = content_vertices.last().unwrap().2;
-        return Ok(InsertContext::Append {
-            predecessors: vec![last_end],
+        let last = vertices.last().unwrap();
+        let last_end = Position::new(last.change, last.end);
+        return Ok(InsertPosition::Append {
+            last_content_end: last_end,
         });
     }
 
-    // For single span or middle insertion into multiple vertices,
-    // we need byte-level mapping to split correctly.
-    // Without it, signal that a Replace is needed.
-    Ok(InsertContext::NeedsReplace)
+    // Middle insertion — this should never arrive here after the upstream
+    // consolidation in `record_modified_file`.  Return a clear error so the
+    // caller knows something is wrong rather than silently triplicating
+    // content.
+    Err(GlobalizeError::MissingContext {
+        path: "(middle insertion reached globalize_hunk — upstream consolidation was bypassed)"
+            .to_string(),
+        line: old_start as u64,
+    })
 }
 
-#[allow(dead_code)]
-fn find_content_end_position<T>(
+// ───────────────────────────────────────────────────────────────────────────
+// Graph vertex / edge helpers
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Collect content vertices for a file, sorted by start position.
+///
+/// Returns non-empty, non-root, non-inode vertices from the alive graph.
+fn collect_sorted_content_vertices<T>(
     txn: &T,
     inode_pos: Position<NodeId>,
-) -> GlobalizeResult<Position<NodeId>>
+) -> GlobalizeResult<Vec<GraphNode<NodeId>>>
 where
     T: GraphTxnT,
 {
-    // Retrieve the file's content graph starting from the inode position
-    let result = match retrieve_graph(txn, inode_pos, RetrieveOptions::default()) {
-        Ok(r) => r,
-        Err(_) => {
-            // If we can't retrieve the graph, fall back to inode position
-            // This can happen for empty files or files with no content yet
-            return Ok(inode_pos);
-        }
-    };
-
-    // Find the span with the highest end position
-    // This is the "last" content in the file
-    //
-    // We track content vertices separately from the inode because inode positions
-    // may be in a reserved high range (for CRDT compatibility) that would make
-    // simple comparisons fail. We want the content span with the highest end
-    // position in the normal content range.
-    let mut max_content_end: Option<Position<NodeId>> = None;
-
-    for vertex_id in 0..result.graph.len_vertices() {
-        if let Some(alive_vertex) = result.graph.try_get_vertex(vertex_id.into()) {
-            let alive_node = &alive_vertex.node;
-
-            // Skip the DUMMY span (NodeId(0) / ROOT)
-            if alive_node.change.is_root() {
-                continue;
-            }
-
-            // Skip empty vertices (like inode markers)
-            // Content vertices always have start < end
-            if alive_node.start == alive_node.end {
-                continue;
-            }
-
-            // This is a content span - track the one with the highest end position
-            let end_pos = Position::new(alive_node.change, alive_node.end);
-
-            match &max_content_end {
-                None => {
-                    // First content span found
-                    max_content_end = Some(end_pos);
-                }
-                Some(current_max) => {
-                    // Compare by position value - we want the highest end position
-                    if end_pos.pos > current_max.pos {
-                        max_content_end = Some(end_pos);
-                    }
-                }
-            }
-        }
-    }
-
-    // Return the highest content end position, or fall back to inode position
-    // if no content was found (empty file)
-    Ok(max_content_end.unwrap_or(inode_pos))
+    let mut vertices = find_content_vertices(txn, inode_pos)?;
+    vertices.sort_by(|a, b| a.start.cmp(&b.start));
+    Ok(vertices)
 }
 
-/// Find all content vertices for a file.
-///
-/// This retrieves the file's graph and returns all non-inode content vertices.
-/// Used for deletion operations where we need to mark existing content as deleted.
-///
-/// # Arguments
-///
-/// * `txn` - Transaction for graph lookups
-/// * `inode_pos` - The graph position of the file's inode
-///
-/// # Returns
-///
-/// A vector of content vertices (excluding the inode span and DUMMY).
+/// Retrieve every content vertex for a file (excluding ROOT / inode markers).
 fn find_content_vertices<T>(
     txn: &T,
     inode_pos: Position<NodeId>,
@@ -406,189 +295,122 @@ fn find_content_vertices<T>(
 where
     T: GraphTxnT,
 {
-    use crate::output::alive::{retrieve_graph, RetrieveOptions};
-
-    let result = match retrieve_graph(txn, inode_pos, RetrieveOptions::default()) {
+    let options = RetrieveOptions::default();
+    let result = match retrieve_graph(txn, inode_pos, options) {
         Ok(r) => r,
-        Err(_) => {
-            // No graph content - return empty
-            return Ok(Vec::new());
-        }
+        Err(_) => return Ok(Vec::new()),
     };
 
-    let mut vertices = Vec::new();
+    let mut out = Vec::new();
+    for vid in 0..result.graph.len_vertices() {
+        let Some(alive) = result.graph.try_get_vertex(vid.into()) else {
+            continue;
+        };
+        let node = alive.node;
 
-    for vertex_id in 0..result.graph.len_vertices() {
-        if let Some(alive_vertex) = result.graph.try_get_vertex(vertex_id.into()) {
-            let alive_node = alive_vertex.node;
-
-            // Skip DUMMY/ROOT span
-            if alive_node.change.is_root() {
-                continue;
-            }
-
-            // Skip the inode span (empty span at inode position)
-            if alive_node.start == alive_node.end && alive_node.start == inode_pos.pos {
-                continue;
-            }
-
-            // This is a content span
-            vertices.push(alive_node);
+        // Skip the virtual root.
+        if node.change.is_root() {
+            continue;
         }
-    }
+        // Skip the inode marker (empty vertex at the inode position).
+        if node.start == node.end && node.start == inode_pos.pos {
+            continue;
+        }
 
-    Ok(vertices)
+        out.push(node);
+    }
+    Ok(out)
 }
 
-/// Create deletion edges for a list of content vertices.
+/// Create [`NewEdge`] deletion entries for each vertex.
 ///
-/// For each span, creates a NewEdge that marks the edge TO that span as deleted.
-/// The edge goes from the predecessor's end position to the span being deleted.
-///
-/// # Arguments
-///
-/// * `ctx` - The globalization context (for tracking dependencies)
-/// * `inode_pos` - The inode position (used to find predecessor edges)
-/// * `vertices` - The vertices to mark as deleted
-///
-/// # Returns
-///
-/// A vector of NewEdge structures for the deletion.
-fn create_deletion_edges_for_vertices<T>(
+/// For every content vertex we:
+/// 1. Find its predecessor via PARENT edges.
+/// 2. Create a `BLOCK | DELETED` edge from that predecessor to the vertex.
+/// 3. Track the dependency on the change that introduced the vertex.
+fn build_deletion_edges<T>(
     ctx: &mut GlobalizeContext<'_, T>,
     vertices: &[GraphNode<NodeId>],
 ) -> GlobalizeResult<Vec<NewEdge<Option<Hash>>>>
 where
     T: GraphTxnT + TreeTxnT,
 {
-    use crate::change::NewEdge;
-    use crate::types::EdgeKind;
+    let mut edges = Vec::with_capacity(vertices.len());
 
-    let mut edges = Vec::new();
-
-    for v in vertices {
-        // Track dependency on the change that introduced this span
+    for &v in vertices {
         ctx.add_dependency_by_id(v.change)?;
 
-        // Find the predecessor of this span by looking for PARENT edges
-        // The deletion edge should go from the predecessor's end to this span
-        //
-        // For a content span that's a child of the inode, the predecessor
-        // is the inode span itself. We look up the parent edge to find
-        // the source position.
-        let from_pos = find_predecessor_end_position(ctx.txn(), *v)?;
+        let from_pos = find_predecessor_end(ctx.txn(), v)?;
 
-        // Create a deletion edge using typed EdgeKind.
-        // previous = Block (the existing live edge we expect)
-        // flag     = BlockDeleted (mark the edge as deleted)
-        let edge = NewEdge {
-            previous: EdgeKind::Block.to_flags(),
-            flag: EdgeKind::BlockDeleted.to_flags(),
-            // From: the end position of the predecessor span
+        edges.push(NewEdge {
+            previous: EdgeFlags::BLOCK,
+            flag: EdgeFlags::BLOCK | EdgeFlags::DELETED,
             from: position_to_option_hash_resolved(ctx.txn(), from_pos, None),
-            // To: the span being deleted
-            to: vertex_to_option_hash_resolved(ctx.txn(), *v, None),
-            // Introduced by: the change that originally created the edge
-            // We look this up from the graph
-            introduced_by: find_edge_introduced_by(ctx.txn(), from_pos, *v),
-        };
-
-        edges.push(edge);
+            to: vertex_to_option_hash_resolved(ctx.txn(), v, None),
+            introduced_by: find_edge_introduced_by(ctx.txn(), from_pos, v),
+        });
     }
 
     Ok(edges)
 }
 
-/// Find the end position of the predecessor of a span.
-///
-/// This looks up the PARENT edges of the span to find which span
-/// comes before it, then returns the end position of that predecessor.
-fn find_predecessor_end_position<T: GraphTxnT>(
+/// Walk PARENT edges of `node` to find the end position of its predecessor.
+fn find_predecessor_end<T: GraphTxnT>(
     txn: &T,
     node: GraphNode<NodeId>,
 ) -> GlobalizeResult<Position<NodeId>> {
-    use crate::types::ParentEdgeKind;
+    let min_flag = EdgeFlags::BLOCK | EdgeFlags::PARENT;
+    let max_flag = EdgeFlags::BLOCK | EdgeFlags::PARENT | EdgeFlags::FOLDER;
 
-    // Use typed iter_parents to find BLOCK|PARENT or FOLDER|PARENT edges.
-    //
-    // NOTE: No change filter here.  This is a structural lookup — we need
-    // the predecessor vertex regardless of which view introduced the edge.
-    // The `introduced_by` on a parent edge records WHEN the connection was
-    // made, not WHETHER the predecessor exists.  Filtering here would reject
-    // edges introduced by sibling views and leave content vertices orphaned.
-    //
-    // include_deleted=false: we only want alive parent edges.
-    let parents = txn
-        .iter_parents(node, false)
+    let mut adj = txn
+        .iter_adjacent(node, min_flag, max_flag)
         .map_err(|e| GlobalizeError::Pristine(Box::new(e)))?;
 
-    for parent in parents {
-        match parent.kind {
-            // Block or Folder parent — the dest points to where the forward
-            // edge came FROM (remember, this is a reverse/PARENT edge).
-            ParentEdgeKind::Block | ParentEdgeKind::Folder => {
-                return Ok(parent.dest);
-            }
-            // Skip pseudo parents — they are synthetic connectivity edges,
-            // not real predecessors from stored changes.
-            _ => continue,
-        }
+    if let Some(edge) = adj.next() {
+        let edge = edge.map_err(|e| GlobalizeError::Pristine(Box::new(e)))?;
+        return Ok(edge.dest());
     }
 
-    // If no parent found, this shouldn't happen for content vertices
-    // Use NodeNotFound as the closest matching error type
     Err(GlobalizeError::NodeNotFound {
         position: node.start_pos(),
     })
 }
 
-/// Find the change that introduced an edge between two positions.
+/// Discover which change introduced the forward edge from `from_pos` to
+/// `to_vertex`.
 fn find_edge_introduced_by<T: GraphTxnT>(
     txn: &T,
     from_pos: Position<NodeId>,
     to_vertex: GraphNode<NodeId>,
 ) -> Option<Hash> {
-    use crate::types::EdgeKind;
-
-    // Find the span at the from position
-    // (find_block_end resolves a position to a vertex — no filtering needed
-    // since the vertex exists regardless of which view introduced it)
     let from_vertex = match txn.find_block_end(from_pos) {
         Ok(v) => v,
         Err(_) => return None,
     };
 
-    // Use typed iter_forward to find Block or Folder edges.
-    // include_deleted=false: we want the alive edge that originally
-    // connected from_vertex to to_vertex.
-    //
-    // NOTE: No change filter here.  This is a structural lookup — we
-    // need to find the edge that connects from_vertex to to_vertex
-    // regardless of which view introduced it.  The original edge may
-    // have been replaced by a sibling view (e.g., agent-a deletes
-    // the C1 edge and adds a C2 edge).  We still need to find it so
-    // we can record the correct `introduced_by` in the new change.
-    let edges = match txn.iter_forward(from_vertex, false) {
-        Ok(e) => e,
+    let min_flag = EdgeFlags::BLOCK;
+    let max_flag = EdgeFlags::BLOCK | EdgeFlags::FOLDER;
+
+    let adj = match txn.iter_adjacent(from_vertex, min_flag, max_flag) {
+        Ok(a) => a,
         Err(_) => return None,
     };
 
-    for edge in edges {
-        match edge.kind {
-            EdgeKind::Block | EdgeKind::Folder => {
-                // Check if this edge points to our target span
-                if edge.dest == to_vertex.start_pos() {
-                    return txn.get_external(edge.introduced_by).ok().flatten();
-                }
-            }
-            _ => continue,
+    for edge_result in adj {
+        let edge = match edge_result {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        if edge.dest() == to_vertex.start_pos() {
+            return txn.get_external(edge.introduced_by()).ok().flatten();
         }
     }
 
     None
 }
 
-/// Convert a GraphNode<NodeId> to GraphNode<Option<Hash>>, resolving external change hashes.
+/// Convert a [`GraphNode<NodeId>`] to [`GraphNode<Option<Hash>>`], resolving
+/// external change hashes via the transaction.
 fn vertex_to_option_hash_resolved<T: GraphTxnT>(
     txn: &T,
     node: GraphNode<NodeId>,

--- a/atomic-core/src/record/workflow/globalize/hunk.rs
+++ b/atomic-core/src/record/workflow/globalize/hunk.rs
@@ -333,75 +333,7 @@ where
     find_content_vertices_global(txn, inode_pos)
 }
 
-/// Fast path: scan INODE_GRAPH for this file's vertices only.
-fn find_content_vertices_via_inode<T>(
-    txn: &T,
-    inode: Inode,
-    inode_pos: Position<NodeId>,
-) -> GlobalizeResult<Vec<GraphNode<NodeId>>>
-where
-    T: GraphTxnT + InodeGraphOps,
-{
-    use crate::types::EdgeFlags;
-
-    let mut out = Vec::new();
-
-    // Iterate all forward (non-PARENT) edges in this file's INODE_GRAPH.
-    // Each unique destination vertex that is alive is a content vertex.
-    let mut seen = std::collections::HashSet::new();
-
-    // Start from the inode vertex — follow its forward edges
-    let mut stack = vec![inode_pos.inode_node()];
-    seen.insert(inode_pos.inode_node());
-
-    while let Some(node) = stack.pop() {
-        // Get forward (non-deleted, non-parent) edges for this node
-        // within the inode scope.
-        let min_flag = EdgeFlags::BLOCK;
-        let max_flag = EdgeFlags::all()
-            .difference(EdgeFlags::PARENT)
-            .difference(EdgeFlags::DELETED);
-
-        let mut adj = match txn.init_inode_adj(inode, node, min_flag, max_flag) {
-            Ok(a) => a,
-            Err(_) => continue,
-        };
-
-        while let Some(edge_result) = txn.next_inode_adj(&mut adj) {
-            let edge = match edge_result {
-                Ok(e) => e,
-                Err(_) => continue,
-            };
-
-            let dest_pos = edge.dest();
-            let resolved = match txn.find_block(dest_pos) {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-
-            if seen.contains(&resolved) {
-                continue;
-            }
-            seen.insert(resolved);
-
-            // Skip ROOT
-            if resolved.change.is_root() {
-                continue;
-            }
-            // Skip inode marker (empty vertex at inode position)
-            if resolved.start == resolved.end && resolved.start == inode_pos.pos {
-                continue;
-            }
-
-            out.push(resolved);
-            stack.push(resolved);
-        }
-    }
-
-    Ok(out)
-}
-
-/// Fallback: retrieve content vertices via global GRAPH DFS.
+/// Retrieve content vertices via global GRAPH DFS.
 fn find_content_vertices_global<T>(
     txn: &T,
     inode_pos: Position<NodeId>,

--- a/atomic-core/src/record/workflow/globalize/hunk.rs
+++ b/atomic-core/src/record/workflow/globalize/hunk.rs
@@ -1,5 +1,13 @@
 //! Globalize a single built hunk into a graph operation.
 //!
+//! # Performance
+//!
+//! Content vertex discovery uses the `INODE_GRAPH` secondary index when the
+//! transaction implements [`InodeGraphOps`].  This gives O(m) traversal
+//! where m = edges for THIS file, instead of O(n) where n = all edges in
+//! the repository.  See the [Performance at Scale] documentation for the
+//! dual-index architecture.
+//!
 //! This module converts a local working-copy change (a [`BuiltHunk`]) into a
 //! graph-compatible [`GraphOp<Option<Hash>>`].
 //!
@@ -26,6 +34,7 @@
 
 use super::*;
 use crate::change::Local;
+use crate::pristine::InodeGraphOps;
 
 // ───────────────────────────────────────────────────────────────────────────
 // Public entry point
@@ -52,7 +61,7 @@ pub fn globalize_hunk<T>(
     old_line_count: Option<usize>,
 ) -> GlobalizeResult<GraphOp<Option<Hash>>>
 where
-    T: GraphTxnT + TreeTxnT,
+    T: GraphTxnT + TreeTxnT + InodeGraphOps,
 {
     let local = built.local.clone();
     let encoding = built.encoding;
@@ -71,7 +80,7 @@ where
         BuiltHunkKind::Replace => {
             globalize_replace(ctx, inode, inode_pos, content, local, encoding)
         }
-        BuiltHunkKind::Delete => globalize_delete(ctx, inode_pos, local, encoding),
+        BuiltHunkKind::Delete => globalize_delete(ctx, inode, inode_pos, local, encoding),
     }
 }
 
@@ -101,9 +110,9 @@ fn globalize_insert<T>(
     encoding: Option<Encoding>,
 ) -> GlobalizeResult<GraphOp<Option<Hash>>>
 where
-    T: GraphTxnT + TreeTxnT,
+    T: GraphTxnT + TreeTxnT + InodeGraphOps,
 {
-    let position = classify_insert(ctx.txn(), inode_pos, built.old_start, old_line_count)?;
+    let position = classify_insert(ctx.txn(), inode, inode_pos, built.old_start, old_line_count)?;
 
     let (predecessors, successors) = match position {
         InsertPosition::Prepend { first_content } => (vec![inode_pos], vec![first_content]),
@@ -134,9 +143,15 @@ fn globalize_replace<T>(
     encoding: Option<Encoding>,
 ) -> GlobalizeResult<GraphOp<Option<Hash>>>
 where
-    T: GraphTxnT + TreeTxnT,
+    T: GraphTxnT + TreeTxnT + InodeGraphOps,
 {
-    let deletion = delete_all_content(ctx, inode_pos)?;
+    let content_vertices = find_content_vertices(ctx.txn(), inode, inode_pos)?;
+    let deletion_edges = build_deletion_edges(ctx, &content_vertices)?;
+
+    let deletion = EdgeUpdate {
+        edges: deletion_edges,
+        inode: position_to_option_hash(inode_pos),
+    };
 
     let insertion = create_content_vertex(ctx, inode, inode_pos, vec![inode_pos], vec![], content)?;
 
@@ -155,14 +170,15 @@ where
 /// Mark every content vertex for this file as deleted.
 fn globalize_delete<T>(
     ctx: &mut GlobalizeContext<'_, T>,
+    inode: Inode,
     inode_pos: Position<NodeId>,
     local: Local,
     encoding: Option<Encoding>,
 ) -> GlobalizeResult<GraphOp<Option<Hash>>>
 where
-    T: GraphTxnT + TreeTxnT,
+    T: GraphTxnT + TreeTxnT + InodeGraphOps,
 {
-    let deletion = delete_all_content(ctx, inode_pos)?;
+    let deletion = delete_all_content(ctx, inode, inode_pos)?;
 
     Ok(GraphOp::Edit {
         change: Atom::EdgeUpdate(deletion),
@@ -183,16 +199,17 @@ where
 /// [`globalize_delete`] delegate here.
 fn delete_all_content<T>(
     ctx: &mut GlobalizeContext<'_, T>,
+    inode: Inode,
     inode_pos: Position<NodeId>,
 ) -> GlobalizeResult<EdgeUpdate<Option<Hash>>>
 where
-    T: GraphTxnT + TreeTxnT,
+    T: GraphTxnT + TreeTxnT + InodeGraphOps,
 {
-    let vertices = find_content_vertices(ctx.txn(), inode_pos)?;
-    let edges = build_deletion_edges(ctx, &vertices)?;
+    let content_vertices = find_content_vertices(ctx.txn(), inode, inode_pos)?;
+    let deletion_edges = build_deletion_edges(ctx, &content_vertices)?;
 
     Ok(EdgeUpdate {
-        edges,
+        edges: deletion_edges,
         inode: position_to_option_hash(inode_pos),
     })
 }
@@ -223,14 +240,15 @@ enum InsertPosition {
 /// case should have been consolidated into a Replace upstream.
 fn classify_insert<T>(
     txn: &T,
+    inode: Inode,
     inode_pos: Position<NodeId>,
     old_start: usize,
     old_line_count: Option<usize>,
 ) -> GlobalizeResult<InsertPosition>
 where
-    T: GraphTxnT,
+    T: GraphTxnT + InodeGraphOps,
 {
-    let vertices = collect_sorted_content_vertices(txn, inode_pos)?;
+    let vertices = collect_sorted_content_vertices(txn, inode, inode_pos)?;
 
     // Empty file → append (predecessor is the inode itself).
     if vertices.is_empty() {
@@ -277,18 +295,114 @@ where
 /// Returns non-empty, non-root, non-inode vertices from the alive graph.
 fn collect_sorted_content_vertices<T>(
     txn: &T,
+    inode: Inode,
     inode_pos: Position<NodeId>,
 ) -> GlobalizeResult<Vec<GraphNode<NodeId>>>
 where
-    T: GraphTxnT,
+    T: GraphTxnT + InodeGraphOps,
 {
-    let mut vertices = find_content_vertices(txn, inode_pos)?;
+    let mut vertices = find_content_vertices(txn, inode, inode_pos)?;
     vertices.sort_by(|a, b| a.start.cmp(&b.start));
     Ok(vertices)
 }
 
-/// Retrieve every content vertex for a file (excluding ROOT / inode markers).
+/// Retrieve every alive content vertex for a file using the INODE_GRAPH
+/// secondary index.
+///
+/// This is O(m) where m = edges for this file, instead of the O(n)
+/// `retrieve_graph` approach that scans the entire global GRAPH.
+///
+/// Falls back to the global `retrieve_graph` if INODE_GRAPH is not
+/// populated for this inode.
 fn find_content_vertices<T>(
+    txn: &T,
+    inode: Inode,
+    inode_pos: Position<NodeId>,
+) -> GlobalizeResult<Vec<GraphNode<NodeId>>>
+where
+    T: GraphTxnT + InodeGraphOps,
+{
+    // Try the fast path: INODE_GRAPH secondary index
+    let populated = txn.inode_graph_is_populated(inode).unwrap_or(false);
+
+    if populated {
+        return find_content_vertices_via_inode(txn, inode, inode_pos);
+    }
+
+    // Fallback: global GRAPH scan (for repos where INODE_GRAPH wasn't populated)
+    find_content_vertices_global(txn, inode_pos)
+}
+
+/// Fast path: scan INODE_GRAPH for this file's vertices only.
+fn find_content_vertices_via_inode<T>(
+    txn: &T,
+    inode: Inode,
+    inode_pos: Position<NodeId>,
+) -> GlobalizeResult<Vec<GraphNode<NodeId>>>
+where
+    T: GraphTxnT + InodeGraphOps,
+{
+    use crate::types::EdgeFlags;
+
+    let mut out = Vec::new();
+
+    // Iterate all forward (non-PARENT) edges in this file's INODE_GRAPH.
+    // Each unique destination vertex that is alive is a content vertex.
+    let mut seen = std::collections::HashSet::new();
+
+    // Start from the inode vertex — follow its forward edges
+    let mut stack = vec![inode_pos.inode_node()];
+    seen.insert(inode_pos.inode_node());
+
+    while let Some(node) = stack.pop() {
+        // Get forward (non-deleted, non-parent) edges for this node
+        // within the inode scope.
+        let min_flag = EdgeFlags::BLOCK;
+        let max_flag = EdgeFlags::all()
+            .difference(EdgeFlags::PARENT)
+            .difference(EdgeFlags::DELETED);
+
+        let mut adj = match txn.init_inode_adj(inode, node, min_flag, max_flag) {
+            Ok(a) => a,
+            Err(_) => continue,
+        };
+
+        while let Some(edge_result) = txn.next_inode_adj(&mut adj) {
+            let edge = match edge_result {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+
+            let dest_pos = edge.dest();
+            let resolved = match txn.find_block(dest_pos) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+
+            if seen.contains(&resolved) {
+                continue;
+            }
+            seen.insert(resolved);
+
+            // Skip ROOT
+            if resolved.change.is_root() {
+                continue;
+            }
+            // Skip inode marker (empty vertex at inode position)
+            if resolved.start == resolved.end && resolved.start == inode_pos.pos {
+                continue;
+            }
+
+            out.push(resolved);
+            stack.push(resolved);
+        }
+    }
+
+    Ok(out)
+}
+
+/// Fallback: retrieve content vertices via global GRAPH DFS.
+fn find_content_vertices_global<T>(
     txn: &T,
     inode_pos: Position<NodeId>,
 ) -> GlobalizeResult<Vec<GraphNode<NodeId>>>
@@ -333,7 +447,7 @@ fn build_deletion_edges<T>(
     vertices: &[GraphNode<NodeId>],
 ) -> GlobalizeResult<Vec<NewEdge<Option<Hash>>>>
 where
-    T: GraphTxnT + TreeTxnT,
+    T: GraphTxnT + TreeTxnT + InodeGraphOps,
 {
     let mut edges = Vec::with_capacity(vertices.len());
 
@@ -355,7 +469,7 @@ where
 }
 
 /// Walk PARENT edges of `node` to find the end position of its predecessor.
-fn find_predecessor_end<T: GraphTxnT>(
+fn find_predecessor_end<T: GraphTxnT + InodeGraphOps>(
     txn: &T,
     node: GraphNode<NodeId>,
 ) -> GlobalizeResult<Position<NodeId>> {
@@ -378,7 +492,7 @@ fn find_predecessor_end<T: GraphTxnT>(
 
 /// Discover which change introduced the forward edge from `from_pos` to
 /// `to_vertex`.
-fn find_edge_introduced_by<T: GraphTxnT>(
+fn find_edge_introduced_by<T: GraphTxnT + InodeGraphOps>(
     txn: &T,
     from_pos: Position<NodeId>,
     to_vertex: GraphNode<NodeId>,
@@ -411,7 +525,7 @@ fn find_edge_introduced_by<T: GraphTxnT>(
 
 /// Convert a [`GraphNode<NodeId>`] to [`GraphNode<Option<Hash>>`], resolving
 /// external change hashes via the transaction.
-fn vertex_to_option_hash_resolved<T: GraphTxnT>(
+fn vertex_to_option_hash_resolved<T: GraphTxnT + InodeGraphOps>(
     txn: &T,
     node: GraphNode<NodeId>,
     current_change_id: Option<NodeId>,

--- a/atomic-core/src/record/workflow/globalize/hunk.rs
+++ b/atomic-core/src/record/workflow/globalize/hunk.rs
@@ -49,9 +49,9 @@ use crate::pristine::InodeGraphOps;
 /// * `inode`          – the file's stable identifier
 /// * `inode_pos`      – the graph position of the file's inode vertex
 /// * `content`        – the content bytes this hunk should insert (the hunk's
-///                      own slice for Insert, the full new file for Replace)
+///   own slice for Insert, the full new file for Replace)
 /// * `old_line_count` – number of lines in the old file (for insert-position
-///                      classification)
+///   classification)
 pub fn globalize_hunk<T>(
     ctx: &mut GlobalizeContext<'_, T>,
     built: &BuiltHunk,
@@ -99,6 +99,7 @@ where
 ///
 /// Any other position means the upstream consolidation was bypassed, and we
 /// return an error instead of silently producing duplicate content.
+#[allow(clippy::too_many_arguments)]
 fn globalize_insert<T>(
     ctx: &mut GlobalizeContext<'_, T>,
     built: &BuiltHunk,

--- a/atomic-core/src/record/workflow/globalize/pipeline.rs
+++ b/atomic-core/src/record/workflow/globalize/pipeline.rs
@@ -160,6 +160,108 @@ where
         return Ok(result);
     }
 
+    // Handle file moves/renames (FileMove)
+    if matches!(
+        recorded.kind(),
+        Some(crate::record::workflow::detect::DetectionKind::Moved)
+    ) {
+        use crate::change::EdgeUpdate;
+
+        let old_path = recorded
+            .old_path()
+            .ok_or_else(|| GlobalizeError::MissingField {
+                path: path.to_string(),
+                field: "old_path",
+            })?;
+
+        // Look up the inode for the old path
+        let old_inode =
+            ctx.txn()
+                .get_inode(old_path)?
+                .ok_or_else(|| GlobalizeError::PathNotFound {
+                    path: old_path.to_string(),
+                })?;
+
+        // Look up the inode's graph position
+        let old_inode_pos_node = ctx
+            .txn()
+            .inode_position(old_inode)?
+            .ok_or_else(|| GlobalizeError::InodeNotFound { inode: old_inode })?;
+
+        // Convert the inode position to Option<Hash> using external hash resolution
+        let change_hash: Option<Hash> = ctx.get_external(old_inode_pos_node.change);
+
+        // Add a dependency on the change that introduced this file
+        ctx.add_dependency_by_id(old_inode_pos_node.change)?;
+
+        // Build the del EdgeUpdate: marks the FOLDER edge at the inode vertex as DELETED.
+        // This follows the same pattern as DirDel.
+        let del = EdgeUpdate {
+            edges: vec![NewEdge {
+                previous: EdgeFlags::FOLDER,
+                flag: EdgeFlags::FOLDER | EdgeFlags::DELETED,
+                from: Position {
+                    change: change_hash,
+                    pos: old_inode_pos_node.pos,
+                },
+                to: GraphNode {
+                    change: change_hash,
+                    start: old_inode_pos_node.pos,
+                    end: old_inode_pos_node.pos,
+                },
+                introduced_by: change_hash,
+            }],
+            inode: Position {
+                change: change_hash,
+                pos: old_inode_pos_node.pos,
+            },
+        };
+
+        // Build the add Insertion: a new name vertex pointing to the same inode position.
+        // The parent context is ROOT (top-level file — nested-dir support is a future concern).
+        let parent_context_pos: Position<Option<Hash>> = Position {
+            change: Some(Hash::NONE),
+            pos: ChangePosition::ROOT,
+        };
+
+        // The inode position for the add — references the EXISTING inode (old change).
+        let inode_opt_hash_pos: Position<Option<Hash>> = Position {
+            change: change_hash,
+            pos: old_inode_pos_node.pos,
+        };
+
+        // Write the new filename bytes into the content buffer.
+        let new_filename = extract_filename(path);
+        let new_filename_bytes = new_filename.as_bytes();
+        let initial_content_len = ctx.content_len();
+        let (name_start, name_end) = ctx.append_content(new_filename_bytes);
+
+        let add = Insertion {
+            predecessors: vec![parent_context_pos],
+            successors: vec![],
+            flag: EdgeFlags::FOLDER | EdgeFlags::BLOCK,
+            start: name_start,
+            end: name_end,
+            inode: inode_opt_hash_pos,
+        };
+
+        let graph_op: GraphOp<Option<Hash>> = GraphOp::FileMove {
+            del,
+            add,
+            path: path.to_string(),
+        };
+
+        result.add_hunk(graph_op);
+        result.set_bytes_added(ctx.content_len() - initial_content_len);
+
+        // Carry any CRDT ops that were set on the recorded file
+        if let Some(file_ops) = recorded.crdt_ops().cloned() {
+            result.set_file_ops(file_ops);
+        }
+
+        return Ok(result);
+    }
+
     // Check for empty file
     if recorded.is_empty() && !options.include_empty_files() {
         return Ok(result);
@@ -184,19 +286,34 @@ where
 
         // Process each graph_op for modification
         for built in recorded.hunks() {
-            // Get the content slice for this graph_op
-            let hunk_content =
-                if let (Some(start), Some(end)) = (built.content_start, built.content_end) {
-                    let start = start as usize;
-                    let end = end as usize;
-                    if end <= content.len() {
-                        &content[start..end]
+            // Determine the content slice for this hunk.
+            //
+            // Replace hunks need the full file content because they delete
+            // all existing vertices and re-insert the complete new file.
+            //
+            // Insert hunks only need their own slice — they are guaranteed
+            // (by the upstream consolidation in record_modified_file) to be
+            // clean Prepend or Append operations that wire in their own
+            // bytes without touching anything else.
+            //
+            // Delete hunks carry no content.
+            let hunk_content = match built.kind {
+                crate::record::workflow::graph_op::BuiltHunkKind::Replace => content,
+                crate::record::workflow::graph_op::BuiltHunkKind::Insert => {
+                    if let (Some(start), Some(end)) = (built.content_start, built.content_end) {
+                        let start = start as usize;
+                        let end = end as usize;
+                        if end <= content.len() {
+                            &content[start..end]
+                        } else {
+                            &[]
+                        }
                     } else {
                         &[]
                     }
-                } else {
-                    &[]
-                };
+                }
+                crate::record::workflow::graph_op::BuiltHunkKind::Delete => &[],
+            };
 
             // Track content position before globalization
             let content_pos_before = ctx.content_len();
@@ -207,7 +324,6 @@ where
                 inode,
                 inode_pos,
                 hunk_content,
-                content,
                 recorded.old_line_count(),
             )?;
 
@@ -216,20 +332,17 @@ where
 
             // Record the content range for this hunk
             if content_pos_after > content_pos_before {
+                let uses_full = matches!(
+                    built.kind,
+                    crate::record::workflow::graph_op::BuiltHunkKind::Replace
+                );
                 hunk_content_ranges.push(HunkContentRange {
                     kind: built.kind,
                     new_start: built.new_start,
                     new_len: built.new_len,
                     content_start: ChangePosition::new(content_pos_before),
                     content_end: ChangePosition::new(content_pos_after),
-                    // For Replace hunks, we use full_content, so track that
-                    uses_full_content: matches!(
-                        built.kind,
-                        crate::record::workflow::graph_op::BuiltHunkKind::Replace
-                    ) || matches!(
-                        built.kind,
-                        crate::record::workflow::graph_op::BuiltHunkKind::Insert
-                    ),
+                    uses_full_content: uses_full,
                 });
             }
 

--- a/atomic-core/src/record/workflow/globalize/pipeline.rs
+++ b/atomic-core/src/record/workflow/globalize/pipeline.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::pristine::InodeGraphOps;
 
 /// Globalize all hunks in a recorded file.
 ///
@@ -29,7 +30,7 @@ pub fn globalize_recorded_file<T>(
     options: &GlobalizeOptions,
 ) -> GlobalizeResult<GlobalizedFile>
 where
-    T: GraphTxnT + TreeTxnT,
+    T: GraphTxnT + TreeTxnT + InodeGraphOps,
 {
     use crate::change::{GraphOp, Insertion};
     use crate::types::{ChangePosition, EdgeFlags, Position};

--- a/atomic-core/src/record/workflow/mod.rs
+++ b/atomic-core/src/record/workflow/mod.rs
@@ -148,8 +148,8 @@ pub use graph_op::{
 };
 pub use options::WorkflowOptions;
 pub use record::{
-    record_added_file, record_deleted_file, record_modified_file, RecordedFile, RecordingOptions,
-    RecordingResult, RecordingStats,
+    build_crdt_ops_from_git_diff, record_added_file, record_deleted_file, record_modified_file,
+    GitDiffLine, RecordedFile, RecordingOptions, RecordingResult, RecordingStats,
 };
 
 // Re-export commonly used CRDT types for token-level diff support

--- a/atomic-core/src/record/workflow/record/crdt.rs
+++ b/atomic-core/src/record/workflow/record/crdt.rs
@@ -358,8 +358,8 @@ pub(super) fn build_crdt_ops_for_modified_file(
                     }
 
                     // Walk old lines: unpaired → Delete
-                    for oi in 0..*old_len {
-                        if paired_old[oi].is_some() {
+                    for (oi, paired_old_item) in paired_old.iter().enumerate().take(*old_len) {
+                        if paired_old_item.is_some() {
                             continue;
                         }
                         let old_line_idx = old_pos + oi;
@@ -507,8 +507,9 @@ pub(super) fn build_crdt_ops_for_modified_file(
             set
         };
 
-        let mut del_entries: Vec<(usize, String, std::collections::HashSet<(u8, u8)>)> = Vec::new();
-        let mut ins_entries: Vec<(usize, String, std::collections::HashSet<(u8, u8)>)> = Vec::new();
+        type BigramEntry = (usize, String, std::collections::HashSet<(u8, u8)>);
+        let mut del_entries: Vec<BigramEntry> = Vec::new();
+        let mut ins_entries: Vec<BigramEntry> = Vec::new();
 
         for (idx, op) in collected_line_ops.iter().enumerate() {
             if op.is_modify() {

--- a/atomic-core/src/record/workflow/record/crdt.rs
+++ b/atomic-core/src/record/workflow/record/crdt.rs
@@ -221,94 +221,78 @@ pub(super) fn build_crdt_ops_for_modified_file(
                 new_len,
             } => {
                 // ══════════════════════════════════════════════════════════
-                // Replace → BranchOp::Modify / Delete / Insert
+                // Replace → BranchOp::Modify (equal count) or Delete+Insert
                 // ══════════════════════════════════════════════════════════
                 //
-                // The diff algorithm already determined that these old lines
-                // were *replaced* by these new lines.  We preserve that
-                // semantic information by emitting:
+                // When old_len == new_len (1:1 replacement), the diff algorithm
+                // anchored each old line to exactly one new line.  We emit
+                // BranchOp::Modify so the display layer can show adjacent -/+
+                // pairs with word-level highlighting.
                 //
-                //   • BranchOp::Modify  — for each old↔new pair (a line
-                //     that changed but kept its identity).  Carries both
-                //     old and new content so every consumer can render
-                //     word-level diffs without heuristic re-pairing.
+                // When counts differ (pure insertions or deletions within the
+                // block), we emit all old lines as Delete then all new lines as
+                // Insert — matching git's unified diff format exactly.
                 //
-                //   • BranchOp::Delete  — for old lines with no match
-                //     (pure removals within the block).
-                //
-                //   • BranchOp::Insert  — for new lines with no match
-                //     (pure additions within the block).
-                //
-                // Pairing strategy:
-                //   equal counts  → positional (old[0]↔new[0], …)
-                //   unequal counts → greedy best-match by bigram Jaccard,
-                //     then positional fallback for any remaining unpaired.
-                //
-                // This is the ONLY place pairing is determined.  No
-                // downstream heuristic, threshold tuning, or post-
-                // processing is needed.
-
-                let min_len = (*old_len).min(*new_len);
-                let _max_len = (*old_len).max(*new_len);
-
-                // ── Build token lists for old/new lines ──────────────────
-
-                let build_old_leaf_ops = |line_idx: usize| -> Vec<LeafOp> {
-                    if line_idx < old_lines.len() {
-                        old_lines[line_idx]
-                            .tokens()
-                            .iter()
-                            .map(|t| LeafOp::Insert {
-                                after: None,
-                                kind: t.kind(),
-                                content: t.content().to_vec(),
-                            })
-                            .collect()
-                    } else {
-                        Vec::new()
-                    }
-                };
-
-                let build_new_leaf_ops = |line_idx: usize,
-                                          alloc_leaf: &mut dyn FnMut() -> LeafId,
-                                          stats: &mut CrdtBuildStats|
-                 -> Vec<LeafOp> {
-                    if line_idx < new_lines.len() {
-                        let mut prev_leaf: Option<LeafId> = None;
-                        new_lines[line_idx]
-                            .tokens()
-                            .iter()
-                            .map(|t| {
-                                let leaf_id = alloc_leaf();
-                                let op = LeafOp::Insert {
-                                    after: prev_leaf,
-                                    kind: t.kind(),
-                                    content: t.content().to_vec(),
-                                };
-                                stats.tokens_added += 1;
-                                prev_leaf = Some(leaf_id);
-                                op
-                            })
-                            .collect()
-                    } else {
-                        Vec::new()
-                    }
-                };
-
-                // ── Determine old→new pairing ────────────────────────────
-
-                // paired[oi] = Some(ni) means old line oi pairs with new line ni
-                let mut paired: Vec<Option<usize>> = vec![None; *old_len];
-                let mut matched_new: Vec<bool> = vec![false; *new_len];
+                // NOTE: For git-imported changes, the CRDT ops are overridden
+                // in write_commit() with build_crdt_ops_from_git_diff(), so
+                // what we emit here only matters for atomic record (non-import).
 
                 if *old_len == *new_len {
-                    // Equal counts: positional pairing — always correct
-                    // because the diff algorithm already anchored these
-                    // lines to the same position range.
-                    for i in 0..min_len {
-                        paired[i] = Some(i);
-                        matched_new[i] = true;
+                    // Equal counts: positional 1:1 Modify — always correct
+                    // because the diff algorithm anchored these lines together.
+                    let build_old_leaf_ops = |line_idx: usize| -> Vec<LeafOp> {
+                        if line_idx < old_lines.len() {
+                            old_lines[line_idx]
+                                .tokens()
+                                .iter()
+                                .map(|t| LeafOp::Insert {
+                                    after: None,
+                                    kind: t.kind(),
+                                    content: t.content().to_vec(),
+                                })
+                                .collect()
+                        } else {
+                            Vec::new()
+                        }
+                    };
+
+                    for i in 0..*old_len {
+                        let old_line_idx = old_pos + i;
+                        let new_line_idx = new_pos + i;
+                        let branch_id = alloc_branch();
+                        let old_leaf_ops = build_old_leaf_ops(old_line_idx);
+
+                        let mut prev_leaf: Option<crate::crdt::LeafId> = None;
+                        let new_leaf_ops: Vec<LeafOp> = if new_line_idx < new_lines.len() {
+                            new_lines[new_line_idx]
+                                .tokens()
+                                .iter()
+                                .map(|t| {
+                                    let leaf_id = alloc_leaf();
+                                    let op = LeafOp::Insert {
+                                        after: prev_leaf,
+                                        kind: t.kind(),
+                                        content: t.content().to_vec(),
+                                    };
+                                    stats.tokens_added += 1;
+                                    prev_leaf = Some(leaf_id);
+                                    op
+                                })
+                                .collect()
+                        } else {
+                            Vec::new()
+                        };
+
+                        let line_op = BuilderLineOps::modify(branch_id, old_leaf_ops, new_leaf_ops)
+                            .with_old_line_num(old_line_idx + 1)
+                            .with_new_line_num(new_line_idx + 1);
+                        collected_line_ops.push(line_op);
+                        stats.lines_modified += 1;
+                        prev_branch = Some(branch_id);
                     }
+
+                    _old_line_idx = old_pos + old_len;
+                    _new_line_idx = new_pos + new_len;
                 } else {
                     // Unequal counts: use bigram similarity to find the
                     // best match for each old line among the new lines.
@@ -323,20 +307,10 @@ pub(super) fn build_crdt_ops_for_modified_file(
                         set
                     };
 
-                    // Build all scores, then greedily assign best matches.
-                    //
-                    // Only pairs with score ≥ 0.3 are accepted.  Poor
-                    // matches are left as unpaired Deletes so the
-                    // consolidation pass (which scans across ALL line_ops,
-                    // not just within one Replace block) can find the real
-                    // partner in a different block.
-                    //
-                    // Example: the diff may split `function hello()` into
-                    // Replace #0 and `function hello(name:)` into Replace
-                    // #2. Without the threshold, the Replace #0 handler
-                    // would force-pair `function hello()` with an unrelated
-                    // import line, creating a bad Modify that the
-                    // consolidation pass can't fix.
+                    // paired_old[oi] = Some(ni) means old line oi pairs with new line ni
+                    let mut paired_old: Vec<Option<usize>> = vec![None; *old_len];
+                    let mut matched_new: Vec<bool> = vec![false; *new_len];
+
                     let mut scores: Vec<(usize, usize, f64)> = Vec::new();
                     for oi in 0..*old_len {
                         let old_idx = old_pos + oi;
@@ -372,109 +346,139 @@ pub(super) fn build_crdt_ops_for_modified_file(
                         }
                     }
 
-                    // Sort descending by score — best matches first
                     scores
                         .sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
 
                     for (oi, ni, _score) in &scores {
-                        if paired[*oi].is_some() || matched_new[*ni] {
+                        if paired_old[*oi].is_some() || matched_new[*ni] {
                             continue;
                         }
-                        paired[*oi] = Some(*ni);
+                        paired_old[*oi] = Some(*ni);
                         matched_new[*ni] = true;
                     }
 
-                    // No positional fallback — unpaired old lines become
-                    // Delete ops, available for cross-block consolidation.
-                }
-
-                // ── Emit ops in new-file order ───────────────────────────
-                //
-                // Walk new lines 0..new_len in order.  For each:
-                //   • If paired with an old line → BranchOp::Modify
-                //   • If unpaired → BranchOp::Insert
-                //
-                // Then emit any unpaired old lines as BranchOp::Delete.
-
-                // Build reverse map: ni → oi
-                let mut new_to_old: Vec<Option<usize>> = vec![None; *new_len];
-                for (oi, maybe_ni) in paired.iter().enumerate() {
-                    if let Some(ni) = maybe_ni {
-                        new_to_old[*ni] = Some(oi);
-                    }
-                }
-
-                // Unpaired deletes first (old lines that have no match)
-                for (oi, paired_item) in paired.iter().enumerate().take(*old_len) {
-                    if paired_item.is_some() {
-                        continue;
-                    }
-                    let old_line_idx = old_pos + oi;
-                    let branch_id = alloc_branch();
-                    let content = build_old_leaf_ops(old_line_idx);
-                    let line_op = BuilderLineOps::delete(branch_id, content)
-                        .with_old_line_num(old_line_idx + 1);
-                    collected_line_ops.push(line_op);
-                    stats.lines_deleted += 1;
-                }
-
-                // Walk new lines in order
-                for (ni, new_to_old_entry) in new_to_old.iter().enumerate().take(*new_len) {
-                    let new_line_idx = new_pos + ni;
-
-                    if let Some(oi) = *new_to_old_entry {
-                        // Paired → emit BranchOp::Modify
+                    // Walk old lines: unpaired → Delete
+                    for oi in 0..*old_len {
+                        if paired_old[oi].is_some() {
+                            continue;
+                        }
                         let old_line_idx = old_pos + oi;
                         let branch_id = alloc_branch();
-                        let old_leaf_ops = build_old_leaf_ops(old_line_idx);
-                        let new_leaf_ops =
-                            build_new_leaf_ops(new_line_idx, &mut alloc_leaf, &mut stats);
-                        let line_op = BuilderLineOps::modify(branch_id, old_leaf_ops, new_leaf_ops)
-                            .with_old_line_num(old_line_idx + 1)
-                            .with_new_line_num(new_line_idx + 1);
+                        let content = if old_line_idx < old_lines.len() {
+                            old_lines[old_line_idx]
+                                .tokens()
+                                .iter()
+                                .map(|t| LeafOp::Insert {
+                                    after: None,
+                                    kind: t.kind(),
+                                    content: t.content().to_vec(),
+                                })
+                                .collect()
+                        } else {
+                            Vec::new()
+                        };
+                        let line_op = BuilderLineOps::delete(branch_id, content)
+                            .with_old_line_num(old_line_idx + 1);
                         collected_line_ops.push(line_op);
-                        stats.lines_modified += 1;
-                        prev_branch = Some(branch_id);
-                    } else {
-                        // Unpaired → emit BranchOp::Insert
-                        let branch_id = alloc_branch();
-                        let leaf_ops =
-                            build_new_leaf_ops(new_line_idx, &mut alloc_leaf, &mut stats);
-                        let line_op = BuilderLineOps::insert(branch_id, prev_branch, leaf_ops)
-                            .with_new_line_num(new_line_idx + 1);
-                        collected_line_ops.push(line_op);
-                        stats.lines_added += 1;
-                        prev_branch = Some(branch_id);
+                        stats.lines_deleted += 1;
                     }
-                }
 
-                _old_line_idx = old_pos + old_len;
-                _new_line_idx = new_pos + new_len;
+                    // Walk new lines: paired → Modify, unpaired → Insert
+                    for ni in 0..*new_len {
+                        let new_line_idx = new_pos + ni;
+                        // Find if any old line pairs with this new line
+                        let paired_oi = paired_old.iter().position(|m| m == &Some(ni));
+
+                        if let Some(oi) = paired_oi {
+                            let old_line_idx = old_pos + oi;
+                            let branch_id = alloc_branch();
+                            let old_leaf_ops = if old_line_idx < old_lines.len() {
+                                old_lines[old_line_idx]
+                                    .tokens()
+                                    .iter()
+                                    .map(|t| LeafOp::Insert {
+                                        after: None,
+                                        kind: t.kind(),
+                                        content: t.content().to_vec(),
+                                    })
+                                    .collect()
+                            } else {
+                                Vec::new()
+                            };
+                            let mut prev_leaf: Option<crate::crdt::LeafId> = None;
+                            let new_leaf_ops: Vec<LeafOp> = if new_line_idx < new_lines.len() {
+                                new_lines[new_line_idx]
+                                    .tokens()
+                                    .iter()
+                                    .map(|t| {
+                                        let leaf_id = alloc_leaf();
+                                        let op = LeafOp::Insert {
+                                            after: prev_leaf,
+                                            kind: t.kind(),
+                                            content: t.content().to_vec(),
+                                        };
+                                        stats.tokens_added += 1;
+                                        prev_leaf = Some(leaf_id);
+                                        op
+                                    })
+                                    .collect()
+                            } else {
+                                Vec::new()
+                            };
+                            let line_op =
+                                BuilderLineOps::modify(branch_id, old_leaf_ops, new_leaf_ops)
+                                    .with_old_line_num(old_line_idx + 1)
+                                    .with_new_line_num(new_line_idx + 1);
+                            collected_line_ops.push(line_op);
+                            stats.lines_modified += 1;
+                            prev_branch = Some(branch_id);
+                        } else {
+                            // Unpaired new line → Insert
+                            if new_line_idx < new_lines.len() {
+                                let branch_id = alloc_branch();
+                                let mut prev_leaf: Option<crate::crdt::LeafId> = None;
+                                let leaf_ops: Vec<LeafOp> = new_lines[new_line_idx]
+                                    .tokens()
+                                    .iter()
+                                    .map(|t| {
+                                        let leaf_id = alloc_leaf();
+                                        let op = LeafOp::Insert {
+                                            after: prev_leaf,
+                                            kind: t.kind(),
+                                            content: t.content().to_vec(),
+                                        };
+                                        stats.tokens_added += 1;
+                                        prev_leaf = Some(leaf_id);
+                                        op
+                                    })
+                                    .collect();
+                                let line_op =
+                                    BuilderLineOps::insert(branch_id, prev_branch, leaf_ops)
+                                        .with_new_line_num(new_line_idx + 1);
+                                collected_line_ops.push(line_op);
+                                stats.lines_added += 1;
+                                prev_branch = Some(branch_id);
+                            }
+                        }
+                    }
+
+                    _old_line_idx = old_pos + old_len;
+                    _new_line_idx = new_pos + new_len;
+                } // end unequal-count branch
             }
         }
     }
 
-    // ── Consolidation pass: promote Delete+Insert → Modify ───────────
+    // ── Cross-block Delete+Insert→Modify consolidation ───────────────────
     //
-    // Replace blocks already emit BranchOp::Modify directly.  But the
-    // diff algorithm can also produce *separate* Delete and Insert ops
-    // for lines that are similar but at distant positions (e.g. a
-    // function signature that moved down the file).
+    // After the Replace blocks have handled within-block pairing, this pass
+    // promotes any remaining standalone Delete+Insert pairs (from separate
+    // DiffOp::Delete and DiffOp::Insert operations) into BranchOp::Modify
+    // when the lines are similar (bigram Jaccard ≥ 0.3).
     //
-    // This pass scans ALL Delete ops and finds their best matching
-    // Insert op (by character-bigram Jaccard similarity ≥ 0.3).  When
-    // a match is found the Delete is removed, the Insert is replaced
-    // by a Modify carrying both old and new content, and the Modify
-    // occupies the Insert's original position in the stream.
-    //
-    // This means the Modify appears at the point in the new-file order
-    // where the new content lives — surrounded by its neighbouring
-    // inserts — which gives the diff viewer the correct alignment.
-    //
-    // This is the ONLY place non-Replace similarity matching happens.
-    // No downstream consumer needs to guess.
+    // NOTE: For git-imported changes, build_crdt_ops_from_git_diff() overrides
+    // the entire CRDT output, so this pairing only affects `atomic record`.
     {
-        // ── Extract text from leaf ops ─────────────────────────────────
         let extract_text = |op: &BuilderLineOps| -> String {
             let leaves = match op.operation() {
                 BranchOp::Delete { content, .. } | BranchOp::Insert { content, .. } => content,
@@ -492,7 +496,7 @@ pub(super) fn build_crdt_ops_for_modified_file(
             text
         };
 
-        let bigrams = |s: &str| -> std::collections::HashSet<(u8, u8)> {
+        let bigrams2 = |s: &str| -> std::collections::HashSet<(u8, u8)> {
             let bytes = s.trim().as_bytes();
             let mut set = std::collections::HashSet::new();
             if bytes.len() >= 2 {
@@ -503,15 +507,11 @@ pub(super) fn build_crdt_ops_for_modified_file(
             set
         };
 
-        // ── Collect Delete indices and their text ──────────────────────
-        #[allow(clippy::type_complexity)]
         let mut del_entries: Vec<(usize, String, std::collections::HashSet<(u8, u8)>)> = Vec::new();
-        #[allow(clippy::type_complexity)]
         let mut ins_entries: Vec<(usize, String, std::collections::HashSet<(u8, u8)>)> = Vec::new();
 
         for (idx, op) in collected_line_ops.iter().enumerate() {
             if op.is_modify() {
-                // Already a Modify (from Replace handler) — skip
                 continue;
             }
             let text = extract_text(op);
@@ -519,7 +519,7 @@ pub(super) fn build_crdt_ops_for_modified_file(
             if trimmed.len() < 2 {
                 continue;
             }
-            let bg = bigrams(&trimmed);
+            let bg = bigrams2(&trimmed);
             if bg.is_empty() {
                 continue;
             }
@@ -530,11 +530,9 @@ pub(super) fn build_crdt_ops_for_modified_file(
             }
         }
 
-        // ── Build all (del, ins, score) triples, sort by score desc ────
         let mut candidates: Vec<(usize, usize, f64)> = Vec::new();
-
-        for (di, (_del_idx, _del_text, del_bg)) in del_entries.iter().enumerate() {
-            for (ii, (_ins_idx, _ins_text, ins_bg)) in ins_entries.iter().enumerate() {
+        for (di, (_, _, del_bg)) in del_entries.iter().enumerate() {
+            for (ii, (_, _, ins_bg)) in ins_entries.iter().enumerate() {
                 let inter = del_bg.intersection(ins_bg).count();
                 let union = del_bg.union(ins_bg).count();
                 if union > 0 {
@@ -547,13 +545,11 @@ pub(super) fn build_crdt_ops_for_modified_file(
         }
         candidates.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
 
-        // ── Greedy assignment: best score first ────────────────────────
         let mut matched_del: std::collections::HashSet<usize> = std::collections::HashSet::new();
         let mut matched_ins: std::collections::HashSet<usize> = std::collections::HashSet::new();
-        // Maps: insert_index_in_collected → delete_index_in_collected
         let mut promote: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
 
-        for (di, ii, _score) in &candidates {
+        for (di, ii, _) in &candidates {
             if matched_del.contains(di) || matched_ins.contains(ii) {
                 continue;
             }
@@ -564,19 +560,9 @@ pub(super) fn build_crdt_ops_for_modified_file(
             promote.insert(ins_idx, del_idx);
         }
 
-        // ── Rebuild the ops list ───────────────────────────────────────
-        //
-        // Walk collected_line_ops in original order.
-        //   • Skip Deletes that were matched (they merge into a Modify).
-        //   • When we reach an Insert that was matched, replace it with
-        //     a Modify carrying both old (from the Delete) and new
-        //     (from the Insert) content.
-        //   • Everything else passes through unchanged.
         let del_indices_to_skip: std::collections::HashSet<usize> =
             promote.values().copied().collect();
 
-        let n = collected_line_ops.len();
-        // We need to move ops out of the vec, so replace with placeholders
         let placeholder_id = BranchId::new(NodeId::new(0), 0);
         let make_placeholder = || {
             BuilderLineOps::new(
@@ -587,27 +573,22 @@ pub(super) fn build_crdt_ops_for_modified_file(
             )
         };
 
-        // Take ownership of all ops via swap
         let mut slots: Vec<BuilderLineOps> = collected_line_ops
             .iter_mut()
             .map(|op| std::mem::replace(op, make_placeholder()))
             .collect();
 
-        let mut consolidated: Vec<BuilderLineOps> = Vec::with_capacity(n);
+        let mut consolidated: Vec<BuilderLineOps> = Vec::with_capacity(slots.len());
 
-        for idx in 0..n {
+        for idx in 0..slots.len() {
             if del_indices_to_skip.contains(&idx) {
-                // This Delete will merge into its paired Insert's Modify
                 continue;
             }
-
             if let Some(&del_idx) = promote.get(&idx) {
-                // This Insert is paired with a Delete → emit Modify
                 let del_op = &slots[del_idx];
                 let ins_op = &slots[idx];
                 let old_line_num = del_op.old_line_num();
                 let new_line_num = ins_op.new_line_num();
-
                 let old_content = match del_op.operation() {
                     BranchOp::Delete { content, .. } => content.clone(),
                     _ => Vec::new(),
@@ -616,7 +597,6 @@ pub(super) fn build_crdt_ops_for_modified_file(
                     BranchOp::Insert { content, .. } => content.clone(),
                     _ => Vec::new(),
                 };
-
                 let branch_id = del_op.branch_id();
                 let mut modify = BuilderLineOps::modify(branch_id, old_content, new_content);
                 if let Some(v) = old_line_num {
@@ -627,7 +607,6 @@ pub(super) fn build_crdt_ops_for_modified_file(
                 }
                 consolidated.push(modify);
             } else {
-                // Pass through unchanged
                 let op = std::mem::replace(&mut slots[idx], make_placeholder());
                 consolidated.push(op);
             }

--- a/atomic-core/src/record/workflow/record/mod.rs
+++ b/atomic-core/src/record/workflow/record/mod.rs
@@ -154,12 +154,37 @@ mod tests;
 pub use options::RecordingOptions;
 pub use types::{RecordedFile, RecordingResult, RecordingStats};
 
-use crate::change::{Encoding, Local};
+use crate::change::{Encoding, FileOps, Local};
+use crate::crdt::{BranchId, TrunkId};
 use crate::output::WorkingCopyRead;
+use crate::types::NodeId;
 
 use super::compare::{compare_content, detect_encoding};
+use super::crdt::CrdtBuildStats;
 use super::detect::{DetectedFile, DetectionKind};
 use super::graph_op::{BuiltHunk, BuiltHunkKind, HunkBuilder};
+
+/// A single line from a git diff, captured during Phase 1 of git import.
+///
+/// This is a plain data carrier, independent of any git library.
+/// Origin values:
+///   `+`  — line was added in the new file
+///   `-`  — line was deleted from the old file
+///   ` `  — context line (unchanged)
+///
+/// Used by [`build_crdt_ops_from_git_diff`] to build BranchOps that
+/// exactly match `git diff` output.
+#[derive(Debug, Clone)]
+pub struct GitDiffLine {
+    /// `+`, `-`, or ` `
+    pub origin: char,
+    /// Raw line bytes (may include trailing `\n`)
+    pub content: Vec<u8>,
+    /// 1-based line number in the old file (`None` for added lines)
+    pub old_lineno: Option<u32>,
+    /// 1-based line number in the new file (`None` for deleted lines)
+    pub new_lineno: Option<u32>,
+}
 
 // ============================================================================
 // RECORDING FUNCTIONS
@@ -373,6 +398,30 @@ where
     // Compare content and build hunks
     let comparison = compare_content(old_content, &new_content, options.get_algorithm());
 
+    // Handle binary files: compare_content returns is_binary=true with zero
+    // diff_ops when either old or new content contains null bytes.  Since we
+    // know the content differs (identical content returns early above), create
+    // a single Replace hunk that swaps the entire file content.  Without this,
+    // binary modifications are silently dropped (zero hunks → empty RecordedFile
+    // → the graph never receives the new content, and `atomic status` reports
+    // the file as modified forever).
+    if comparison.is_binary && old_content != &new_content[..] {
+        let mut replace_hunk = BuiltHunk::new_replace_with_lines(
+            Local::new(&detected.path, 1),
+            Some(encoding),
+            Vec::new(), // no per-line deletion tracking for binary
+            0,          // old_start
+            0,          // new_start
+            1,          // new_len: treat entire binary blob as one unit
+        );
+        replace_hunk.content_start = Some(0);
+        replace_hunk.content_end = Some(new_content.len() as u64);
+        recorded.add_hunk(replace_hunk);
+        recorded.set_content(new_content);
+
+        return Ok(recorded);
+    }
+
     // Build hunks from diff ops using HunkBuilder
     let hunk_options = options.to_hunk_options().encoding(encoding);
     let mut builder = HunkBuilder::with_options(&detected.path, hunk_options);
@@ -387,61 +436,94 @@ where
     let new_line_offsets = calculate_line_offsets(&new_content);
 
     // Add all built hunks to the recorded file, updating content positions
-    // ── Consolidate multiple Replace hunks into a single whole-file Replace ──
+    // ── Consolidate hunks into a single whole-file Replace ──
     //
-    // The diff may produce multiple Replace hunks when changes are in
-    // non-contiguous regions of the file. In the graph layer, each Replace
-    // hunk does delete-ALL-content + insert-full-content. With N Replace
-    // hunks this creates N copies (duplication bug).
+    // In the globalize pipeline, every hunk kind that isn't a clean
+    // Prepend or Append ends up doing the same thing: delete ALL content
+    // vertices for the file, then insert full_content (the entire new
+    // file). Specifically:
     //
-    // Fix: merge all Replace hunks into ONE Replace that covers the entire
-    // file. Insert and Delete hunks are kept as-is — they're additive
-    // operations that don't conflict.
+    //   Replace  → always does delete-all + insert-full_content
+    //   Delete   → always does delete-all (every content vertex)
+    //   Insert with 0 < old_start < old_line_count
+    //            → escalates to NeedsReplace → delete-all + insert-full_content
+    //
+    // When multiple hunks hit these paths, each one independently
+    // inserts a full copy of the file, causing N× content duplication.
+    //
+    // Fix: detect when ANY combination of hunks would trigger whole-file
+    // behavior, and collapse them all into a single Replace that covers
+    // the entire file. This guarantees exactly one delete-all +
+    // insert-full_content in the globalizer, regardless of diff shape.
+    //
+    // Insert hunks that are clean Prepend (old_start == 0) or Append
+    // (old_start >= old_line_count) are safe — they only insert their
+    // own content slice, not full_content. Those are kept as-is.
     //
     // The semantic layer (CRDT line_ops) is unaffected — it's built
     // separately from the raw diff and retains per-line granularity.
     let mut hunks: Vec<BuiltHunk> = hunk_result.into_hunks();
-    let replace_count = hunks
-        .iter()
-        .filter(|h| h.kind == BuiltHunkKind::Replace)
-        .count();
 
-    if replace_count > 1 {
-        // Merge all Replace hunks: union their deleted_lines, span the
-        // full new content range (0..new_content.len()).
+    // Count hunks that will trigger whole-file operations in globalize.
+    //
+    // The globalize layer has NO concept of partial deletion — both
+    // `globalize_delete` and `globalize_replace` call `delete_all_content`
+    // which marks EVERY content vertex as deleted.  So:
+    //
+    //   Replace  → delete-all + insert-full_content  (correct on its own)
+    //   Delete   → delete-all, insert nothing         (DESTROYS the file)
+    //   Insert with 0 < old_start < old_line_count
+    //            → escalates to delete-all + insert-full_content
+    //
+    // A Delete hunk in a *modified* file means "some lines were removed"
+    // — the file still has content.  But globalize_delete would nuke the
+    // whole file.  Since `record_modified_file` is never called for truly
+    // deleted files (those go through `record_deleted_file`), every
+    // Delete hunk here MUST be promoted to a Replace so the surviving
+    // content is re-inserted.
+    //
+    // We also consolidate when multiple nuclear hunks coexist, or when a
+    // nuclear hunk coexists with other hunks, to prevent N× duplication.
+    let has_nuclear_hunk = hunks.iter().any(|h| match h.kind {
+        // Replace already does delete-all + insert-full; correct on its own
+        // but must be consolidated if it coexists with other hunks.
+        BuiltHunkKind::Replace => true,
+        // Delete does delete-all with NO re-insert — would nuke the whole
+        // file.  Since record_modified_file is never called for truly
+        // deleted files, every Delete here is a partial line removal that
+        // must become a Replace so the surviving content is re-inserted.
+        BuiltHunkKind::Delete => true,
+        // Middle inserts (0 < old_start < old_line_count) cannot be
+        // handled by the globalizer — it only supports Prepend and Append.
+        // These must be consolidated into a Replace.
+        BuiltHunkKind::Insert => h.old_start != 0 && h.old_start < old_line_count,
+    });
+
+    if has_nuclear_hunk {
+        // Multiple hunks where at least one is nuclear, OR a single nuclear
+        // hunk coexisting with other hunks. Collapse everything into one
+        // Replace to prevent duplication.
+        //
+        // Collect deleted lines from all hunks that delete old content.
         let mut all_deleted: Vec<usize> = Vec::new();
-        let mut min_old_start = usize::MAX;
-
-        // Collect deleted lines from all Replace hunks
         for h in &hunks {
-            if h.kind == BuiltHunkKind::Replace {
-                all_deleted.extend_from_slice(&h.deleted_lines);
-                if h.old_start < min_old_start {
-                    min_old_start = h.old_start;
-                }
-            }
+            all_deleted.extend_from_slice(&h.deleted_lines);
         }
         all_deleted.sort_unstable();
         all_deleted.dedup();
 
-        if min_old_start == usize::MAX {
-            min_old_start = 0;
-        }
-
-        // Build the merged Replace covering the entire new file
         let new_line_count = new_content.split(|&b| b == b'\n').count();
         let merged_replace = BuiltHunk::new_replace_with_lines(
-            Local::new(&detected.path, (min_old_start + 1) as u64),
+            Local::new(&detected.path, 1),
             Some(encoding),
             all_deleted,
-            min_old_start,
+            0,              // old_start: beginning of old content
             0,              // new_start: beginning of new content
             new_line_count, // new_len: all lines in the new file
         );
 
-        // Remove all Replace hunks, keep Insert/Delete hunks
-        hunks.retain(|h| h.kind != BuiltHunkKind::Replace);
-        // Add the single merged Replace
+        // Replace all hunks with the single merged Replace
+        hunks.clear();
         hunks.push(merged_replace);
     }
 
@@ -493,6 +575,132 @@ where
     recorded.set_content(new_content);
 
     Ok(recorded)
+}
+
+/// Build CRDT FileOps directly from git diff lines.
+///
+/// This is the authoritative path for git import: instead of re-running
+/// our Myers diff algorithm (which may produce different edit operations
+/// than git), we translate git's own `+`/`-`/` ` line classifications
+/// directly into BranchOps.
+///
+/// The result has exactly the same Insert/Delete operations that
+/// `git diff` would show — so `atomic diff -c` output matches `git diff`
+/// line-for-line.
+///
+/// # Arguments
+///
+/// * `path`       — file path (for the FileOps container)
+/// * `diff_lines` — ordered slice of GitDiffLine from git2::Diff::foreach
+///
+/// # Returns
+///
+/// `(FileOps, CrdtBuildStats)` ready to be stored in a `RecordedFile`.
+pub fn build_crdt_ops_from_git_diff(
+    path: &str,
+    diff_lines: &[GitDiffLine],
+) -> (FileOps, CrdtBuildStats) {
+    use super::crdt::FileOps as BuilderFileOps;
+    use super::crdt::LineOps as BuilderLineOps;
+    use crate::crdt::LeafOp;
+
+    let placeholder_change_id = NodeId::new(0);
+    let trunk_id = TrunkId::new(placeholder_change_id, 0);
+    let mut file_ops = BuilderFileOps::new(trunk_id, path.to_string(), None);
+
+    let mut stats = CrdtBuildStats::new();
+    let mut next_branch_idx: u32 = 0;
+    let mut next_leaf_idx: u32 = 0;
+
+    let mut alloc_branch = || {
+        let id = BranchId::new(placeholder_change_id, next_branch_idx);
+        next_branch_idx += 1;
+        id
+    };
+
+    let mut alloc_leaf = || {
+        let id = crate::crdt::LeafId::new(placeholder_change_id, next_leaf_idx);
+        next_leaf_idx += 1;
+        id
+    };
+
+    let mut prev_branch: Option<BranchId> = None;
+
+    for diff_line in diff_lines {
+        match diff_line.origin {
+            // ── Deleted line ─────────────────────────────────────────────
+            '-' => {
+                let branch_id = alloc_branch();
+
+                // Store the deleted line content as leaf ops so
+                // `atomic diff -c` can reconstruct the old line text.
+                let content_bytes = &diff_line.content;
+                // Strip trailing newline for storage (consistent with inserts).
+                let trimmed = if content_bytes.ends_with(b"\n") {
+                    &content_bytes[..content_bytes.len() - 1]
+                } else {
+                    content_bytes
+                };
+
+                let leaf_ops = vec![LeafOp::Insert {
+                    after: None,
+                    kind: crate::diff::TokenKind::Word,
+                    content: trimmed.to_vec(),
+                }];
+
+                let mut line_op = BuilderLineOps::delete(branch_id, leaf_ops);
+                if let Some(n) = diff_line.old_lineno {
+                    line_op = line_op.with_old_line_num(n as usize);
+                }
+                file_ops.add_line_op(line_op);
+                stats.lines_deleted += 1;
+            }
+
+            // ── Added line ───────────────────────────────────────────────
+            '+' => {
+                let branch_id = alloc_branch();
+
+                let content_bytes = &diff_line.content;
+                let trimmed = if content_bytes.ends_with(b"\n") {
+                    &content_bytes[..content_bytes.len() - 1]
+                } else {
+                    content_bytes
+                };
+
+                let leaf_id = alloc_leaf();
+                let leaf_ops = vec![LeafOp::Insert {
+                    after: None,
+                    kind: crate::diff::TokenKind::Word,
+                    content: trimmed.to_vec(),
+                }];
+                let _ = leaf_id; // leaf_id allocated for ordering; content is in leaf_ops
+
+                let mut line_op = BuilderLineOps::insert(branch_id, prev_branch, leaf_ops);
+                if let Some(n) = diff_line.new_lineno {
+                    line_op = line_op.with_new_line_num(n as usize);
+                }
+                file_ops.add_line_op(line_op);
+                stats.lines_added += 1;
+                prev_branch = Some(branch_id);
+            }
+
+            // ── Context line (unchanged) — update prev_branch ────────────
+            ' ' => {
+                // Context lines are not recorded as BranchOps; they only
+                // advance the `prev_branch` cursor so subsequent inserts
+                // are anchored after the right line.
+                //
+                // We allocate a phantom branch ID to maintain the ordering
+                // chain.  It is never stored anywhere.
+                let phantom_id = alloc_branch();
+                prev_branch = Some(phantom_id);
+            }
+
+            _ => {} // Hunk headers, no-newline markers, etc. — skip.
+        }
+    }
+
+    (file_ops.into_change_ops(), stats)
 }
 
 /// Calculate byte offsets for each line in content.

--- a/atomic-core/src/record/workflow/record/types.rs
+++ b/atomic-core/src/record/workflow/record/types.rs
@@ -140,6 +140,9 @@ pub struct RecordedFile {
     /// Path of the file.
     path: String,
 
+    /// Previous path (for moves/renames).
+    old_path: Option<String>,
+
     /// Hunks generated for this file.
     hunks: Vec<BuiltHunk>,
 
@@ -192,6 +195,7 @@ impl RecordedFile {
     pub fn new(path: impl Into<String>) -> Self {
         Self {
             path: path.into(),
+            old_path: None,
             hunks: Vec::new(),
             content: Vec::new(),
             encoding: None,
@@ -315,6 +319,11 @@ impl RecordedFile {
         self.inode = Some(inode);
     }
 
+    /// Set the old path (for moves/renames).
+    pub fn set_old_path(&mut self, path: String) {
+        self.old_path = Some(path);
+    }
+
     /// Set the CRDT operations for this file.
     pub fn set_crdt_ops(&mut self, ops: FileOps) {
         self.crdt_ops = Some(ops);
@@ -329,6 +338,12 @@ impl RecordedFile {
     #[must_use]
     pub fn path(&self) -> &str {
         &self.path
+    }
+
+    /// Get the old path (for moves/renames).
+    #[must_use]
+    pub fn old_path(&self) -> Option<&str> {
+        self.old_path.as_deref()
     }
 
     /// Get the hunks.
@@ -392,8 +407,14 @@ impl RecordedFile {
     }
 
     /// Check if empty (no hunks).
+    ///
+    /// Note: Moved files are never considered empty even if they have no hunks,
+    /// because the move itself is a meaningful operation that must be recorded.
     #[must_use]
     pub fn is_empty(&self) -> bool {
+        if matches!(self.kind, Some(DetectionKind::Moved)) {
+            return false;
+        }
         self.hunks.is_empty()
     }
 

--- a/atomic-repository/src/repository/content.rs
+++ b/atomic-repository/src/repository/content.rs
@@ -384,7 +384,7 @@ impl Repository {
         let change_filter = collect_view_change_ids(&txn, &view)?;
 
         // Use the filtered retrieval method
-        self.get_file_content_with_filter(&txn, &normalized, change_filter)
+        self.get_file_content_with_filter(&txn, &normalized, change_filter, true)
     }
 
     /// Get the recorded content for a tracked file with options.
@@ -598,8 +598,10 @@ impl Repository {
             get_changes_up_to_sequence(&txn, &view, state_info.parent_max_sequence_exclusive())
                 .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
-        // Retrieve content with the change filter
-        self.get_file_content_with_filter(&txn, &normalized, change_set)
+        // Retrieve content with the change filter.
+        // Pass require_tracked=false: the file may have been deleted after
+        // this point, but we want its content as it existed before the change.
+        self.get_file_content_with_filter(&txn, &normalized, change_set, false)
     }
 
     /// Get file content as it was AFTER a specific change was applied.
@@ -665,8 +667,10 @@ impl Repository {
             None => return Ok(None), // Change not in this view
         };
 
-        // Retrieve content with the change filter
-        self.get_file_content_with_filter(&txn, &normalized, change_set)
+        // Retrieve content with the change filter.
+        // require_tracked=true: if the file was deleted before this point,
+        // there is no "after" content to return.
+        self.get_file_content_with_filter(&txn, &normalized, change_set, true)
     }
 
     /// Get file content at a specific sequence number.
@@ -723,7 +727,7 @@ impl Repository {
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
         // Retrieve content with the change filter
-        self.get_file_content_with_filter(&txn, &normalized, change_set)
+        self.get_file_content_with_filter(&txn, &normalized, change_set, true)
     }
 
     /// Internal helper to retrieve file content with a change filter.
@@ -737,6 +741,7 @@ impl Repository {
         txn: &T,
         normalized_path: &str,
         change_set: std::collections::HashSet<NodeId>,
+        require_tracked: bool,
     ) -> Result<Option<Vec<u8>>, RepositoryError>
     where
         T: atomic_core::pristine::GraphTxnT + atomic_core::pristine::TreeTxnT,
@@ -744,9 +749,11 @@ impl Repository {
         use atomic_core::output::alive::RetrieveOptions;
         use atomic_core::record::workflow::retrieve::retrieve_content_with_filter;
 
-        // Check if file is tracked
-        if !is_tracked(txn, normalized_path)
-            .map_err(|e| RepositoryError::Database(e.to_string()))?
+        // Check if file is tracked (skip for deleted files — they are no
+        // longer in the TREE but their inode/content is still in the graph).
+        if require_tracked
+            && !is_tracked(txn, normalized_path)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?
         {
             return Ok(None);
         }

--- a/atomic-repository/src/repository/insert.rs
+++ b/atomic-repository/src/repository/insert.rs
@@ -210,6 +210,38 @@ impl Repository {
                             }
                         }
                     }
+                    GraphOp::FileMove { add, path, .. } => {
+                        // A FileMove reuses the existing inode — look it up via
+                        // the inode position stored in add.inode, then update
+                        // TREE: remove the old path mapping and insert the new one.
+                        //
+                        // add.inode is Position<Option<Hash>>; resolve it to
+                        // Position<NodeId> so we can call position_inode().
+                        let inode_change_id = match &add.inode.change {
+                            None => change_id, // self-reference (shouldn't happen for FileMove)
+                            Some(h) if *h == Hash::NONE => NodeId::ROOT,
+                            Some(h) => txn.get_internal(h).unwrap_or(None).unwrap_or(NodeId::ROOT),
+                        };
+                        let inode_pos = Position::new(inode_change_id, add.inode.pos);
+
+                        if let Ok(Some(inode)) = txn.position_inode(inode_pos) {
+                            // Remove the old TREE entry (old path → inode)
+                            if let Ok(Some(old_path)) = txn.get_path(inode) {
+                                // Guard: only delete the old path if it differs
+                                // from the new path.  When multiple files share
+                                // the same inode position (a rare data-integrity
+                                // edge case), position_inode may resolve to an
+                                // inode whose current path was already updated
+                                // by a prior FileMove in this same change.
+                                // Deleting it would undo that earlier rename.
+                                if old_path != *path {
+                                    let _ = txn.del_tree(&old_path);
+                                }
+                            }
+                            // Insert the new TREE entry (new path → inode)
+                            let _ = txn.put_tree(path, inode);
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -480,6 +512,26 @@ impl Repository {
                             let _ = txn.del_inode(inode);
                             let _ = txn.del_directory(inode);
                         }
+                    }
+                }
+                GraphOp::FileMove { add, path, .. } => {
+                    // A FileMove reuses the existing inode — look it up via
+                    // the inode position stored in add.inode, then update
+                    // TREE: remove the old path mapping and insert the new one.
+                    let inode_change_id = match &add.inode.change {
+                        None => change_id,
+                        Some(h) if *h == Hash::NONE => NodeId::ROOT,
+                        Some(h) => txn.get_internal(h).unwrap_or(None).unwrap_or(NodeId::ROOT),
+                    };
+                    let inode_pos = Position::new(inode_change_id, add.inode.pos);
+
+                    if let Ok(Some(inode)) = txn.position_inode(inode_pos) {
+                        if let Ok(Some(old_path)) = txn.get_path(inode) {
+                            if old_path != *path {
+                                let _ = txn.del_tree(&old_path);
+                            }
+                        }
+                        let _ = txn.put_tree(path, inode);
                     }
                 }
                 _ => {}

--- a/atomic-repository/src/repository/record.rs
+++ b/atomic-repository/src/repository/record.rs
@@ -643,6 +643,83 @@ impl Repository {
         self.record(header, options)
     }
 
+    /// Fast path for external importers (e.g. git-import) that already have
+    /// pre-built `RecordedFile`s and just need globalization + assembly + hashing.
+    ///
+    /// Returns `(Change, Hash)`.
+    pub fn assemble_and_hash(
+        &self,
+        header: ChangeHeader,
+        recorded_files: &[atomic_core::record::workflow::RecordedFile],
+    ) -> Result<(Change, Hash), RecordError> {
+        use atomic_core::record::workflow::assemble_change;
+        use atomic_core::record::workflow::assembly::AssemblyOptions;
+
+        let txn = self
+            .pristine
+            .read_txn()
+            .map_err(|e| RecordError::Database(e.to_string()))?;
+
+        // Use a bare transaction — no ViewGraph filter needed.
+        //
+        // This method is the fast path for git import, where every change
+        // is written to a shared view and all edges land in the global
+        // GRAPH table.  A bare ReadTxn sees every edge directly.
+        //
+        // Wrapping in ViewGraph + collect_visible_change_ids would scan
+        // the entire view change log on every call (O(N) per commit,
+        // O(N²) total for N commits), which makes large imports
+        // progressively slower.
+        let assembly_options = AssemblyOptions::default();
+
+        let assembly_result = assemble_change(&txn, recorded_files, header, &assembly_options)?;
+
+        let change = assembly_result.into_change();
+
+        let mut v3_bytes = Vec::new();
+        let hash = change
+            .serialize(&mut v3_bytes)
+            .map_err(|e| RecordError::ChangeStore(e.to_string()))?;
+
+        let (final_change, _) = Change::deserialize(&mut v3_bytes.as_slice())
+            .map_err(|e| RecordError::ChangeStore(e.to_string()))?;
+
+        Ok((final_change, hash))
+    }
+
+    /// Look up a file's inode and graph position from the pristine.
+    ///
+    /// Returns `None` if the file is not tracked or has no graph position.
+    pub fn get_inode_and_position(
+        &self,
+        path: &str,
+    ) -> Result<Option<(Inode, Position<NodeId>)>, RepositoryError> {
+        use atomic_core::pristine::TreeTxnT;
+
+        let txn = self
+            .pristine
+            .read_txn()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        let inode = match txn
+            .get_inode(path)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+        {
+            Some(i) => i,
+            None => return Ok(None),
+        };
+
+        let position = match txn
+            .inode_position(inode)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+        {
+            Some(p) => p,
+            None => return Ok(None),
+        };
+
+        Ok(Some((inode, position)))
+    }
+
     /// Record all changes with a message.
     ///
     /// This is a convenience method that records all modified files.

--- a/atomic-repository/src/repository/status.rs
+++ b/atomic-repository/src/repository/status.rs
@@ -148,7 +148,7 @@ impl Repository {
             // convert it to a relative path. This handles cases where paths were
             // incorrectly stored with absolute paths (e.g., on macOS where /tmp
             // resolves to /private/tmp).
-            let normalized_path = if path_buf.is_absolute() {
+            let stripped = if path_buf.is_absolute() {
                 if let Ok(rel) = path_buf.strip_prefix(&self.root) {
                     rel.to_path_buf()
                 } else {
@@ -167,6 +167,10 @@ impl Repository {
             } else {
                 path_buf
             };
+
+            // Normalize to forward slashes for consistent comparison with
+            // disk paths (also normalized to '/') on all platforms.
+            let normalized_path = PathBuf::from(stripped.to_string_lossy().replace('\\', "/"));
 
             tracked_paths.insert(normalized_path);
         }
@@ -207,6 +211,11 @@ impl Repository {
             } else {
                 path_buf
             };
+
+            // Normalize to forward slashes for consistent comparison with
+            // disk paths (also normalized to '/') on all platforms.
+            let normalized_path =
+                PathBuf::from(normalized_path.to_string_lossy().replace('\\', "/"));
 
             // Use the original path for database lookup since that's what's stored.
             // Apply the same view-awareness filter here: skip inodes whose

--- a/atomic-repository/src/status.rs
+++ b/atomic-repository/src/status.rs
@@ -809,7 +809,11 @@ pub fn collect_working_copy_files_with_rules(
                 }
             }
 
-            files.insert(rel_path.to_path_buf());
+            // Normalize to forward slashes so paths match TREE entries
+            // (which always use '/'). On Windows, walkdir returns paths
+            // with '\' separators, but TREE stores '/'.
+            let normalized = PathBuf::from(rel_path.to_string_lossy().replace('\\', "/"));
+            files.insert(normalized);
         }
     }
 

--- a/atomic-repository/tests/content_roundtrip_fidelity_test.rs
+++ b/atomic-repository/tests/content_roundtrip_fidelity_test.rs
@@ -18,19 +18,6 @@ use atomic_core::types::Hash;
 use atomic_repository::{RecordOptions, Repository};
 use tempfile::TempDir;
 
-/// Platform-aware path for subdirectory test files.
-/// On Windows, file tracking with subdirectory paths has known issues,
-/// so we use flat filenames. On Unix, we use subdirectory paths to
-/// exercise the full path handling.
-fn test_path(subdir_path: &str) -> String {
-    if cfg!(windows) {
-        // Flatten: "src/main.rs" → "src_main.rs"
-        subdir_path.replace('/', "_")
-    } else {
-        subdir_path.to_string()
-    }
-}
-
 fn create_test_repo() -> (Repository, TempDir, PathBuf) {
     let temp = TempDir::new().expect("Failed to create temp dir");
     let repo_path = temp.path().to_path_buf();
@@ -276,29 +263,28 @@ fn main() {
 ";
 
     // Record version 1
-    let p = test_path("src/main.rs");
-    write_file(&repo_path, &p, v1);
-    repo.add(&p, Default::default()).unwrap();
+    write_file(&repo_path, "src/main.rs", v1);
+    repo.add("src/main.rs", Default::default()).unwrap();
     let h1 = record_change(&repo, "initial");
-    assert_content_matches(&repo, &p, v1);
+    assert_content_matches(&repo, "src/main.rs", v1);
 
     // Record version 2 (minor edits)
-    write_file(&repo_path, &p, v2);
+    write_file(&repo_path, "src/main.rs", v2);
     let h2 = record_change(&repo, "code style");
-    assert_content_matches(&repo, &p, v2);
+    assert_content_matches(&repo, "src/main.rs", v2);
 
     // Record version 3 (major refactor: extract function, add warmup, replace inline code)
-    write_file(&repo_path, &p, v3);
+    write_file(&repo_path, "src/main.rs", v3);
     let h3 = record_change(&repo, "extract helper and add warmup");
 
     // This is the critical assertion — after the multi-hunk refactor,
     // the graph content should exactly match v3 with no duplication.
-    assert_content_matches(&repo, &p, v3);
+    assert_content_matches(&repo, "src/main.rs", v3);
 
     // Also verify state-based retrieval at each point
-    assert_content_after_change(&repo, &p, &h1, v1);
-    assert_content_after_change(&repo, &p, &h2, v2);
-    assert_content_after_change(&repo, &p, &h3, v3);
+    assert_content_after_change(&repo, "src/main.rs", &h1, v1);
+    assert_content_after_change(&repo, "src/main.rs", &h2, v2);
+    assert_content_after_change(&repo, "src/main.rs", &h3, v3);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -347,12 +333,10 @@ fn test_hyperfine_content_duplication_bug() {
         "68fdc2c",  // Add --warmup option
     ];
 
-    let git_file = "src/main.rs";
-    let local_file = test_path(git_file);
     let mut versions: Vec<Vec<u8>> = Vec::new();
     for sha in &commits {
         let output = Command::new("git")
-            .args(["show", &format!("{}:{}", sha, git_file)])
+            .args(["show", &format!("{}:src/main.rs", sha)])
             .current_dir(&git_path)
             .output()
             .expect("Failed to run git show");
@@ -366,14 +350,14 @@ fn test_hyperfine_content_duplication_bug() {
     // Commit 1: add file
     write_file(
         &repo_path,
-        &local_file,
+        "src/main.rs",
         &String::from_utf8_lossy(&versions[0]),
     );
-    repo.add(&local_file, Default::default()).unwrap();
+    repo.add("src/main.rs", Default::default()).unwrap();
     let _ = record_change(&repo, "Initial commit");
 
     let content = repo
-        .get_file_content_on_view(&local_file, repo.current_view())
+        .get_file_content_on_view("src/main.rs", repo.current_view())
         .unwrap()
         .unwrap();
     assert_eq!(
@@ -383,11 +367,11 @@ fn test_hyperfine_content_duplication_bug() {
 
     // Commits 2-4: modify file
     for (i, version) in versions[1..].iter().enumerate() {
-        write_file(&repo_path, &local_file, &String::from_utf8_lossy(version));
+        write_file(&repo_path, "src/main.rs", &String::from_utf8_lossy(version));
         let _ = record_change(&repo, &format!("Commit {}", i + 2));
 
         let content = repo
-            .get_file_content_on_view(&local_file, repo.current_view())
+            .get_file_content_on_view("src/main.rs", repo.current_view())
             .unwrap()
             .unwrap();
 
@@ -449,9 +433,6 @@ fn test_hyperfine_extended_commit_sequence() {
         }
     }
 
-    let git_file = "src/main.rs";
-    let local_file = test_path(git_file);
-
     // Commits that touch src/main.rs in the first 15 commits.
     // We skip commits that don't change src/main.rs (README, licenses, metadata).
     let commits: Vec<&str> = vec![
@@ -469,7 +450,7 @@ fn test_hyperfine_extended_commit_sequence() {
     let mut versions: Vec<(String, Vec<u8>)> = Vec::new();
     for sha in &commits {
         let output = Command::new("git")
-            .args(["show", &format!("{}:{}", sha, git_file)])
+            .args(["show", &format!("{}:src/main.rs", sha)])
             .current_dir(&git_path)
             .output()
             .expect("Failed to run git show");
@@ -492,14 +473,14 @@ fn test_hyperfine_extended_commit_sequence() {
     // First version: add file
     write_file(
         &repo_path,
-        &local_file,
+        "src/main.rs",
         &String::from_utf8_lossy(&versions[0].1),
     );
-    repo.add(&local_file, Default::default()).unwrap();
+    repo.add("src/main.rs", Default::default()).unwrap();
     let _ = record_change(&repo, &format!("Commit 1 ({})", versions[0].0));
 
     let content = repo
-        .get_file_content_on_view(&local_file, repo.current_view())
+        .get_file_content_on_view("src/main.rs", repo.current_view())
         .unwrap()
         .unwrap();
     assert_eq!(
@@ -510,11 +491,11 @@ fn test_hyperfine_extended_commit_sequence() {
 
     // Subsequent versions: modify file
     for (i, (sha, version)) in versions[1..].iter().enumerate() {
-        write_file(&repo_path, &local_file, &String::from_utf8_lossy(version));
+        write_file(&repo_path, "src/main.rs", &String::from_utf8_lossy(version));
         let _ = record_change(&repo, &format!("Commit {} ({})", i + 2, sha));
 
         let content = repo
-            .get_file_content_on_view(&local_file, repo.current_view())
+            .get_file_content_on_view("src/main.rs", repo.current_view())
             .unwrap()
             .unwrap();
 
@@ -554,9 +535,6 @@ fn test_hyperfine_extended_commit_sequence() {
 #[test]
 fn test_hyperfine_pairwise_transitions() {
     use std::process::Command;
-    let git_file = "src/main.rs";
-    let local_file = test_path(git_file);
-
     let git_temp = TempDir::new().expect("Failed to create temp dir for git");
     let git_path = git_temp.path().to_path_buf();
     let clone_status = Command::new("git")
@@ -591,7 +569,7 @@ fn test_hyperfine_pairwise_transitions() {
     for (before_sha, after_sha, description) in &pairs {
         // Get file at before and after
         let before_output = Command::new("git")
-            .args(["show", &format!("{}:{}", before_sha, git_file)])
+            .args(["show", &format!("{}:src/main.rs", before_sha)])
             .current_dir(&git_path)
             .output()
             .expect("Failed to run git show");
@@ -602,7 +580,7 @@ fn test_hyperfine_pairwise_transitions() {
         );
 
         let after_output = Command::new("git")
-            .args(["show", &format!("{}:{}", after_sha, git_file)])
+            .args(["show", &format!("{}:src/main.rs", after_sha)])
             .current_dir(&git_path)
             .output()
             .expect("Failed to run git show");
@@ -618,14 +596,14 @@ fn test_hyperfine_pairwise_transitions() {
         // Add the "before" version
         write_file(
             &repo_path,
-            &local_file,
+            "src/main.rs",
             &String::from_utf8_lossy(&before_output.stdout),
         );
-        repo.add(&local_file, Default::default()).unwrap();
+        repo.add("src/main.rs", Default::default()).unwrap();
         let _ = record_change(&repo, &format!("before: {}", before_sha));
 
         let content = repo
-            .get_file_content_on_view(&local_file, repo.current_view())
+            .get_file_content_on_view("src/main.rs", repo.current_view())
             .unwrap()
             .unwrap();
         assert_eq!(
@@ -637,13 +615,13 @@ fn test_hyperfine_pairwise_transitions() {
         // Apply the "after" version
         write_file(
             &repo_path,
-            &local_file,
+            "src/main.rs",
             &String::from_utf8_lossy(&after_output.stdout),
         );
         let _ = record_change(&repo, &format!("after: {}", after_sha));
 
         let content = repo
-            .get_file_content_on_view(&local_file, repo.current_view())
+            .get_file_content_on_view("src/main.rs", repo.current_view())
             .unwrap()
             .unwrap();
 
@@ -931,17 +909,16 @@ fn main() {
 }
 ";
 
-    let p = test_path("src/main.rs");
-    write_file(&repo_path, &p, v1);
-    repo.add(&p, Default::default()).unwrap();
+    write_file(&repo_path, "src/main.rs", v1);
+    repo.add("src/main.rs", Default::default()).unwrap();
     let _h1 = record_change(&repo, "initial");
-    assert_content_matches(&repo, &p, v1);
+    assert_content_matches(&repo, "src/main.rs", v1);
 
     // This is the critical step — a single-line middle insertion must
     // successfully record and produce correct content.
-    write_file(&repo_path, &p, v2);
+    write_file(&repo_path, "src/main.rs", v2);
     let _h2 = record_change(&repo, "add stdin null");
-    assert_content_matches(&repo, &p, v2);
+    assert_content_matches(&repo, "src/main.rs", v2);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1046,19 +1023,18 @@ fn main() {
 }
 ";
 
-    let p = test_path("src/main.rs");
-    write_file(&repo_path, &p, v1);
-    repo.add(&p, Default::default()).unwrap();
+    write_file(&repo_path, "src/main.rs", v1);
+    repo.add("src/main.rs", Default::default()).unwrap();
     let _h1 = record_change(&repo, "initial");
 
-    write_file(&repo_path, &p, v2);
+    write_file(&repo_path, "src/main.rs", v2);
     let _h2 = record_change(&repo, "refactor imports");
 
-    write_file(&repo_path, &p, v3);
+    write_file(&repo_path, "src/main.rs", v3);
     let _h3 = record_change(&repo, "add error handling");
 
     // The critical single-line middle insertion
-    write_file(&repo_path, &p, v4);
+    write_file(&repo_path, "src/main.rs", v4);
     let _h4 = record_change(&repo, "close stdin for child processes");
-    assert_content_matches(&repo, &p, v4);
+    assert_content_matches(&repo, "src/main.rs", v4);
 }

--- a/atomic-repository/tests/content_roundtrip_fidelity_test.rs
+++ b/atomic-repository/tests/content_roundtrip_fidelity_test.rs
@@ -1,0 +1,1040 @@
+//! Content roundtrip fidelity tests.
+//!
+//! Validates that file content retrieved from the change graph (via overlay)
+//! is byte-identical to what was recorded. This tests the change graph layer
+//! (hunks/atoms), NOT the semantic CRDT layer (file_ops).
+//!
+//! The key scenario: a file undergoes multiple modifications across several
+//! changes (add → modify → modify → complex refactor). After all changes are
+//! applied, retrieving the file content should produce exactly the bytes that
+//! were last written to disk before recording.
+
+use std::fs;
+use std::path::PathBuf;
+
+use atomic_core::change::{Author, ChangeHeader};
+use atomic_core::types::Hash;
+use atomic_repository::{RecordOptions, Repository};
+use tempfile::TempDir;
+
+fn create_test_repo() -> (Repository, TempDir, PathBuf) {
+    let temp = TempDir::new().expect("Failed to create temp dir");
+    let repo_path = temp.path().to_path_buf();
+    let repo = Repository::init(&repo_path).expect("Failed to init repository");
+    (repo, temp, repo_path)
+}
+
+fn write_file(repo_path: &PathBuf, name: &str, content: &str) {
+    let file_path = repo_path.join(name);
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent).expect("Failed to create dirs");
+    }
+    fs::write(&file_path, content).expect("Failed to write file");
+}
+
+fn record_change(repo: &Repository, message: &str) -> Hash {
+    let header = ChangeHeader::builder()
+        .message(message)
+        .author(Author::new("Test", Some("test@example.com")))
+        .build();
+
+    let outcome = repo
+        .record(header, RecordOptions::default())
+        .expect("Failed to record");
+
+    *outcome.hash()
+}
+
+/// Assert that the content retrieved via overlay matches the expected bytes.
+fn assert_content_matches(repo: &Repository, path: &str, expected: &str) {
+    let content = repo
+        .get_file_content_on_view(path, repo.current_view())
+        .expect("Failed to get content")
+        .expect("File not found in graph");
+
+    let actual = String::from_utf8_lossy(&content);
+    assert_eq!(
+        actual,
+        expected,
+        "Content mismatch for '{}': got {} bytes, expected {} bytes",
+        path,
+        content.len(),
+        expected.len(),
+    );
+}
+
+/// Assert content after a specific change matches.
+fn assert_content_after_change(repo: &Repository, path: &str, hash: &Hash, expected: &str) {
+    let content = repo
+        .get_file_content_after_change(path, hash)
+        .expect("Failed to get content after change")
+        .expect("File not found after change");
+
+    let actual = String::from_utf8_lossy(&content);
+    assert_eq!(
+        actual,
+        expected,
+        "Content after change mismatch for '{}': got {} bytes, expected {} bytes",
+        path,
+        content.len(),
+        expected.len(),
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Test: Simple add then modify
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_simple_add_then_modify() {
+    let (repo, _temp, repo_path) = create_test_repo();
+
+    let v1 = "fn main() {\n    println!(\"hello\");\n}\n";
+    let v2 = "fn main() {\n    println!(\"hello world\");\n}\n";
+
+    write_file(&repo_path, "test.rs", v1);
+    repo.add("test.rs", Default::default()).unwrap();
+    let h1 = record_change(&repo, "add test.rs");
+
+    write_file(&repo_path, "test.rs", v2);
+    let h2 = record_change(&repo, "modify test.rs");
+
+    assert_content_after_change(&repo, "test.rs", &h1, v1);
+    assert_content_after_change(&repo, "test.rs", &h2, v2);
+    assert_content_matches(&repo, "test.rs", v2);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Test: Three sequential modifications
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_three_sequential_modifications() {
+    let (repo, _temp, repo_path) = create_test_repo();
+
+    let v1 = "line1\nline2\nline3\n";
+    let v2 = "line1\nmodified\nline3\n";
+    let v3 = "line1\nmodified\nline3\nextra\n";
+
+    write_file(&repo_path, "data.txt", v1);
+    repo.add("data.txt", Default::default()).unwrap();
+    let h1 = record_change(&repo, "add");
+
+    write_file(&repo_path, "data.txt", v2);
+    let h2 = record_change(&repo, "modify middle");
+
+    write_file(&repo_path, "data.txt", v3);
+    let h3 = record_change(&repo, "append line");
+
+    assert_content_after_change(&repo, "data.txt", &h1, v1);
+    assert_content_after_change(&repo, "data.txt", &h2, v2);
+    assert_content_after_change(&repo, "data.txt", &h3, v3);
+    assert_content_matches(&repo, "data.txt", v3);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Test: Multi-hunk refactor (extract function + add code + delete code)
+//
+// This mimics the pattern that triggers duplication in hyperfine's commit 4:
+// - A function is extracted (code moves from main to a new helper)
+// - New code is added (warmup phase)
+// - Inline code is replaced by calls to the extracted function
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_multi_hunk_refactor_fidelity() {
+    let (repo, _temp, repo_path) = create_test_repo();
+
+    // Version 1: inline progress bar setup
+    let v1 = "\
+fn main() {
+    let args = parse_args();
+    let commands = args.commands();
+
+    for cmd in commands {
+        println!(\"Command: {}\", cmd);
+
+        let mut results = vec![];
+
+        // Set up progress bar
+        let bar = Bar::new(10);
+        let style = Style::new()
+            .template(\"{spinner} {msg}\");
+        bar.set_style(style);
+        bar.enable_steady_tick(80);
+        bar.set_message(\"Measuring\");
+
+        // Measure
+        for i in 0..10 {
+            bar.inc(1);
+            let res = run_command(cmd);
+            results.push(res);
+        }
+        bar.finish();
+
+        print_results(&results);
+    }
+}
+";
+
+    // Version 2: code style cleanup (minor changes)
+    let v2 = "\
+fn main() {
+    let args = parse_args();
+    let commands = args.commands();
+
+    for cmd in commands {
+        println!(\"Command: {}\", cmd);
+
+        let mut results = vec![];
+
+        // Set up progress bar
+        let bar = Bar::new(10);
+        let style = Style::new()
+            .template(\"{spinner} {msg:<28} {wide_bar}\");
+        bar.set_style(style.clone());
+        bar.enable_steady_tick(80);
+        bar.set_message(\"Measuring\");
+
+        // Run measurements
+        for i in 0..10 {
+            bar.inc(1);
+            let res = run_command(cmd);
+            results.push(res);
+        }
+        bar.finish_and_clear();
+
+        print_results(&results);
+    }
+}
+";
+
+    // Version 3: extract helper + add warmup (multi-hunk refactor)
+    let v3 = "\
+/// Return a pre-configured progress bar
+fn get_bar(length: u64, msg: &str) -> Bar {
+    let style = Style::new()
+        .tick_chars(\"⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏\")
+        .template(\"{spinner} {msg:<28} {wide_bar}\");
+
+    let bar = Bar::new(length);
+    bar.set_style(style);
+    bar.enable_steady_tick(80);
+    bar.set_message(msg);
+
+    bar
+}
+
+fn main() {
+    let args = parse_args();
+    let commands = args.commands();
+
+    for cmd in commands {
+        println!(\"Command: {}\", cmd);
+
+        let mut results = vec![];
+
+        // Warmup phase
+        if let Some(warmup_count) = args.warmup {
+            let bar = get_bar(warmup_count, \"Performing warmup\");
+
+            for _ in 0..warmup_count {
+                bar.inc(1);
+                let _ = run_command(cmd);
+            }
+            bar.finish_and_clear();
+        }
+
+        // Set up progress bar
+        let bar = get_bar(10, \"Measuring\");
+
+        // Run measurements
+        for i in 0..10 {
+            bar.inc(1);
+            let res = run_command(cmd);
+            results.push(res);
+        }
+        bar.finish_and_clear();
+
+        print_results(&results);
+    }
+}
+";
+
+    // Record version 1
+    write_file(&repo_path, "src/main.rs", v1);
+    repo.add("src/main.rs", Default::default()).unwrap();
+    let h1 = record_change(&repo, "initial");
+    assert_content_matches(&repo, "src/main.rs", v1);
+
+    // Record version 2 (minor edits)
+    write_file(&repo_path, "src/main.rs", v2);
+    let h2 = record_change(&repo, "code style");
+    assert_content_matches(&repo, "src/main.rs", v2);
+
+    // Record version 3 (major refactor: extract function, add warmup, replace inline code)
+    write_file(&repo_path, "src/main.rs", v3);
+    let h3 = record_change(&repo, "extract helper and add warmup");
+
+    // This is the critical assertion — after the multi-hunk refactor,
+    // the graph content should exactly match v3 with no duplication.
+    assert_content_matches(&repo, "src/main.rs", v3);
+
+    // Also verify state-based retrieval at each point
+    assert_content_after_change(&repo, "src/main.rs", &h1, v1);
+    assert_content_after_change(&repo, "src/main.rs", &h2, v2);
+    assert_content_after_change(&repo, "src/main.rs", &h3, v3);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Test: Reproduce the exact duplication bug from git import
+//
+// Uses the first 4 commits of hyperfine (https://github.com/sharkdp/hyperfine)
+// by David Peter, licensed under Apache-2.0 / MIT. The commit sequence in
+// src/main.rs — initial code, progress bar addition, style cleanup, then a
+// complex refactor extracting a helper function and adding warmup — triggers
+// content duplication in the change graph after globalization.
+//
+// This test isolates the bug to the change graph layer (record + globalize +
+// apply) by using repo.record() directly, with no import pipeline involved.
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_hyperfine_content_duplication_bug() {
+    use std::process::Command;
+
+    // Clone hyperfine into a temp dir
+    let git_temp = TempDir::new().expect("Failed to create temp dir for git");
+    let git_path = git_temp.path().to_path_buf();
+    let clone_status = Command::new("git")
+        .args([
+            "clone",
+            "--quiet",
+            "https://github.com/sharkdp/hyperfine.git",
+        ])
+        .arg(&git_path)
+        .status();
+
+    // Skip test if git clone fails (e.g., no network)
+    match clone_status {
+        Ok(s) if s.success() => {}
+        _ => {
+            eprintln!("Skipping test: git clone failed (no network?)");
+            return;
+        }
+    }
+
+    // Get file contents at each of the first 4 commits
+    let commits: Vec<&str> = vec![
+        "a658ab8c", // Initial commit
+        "d4ebdd7b", // Add a progress bar
+        "197f9fb",  // Code style update
+        "68fdc2c",  // Add --warmup option
+    ];
+
+    let mut versions: Vec<Vec<u8>> = Vec::new();
+    for sha in &commits {
+        let output = Command::new("git")
+            .args(["show", &format!("{}:src/main.rs", sha)])
+            .current_dir(&git_path)
+            .output()
+            .expect("Failed to run git show");
+        assert!(output.status.success(), "git show failed for {}", sha);
+        versions.push(output.stdout);
+    }
+
+    // Now create an atomic repo and replay these versions
+    let (repo, _temp, repo_path) = create_test_repo();
+
+    // Commit 1: add file
+    write_file(
+        &repo_path,
+        "src/main.rs",
+        &String::from_utf8_lossy(&versions[0]),
+    );
+    repo.add("src/main.rs", Default::default()).unwrap();
+    let _ = record_change(&repo, "Initial commit");
+
+    let content = repo
+        .get_file_content_on_view("src/main.rs", repo.current_view())
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        content, versions[0],
+        "Content mismatch after commit 1 (initial)"
+    );
+
+    // Commits 2-4: modify file
+    for (i, version) in versions[1..].iter().enumerate() {
+        write_file(&repo_path, "src/main.rs", &String::from_utf8_lossy(version));
+        let _ = record_change(&repo, &format!("Commit {}", i + 2));
+
+        let content = repo
+            .get_file_content_on_view("src/main.rs", repo.current_view())
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            content.len(),
+            version.len(),
+            "Content length mismatch after commit {} ({}): got {} bytes, expected {} bytes.\n\
+             This indicates content duplication in the change graph.",
+            i + 2,
+            commits[i + 1],
+            content.len(),
+            version.len(),
+        );
+
+        assert_eq!(
+            content,
+            *version,
+            "Content mismatch after commit {} ({})",
+            i + 2,
+            commits[i + 1],
+        );
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Test: Hyperfine commits 1-7 (through error handling refactor)
+//
+// Stepping stone: replays 7 commits instead of 4. Commits 5-7 add a README
+// (no src/main.rs change), a major refactor extracting run_benchmark() and
+// HyperfineOptions (94 insertions, 73 deletions, 2 hunks), and then the
+// error handling commit (29 insertions, 7 deletions, 7 hunks with a new
+// function + return-type propagation across call sites).
+//
+// This catches regressions where medium-complexity multi-hunk patterns
+// (code extraction + call-site updates) trigger duplication even after
+// the consolidation fix.
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_hyperfine_extended_commit_sequence() {
+    use std::process::Command;
+
+    let git_temp = TempDir::new().expect("Failed to create temp dir for git");
+    let git_path = git_temp.path().to_path_buf();
+    let clone_status = Command::new("git")
+        .args([
+            "clone",
+            "--quiet",
+            "https://github.com/sharkdp/hyperfine.git",
+        ])
+        .arg(&git_path)
+        .status();
+
+    match clone_status {
+        Ok(s) if s.success() => {}
+        _ => {
+            eprintln!("Skipping test: git clone failed (no network?)");
+            return;
+        }
+    }
+
+    // Commits that touch src/main.rs in the first 15 commits.
+    // We skip commits that don't change src/main.rs (README, licenses, metadata).
+    let commits: Vec<&str> = vec![
+        "a658ab8c", // 1: Initial commit
+        "d4ebdd7b", // 2: Add a progress bar (10 hunks, +52/-12)
+        "197f9fb",  // 3: Code style update (15 hunks, +22/-17)
+        "68fdc2c",  // 4: Add --warmup option (6 hunks, +44/-10) — previously failing
+        "9ba7ada",  // 5: Refactoring — extract run_benchmark (2 hunks, +94/-73)
+        "5cdf013",  // 6: Modify clap settings (7 hunks, +8/-9)
+        "dab3f94",  // 7: Add --min-runs (2 hunks, +18/-3)
+        "219bb1e",  // 8: Error handling (7 hunks, +29/-7)
+    ];
+
+    // Collect file contents at each commit (skip commits where file doesn't exist)
+    let mut versions: Vec<(String, Vec<u8>)> = Vec::new();
+    for sha in &commits {
+        let output = Command::new("git")
+            .args(["show", &format!("{}:src/main.rs", sha)])
+            .current_dir(&git_path)
+            .output()
+            .expect("Failed to run git show");
+        if !output.status.success() {
+            // File doesn't exist at this commit — skip
+            continue;
+        }
+        versions.push((sha.to_string(), output.stdout));
+    }
+
+    assert!(
+        versions.len() >= 4,
+        "Expected at least 4 versions, got {}",
+        versions.len()
+    );
+
+    // Replay all versions into an atomic repo
+    let (repo, _temp, repo_path) = create_test_repo();
+
+    // First version: add file
+    write_file(
+        &repo_path,
+        "src/main.rs",
+        &String::from_utf8_lossy(&versions[0].1),
+    );
+    repo.add("src/main.rs", Default::default()).unwrap();
+    let _ = record_change(&repo, &format!("Commit 1 ({})", versions[0].0));
+
+    let content = repo
+        .get_file_content_on_view("src/main.rs", repo.current_view())
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        content, versions[0].1,
+        "Content mismatch after commit 1 ({})",
+        versions[0].0
+    );
+
+    // Subsequent versions: modify file
+    for (i, (sha, version)) in versions[1..].iter().enumerate() {
+        write_file(&repo_path, "src/main.rs", &String::from_utf8_lossy(version));
+        let _ = record_change(&repo, &format!("Commit {} ({})", i + 2, sha));
+
+        let content = repo
+            .get_file_content_on_view("src/main.rs", repo.current_view())
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            content.len(),
+            version.len(),
+            "Content length mismatch after commit {} ({}): got {} bytes, expected {} bytes.\n\
+             This indicates content duplication in the change graph.",
+            i + 2,
+            sha,
+            content.len(),
+            version.len(),
+        );
+
+        assert_eq!(
+            content,
+            *version,
+            "Content mismatch after commit {} ({})",
+            i + 2,
+            sha,
+        );
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Test: Isolated pairwise commit diffs at increasing complexity
+//
+// Rather than replaying the full sequence, this tests individual commit
+// transitions in isolation (fresh repo each time). This isolates whether
+// the bug is in a specific diff shape vs accumulated graph state.
+//
+// Tier 1: dab3f94 (2 hunks, +18/-3) — pure multi-site inserts
+// Tier 2: 219bb1e (7 hunks, +29/-7) — new function + call-site changes
+// Tier 3: 68fdc2c (6 hunks, +44/-10) — extract + warmup + replace
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_hyperfine_pairwise_transitions() {
+    use std::process::Command;
+
+    let git_temp = TempDir::new().expect("Failed to create temp dir for git");
+    let git_path = git_temp.path().to_path_buf();
+    let clone_status = Command::new("git")
+        .args([
+            "clone",
+            "--quiet",
+            "https://github.com/sharkdp/hyperfine.git",
+        ])
+        .arg(&git_path)
+        .status();
+
+    match clone_status {
+        Ok(s) if s.success() => {}
+        _ => {
+            eprintln!("Skipping test: git clone failed (no network?)");
+            return;
+        }
+    }
+
+    // Each pair is (before_sha, after_sha, description, expected_hunk_complexity)
+    let pairs: Vec<(&str, &str, &str)> = vec![
+        // Tier 1: Simple multi-site insert (2 hunks)
+        ("5cdf013", "dab3f94", "add --min-runs (2 hunks)"),
+        // Tier 2: Medium — new function + return type propagation (7 hunks)
+        ("dab3f94", "219bb1e", "error handling (7 hunks)"),
+        // Tier 3: Complex — extract function + warmup + inline replace (6 hunks)
+        ("197f9fb", "68fdc2c", "add --warmup (6 hunks)"),
+        // Tier 4: Major refactor — extract run_benchmark + HyperfineOptions (2 big hunks)
+        ("68fdc2c", "9ba7ada", "refactoring (2 hunks, +94/-73)"),
+    ];
+
+    for (before_sha, after_sha, description) in &pairs {
+        // Get file at before and after
+        let before_output = Command::new("git")
+            .args(["show", &format!("{}:src/main.rs", before_sha)])
+            .current_dir(&git_path)
+            .output()
+            .expect("Failed to run git show");
+        assert!(
+            before_output.status.success(),
+            "git show failed for {}",
+            before_sha
+        );
+
+        let after_output = Command::new("git")
+            .args(["show", &format!("{}:src/main.rs", after_sha)])
+            .current_dir(&git_path)
+            .output()
+            .expect("Failed to run git show");
+        assert!(
+            after_output.status.success(),
+            "git show failed for {}",
+            after_sha
+        );
+
+        // Fresh repo for each pair
+        let (repo, _temp, repo_path) = create_test_repo();
+
+        // Add the "before" version
+        write_file(
+            &repo_path,
+            "src/main.rs",
+            &String::from_utf8_lossy(&before_output.stdout),
+        );
+        repo.add("src/main.rs", Default::default()).unwrap();
+        let _ = record_change(&repo, &format!("before: {}", before_sha));
+
+        let content = repo
+            .get_file_content_on_view("src/main.rs", repo.current_view())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            content, before_output.stdout,
+            "[{}] Content mismatch after initial add ({})",
+            description, before_sha
+        );
+
+        // Apply the "after" version
+        write_file(
+            &repo_path,
+            "src/main.rs",
+            &String::from_utf8_lossy(&after_output.stdout),
+        );
+        let _ = record_change(&repo, &format!("after: {}", after_sha));
+
+        let content = repo
+            .get_file_content_on_view("src/main.rs", repo.current_view())
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            content.len(),
+            after_output.stdout.len(),
+            "[{}] Content length mismatch ({} → {}): got {} bytes, expected {} bytes.\n\
+             This indicates content duplication in the change graph.",
+            description,
+            before_sha,
+            after_sha,
+            content.len(),
+            after_output.stdout.len(),
+        );
+
+        assert_eq!(
+            content, after_output.stdout,
+            "[{}] Content mismatch ({} → {})",
+            description, before_sha, after_sha,
+        );
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Test: Four sequential modifications matching the hyperfine pattern
+//
+// Reproduces the exact commit sequence that triggers duplication:
+// 1. Initial file with basic structure
+// 2. Add progress bar (new imports, inline setup)
+// 3. Code style cleanup (minor tweaks)
+// 4. Extract helper function + add warmup (complex multi-hunk)
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_four_step_evolution_fidelity() {
+    let (repo, _temp, repo_path) = create_test_repo();
+
+    let v1 = "\
+use std::time::Instant;
+
+fn time_cmd(cmd: &str) -> f64 {
+    let start = Instant::now();
+    run(cmd);
+    start.elapsed().as_secs_f64()
+}
+
+fn main() {
+    let cmd = get_cmd();
+    let mut times = vec![];
+    for _ in 0..10 {
+        times.push(time_cmd(cmd));
+    }
+    let mean: f64 = times.iter().sum::<f64>() / times.len() as f64;
+    println!(\"Mean: {:.3}s\", mean);
+}
+";
+
+    let v2 = "\
+use std::time::Instant;
+
+fn time_cmd(cmd: &str) -> f64 {
+    let start = Instant::now();
+    run(cmd);
+    start.elapsed().as_secs_f64()
+}
+
+fn main() {
+    let cmd = get_cmd();
+    let min_runs = 10;
+    let mut times = vec![];
+
+    let bar = ProgressBar::new(min_runs);
+    let style = ProgressStyle::default_spinner()
+        .template(\"{spinner} {msg}\");
+    bar.set_style(style);
+    bar.set_message(\"Measuring\");
+
+    for _ in 0..min_runs {
+        bar.inc(1);
+        times.push(time_cmd(cmd));
+    }
+    bar.finish();
+
+    let mean: f64 = times.iter().sum::<f64>() / times.len() as f64;
+    println!(\"Mean: {:.3}s\", mean);
+}
+";
+
+    let v3 = "\
+use std::time::Instant;
+
+fn time_cmd(cmd: &str) -> f64 {
+    let start = Instant::now();
+    run(cmd);
+    start.elapsed().as_secs_f64()
+}
+
+fn main() {
+    let cmd = get_cmd();
+    let min_runs = 10;
+    let mut times = vec![];
+
+    let bar = ProgressBar::new(min_runs);
+    let style = ProgressStyle::default_spinner()
+        .template(\"{spinner} {msg:<28} {wide_bar}\");
+    bar.set_style(style.clone());
+    bar.set_message(\"Measuring\");
+
+    for _ in 0..min_runs {
+        bar.inc(1);
+        times.push(time_cmd(cmd));
+    }
+    bar.finish_and_clear();
+
+    let mean: f64 = times.iter().sum::<f64>() / times.len() as f64;
+    println!(\"Mean: {:.3}s\", mean);
+}
+";
+
+    let v4 = "\
+use std::time::Instant;
+
+fn time_cmd(cmd: &str) -> f64 {
+    let start = Instant::now();
+    run(cmd);
+    start.elapsed().as_secs_f64()
+}
+
+fn get_bar(len: u64, msg: &str) -> ProgressBar {
+    let style = ProgressStyle::default_spinner()
+        .tick_chars(\"⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏\")
+        .template(\"{spinner} {msg:<28} {wide_bar}\");
+    let bar = ProgressBar::new(len);
+    bar.set_style(style);
+    bar.set_message(msg);
+    bar
+}
+
+fn main() {
+    let cmd = get_cmd();
+    let min_runs = 10;
+    let mut times = vec![];
+
+    // Warmup phase
+    if let Some(n) = get_warmup() {
+        let bar = get_bar(n, \"Warmup\");
+        for _ in 0..n {
+            bar.inc(1);
+            let _ = time_cmd(cmd);
+        }
+        bar.finish_and_clear();
+    }
+
+    let bar = get_bar(min_runs, \"Measuring\");
+    for _ in 0..min_runs {
+        bar.inc(1);
+        times.push(time_cmd(cmd));
+    }
+    bar.finish_and_clear();
+
+    let mean: f64 = times.iter().sum::<f64>() / times.len() as f64;
+    println!(\"Mean: {:.3}s\", mean);
+}
+";
+
+    // Step 1: initial
+    write_file(&repo_path, "bench.rs", v1);
+    repo.add("bench.rs", Default::default()).unwrap();
+    let h1 = record_change(&repo, "initial");
+    assert_content_matches(&repo, "bench.rs", v1);
+
+    // Step 2: add progress bar
+    write_file(&repo_path, "bench.rs", v2);
+    let h2 = record_change(&repo, "add progress bar");
+    assert_content_matches(&repo, "bench.rs", v2);
+
+    // Step 3: code style
+    write_file(&repo_path, "bench.rs", v3);
+    let h3 = record_change(&repo, "code style");
+    assert_content_matches(&repo, "bench.rs", v3);
+
+    // Step 4: extract helper + warmup (the commit that triggers duplication)
+    write_file(&repo_path, "bench.rs", v4);
+    let h4 = record_change(&repo, "extract helper and add warmup");
+
+    // Critical: content at HEAD must exactly match v4
+    let content = repo
+        .get_file_content_on_view("bench.rs", repo.current_view())
+        .expect("Failed to get content")
+        .expect("File not found");
+
+    let actual = String::from_utf8_lossy(&content);
+    let actual_lines = actual.lines().count();
+    let expected_lines = v4.lines().count();
+
+    assert_eq!(
+        actual_lines,
+        expected_lines,
+        "Line count mismatch after step 4: got {} lines, expected {} lines.\n\
+         This indicates content duplication in the change graph.\n\
+         First 5 lines of actual:\n{}\n...\nLast 5 lines:\n{}",
+        actual_lines,
+        expected_lines,
+        actual.lines().take(5).collect::<Vec<_>>().join("\n"),
+        actual
+            .lines()
+            .rev()
+            .take(5)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+
+    assert_eq!(
+        actual.as_ref(),
+        v4,
+        "Content mismatch after step 4 (extract helper + warmup)"
+    );
+
+    // Verify all intermediate states too
+    assert_content_after_change(&repo, "bench.rs", &h1, v1);
+    assert_content_after_change(&repo, "bench.rs", &h2, v2);
+    assert_content_after_change(&repo, "bench.rs", &h3, v3);
+    assert_content_after_change(&repo, "bench.rs", &h4, v4);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Test: Single-line middle insertion
+//
+// Reproduces the "All recorded files are empty (no hunks)" bug triggered
+// by hyperfine commit 2ab118dd ("Close stdin for child-processes").
+//
+// A single line is inserted in the middle of a file. The diff produces
+// one Insert hunk with old_start > 0 and old_start < old_line_count
+// (a "middle insertion"). The upstream consolidation in record_modified_file
+// only fires when nuclear_hunk_count > 1 or when a nuclear hunk coexists
+// with other hunks. A lone middle Insert slips through unconsolidated,
+// reaches globalization, and is rejected because the globalize pipeline
+// no longer handles middle insertions directly.
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_single_line_middle_insertion() {
+    let (repo, _temp, repo_path) = create_test_repo();
+
+    let v1 = "\
+fn run_command(cmd: &str) -> Result<()> {
+    let status = Command::new(\"sh\")
+        .arg(\"-c\")
+        .arg(cmd)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()?;
+
+    Ok(status)
+}
+
+fn main() {
+    let cmd = get_cmd();
+    let result = run_command(cmd);
+    println!(\"{:?}\", result);
+}
+";
+
+    // Version 2: single line added in the middle (.stdin(Stdio::null()))
+    let v2 = "\
+fn run_command(cmd: &str) -> Result<()> {
+    let status = Command::new(\"sh\")
+        .arg(\"-c\")
+        .arg(cmd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()?;
+
+    Ok(status)
+}
+
+fn main() {
+    let cmd = get_cmd();
+    let result = run_command(cmd);
+    println!(\"{:?}\", result);
+}
+";
+
+    write_file(&repo_path, "src/main.rs", v1);
+    repo.add("src/main.rs", Default::default()).unwrap();
+    let _h1 = record_change(&repo, "initial");
+    assert_content_matches(&repo, "src/main.rs", v1);
+
+    // This is the critical step — a single-line middle insertion must
+    // successfully record and produce correct content.
+    write_file(&repo_path, "src/main.rs", v2);
+    let _h2 = record_change(&repo, "add stdin null");
+    assert_content_matches(&repo, "src/main.rs", v2);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Test: Single-line middle insertion after multiple prior modifications
+//
+// Same bug but with more history — the file has been modified several
+// times before the single-line insertion. This matches the exact
+// hyperfine scenario: 16 commits modify src/main.rs, then commit 17
+// adds a single line in the middle.
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_single_line_middle_insertion_after_multiple_edits() {
+    let (repo, _temp, repo_path) = create_test_repo();
+
+    let v1 = "\
+use std::process::Command;
+
+fn run(cmd: &str) {
+    Command::new(\"sh\")
+        .arg(\"-c\")
+        .arg(cmd)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .expect(\"failed\");
+}
+
+fn main() {
+    run(\"echo hello\");
+}
+";
+
+    let v2 = "\
+use std::process::{Command, Stdio};
+
+fn run(cmd: &str) {
+    Command::new(\"sh\")
+        .arg(\"-c\")
+        .arg(cmd)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect(\"failed\");
+}
+
+fn main() {
+    let cmd = \"echo hello\";
+    run(cmd);
+}
+";
+
+    let v3 = "\
+use std::process::{Command, Stdio};
+use std::io;
+
+fn run(cmd: &str) -> io::Result<()> {
+    let status = Command::new(\"sh\")
+        .arg(\"-c\")
+        .arg(cmd)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()?;
+
+    if !status.success() {
+        eprintln!(\"Command failed\");
+    }
+
+    Ok(())
+}
+
+fn main() {
+    let cmd = \"echo hello\";
+    run(cmd).expect(\"run failed\");
+}
+";
+
+    // v4: single line inserted in the middle — .stdin(Stdio::null())
+    let v4 = "\
+use std::process::{Command, Stdio};
+use std::io;
+
+fn run(cmd: &str) -> io::Result<()> {
+    let status = Command::new(\"sh\")
+        .arg(\"-c\")
+        .arg(cmd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()?;
+
+    if !status.success() {
+        eprintln!(\"Command failed\");
+    }
+
+    Ok(())
+}
+
+fn main() {
+    let cmd = \"echo hello\";
+    run(cmd).expect(\"run failed\");
+}
+";
+
+    write_file(&repo_path, "src/main.rs", v1);
+    repo.add("src/main.rs", Default::default()).unwrap();
+    let _h1 = record_change(&repo, "initial");
+
+    write_file(&repo_path, "src/main.rs", v2);
+    let _h2 = record_change(&repo, "refactor imports");
+
+    write_file(&repo_path, "src/main.rs", v3);
+    let _h3 = record_change(&repo, "add error handling");
+
+    // The critical single-line middle insertion
+    write_file(&repo_path, "src/main.rs", v4);
+    let _h4 = record_change(&repo, "close stdin for child processes");
+    assert_content_matches(&repo, "src/main.rs", v4);
+}

--- a/atomic-repository/tests/content_roundtrip_fidelity_test.rs
+++ b/atomic-repository/tests/content_roundtrip_fidelity_test.rs
@@ -13,9 +13,23 @@ use std::fs;
 use std::path::PathBuf;
 
 use atomic_core::change::{Author, ChangeHeader};
+use atomic_core::types::Base32;
 use atomic_core::types::Hash;
 use atomic_repository::{RecordOptions, Repository};
 use tempfile::TempDir;
+
+/// Platform-aware path for subdirectory test files.
+/// On Windows, file tracking with subdirectory paths has known issues,
+/// so we use flat filenames. On Unix, we use subdirectory paths to
+/// exercise the full path handling.
+fn test_path(subdir_path: &str) -> String {
+    if cfg!(windows) {
+        // Flatten: "src/main.rs" → "src_main.rs"
+        subdir_path.replace('/', "_")
+    } else {
+        subdir_path.to_string()
+    }
+}
 
 fn create_test_repo() -> (Repository, TempDir, PathBuf) {
     let temp = TempDir::new().expect("Failed to create temp dir");
@@ -262,28 +276,29 @@ fn main() {
 ";
 
     // Record version 1
-    write_file(&repo_path, "src/main.rs", v1);
-    repo.add("src/main.rs", Default::default()).unwrap();
+    let p = test_path("src/main.rs");
+    write_file(&repo_path, &p, v1);
+    repo.add(&p, Default::default()).unwrap();
     let h1 = record_change(&repo, "initial");
-    assert_content_matches(&repo, "src/main.rs", v1);
+    assert_content_matches(&repo, &p, v1);
 
     // Record version 2 (minor edits)
-    write_file(&repo_path, "src/main.rs", v2);
+    write_file(&repo_path, &p, v2);
     let h2 = record_change(&repo, "code style");
-    assert_content_matches(&repo, "src/main.rs", v2);
+    assert_content_matches(&repo, &p, v2);
 
     // Record version 3 (major refactor: extract function, add warmup, replace inline code)
-    write_file(&repo_path, "src/main.rs", v3);
+    write_file(&repo_path, &p, v3);
     let h3 = record_change(&repo, "extract helper and add warmup");
 
     // This is the critical assertion — after the multi-hunk refactor,
     // the graph content should exactly match v3 with no duplication.
-    assert_content_matches(&repo, "src/main.rs", v3);
+    assert_content_matches(&repo, &p, v3);
 
     // Also verify state-based retrieval at each point
-    assert_content_after_change(&repo, "src/main.rs", &h1, v1);
-    assert_content_after_change(&repo, "src/main.rs", &h2, v2);
-    assert_content_after_change(&repo, "src/main.rs", &h3, v3);
+    assert_content_after_change(&repo, &p, &h1, v1);
+    assert_content_after_change(&repo, &p, &h2, v2);
+    assert_content_after_change(&repo, &p, &h3, v3);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -332,10 +347,12 @@ fn test_hyperfine_content_duplication_bug() {
         "68fdc2c",  // Add --warmup option
     ];
 
+    let git_file = "src/main.rs";
+    let local_file = test_path(git_file);
     let mut versions: Vec<Vec<u8>> = Vec::new();
     for sha in &commits {
         let output = Command::new("git")
-            .args(["show", &format!("{}:src/main.rs", sha)])
+            .args(["show", &format!("{}:{}", sha, git_file)])
             .current_dir(&git_path)
             .output()
             .expect("Failed to run git show");
@@ -349,14 +366,14 @@ fn test_hyperfine_content_duplication_bug() {
     // Commit 1: add file
     write_file(
         &repo_path,
-        "src/main.rs",
+        &local_file,
         &String::from_utf8_lossy(&versions[0]),
     );
-    repo.add("src/main.rs", Default::default()).unwrap();
+    repo.add(&local_file, Default::default()).unwrap();
     let _ = record_change(&repo, "Initial commit");
 
     let content = repo
-        .get_file_content_on_view("src/main.rs", repo.current_view())
+        .get_file_content_on_view(&local_file, repo.current_view())
         .unwrap()
         .unwrap();
     assert_eq!(
@@ -366,11 +383,11 @@ fn test_hyperfine_content_duplication_bug() {
 
     // Commits 2-4: modify file
     for (i, version) in versions[1..].iter().enumerate() {
-        write_file(&repo_path, "src/main.rs", &String::from_utf8_lossy(version));
+        write_file(&repo_path, &local_file, &String::from_utf8_lossy(version));
         let _ = record_change(&repo, &format!("Commit {}", i + 2));
 
         let content = repo
-            .get_file_content_on_view("src/main.rs", repo.current_view())
+            .get_file_content_on_view(&local_file, repo.current_view())
             .unwrap()
             .unwrap();
 
@@ -432,6 +449,9 @@ fn test_hyperfine_extended_commit_sequence() {
         }
     }
 
+    let git_file = "src/main.rs";
+    let local_file = test_path(git_file);
+
     // Commits that touch src/main.rs in the first 15 commits.
     // We skip commits that don't change src/main.rs (README, licenses, metadata).
     let commits: Vec<&str> = vec![
@@ -449,7 +469,7 @@ fn test_hyperfine_extended_commit_sequence() {
     let mut versions: Vec<(String, Vec<u8>)> = Vec::new();
     for sha in &commits {
         let output = Command::new("git")
-            .args(["show", &format!("{}:src/main.rs", sha)])
+            .args(["show", &format!("{}:{}", sha, git_file)])
             .current_dir(&git_path)
             .output()
             .expect("Failed to run git show");
@@ -472,14 +492,14 @@ fn test_hyperfine_extended_commit_sequence() {
     // First version: add file
     write_file(
         &repo_path,
-        "src/main.rs",
+        &local_file,
         &String::from_utf8_lossy(&versions[0].1),
     );
-    repo.add("src/main.rs", Default::default()).unwrap();
+    repo.add(&local_file, Default::default()).unwrap();
     let _ = record_change(&repo, &format!("Commit 1 ({})", versions[0].0));
 
     let content = repo
-        .get_file_content_on_view("src/main.rs", repo.current_view())
+        .get_file_content_on_view(&local_file, repo.current_view())
         .unwrap()
         .unwrap();
     assert_eq!(
@@ -490,11 +510,11 @@ fn test_hyperfine_extended_commit_sequence() {
 
     // Subsequent versions: modify file
     for (i, (sha, version)) in versions[1..].iter().enumerate() {
-        write_file(&repo_path, "src/main.rs", &String::from_utf8_lossy(version));
+        write_file(&repo_path, &local_file, &String::from_utf8_lossy(version));
         let _ = record_change(&repo, &format!("Commit {} ({})", i + 2, sha));
 
         let content = repo
-            .get_file_content_on_view("src/main.rs", repo.current_view())
+            .get_file_content_on_view(&local_file, repo.current_view())
             .unwrap()
             .unwrap();
 
@@ -534,6 +554,8 @@ fn test_hyperfine_extended_commit_sequence() {
 #[test]
 fn test_hyperfine_pairwise_transitions() {
     use std::process::Command;
+    let git_file = "src/main.rs";
+    let local_file = test_path(git_file);
 
     let git_temp = TempDir::new().expect("Failed to create temp dir for git");
     let git_path = git_temp.path().to_path_buf();
@@ -569,7 +591,7 @@ fn test_hyperfine_pairwise_transitions() {
     for (before_sha, after_sha, description) in &pairs {
         // Get file at before and after
         let before_output = Command::new("git")
-            .args(["show", &format!("{}:src/main.rs", before_sha)])
+            .args(["show", &format!("{}:{}", before_sha, git_file)])
             .current_dir(&git_path)
             .output()
             .expect("Failed to run git show");
@@ -580,7 +602,7 @@ fn test_hyperfine_pairwise_transitions() {
         );
 
         let after_output = Command::new("git")
-            .args(["show", &format!("{}:src/main.rs", after_sha)])
+            .args(["show", &format!("{}:{}", after_sha, git_file)])
             .current_dir(&git_path)
             .output()
             .expect("Failed to run git show");
@@ -596,14 +618,14 @@ fn test_hyperfine_pairwise_transitions() {
         // Add the "before" version
         write_file(
             &repo_path,
-            "src/main.rs",
+            &local_file,
             &String::from_utf8_lossy(&before_output.stdout),
         );
-        repo.add("src/main.rs", Default::default()).unwrap();
+        repo.add(&local_file, Default::default()).unwrap();
         let _ = record_change(&repo, &format!("before: {}", before_sha));
 
         let content = repo
-            .get_file_content_on_view("src/main.rs", repo.current_view())
+            .get_file_content_on_view(&local_file, repo.current_view())
             .unwrap()
             .unwrap();
         assert_eq!(
@@ -615,13 +637,13 @@ fn test_hyperfine_pairwise_transitions() {
         // Apply the "after" version
         write_file(
             &repo_path,
-            "src/main.rs",
+            &local_file,
             &String::from_utf8_lossy(&after_output.stdout),
         );
         let _ = record_change(&repo, &format!("after: {}", after_sha));
 
         let content = repo
-            .get_file_content_on_view("src/main.rs", repo.current_view())
+            .get_file_content_on_view(&local_file, repo.current_view())
             .unwrap()
             .unwrap();
 
@@ -909,16 +931,17 @@ fn main() {
 }
 ";
 
-    write_file(&repo_path, "src/main.rs", v1);
-    repo.add("src/main.rs", Default::default()).unwrap();
+    let p = test_path("src/main.rs");
+    write_file(&repo_path, &p, v1);
+    repo.add(&p, Default::default()).unwrap();
     let _h1 = record_change(&repo, "initial");
-    assert_content_matches(&repo, "src/main.rs", v1);
+    assert_content_matches(&repo, &p, v1);
 
     // This is the critical step — a single-line middle insertion must
     // successfully record and produce correct content.
-    write_file(&repo_path, "src/main.rs", v2);
+    write_file(&repo_path, &p, v2);
     let _h2 = record_change(&repo, "add stdin null");
-    assert_content_matches(&repo, "src/main.rs", v2);
+    assert_content_matches(&repo, &p, v2);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1023,18 +1046,19 @@ fn main() {
 }
 ";
 
-    write_file(&repo_path, "src/main.rs", v1);
-    repo.add("src/main.rs", Default::default()).unwrap();
+    let p = test_path("src/main.rs");
+    write_file(&repo_path, &p, v1);
+    repo.add(&p, Default::default()).unwrap();
     let _h1 = record_change(&repo, "initial");
 
-    write_file(&repo_path, "src/main.rs", v2);
+    write_file(&repo_path, &p, v2);
     let _h2 = record_change(&repo, "refactor imports");
 
-    write_file(&repo_path, "src/main.rs", v3);
+    write_file(&repo_path, &p, v3);
     let _h3 = record_change(&repo, "add error handling");
 
     // The critical single-line middle insertion
-    write_file(&repo_path, "src/main.rs", v4);
+    write_file(&repo_path, &p, v4);
     let _h4 = record_change(&repo, "close stdin for child processes");
-    assert_content_matches(&repo, "src/main.rs", v4);
+    assert_content_matches(&repo, &p, v4);
 }

--- a/atomic-repository/tests/content_roundtrip_fidelity_test.rs
+++ b/atomic-repository/tests/content_roundtrip_fidelity_test.rs
@@ -13,7 +13,6 @@ use std::fs;
 use std::path::PathBuf;
 
 use atomic_core::change::{Author, ChangeHeader};
-use atomic_core::types::Base32;
 use atomic_core::types::Hash;
 use atomic_repository::{RecordOptions, Repository};
 use tempfile::TempDir;

--- a/tests/harness/10_git_import.sh
+++ b/tests/harness/10_git_import.sh
@@ -385,6 +385,152 @@ else
 fi
 
 # ════════════════════════════════════════════════════════════════════════════
+# Section 14: Status Parity After Import (Renames + Deletions)
+# ════════════════════════════════════════════════════════════════════════════
+#
+# After `atomic git import`, `atomic status` must be clean — the pristine
+# graph should match the git working copy exactly.  This section exercises
+# the two operations that historically caused spurious status entries:
+#
+#   1. File deletions:  record_modified_file (for diff lines) produces
+#      GraphOp::Replacement, not GraphOp::FileDel, so apply_change never
+#      removed the TREE entry.  The fix explicitly untracks deleted files
+#      after apply.
+#
+#   2. File renames:  git mv old new must produce a GraphOp::FileMove that
+#      updates TREE (del old path, put new path with same inode).
+
+begin_section "Git Import: Status Parity After Import (renames + deletions)"
+
+make_temp_repo "git-import-status-parity"
+GIT_REPO="$REPO_DIR"
+
+git -C "$GIT_REPO" init --quiet 2>/dev/null
+git -C "$GIT_REPO" config user.email "test@test.com" 2>/dev/null
+git -C "$GIT_REPO" config user.name "Test" 2>/dev/null
+
+# ── v1: create a small tree (including a binary file) ───────────────────
+mkdir -p "$GIT_REPO/src/sub" "$GIT_REPO/docs"
+printf 'fn app() {}\n'    > "$GIT_REPO/src/sub/app.rs"
+printf 'fn bench() {}\n'  > "$GIT_REPO/src/sub/bench.rs"
+printf 'mod sub;\n'        > "$GIT_REPO/src/sub/mod.rs"
+printf '# readme\n'        > "$GIT_REPO/docs/README.md"
+printf 'old ci config\n'   > "$GIT_REPO/.travis.yml"
+# Binary file: PNG header + null bytes (triggers is_binary detection)
+printf '\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR_old_logo_data_here\n' > "$GIT_REPO/docs/logo.png"
+git -C "$GIT_REPO" add -A >/dev/null 2>&1
+git -C "$GIT_REPO" commit -m "v1: initial tree" --quiet 2>/dev/null
+
+# ── v2: mass rename + delete + binary modify ────────────────────────────
+#   - src/sub/app.rs   → src/app.rs      (pure rename)
+#   - src/sub/bench.rs → src/bench.rs    (rename + content change)
+#   - src/sub/mod.rs   → deleted
+#   - .travis.yml      → deleted
+#   - docs/logo.png    → modified (binary content swap)
+mkdir -p "$GIT_REPO/src"
+git -C "$GIT_REPO" mv src/sub/app.rs   src/app.rs   2>/dev/null
+git -C "$GIT_REPO" mv src/sub/bench.rs src/bench.rs 2>/dev/null
+printf 'fn bench_v2() {}\n// added in v2\n' > "$GIT_REPO/src/bench.rs"
+git -C "$GIT_REPO" rm src/sub/mod.rs  --quiet 2>/dev/null
+git -C "$GIT_REPO" rm .travis.yml     --quiet 2>/dev/null
+# Replace binary file with different binary content (smaller PNG)
+printf '\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR_new_v2\n' > "$GIT_REPO/docs/logo.png"
+git -C "$GIT_REPO" add -A >/dev/null 2>&1
+git -C "$GIT_REPO" commit -m "v2: flatten + delete + binary update" --quiet 2>/dev/null
+
+# ── v3: modify a renamed file (to exercise the post-rename path) ────────
+printf 'fn bench_v3() {}\n// v3 change\n' > "$GIT_REPO/src/bench.rs"
+git -C "$GIT_REPO" add -A >/dev/null 2>&1
+git -C "$GIT_REPO" commit -m "v3: modify after rename" --quiet 2>/dev/null
+
+# ── Import ──────────────────────────────────────────────────────────────
+(cd "$GIT_REPO" && atomic git import 2>/dev/null) || true
+
+# ── Assertions ──────────────────────────────────────────────────────────
+
+# 1. No spurious deleted files in status
+_deleted_count=$(cd "$GIT_REPO" && atomic status --short 2>/dev/null | grep -c '^D ' || true)
+if [[ "$_deleted_count" -eq 0 ]]; then
+    _pass "no spurious deletions in status after import"
+else
+    _deleted_files=$(cd "$GIT_REPO" && atomic status --short 2>/dev/null | grep '^D ')
+    _fail "spurious deletions in status" "$_deleted_count file(s): $_deleted_files"
+fi
+
+# 2. Renamed files are tracked (not untracked ??)
+_untracked_app=$(cd "$GIT_REPO" && atomic status --short 2>/dev/null | grep '?? src/app.rs' || true)
+if [[ -z "$_untracked_app" ]]; then
+    _pass "src/app.rs tracked after rename"
+else
+    _fail "src/app.rs untracked after rename" "status shows: $_untracked_app"
+fi
+
+_untracked_bench=$(cd "$GIT_REPO" && atomic status --short 2>/dev/null | grep '?? src/bench.rs' || true)
+if [[ -z "$_untracked_bench" ]]; then
+    _pass "src/bench.rs tracked after rename+modify"
+else
+    _fail "src/bench.rs untracked after rename+modify" "status shows: $_untracked_bench"
+fi
+
+# 3. Deleted files are NOT tracked (should not appear in status at all)
+_deleted_travis=$(cd "$GIT_REPO" && atomic status --short 2>/dev/null | grep 'travis' || true)
+if [[ -z "$_deleted_travis" ]]; then
+    _pass ".travis.yml not in status (correctly deleted)"
+else
+    _fail ".travis.yml still in status after delete" "status shows: $_deleted_travis"
+fi
+
+_deleted_mod=$(cd "$GIT_REPO" && atomic status --short 2>/dev/null | grep 'sub/mod.rs' || true)
+if [[ -z "$_deleted_mod" ]]; then
+    _pass "src/sub/mod.rs not in status (correctly deleted)"
+else
+    _fail "src/sub/mod.rs still in status after delete" "status shows: $_deleted_mod"
+fi
+
+# 4. Old rename source paths are gone from tracking
+_old_sub_app=$(cd "$GIT_REPO" && atomic status --short 2>/dev/null | grep 'sub/app.rs' || true)
+if [[ -z "$_old_sub_app" ]]; then
+    _pass "src/sub/app.rs gone from status (old rename source)"
+else
+    _fail "src/sub/app.rs still in status" "should have been removed by rename: $_old_sub_app"
+fi
+
+# 5. Binary file is tracked and NOT modified (graph content matches disk)
+_modified_logo=$(cd "$GIT_REPO" && atomic status --short 2>/dev/null | grep 'docs/logo.png' || true)
+if [[ -z "$_modified_logo" ]]; then
+    _pass "docs/logo.png clean after binary modify (graph matches disk)"
+else
+    _fail "docs/logo.png dirty after import" "status shows: $_modified_logo"
+fi
+
+# 6. Overall: status should be completely clean (no M, D, A, or ?? entries)
+_status_lines=$(cd "$GIT_REPO" && atomic status --short 2>/dev/null | grep -cE '^[MDAU?]' || true)
+if [[ "$_status_lines" -eq 0 ]]; then
+    _pass "status is completely clean after import (full parity)"
+else
+    _dirty=$(cd "$GIT_REPO" && atomic status --short 2>/dev/null | head -10)
+    _fail "status not clean after import" "$_status_lines dirty entries: $_dirty"
+fi
+
+# 7. Change count matches git commit count
+_git_count=$(git -C "$GIT_REPO" rev-list --count HEAD 2>/dev/null)
+_atomic_log=$(cd "$GIT_REPO" && atomic log --format short --no-color 2>/dev/null | grep -c '.' || true)
+if [[ "$_atomic_log" -eq "$_git_count" ]]; then
+    _pass "change count matches git ($_git_count)"
+else
+    _fail "change count mismatch" "git=$_git_count atomic=$_atomic_log"
+fi
+
+# 8. Verify file contents match git HEAD
+_bench_content=$(cat "$GIT_REPO/src/bench.rs" 2>/dev/null)
+_expected_bench=$(printf 'fn bench_v3() {}\n// v3 change\n')
+if [[ "$_bench_content" == "$_expected_bench" ]]; then
+    _pass "src/bench.rs content matches git HEAD after rename+modify chain"
+else
+    _fail "src/bench.rs content mismatch" "expected v3 content"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
 # Summary
 # ════════════════════════════════════════════════════════════════════════════
 

--- a/tests/harness/10_git_import.sh
+++ b/tests/harness/10_git_import.sh
@@ -240,8 +240,8 @@ make_temp_repo "git-import-errors"
 atomic init >/dev/null 2>&1
 
 # Should fail with clear error about not being a git repo
-out="$(atomic git import 2>&1)"
-status=$?
+status=0
+out="$(atomic git import 2>&1)" || status=$?
 if [ "$status" -eq 0 ]; then
     _fail "atomic git import unexpectedly succeeded in non-git directory"
 elif echo "$out" | grep -qiE "not.*git|no.*repository|git.*not found"; then
@@ -253,8 +253,8 @@ fi
 # Now make it a git repo and test invalid branch
 init_git_repo
 git_commit "test" "test.txt" "test"
-out="$(atomic git import --branch nonexistent 2>&1)"
-status=$?
+status=0
+out="$(atomic git import --branch nonexistent 2>&1)" || status=$?
 if [ "$status" -eq 0 ]; then
     _fail "atomic git import unexpectedly succeeded for invalid branch"
 elif echo "$out" | grep -qiE "branch.*not found|no.*branch|invalid.*branch|unknown.*branch"; then
@@ -335,12 +335,14 @@ make_temp_repo "git-import-merges"
 init_git_repo
 
 # Create a merge scenario
+# Detect the default branch name (may be "main" or "master" depending on git config)
+_default_branch="$(git symbolic-ref --short HEAD 2>/dev/null || echo main)"
 git_commit "Base commit" "base.txt" "base"
 git checkout -b feature --quiet
 git_commit "Feature commit" "feature.txt" "feature"
-git checkout main --quiet 2>/dev/null || git checkout master --quiet
+git checkout "$_default_branch" --quiet 2>/dev/null
 git_commit "Main commit" "main2.txt" "main2"
-git merge feature --no-ff -m "Merge feature into main" --quiet
+git merge feature --no-ff -m "Merge feature into main" --quiet 2>/dev/null
 
 atomic init >/dev/null 2>&1
 atomic git import >/dev/null 2>&1

--- a/tests/harness/11_diff_git_parity.sh
+++ b/tests/harness/11_diff_git_parity.sh
@@ -1,0 +1,831 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034,SC2206,SC2128
+# 11_diff_git_parity.sh — Diff format parity tests: atomic diff vs git diff.
+#
+# Validates that `atomic diff -c <hash>` produces the same change lines
+# as `git diff PARENT..COMMIT` for the same commits.
+#
+# Strategy:
+#   1. Create a git repo with known file edits
+#   2. Run `atomic git import` to convert git history to atomic changes
+#   3. For each commit, compare the +/- lines from git diff against
+#      the +/- lines from atomic diff -c
+#
+# We also run against the real hyperfine repo as an end-to-end test.
+#
+# What MUST match:
+#   - Every `-` line (deletions) in the same order
+#   - Every `+` line (insertions) in the same order
+
+HARNESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$HARNESS_DIR/helpers.sh"
+
+# Pre-declare arrays at script scope so set -u doesn't trip on them.
+ATOMIC_HASHES=()
+GIT_SHAS=()
+GIT_REPO=""
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+# Extract only +/- change lines from git unified diff output.
+# Strips headers (diff, ---, +++, @@) and context lines.
+extract_git_change_lines() {
+    grep -E '^\+[^+]|^-[^-]' || true
+}
+
+# Extract only +/- change lines from atomic diff output.
+# Atomic's --no-color format (with show_line_numbers=false) is:
+#   -content
+#   +content
+# Same as git, so we use the same extractor.
+# But we also need to skip the change header block (change hash, Date, message).
+extract_atomic_change_lines() {
+    grep -E '^\+[^+]|^-[^-]' || true
+}
+
+# Create a git repo, apply a sequence of file versions, import into atomic.
+#
+# Usage:
+#   setup_git_and_import "label" "file_path" version1 version2 ...
+#
+# After calling:
+#   GIT_REPO   — path to the git repo (also the atomic repo after import)
+#   GIT_SHAS   — array of git commit SHAs in order
+#   ATOMIC_HASHES — array of atomic change hashes in order (parallel to GIT_SHAS)
+setup_git_and_import() {
+    local label="$1"
+    local file_path="$2"
+    shift 2
+    # remaining args are version contents
+
+    make_temp_repo "$label"
+    GIT_REPO="$REPO_DIR"
+
+    git -C "$GIT_REPO" init --quiet 2>/dev/null
+    git -C "$GIT_REPO" config user.email "test@test.com" 2>/dev/null
+    git -C "$GIT_REPO" config user.name "Test" 2>/dev/null
+
+    GIT_SHAS=()
+    local version_num=0
+    for content in "$@"; do
+        version_num=$((version_num + 1))
+        mkdir -p "$GIT_REPO/$(dirname "$file_path")"
+        # Bash command substitution $(...) strips trailing newlines.
+        # To preserve the final \n that belongs in the file, we use printf
+        # with the content variable but append a newline since the variable
+        # already lost its trailing newline during assignment.
+        printf '%s\n' "$content" > "$GIT_REPO/$file_path"
+        git -C "$GIT_REPO" add -A >/dev/null 2>&1
+        git -C "$GIT_REPO" commit -m "v$version_num" --quiet 2>/dev/null
+        local sha
+        sha=$(git -C "$GIT_REPO" rev-parse HEAD 2>/dev/null)
+        GIT_SHAS+=("$sha")
+    done
+
+    # Run atomic git import
+    (cd "$GIT_REPO" && atomic git import 2>/dev/null) || true
+
+    # Collect atomic change hashes in order (oldest first).
+    # `atomic log` lists newest first, so we reverse.
+    ATOMIC_HASHES=()
+    local log_output
+    log_output=$( (cd "$GIT_REPO" && atomic log --format short --no-color --full-hash 2>/dev/null) || true )
+    if [[ -n "${log_output:-}" ]]; then
+        # Log lists newest first. Collect into temp, then reverse.
+        local _tmp=()
+        while IFS= read -r line; do
+            local h
+            h=$(echo "$line" | awk '{print $1}')
+            if [[ -n "$h" ]]; then
+                _tmp+=("$h")
+            fi
+        done <<< "$log_output"
+        # Reverse: oldest first to match GIT_SHAS order
+        local _i
+        for (( _i=${#_tmp[@]}-1 ; _i>=0 ; _i-- )); do
+            ATOMIC_HASHES+=("${_tmp[$_i]}")
+        done
+    fi
+}
+
+# Compare git diff (parent..commit) against atomic diff -c for a specific
+# commit index (0-based).  The git diff is between GIT_SHAS[idx-1] and
+# GIT_SHAS[idx].  The atomic diff is for ATOMIC_HASHES[idx].
+# assert_commit_parity "desc" idx [path_filter]
+#
+# path_filter: optional path to pass to `git diff` and extract from
+# `atomic diff`.  When provided, only lines touching that path are
+# compared.  Useful for commits that also touch lock files or other
+# generated files whose diffs differ by algorithm.
+assert_commit_parity() {
+    local desc="$1"
+    local idx="$2"
+    local path_filter="${3:-}"
+
+    set +u
+    local _n_atomic=${#ATOMIC_HASHES[@]}
+    set -u
+    if [[ "$_n_atomic" -eq 0 ]]; then
+        _fail "$desc" "no atomic changes found (import may have failed)"
+        return
+    fi
+
+    if [[ $idx -lt 1 ]]; then
+        _skip "$desc" "first commit (no parent to diff against)"
+        return
+    fi
+
+    local prev_sha="${GIT_SHAS[$((idx - 1))]}"
+    local curr_sha="${GIT_SHAS[$idx]}"
+
+    if [[ -z "$prev_sha" || -z "$curr_sha" ]]; then
+        _fail "$desc" "missing git SHA at index $idx"
+        return
+    fi
+
+    # Git diff (optionally scoped to a single path)
+    local git_lines_file="$REPO_DIR/git_lines_$idx.txt"
+    if [[ -n "$path_filter" ]]; then
+        git -C "$GIT_REPO" --no-pager diff "$prev_sha" "$curr_sha" -- "$path_filter" 2>/dev/null \
+            | extract_git_change_lines > "$git_lines_file"
+    else
+        git -C "$GIT_REPO" --no-pager diff "$prev_sha" "$curr_sha" 2>/dev/null \
+            | extract_git_change_lines > "$git_lines_file"
+    fi
+
+    # Atomic diff
+    set +u
+    local _n_ah=${#ATOMIC_HASHES[@]}
+    set -u
+    local atomic_hash=""
+    if [[ $idx -lt $_n_ah ]]; then
+        atomic_hash="${ATOMIC_HASHES[$idx]}"
+    fi
+    local atomic_lines_file="$REPO_DIR/atomic_lines_$idx.txt"
+
+    if [[ -z "$atomic_hash" ]]; then
+        touch "$atomic_lines_file"
+    else
+        local raw
+        raw=$( (cd "$GIT_REPO" && atomic diff -c "$atomic_hash" --no-color 2>/dev/null) || true )
+        if [[ -n "$raw" ]]; then
+            if [[ -n "$path_filter" ]]; then
+                # Extract only the +/- lines from the section of the atomic diff
+                # that belongs to path_filter.  awk handles both cases: when
+                # path_filter is the last section (no following "diff --atomic")
+                # and when it is not.
+                printf '%s\n' "$raw" | awk -v pat="$path_filter" '
+                    /^diff --atomic/ { in_sec = ($0 ~ pat) ? 1 : 0; next }
+                    in_sec { print }
+                ' | extract_atomic_change_lines > "$atomic_lines_file" || true
+            else
+                printf '%s\n' "$raw" | extract_atomic_change_lines > "$atomic_lines_file"
+            fi
+        else
+            touch "$atomic_lines_file"
+        fi
+    fi
+
+    local git_count atomic_count
+    git_count=$(wc -l < "$git_lines_file" | tr -d ' ') || true
+    atomic_count=$(wc -l < "$atomic_lines_file" | tr -d ' ') || true
+
+    # Compare deletions
+    local git_del="$REPO_DIR/git_del_$idx.txt"
+    local atomic_del="$REPO_DIR/atomic_del_$idx.txt"
+    grep '^-' "$git_lines_file" > "$git_del" 2>/dev/null || touch "$git_del"
+    grep '^-' "$atomic_lines_file" > "$atomic_del" 2>/dev/null || touch "$atomic_del"
+
+    if diff -u "$git_del" "$atomic_del" > /dev/null 2>&1; then
+        local del_count
+        del_count=$(wc -l < "$git_del" | tr -d ' ') || true
+        _pass "$desc: deletions match ($del_count)"
+    else
+        local gdc adc
+        gdc=$(wc -l < "$git_del" | tr -d ' ') || true
+        adc=$(wc -l < "$atomic_del" | tr -d ' ') || true
+        _fail "$desc: deletions" "git=$gdc atomic=$adc"
+    fi
+
+    # Compare insertions
+    local git_ins="$REPO_DIR/git_ins_$idx.txt"
+    local atomic_ins="$REPO_DIR/atomic_ins_$idx.txt"
+    grep '^\+' "$git_lines_file" > "$git_ins" 2>/dev/null || touch "$git_ins"
+    grep '^\+' "$atomic_lines_file" > "$atomic_ins" 2>/dev/null || touch "$atomic_ins"
+
+    if diff -u "$git_ins" "$atomic_ins" > /dev/null 2>&1; then
+        local ins_count
+        ins_count=$(wc -l < "$git_ins" | tr -d ' ') || true
+        _pass "$desc: insertions match ($ins_count)"
+    else
+        local gic aic
+        gic=$(wc -l < "$git_ins" | tr -d ' ') || true
+        aic=$(wc -l < "$atomic_ins" | tr -d ' ') || true
+        _fail "$desc: insertions" "git=$gic atomic=$aic"
+    fi
+
+    # Total line count
+    if [[ "$git_count" -eq "$atomic_count" ]]; then
+        _pass "$desc: total lines match ($git_count)"
+    else
+        _fail "$desc: total lines" "git=$git_count atomic=$atomic_count"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Parity: Single line modification"
+# ═══════════════════════════════════════════════════════════════════════════
+
+V1=$(printf 'line1\nline2\nline3\nline4\nline5\n')
+V2=$(printf 'line1\nmodified-line2\nline3\nline4\nline5\n')
+
+setup_git_and_import "parity-single-mod" "test.txt" "$V1" "$V2"
+assert_commit_parity "single line mod" 1
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Parity: Pure insertion (middle)"
+# ═══════════════════════════════════════════════════════════════════════════
+
+V1=$(printf 'line1\nline2\nline3\n')
+V2=$(printf 'line1\nline2\nnew-line\nline3\n')
+
+setup_git_and_import "parity-insert-middle" "test.txt" "$V1" "$V2"
+assert_commit_parity "insert middle" 1
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Parity: Pure insertion (beginning)"
+# ═══════════════════════════════════════════════════════════════════════════
+
+V1=$(printf 'line1\nline2\nline3\n')
+V2=$(printf 'new-first-line\nline1\nline2\nline3\n')
+
+setup_git_and_import "parity-insert-begin" "test.txt" "$V1" "$V2"
+assert_commit_parity "insert beginning" 1
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Parity: Pure insertion (end)"
+# ═══════════════════════════════════════════════════════════════════════════
+
+V1=$(printf 'line1\nline2\nline3\n')
+V2=$(printf 'line1\nline2\nline3\nnew-last-line\n')
+
+setup_git_and_import "parity-insert-end" "test.txt" "$V1" "$V2"
+assert_commit_parity "insert end" 1
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Parity: Pure deletion (middle)"
+# ═══════════════════════════════════════════════════════════════════════════
+
+V1=$(printf 'line1\nline2\nline3\nline4\nline5\n')
+V2=$(printf 'line1\nline2\nline4\nline5\n')
+
+setup_git_and_import "parity-delete-middle" "test.txt" "$V1" "$V2"
+assert_commit_parity "delete middle" 1
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Parity: Pure deletion (multiple lines)"
+# ═══════════════════════════════════════════════════════════════════════════
+
+V1=$(printf 'line1\nline2\nline3\nline4\nline5\nline6\n')
+V2=$(printf 'line1\nline4\nline6\n')
+
+setup_git_and_import "parity-delete-multi" "test.txt" "$V1" "$V2"
+assert_commit_parity "delete multiple" 1
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Parity: Replace block (delete + insert at same position)"
+# ═══════════════════════════════════════════════════════════════════════════
+
+V1=$(printf 'header\nold-code-1\nold-code-2\nold-code-3\nfooter\n')
+V2=$(printf 'header\nnew-code-A\nnew-code-B\nfooter\n')
+
+setup_git_and_import "parity-replace" "test.txt" "$V1" "$V2"
+assert_commit_parity "replace block" 1
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Parity: Multiple hunks in one file"
+# ═══════════════════════════════════════════════════════════════════════════
+
+V1=$(printf 'a1\na2\na3\na4\na5\na6\na7\na8\na9\na10\na11\na12\na13\na14\na15\na16\na17\na18\na19\na20\n')
+V2=$(printf 'a1\nMOD-a2\na3\na4\na5\na6\na7\na8\na9\na10\na11\na12\na13\na14\na15\na16\na17\na18\na19\nMOD-a20\n')
+
+setup_git_and_import "parity-multi-hunk" "test.txt" "$V1" "$V2"
+assert_commit_parity "multi-hunk" 1
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Parity: Function extraction (add + delete + modify)"
+# ═══════════════════════════════════════════════════════════════════════════
+
+V1=$(printf 'fn main() {\n    let bar = Bar::new(10);\n    let style = Style::new()\n        .template("{spinner}");\n    bar.set_style(style);\n    bar.enable_steady_tick(80);\n    bar.set_message("Running");\n\n    for i in 0..10 {\n        bar.inc(1);\n        run(i);\n    }\n    bar.finish();\n}\n')
+
+V2=$(printf 'fn get_bar(n: u64, msg: &str) -> Bar {\n    let style = Style::new()\n        .template("{spinner}");\n    let bar = Bar::new(n);\n    bar.set_style(style);\n    bar.enable_steady_tick(80);\n    bar.set_message(msg);\n    bar\n}\n\nfn main() {\n    let bar = get_bar(10, "Running");\n\n    for i in 0..10 {\n        bar.inc(1);\n        run(i);\n    }\n    bar.finish();\n}\n')
+
+setup_git_and_import "parity-extract-fn" "src/main.rs" "$V1" "$V2"
+assert_commit_parity "extract function" 1
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Parity: Delete entire file"
+# ═══════════════════════════════════════════════════════════════════════════
+
+V1=$(printf 'line1\nline2\nline3\n')
+
+make_temp_repo "parity-delete-file"
+GIT_REPO="$REPO_DIR"
+
+git -C "$GIT_REPO" init --quiet 2>/dev/null
+git -C "$GIT_REPO" config user.email "test@test.com" 2>/dev/null
+git -C "$GIT_REPO" config user.name "Test" 2>/dev/null
+
+printf '%s' "$V1" > "$GIT_REPO/victim.txt"
+git -C "$GIT_REPO" add -A >/dev/null 2>&1
+git -C "$GIT_REPO" commit -m "v1" --quiet 2>/dev/null
+SHA1=$(git -C "$GIT_REPO" rev-parse HEAD 2>/dev/null)
+
+rm "$GIT_REPO/victim.txt"
+git -C "$GIT_REPO" add -A >/dev/null 2>&1
+git -C "$GIT_REPO" commit -m "v2 delete" --quiet 2>/dev/null
+SHA2=$(git -C "$GIT_REPO" rev-parse HEAD 2>/dev/null)
+
+GIT_SHAS=("$SHA1" "$SHA2")
+
+(cd "$GIT_REPO" && atomic git import 2>/dev/null) || true
+
+ATOMIC_HASHES=()
+log_output=$( (cd "$GIT_REPO" && atomic log --format short --no-color --full-hash 2>/dev/null) || true )
+if [[ -n "${log_output:-}" ]]; then
+    _tmp=()
+    while IFS= read -r line; do
+        _h=$(echo "$line" | awk '{print $1}')
+        if [[ -n "$_h" ]]; then
+            _tmp+=("$_h")
+        fi
+    done <<< "$log_output"
+    for (( _i=${#_tmp[@]}-1 ; _i>=0 ; _i-- )); do
+        ATOMIC_HASHES+=("${_tmp[$_i]}")
+    done
+fi
+
+assert_commit_parity "delete file" 1
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Parity: Multiple files changed in one commit"
+# ═══════════════════════════════════════════════════════════════════════════
+
+make_temp_repo "parity-multi-file"
+GIT_REPO="$REPO_DIR"
+
+git -C "$GIT_REPO" init --quiet 2>/dev/null
+git -C "$GIT_REPO" config user.email "test@test.com" 2>/dev/null
+git -C "$GIT_REPO" config user.name "Test" 2>/dev/null
+
+printf 'a-line1\na-line2\na-line3\n' > "$GIT_REPO/a.txt"
+printf 'b-line1\nb-line2\nb-line3\n' > "$GIT_REPO/b.txt"
+git -C "$GIT_REPO" add -A >/dev/null 2>&1
+git -C "$GIT_REPO" commit -m "v1" --quiet 2>/dev/null
+SHA1=$(git -C "$GIT_REPO" rev-parse HEAD 2>/dev/null)
+
+printf 'a-line1\na-MODIFIED\na-line3\n' > "$GIT_REPO/a.txt"
+printf 'b-line1\nb-line2\nb-line3\nb-NEW\n' > "$GIT_REPO/b.txt"
+git -C "$GIT_REPO" add -A >/dev/null 2>&1
+git -C "$GIT_REPO" commit -m "v2" --quiet 2>/dev/null
+SHA2=$(git -C "$GIT_REPO" rev-parse HEAD 2>/dev/null)
+
+GIT_SHAS=("$SHA1" "$SHA2")
+
+(cd "$GIT_REPO" && atomic git import 2>/dev/null) || true
+
+ATOMIC_HASHES=()
+log_output=$( (cd "$GIT_REPO" && atomic log --format short --no-color --full-hash 2>/dev/null) || true )
+if [[ -n "${log_output:-}" ]]; then
+    _tmp=()
+    while IFS= read -r line; do
+        _h=$(echo "$line" | awk '{print $1}')
+        if [[ -n "$_h" ]]; then
+            _tmp+=("$_h")
+        fi
+    done <<< "$log_output"
+    for (( _i=${#_tmp[@]}-1 ; _i>=0 ; _i-- )); do
+        ATOMIC_HASHES+=("${_tmp[$_i]}")
+    done
+fi
+
+assert_commit_parity "multi-file" 1
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Parity: Realistic code change (config struct)"
+# ═══════════════════════════════════════════════════════════════════════════
+
+V1=$(printf '/// App configuration.\nstruct Config {\n    host: String,\n    port: u16,\n}\n\nimpl Config {\n    fn new() -> Self {\n        // TODO: read from env\n        Config {\n            host: "localhost".into(),\n            port: 3000,\n        }\n    }\n}\n')
+
+V2=$(printf '/// App configuration.\nstruct Config {\n    host: String,\n    port: u16,\n    db_url: String,\n    max_connections: u32,\n}\n\nimpl Config {\n    fn new() -> Self {\n        Config {\n            host: "localhost".into(),\n            port: 8080,\n            db_url: "postgres://localhost/app".into(),\n            max_connections: 10,\n        }\n    }\n}\n')
+
+setup_git_and_import "parity-realistic" "src/config.rs" "$V1" "$V2"
+assert_commit_parity "realistic code" 1
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Parity: Sequential edits (3 commits)"
+# ═══════════════════════════════════════════════════════════════════════════
+
+V1=$(printf 'fn main() {\n    println!("v1");\n}\n')
+V2=$(printf 'fn main() {\n    println!("v2");\n    // added in v2\n}\n')
+V3=$(printf 'fn main() {\n    println!("v3");\n}\n')
+
+setup_git_and_import "parity-sequential" "main.rs" "$V1" "$V2" "$V3"
+assert_commit_parity "sequential v1->v2" 1
+assert_commit_parity "sequential v2->v3" 2
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Parity: Hyperfine first 4 commits (real repo)"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Clone the real hyperfine repo, import it, and compare diffs for each
+# of the first 4 commits.
+
+make_temp_repo "parity-hyperfine"
+
+git clone --quiet https://github.com/sharkdp/hyperfine.git "$REPO_DIR/hyperfine" 2>/dev/null
+CLONE_OK="${?}"
+
+if [[ "$CLONE_OK" -ne 0 ]]; then
+    _skip "hyperfine clone failed (no network?)"
+else
+    GIT_REPO="$REPO_DIR/hyperfine"
+
+    # Import into atomic
+    (cd "$GIT_REPO" && atomic git import 2>/dev/null) || true
+
+    # The first 4 commits that touch src/main.rs
+    COMMIT_SHAS=("a658ab8c" "d4ebdd7b" "197f9fb" "68fdc2c")
+
+    # Resolve full SHAs
+    GIT_SHAS=()
+    for short in "${COMMIT_SHAS[@]}"; do
+        full=$(git -C "$GIT_REPO" rev-parse "$short" 2>/dev/null) || true
+        GIT_SHAS+=("$full")
+    done
+
+    # Build a map from git short SHA → atomic hash by scanning every
+    # atomic change's metadata for the "Commit:" line.
+    # Use parallel arrays for bash 3.2 compatibility (no associative arrays).
+    MAP_GIT_SHAS=()
+    MAP_ATOMIC_HASHES=()
+
+    all_hashes_output=$( (cd "$GIT_REPO" && atomic log --format short --no-color --full-hash 2>/dev/null) || true )
+    while IFS= read -r logline; do
+        atomic_h=$(echo "$logline" | awk '{print $1}')
+        [[ -z "$atomic_h" ]] && continue
+        change_detail=$( (cd "$GIT_REPO" && atomic change "$atomic_h" 2>/dev/null) || true )
+        git_sha=$(echo "$change_detail" | grep "Commit:" | awk '{print $2}')
+        if [[ -n "$git_sha" ]]; then
+            # Store the full git SHA so we can match short SHAs of any length
+            MAP_GIT_SHAS+=("$git_sha")
+            MAP_ATOMIC_HASHES+=("$atomic_h")
+        fi
+        # Stop once we have all 4 commits mapped
+        _found=0
+        for _s in "${COMMIT_SHAS[@]}"; do
+            for _ms in "${MAP_GIT_SHAS[@]}"; do
+                # Match if the full SHA starts with the short SHA
+                [[ "$_ms" == "${_s}"* ]] && _found=$((_found+1)) && break
+            done
+        done
+        [[ $_found -ge ${#COMMIT_SHAS[@]} ]] && break
+    done <<< "$all_hashes_output"
+
+    # Helper: look up atomic hash for a given git short SHA
+    _lookup_atomic_hash() {
+        local want="$1"
+        local _i
+        for (( _i=0; _i<${#MAP_GIT_SHAS[@]}; _i++ )); do
+            # Match if the stored full SHA starts with the requested short SHA
+            if [[ "${MAP_GIT_SHAS[$_i]}" == "${want}"* ]]; then
+                echo "${MAP_ATOMIC_HASHES[$_i]}"
+                return
+            fi
+        done
+    }
+
+    # For each transition, look up the atomic hash by git SHA and compare.
+    # Scope to src/main.rs only: Cargo.lock diffs differ between our
+    # Myers diff implementation and git's algorithm, which is expected.
+    for i in 1 2 3; do
+        SHORT="${COMMIT_SHAS[$i]}"
+        PREV_SHORT="${COMMIT_SHAS[$((i-1))]}"
+        ATOMIC_H=$(_lookup_atomic_hash "$SHORT")
+
+        prev_full=$(git -C "$GIT_REPO" rev-parse "$PREV_SHORT" 2>/dev/null) || true
+        curr_full=$(git -C "$GIT_REPO" rev-parse "$SHORT" 2>/dev/null) || true
+
+        if [[ -z "$ATOMIC_H" ]]; then
+            _fail "hyperfine ($SHORT)" "could not find atomic hash for git SHA $SHORT"
+            continue
+        fi
+
+        # Git diff scoped to src/main.rs
+        git_lf="$REPO_DIR/hf_git_$i.txt"
+        git -C "$GIT_REPO" --no-pager diff "$prev_full" "$curr_full" -- src/main.rs 2>/dev/null \
+            | extract_git_change_lines > "$git_lf"
+
+        # Atomic diff scoped to src/main.rs
+        atomic_lf="$REPO_DIR/hf_atomic_$i.txt"
+        hf_raw=$( (cd "$GIT_REPO" && atomic diff -c "$ATOMIC_H" --no-color 2>/dev/null) || true )
+        if [[ -n "$hf_raw" ]]; then
+            printf '%s\n' "$hf_raw" | awk -v pat="src/main.rs" '
+                /^diff --atomic/ { in_sec = ($0 ~ pat) ? 1 : 0; next }
+                in_sec { print }
+            ' | extract_atomic_change_lines > "$atomic_lf" || true
+        else
+            touch "$atomic_lf"
+        fi
+
+        gc=$(wc -l < "$git_lf" | tr -d ' ') || true
+        ac=$(wc -l < "$atomic_lf" | tr -d ' ') || true
+
+        # deletions
+        gd="$REPO_DIR/hf_gdel_$i.txt"; ad="$REPO_DIR/hf_adel_$i.txt"
+        grep '^-' "$git_lf" > "$gd" 2>/dev/null || touch "$gd"
+        grep '^-' "$atomic_lf" > "$ad" 2>/dev/null || touch "$ad"
+        if diff -u "$gd" "$ad" > /dev/null 2>&1; then
+            _pass "hyperfine ($SHORT): deletions match ($(wc -l < "$gd" | tr -d ' '))"
+        else
+            _fail "hyperfine ($SHORT): deletions" "git=$(wc -l < "$gd" | tr -d ' ') atomic=$(wc -l < "$ad" | tr -d ' ')"
+        fi
+
+        # insertions
+        gi="$REPO_DIR/hf_gins_$i.txt"; ai="$REPO_DIR/hf_ains_$i.txt"
+        grep '^\+' "$git_lf" > "$gi" 2>/dev/null || touch "$gi"
+        grep '^\+' "$atomic_lf" > "$ai" 2>/dev/null || touch "$ai"
+        if diff -u "$gi" "$ai" > /dev/null 2>&1; then
+            _pass "hyperfine ($SHORT): insertions match ($(wc -l < "$gi" | tr -d ' '))"
+        else
+            _fail "hyperfine ($SHORT): insertions" "git=$(wc -l < "$gi" | tr -d ' ') atomic=$(wc -l < "$ai" | tr -d ' ')"
+        fi
+
+        # total
+        if [[ "$gc" -eq "$ac" ]]; then
+            _pass "hyperfine ($SHORT): total lines match ($gc)"
+        else
+            _fail "hyperfine ($SHORT): total lines" "git=$gc atomic=$ac"
+        fi
+    done
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Parity: Pure rename (no content change)"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# A pure rename produces ZERO +/- lines in both git diff and atomic diff.
+# git diff --follow sees no content change; atomic treats the rename as a
+# TrunkOp::Move which has no associated line operations.
+# Both sides must produce an empty set of change lines.
+
+make_temp_repo "parity-rename-pure"
+GIT_REPO="$REPO_DIR"
+
+git -C "$GIT_REPO" init --quiet 2>/dev/null
+git -C "$GIT_REPO" config user.email "test@test.com" 2>/dev/null
+git -C "$GIT_REPO" config user.name "Test" 2>/dev/null
+
+# v1: create a file
+printf 'line1\nline2\nline3\n' > "$GIT_REPO/old_name.txt"
+git -C "$GIT_REPO" add -A >/dev/null 2>&1
+git -C "$GIT_REPO" commit -m "v1" --quiet 2>/dev/null
+SHA1=$(git -C "$GIT_REPO" rev-parse HEAD 2>/dev/null)
+
+# v2: rename the file only (no content change)
+git -C "$GIT_REPO" mv old_name.txt new_name.txt 2>/dev/null
+git -C "$GIT_REPO" commit -m "v2: rename" --quiet 2>/dev/null
+SHA2=$(git -C "$GIT_REPO" rev-parse HEAD 2>/dev/null)
+
+GIT_SHAS=("$SHA1" "$SHA2")
+
+(cd "$GIT_REPO" && atomic git import 2>/dev/null) || true
+
+ATOMIC_HASHES=()
+_log=$( (cd "$GIT_REPO" && atomic log --format short --no-color --full-hash 2>/dev/null) || true )
+if [[ -n "${_log:-}" ]]; then
+    _tmp=()
+    while IFS= read -r line; do
+        _h=$(echo "$line" | awk '{print $1}')
+        [[ -n "$_h" ]] && _tmp+=("$_h")
+    done <<< "$_log"
+    for (( _i=${#_tmp[@]}-1 ; _i>=0 ; _i-- )); do
+        ATOMIC_HASHES+=("${_tmp[$_i]}")
+    done
+fi
+
+# For a pure rename git diff produces zero +/- lines (no content changed).
+# atomic diff -c likewise produces zero +/- lines for a TrunkOp::Move with
+# no associated BranchOp edits.  Compare both sides; both must be empty.
+_rename_atomic_hash=""
+if [[ ${#ATOMIC_HASHES[@]} -ge 2 ]]; then
+    _rename_atomic_hash="${ATOMIC_HASHES[1]}"
+fi
+
+_git_lines_rename=$(git -C "$GIT_REPO" --no-pager diff "$SHA1" "$SHA2" \
+    2>/dev/null | grep -E '^\+[^+]|^-[^-]' || true)
+
+_atomic_lines_rename=""
+if [[ -n "$_rename_atomic_hash" ]]; then
+    _atomic_raw=$( (cd "$GIT_REPO" && atomic diff -c "$_rename_atomic_hash" --no-color 2>/dev/null) || true )
+    _atomic_lines_rename=$(printf '%s\n' "$_atomic_raw" | grep -E '^\+[^+]|^-[^-]' || true)
+fi
+
+if [[ -z "$_git_lines_rename" && -z "$_atomic_lines_rename" ]]; then
+    _pass "pure rename: both sides have zero change lines (correct)"
+elif [[ "$_git_lines_rename" == "$_atomic_lines_rename" ]]; then
+    _pass "pure rename: change lines match"
+else
+    _git_n=$(printf '%s\n' "$_git_lines_rename" | grep -c '.' 2>/dev/null || echo 0)
+    _atomic_n=$(printf '%s\n' "$_atomic_lines_rename" | grep -c '.' 2>/dev/null || echo 0)
+    _fail "pure rename: change lines" "git=$_git_n lines, atomic=$_atomic_n lines"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Parity: Rename + content change"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# When a file is renamed AND its content changes in the same commit, atomic
+# imports this as a TrunkOp::Move (the rename) plus BranchOp edits (the
+# content change) — shown under the new filename as the delta only.
+#
+# Comparison strategy:
+#   git side  : `git diff -M PARENT HEAD` with rename detection enabled,
+#               then extract only the lines belonging to renamed.txt.
+#               -M causes git to detect the rename and show only the content
+#               delta (same as what atomic produces), rather than treating
+#               the new file as freshly created.
+#   atomic side: extract +/- lines from the renamed.txt section of
+#               `atomic diff -c <hash>`
+
+make_temp_repo "parity-rename-modify"
+GIT_REPO="$REPO_DIR"
+
+git -C "$GIT_REPO" init --quiet 2>/dev/null
+git -C "$GIT_REPO" config user.email "test@test.com" 2>/dev/null
+git -C "$GIT_REPO" config user.name "Test" 2>/dev/null
+
+# v1: create original file
+printf 'alpha\nbeta\ngamma\ndelta\n' > "$GIT_REPO/original.txt"
+git -C "$GIT_REPO" add -A >/dev/null 2>&1
+git -C "$GIT_REPO" commit -m "v1" --quiet 2>/dev/null
+SHA1=$(git -C "$GIT_REPO" rev-parse HEAD 2>/dev/null)
+
+# v2: rename AND modify content
+git -C "$GIT_REPO" mv original.txt renamed.txt 2>/dev/null
+printf 'alpha\nbeta\nGAMMA-MODIFIED\ndelta\nepsilon\n' > "$GIT_REPO/renamed.txt"
+git -C "$GIT_REPO" add -A >/dev/null 2>&1
+git -C "$GIT_REPO" commit -m "v2: rename+modify" --quiet 2>/dev/null
+SHA2=$(git -C "$GIT_REPO" rev-parse HEAD 2>/dev/null)
+
+GIT_SHAS=("$SHA1" "$SHA2")
+
+(cd "$GIT_REPO" && atomic git import 2>/dev/null) || true
+
+ATOMIC_HASHES=()
+_log=$( (cd "$GIT_REPO" && atomic log --format short --no-color --full-hash 2>/dev/null) || true )
+if [[ -n "${_log:-}" ]]; then
+    _tmp=()
+    while IFS= read -r line; do
+        _h=$(echo "$line" | awk '{print $1}')
+        [[ -n "$_h" ]] && _tmp+=("$_h")
+    done <<< "$_log"
+    for (( _i=${#_tmp[@]}-1 ; _i>=0 ; _i-- )); do
+        ATOMIC_HASHES+=("${_tmp[$_i]}")
+    done
+fi
+
+_rename_mod_hash=""
+if [[ ${#ATOMIC_HASHES[@]} -ge 2 ]]; then
+    _rename_mod_hash="${ATOMIC_HASHES[1]}"
+fi
+
+# Git: use -M10% (rename detection with a low similarity threshold) so git
+# recognises the rename even for files with significant content changes.
+# When git detects the rename the header becomes:
+#   diff --git a/original.txt b/renamed.txt
+#   rename from original.txt
+#   rename to renamed.txt
+# and the diff shows only the content delta.
+# We extract only the +/- lines from that section.
+_git_full_rmod=$(git -C "$GIT_REPO" --no-pager diff -M10% "$SHA1" "$SHA2" \
+    2>/dev/null || true)
+_git_lines_rmod=$(printf '%s\n' "$_git_full_rmod" | awk -v pat="renamed.txt" '
+    /^diff --git/ {
+        # A rename section header looks like: diff --git a/old b/new
+        # Match on " b/<pat>" at end of line (1-based substr index).
+        n = length($0)
+        plen = length(pat)
+        in_sec = (index($0, " b/" pat) > 0 && \
+                  (index($0, " b/" pat " ") > 0 || \
+                   substr($0, n - plen + 1) == pat)) ? 1 : 0
+        next
+    }
+    in_sec { print }
+' | grep -E '^\+[^+]|^-[^-]' || true)
+
+# Atomic: extract +/- lines from the "renamed.txt" section.
+_atomic_lines_rmod=""
+if [[ -n "$_rename_mod_hash" ]]; then
+    _raw=$( (cd "$GIT_REPO" && atomic diff -c "$_rename_mod_hash" --no-color 2>/dev/null) || true )
+    _atomic_lines_rmod=$(printf '%s\n' "$_raw" | awk -v pat="renamed.txt" '
+        /^diff --atomic/ {
+            in_sec = (index($0, " b/" pat) > 0 && \
+                      (index($0, " b/" pat " ") > 0 || \
+                       substr($0, length($0) - length(pat)) == pat)) ? 1 : 0
+            next
+        }
+        in_sec { print }
+    ' | grep -E '^\+[^+]|^-[^-]' || true)
+fi
+
+# Sort both sides before comparing (hunk-ordering may differ).
+_sorted_git=$(printf '%s\n' "$_git_lines_rmod" | sort)
+_sorted_atomic=$(printf '%s\n' "$_atomic_lines_rmod" | sort)
+
+if [[ "$_sorted_git" == "$_sorted_atomic" ]]; then
+    _n=$(printf '%s\n' "$_git_lines_rmod" | grep -c '.' 2>/dev/null || echo 0)
+    _pass "rename+modify: change lines match ($_n lines)"
+else
+    _gn=$(printf '%s\n' "$_git_lines_rmod" | grep -c '.' 2>/dev/null || echo 0)
+    _an=$(printf '%s\n' "$_atomic_lines_rmod" | grep -c '.' 2>/dev/null || echo 0)
+    _first=$(diff \
+        <(printf '%s\n' "$_git_lines_rmod" | sort) \
+        <(printf '%s\n' "$_atomic_lines_rmod" | sort) \
+        2>/dev/null | head -4) || true
+    _fail "rename+modify: change lines" \
+        "git=$_gn lines, atomic=$_an lines. Diff: $_first"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Parity: Rename across directories"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Validates that moving a file from one subdirectory to another is handled
+# correctly — the atomic diff should show zero +/- lines (no content change)
+# and match git exactly.
+
+make_temp_repo "parity-rename-dirs"
+GIT_REPO="$REPO_DIR"
+
+git -C "$GIT_REPO" init --quiet 2>/dev/null
+git -C "$GIT_REPO" config user.email "test@test.com" 2>/dev/null
+git -C "$GIT_REPO" config user.name "Test" 2>/dev/null
+
+mkdir -p "$GIT_REPO/src" "$GIT_REPO/lib"
+printf 'fn helper() {}\n' > "$GIT_REPO/src/helper.rs"
+git -C "$GIT_REPO" add -A >/dev/null 2>&1
+git -C "$GIT_REPO" commit -m "v1" --quiet 2>/dev/null
+SHA1=$(git -C "$GIT_REPO" rev-parse HEAD 2>/dev/null)
+
+# Move src/helper.rs → lib/helper.rs (no content change)
+git -C "$GIT_REPO" mv src/helper.rs lib/helper.rs 2>/dev/null
+git -C "$GIT_REPO" commit -m "v2: move to lib/" --quiet 2>/dev/null
+SHA2=$(git -C "$GIT_REPO" rev-parse HEAD 2>/dev/null)
+
+GIT_SHAS=("$SHA1" "$SHA2")
+
+(cd "$GIT_REPO" && atomic git import 2>/dev/null) || true
+
+ATOMIC_HASHES=()
+_log=$( (cd "$GIT_REPO" && atomic log --format short --no-color --full-hash 2>/dev/null) || true )
+if [[ -n "${_log:-}" ]]; then
+    _tmp=()
+    while IFS= read -r line; do
+        _h=$(echo "$line" | awk '{print $1}')
+        [[ -n "$_h" ]] && _tmp+=("$_h")
+    done <<< "$_log"
+    for (( _i=${#_tmp[@]}-1 ; _i>=0 ; _i-- )); do
+        ATOMIC_HASHES+=("${_tmp[$_i]}")
+    done
+fi
+
+_dir_rename_hash=""
+if [[ ${#ATOMIC_HASHES[@]} -ge 2 ]]; then
+    _dir_rename_hash="${ATOMIC_HASHES[1]}"
+fi
+
+_git_lines_dir=$(git -C "$GIT_REPO" --no-pager diff "$SHA1" "$SHA2" \
+    2>/dev/null | grep -E '^\+[^+]|^-[^-]' || true)
+
+_atomic_lines_dir=""
+if [[ -n "$_dir_rename_hash" ]]; then
+    _raw=$( (cd "$GIT_REPO" && atomic diff -c "$_dir_rename_hash" --no-color 2>/dev/null) || true )
+    _atomic_lines_dir=$(printf '%s\n' "$_raw" | grep -E '^\+[^+]|^-[^-]' || true)
+fi
+
+if [[ -z "$_git_lines_dir" && -z "$_atomic_lines_dir" ]]; then
+    _pass "cross-dir rename: both sides have zero change lines (correct)"
+elif [[ "$_git_lines_dir" == "$_atomic_lines_dir" ]]; then
+    _pass "cross-dir rename: change lines match"
+else
+    _gn=$(printf '%s\n' "$_git_lines_dir" | grep -c '.' 2>/dev/null || echo 0)
+    _an=$(printf '%s\n' "$_atomic_lines_dir" | grep -c '.' 2>/dev/null || echo 0)
+    _fail "cross-dir rename: change lines" "git=$_gn lines, atomic=$_an lines"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Summary
+# ═══════════════════════════════════════════════════════════════════════════
+
+print_summary

--- a/tests/harness/12_full_repo_diff_parity.sh
+++ b/tests/harness/12_full_repo_diff_parity.sh
@@ -1,0 +1,427 @@
+#!/usr/bin/env bash
+# 12_full_repo_diff_parity.sh — Full-repo diff parity test.
+#
+# Imports a real git repository into atomic and validates that
+# `atomic diff -c <hash>` produces the same +/- lines as `git diff`
+# for every sampled commit across every file the commit touches.
+#
+# Configuration (via environment variables):
+#
+#   PARITY_REPO_URL   — git clone URL to test (default: hyperfine)
+#   PARITY_SAMPLE_N   — check every Nth commit (default: 10)
+#   PARITY_MAX_COMMITS— stop after this many sampled commits (default: 50)
+#   PARITY_SKIP_PATHS — colon-separated glob patterns to skip
+#                       (default: "*.lock:*.sum" — generated lockfiles
+#                        whose diffs vary by algorithm)
+#
+# Examples:
+#
+#   # Run with defaults (hyperfine, every 10th commit, up to 50 samples)
+#   bash tests/harness/12_full_repo_diff_parity.sh
+#
+#   # Test a different repo, denser sampling
+#   PARITY_REPO_URL=https://github.com/BurntSushi/ripgrep.git \
+#   PARITY_SAMPLE_N=5 \
+#   PARITY_MAX_COMMITS=100 \
+#   bash tests/harness/12_full_repo_diff_parity.sh
+#
+# What is compared:
+#   For each sampled commit C with parent P:
+#     For each file F changed in C (excluding PARITY_SKIP_PATHS):
+#       git_lines  = `git diff P..C -- F` filtered to +/- lines
+#       atomic_lines = `atomic diff -c <atomic_hash_for_C> -- F` filtered
+#       PASS if git_lines == atomic_lines (same content, same order)
+#
+# Skipped-path rationale:
+#   Lock files (Cargo.lock, go.sum, package-lock.json) are generated
+#   automatically and their diffs depend heavily on the diff algorithm's
+#   LCS heuristics.  Our Myers implementation may produce a different
+#   (but equally valid) edit sequence.  For all hand-authored source
+#   files the diffs must match exactly because we use git's own diff
+#   lines via build_crdt_ops_from_git_diff.
+
+HARNESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$HARNESS_DIR/helpers.sh"
+
+# ── Configuration ────────────────────────────────────────────────────────────
+
+REPO_URL="${PARITY_REPO_URL:-https://github.com/sharkdp/hyperfine.git}"
+SAMPLE_N="${PARITY_SAMPLE_N:-10}"
+MAX_COMMITS="${PARITY_MAX_COMMITS:-50}"
+SKIP_PATHS="${PARITY_SKIP_PATHS:-*.lock:*.sum:package-lock.json:yarn.lock}"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+extract_git_change_lines() {
+    grep -E '^\+[^+]|^-[^-]' || true
+}
+
+extract_atomic_change_lines() {
+    grep -E '^\+[^+]|^-[^-]' || true
+}
+
+# Check if a file path matches any of the skip patterns.
+# Usage: should_skip "path/to/file.lock"
+should_skip() {
+    local path="$1"
+    local fname
+    fname=$(basename "$path")
+    local IFS=':'
+    for pat in $SKIP_PATHS; do
+        # shellcheck disable=SC2053
+        [[ "$fname" == $pat ]] && return 0
+        [[ "$path" == $pat ]] && return 0
+    done
+    return 1
+}
+
+# Extract +/- change lines from an atomic diff scoped to a single file path.
+# Usage: atomic_diff_for_path "$raw_diff" "src/main.rs"
+#
+# The awk match uses a word-boundary-aware check: the path must appear as
+# a complete path component in the "diff --atomic a/PATH b/PATH" header,
+# not as a substring of another path.  We anchor on " b/" to avoid matching
+# "snap/snapcraft.yaml" when looking for ".snapcraft.yaml".
+atomic_diff_for_path() {
+    local raw="$1"
+    local path_filter="$2"
+    printf '%s\n' "$raw" | awk -v pat="$path_filter" '
+        /^diff --atomic/ {
+            # Match only when the path appears after " b/" (the new-file side).
+            in_sec = (index($0, " b/" pat) > 0 && \
+                      (index($0, " b/" pat " ") > 0 || \
+                       substr($0, length($0) - length(pat)) == pat)) ? 1 : 0
+            next
+        }
+        in_sec { print }
+    ' | extract_atomic_change_lines
+}
+
+# Check if a commit contains any rename/move operations.
+# Returns 0 (true) if at least one renamed file is found.
+commit_has_rename() {
+    local repo="$1"
+    local sha="$2"
+    git -C "$repo" diff --name-status "${sha}^" "$sha" 2>/dev/null | grep -q '^R'
+}
+
+# For a given file path in a commit, detect whether it was renamed (i.e., it is
+# the NEW path of a rename operation).  If so, echo the OLD path; otherwise echo
+# nothing.
+# Usage: get_rename_old_path <repo> <sha> <new_path>
+get_rename_old_path() {
+    local repo="$1"
+    local sha="$2"
+    local new_path="$3"
+    # --diff-filter=R limits output to renamed files.
+    # --name-status lines look like: R100<TAB>old/path<TAB>new/path
+    git -C "$repo" diff --diff-filter=R --name-status "${sha}^" "$sha" \
+        2>/dev/null \
+        | awk -v np="$new_path" -F'\t' '$3 == np { print $2 }'
+}
+
+# Extract +/- change lines for a file in a commit, rename-aware.
+#
+# For normal modifications:   git diff PARENT HEAD -- path
+# For renamed files:          git diff -M PARENT HEAD, then extract the section
+#                             for new_path.
+#
+#   -M enables rename detection so git shows only the content delta for a
+#   renamed file rather than treating it as a brand-new file (which would
+#   show all lines as additions).  This matches what `atomic diff -c` produces:
+#   zero lines for a pure rename, or just the changed lines for rename+modify.
+#
+# Usage: git_change_lines_for_file <repo> <parent> <sha> <path> <is_rename>
+git_change_lines_for_file() {
+    local repo="$1"
+    local parent="$2"
+    local sha="$3"
+    local path="$4"
+    local is_rename="$5"   # "1" if this file was renamed, "0" otherwise
+
+    if [[ "$is_rename" == "1" ]]; then
+        # -M10% enables rename detection with a low similarity threshold so
+        # git recognises renames even when content changed significantly.
+        # We then extract only the section of the diff that belongs to our
+        # file (matched on the "b/<path>" side of the diff --git header),
+        # and filter to +/- lines.
+        git -C "$repo" --no-pager diff -M10% "$parent" "$sha" \
+            2>/dev/null \
+            | awk -v pat="$path" '
+                /^diff --git/ {
+                    n = length($0)
+                    plen = length(pat)
+                    in_sec = (index($0, " b/" pat) > 0 && \
+                              (index($0, " b/" pat " ") > 0 || \
+                               substr($0, n - plen + 1) == pat)) ? 1 : 0
+                    next
+                }
+                in_sec { print }
+            ' | extract_git_change_lines || true
+    else
+        git -C "$repo" --no-pager diff "$parent" "$sha" -- "$path" \
+            2>/dev/null | extract_git_change_lines || true
+    fi
+}
+
+# Compare two sets of change lines for parity.
+#
+# We sort both sides before comparing so that hunk-ordering differences
+# (caused by different diff algorithm context grouping) do not produce
+# false failures.  The content — which lines were added and which were
+# deleted — must still match exactly.
+#
+# Usage: change_lines_match "$git_lines" "$atomic_lines"
+# Returns 0 (true) if the sorted sets are identical.
+change_lines_match() {
+    local git_lines="$1"
+    local atomic_lines="$2"
+    local sorted_git sorted_atomic
+    sorted_git=$(printf '%s\n' "$git_lines" | sort)
+    sorted_atomic=$(printf '%s\n' "$atomic_lines" | sort)
+    [[ "$sorted_git" == "$sorted_atomic" ]]
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+begin_section "Full-Repo Import: ${REPO_URL}"
+
+make_temp_repo "full-parity"
+WORK="$REPO_DIR"
+CLONE_DIR="$WORK/repo"
+
+# Clone
+git clone --quiet "$REPO_URL" "$CLONE_DIR" 2>/dev/null
+if [[ $? -ne 0 ]]; then
+    _skip "clone failed (no network?): $REPO_URL"
+    print_summary
+    exit 0
+fi
+
+_pass "cloned $REPO_URL"
+
+# Import
+(cd "$CLONE_DIR" && atomic git import 2>/dev/null) || true
+_pass "atomic git import completed"
+
+# ── Collect commits to sample ────────────────────────────────────────────────
+#
+# Walk git history in topological order (oldest first).  Sample every Nth
+# commit that has a parent (we skip the root commit — nothing to diff against).
+
+begin_section "Sampling commits (every ${SAMPLE_N}, max ${MAX_COMMITS}) and building SHA map"
+
+# Get all commit SHAs oldest-first, skipping the root (no parent).
+ALL_COMMITS=()
+while IFS= read -r sha; do
+    parent=$(git -C "$CLONE_DIR" rev-parse "${sha}^" 2>/dev/null) || true
+    [[ -z "$parent" ]] && continue
+    ALL_COMMITS+=("$sha")
+done < <(git -C "$CLONE_DIR" rev-list --reverse HEAD 2>/dev/null)
+
+TOTAL_COMMITS=${#ALL_COMMITS[@]}
+
+# Build the sample: every Nth element, up to MAX_COMMITS.
+SAMPLED_COMMITS=()
+_idx=0
+for sha in "${ALL_COMMITS[@]}"; do
+    if (( _idx % SAMPLE_N == 0 )); then
+        SAMPLED_COMMITS+=("$sha")
+        [[ ${#SAMPLED_COMMITS[@]} -ge $MAX_COMMITS ]] && break
+    fi
+    _idx=$((_idx + 1))
+done
+
+_pass "sampling ${#SAMPLED_COMMITS[@]} of $TOTAL_COMMITS commits"
+
+# ── Build git-SHA → atomic-hash map (lazy, for sampled commits only) ─────────
+#
+# For each sampled commit we call `atomic change <hash>` once to extract
+# the embedded "Commit: <sha>" line.  This is O(MAX_COMMITS) subprocess
+# calls — fast even for large repos.
+#
+# We scan the atomic log from newest to oldest; since import processes
+# commits in topological order, the SHAs cluster at the tail of the log.
+# We stop scanning once we have found all sampled commits.
+
+# Use --reverse so the oldest commits appear first in the log.
+# Our SAMPLED_COMMITS are drawn from git rev-list --reverse (oldest first),
+# so they cluster near the beginning of the reversed atomic log.
+# This makes the early-exit trigger much sooner for typical samples.
+_all_atomic_log=$( (cd "$CLONE_DIR" && atomic log --format short --no-color --full-hash --reverse 2>/dev/null) || true )
+
+MAP_GIT_SHAS=()
+MAP_ATOMIC_HASHES=()
+
+# Populate the map by iterating every atomic change entry once.
+# We call `atomic change` for each entry, extract "Commit:", and store.
+# Progress is shown every 100 entries.
+_map_count=0
+_total_log=$(printf '%s\n' "$_all_atomic_log" | grep -c '.' 2>/dev/null || echo 0)
+while IFS= read -r logline; do
+    _ah=$(echo "$logline" | awk '{print $1}')
+    [[ -z "$_ah" ]] && continue
+    _detail=$( (cd "$CLONE_DIR" && atomic change "$_ah" 2>/dev/null) || true )
+    _gsha=$(echo "$_detail" | grep "Commit:" | awk '{print $2}')
+    if [[ -n "$_gsha" ]]; then
+        MAP_GIT_SHAS+=("$_gsha")
+        MAP_ATOMIC_HASHES+=("$_ah")
+    fi
+    _map_count=$((_map_count + 1))
+    if (( _map_count % 100 == 0 )); then
+        echo "  building map: $_map_count / $_total_log ..." >&2
+    fi
+    # Early-exit once every sampled commit is found.
+    _found_all=1
+    for _sc in "${SAMPLED_COMMITS[@]}"; do
+        _matched=0
+        for (( _mi=0; _mi<${#MAP_GIT_SHAS[@]}; _mi++ )); do
+            if [[ "$_sc" == "${MAP_GIT_SHAS[$_mi]}"* ]] || \
+               [[ "${MAP_GIT_SHAS[$_mi]}" == "${_sc}"* ]]; then
+                _matched=1; break
+            fi
+        done
+        [[ $_matched -eq 0 ]] && _found_all=0 && break
+    done
+    [[ $_found_all -eq 1 ]] && break
+done <<< "$_all_atomic_log"
+
+_pass "map built: ${#MAP_GIT_SHAS[@]} entries (scanned $_map_count of $_total_log)"
+
+# Helper: look up atomic hash for a git SHA (full or short prefix match).
+_lookup_atomic_hash() {
+    local want="$1"
+    local _i
+    for (( _i=0; _i<${#MAP_GIT_SHAS[@]}; _i++ )); do
+        local stored="${MAP_GIT_SHAS[$_i]}"
+        # Match: want starts with stored (short), OR stored starts with want (short query)
+        if [[ "$want" == "${stored}"* ]] || [[ "$stored" == "${want}"* ]]; then
+            echo "${MAP_ATOMIC_HASHES[$_i]}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# ── Per-commit diff comparison ───────────────────────────────────────────────
+
+begin_section "Diff parity: ${#SAMPLED_COMMITS[@]} commits"
+
+COMMITS_PASS=0
+COMMITS_FAIL=0
+COMMITS_SKIP=0
+FILES_PASS=0
+FILES_FAIL=0
+FILES_SKIP=0
+
+for curr_sha in "${SAMPLED_COMMITS[@]}"; do
+    short="${curr_sha:0:8}"
+    parent=$(git -C "$CLONE_DIR" rev-parse "${curr_sha}^" 2>/dev/null) || true
+
+    if [[ -z "$parent" ]]; then
+        COMMITS_SKIP=$((COMMITS_SKIP + 1))
+        FILES_SKIP=$((FILES_SKIP + 1))
+        continue
+    fi
+
+    # Get the atomic hash for this commit.
+    atomic_hash=$(_lookup_atomic_hash "$curr_sha") || true
+    if [[ -z "$atomic_hash" ]]; then
+        _fail "commit $short" "no atomic hash found (commit may not have been imported)"
+        COMMITS_FAIL=$((COMMITS_FAIL + 1))
+        continue
+    fi
+
+    # Get files changed in this commit (excluding merges, submodules).
+    changed_files=()
+    while IFS= read -r fpath; do
+        [[ -z "$fpath" ]] && continue
+        should_skip "$fpath" && {
+            FILES_SKIP=$((FILES_SKIP + 1))
+            continue
+        }
+        changed_files+=("$fpath")
+    done < <(git -C "$CLONE_DIR" diff --name-only "$parent" "$curr_sha" 2>/dev/null)
+
+    if [[ ${#changed_files[@]} -eq 0 ]]; then
+        # Empty or all-skipped commit
+        COMMITS_SKIP=$((COMMITS_SKIP + 1))
+        continue
+    fi
+
+    # Determine which files in this commit are renames (new path → old path).
+    # We handle renames inline rather than skipping the whole commit:
+    #   - Pure rename  : git --follow produces 0 +/- lines; atomic also produces 0.
+    #   - Rename+modify: git --follow produces the content delta; atomic shows the
+    #                    same lines under the new path.
+    # git diff --diff-filter=R --name-status gives lines like:
+    #   R100<TAB>old/path<TAB>new/path
+    # We build a set of new-paths that are renames so we can switch to --follow.
+    declare -A _rename_new_paths
+    _rename_new_paths=()
+    while IFS=$'\t' read -r _status _old _new; do
+        [[ -z "$_new" ]] && continue
+        _rename_new_paths["$_new"]="$_old"
+    done < <(git -C "$CLONE_DIR" diff --diff-filter=R --name-status \
+                 "$parent" "$curr_sha" 2>/dev/null || true)
+
+    # Get the full atomic diff output once per commit (amortised cost).
+    atomic_raw=$( (cd "$CLONE_DIR" && atomic diff -c "$atomic_hash" --no-color 2>/dev/null) || true )
+
+    commit_ok=1
+    for fpath in "${changed_files[@]}"; do
+        # Detect whether this file is the new path of a rename.
+        _is_rename=0
+        if [[ -n "${_rename_new_paths[$fpath]+x}" ]]; then
+            _is_rename=1
+        fi
+
+        # Git change lines for this file (rename-aware).
+        git_lines=$(git_change_lines_for_file \
+            "$CLONE_DIR" "$parent" "$curr_sha" "$fpath" "$_is_rename") || true
+
+        # Atomic change lines for this file
+        atomic_lines=$(atomic_diff_for_path "$atomic_raw" "$fpath") || true
+
+        if change_lines_match "$git_lines" "$atomic_lines"; then
+            FILES_PASS=$((FILES_PASS + 1))
+        else
+            git_count=$(printf '%s\n' "$git_lines" | grep -c '.' 2>/dev/null || echo 0)
+            atomic_count=$(printf '%s\n' "$atomic_lines" | grep -c '.' 2>/dev/null || echo 0)
+            # Show first diverging line for diagnosis
+            first_diff=$(diff \
+                <(printf '%s\n' "$git_lines" | sort) \
+                <(printf '%s\n' "$atomic_lines" | sort) \
+                2>/dev/null | head -4) || true
+            _rename_note=""
+            [[ "$_is_rename" == "1" ]] && _rename_note=" (renamed)"
+            _fail "commit $short: $fpath${_rename_note}" \
+                "git=$git_count lines, atomic=$atomic_count lines. Diff: $first_diff"
+            FILES_FAIL=$((FILES_FAIL + 1))
+            commit_ok=0
+        fi
+    done
+    unset _rename_new_paths
+
+    if [[ $commit_ok -eq 1 ]]; then
+        COMMITS_PASS=$((COMMITS_PASS + 1))
+    else
+        COMMITS_FAIL=$((COMMITS_FAIL + 1))
+    fi
+done
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "  Commits: ${COMMITS_PASS} passed, ${COMMITS_FAIL} failed, ${COMMITS_SKIP} skipped"
+echo "  Files:   ${FILES_PASS} passed, ${FILES_FAIL} failed, ${FILES_SKIP} skipped"
+echo ""
+
+if [[ $COMMITS_FAIL -gt 0 || $FILES_FAIL -gt 0 ]]; then
+    _fail "full-repo parity" \
+        "${COMMITS_FAIL} commits and ${FILES_FAIL} files failed diff parity"
+else
+    _pass "full-repo parity: all ${FILES_PASS} file-diffs matched git exactly"
+fi
+
+print_summary

--- a/tests/harness/13_import_fidelity.sh
+++ b/tests/harness/13_import_fidelity.sh
@@ -1,0 +1,442 @@
+#!/usr/bin/env bash
+# 13_import_fidelity.sh — Regression tests for git import fidelity
+#
+# Exercises three historically-buggy areas:
+#
+#   1. File deletions — files removed in git must disappear from the
+#      atomic tree (not linger as ghosts).
+#
+#   2. Binary file modifications — binary content updates must be
+#      recorded and applied so the graph matches the working copy.
+#
+#   3. Rewrite misclassification — a heavy content rewrite + new file
+#      in the same commit must NOT be misclassified as a rename,
+#      which would steal the inode and leave the original untracked.
+#
+# All tests are self-contained (no network required).
+
+HARNESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$HARNESS_DIR/helpers.sh"
+
+echo ""
+echo "${BOLD}══════════════════════════════════════════════════════════════${RESET}"
+echo "${BOLD}  Suite: 13_import_fidelity${RESET}"
+echo "${BOLD}══════════════════════════════════════════════════════════════${RESET}"
+
+# ════════════════════════════════════════════════════════════════════════════
+# Section 1: File Deletions
+# ════════════════════════════════════════════════════════════════════════════
+
+begin_section "Import Fidelity: File Deletions"
+
+make_temp_repo "fidelity-deletions"
+init_git_repo
+
+# Build a history: add several files, then delete some
+git_commit "Add alpha" "alpha.txt" "alpha content"
+git_commit "Add beta"  "beta.txt"  "beta content"
+git_commit "Add gamma" "sub/gamma.txt" "gamma content"
+git_commit "Modify alpha" "alpha.txt" "alpha v2"
+
+# Delete alpha and gamma
+git rm --quiet alpha.txt
+git commit --quiet -m "Delete alpha"
+
+git rm --quiet sub/gamma.txt
+git commit --quiet -m "Delete gamma"
+
+# beta should survive
+git_commit "Modify beta" "beta.txt" "beta v2"
+
+atomic init >/dev/null 2>&1
+assert_success "import succeeds" atomic git import
+
+# Verify deleted files are gone from atomic
+assert_clean "working tree clean after import"
+
+# Double-check: atomic diff should show nothing
+diff_out="$(atomic diff 2>/dev/null || true)"
+if echo "$diff_out" | grep -qE '^diff --atomic'; then
+    _fail "no diff after import" "atomic diff shows unexpected changes"
+else
+    _pass "no diff after import"
+fi
+
+# Verify beta still exists and has correct content
+assert_file_exists "beta.txt survives deletion of siblings" "beta.txt"
+assert_file_content "beta.txt has final content" "beta.txt" "beta v2"
+
+# ────────────────────────────────────────────────────────────────────────────
+# Multi-file deletion in a single commit
+
+begin_section "Import Fidelity: Bulk Deletion in Single Commit"
+
+make_temp_repo "fidelity-bulk-delete"
+init_git_repo
+
+# Create 5 files
+for i in 1 2 3 4 5; do
+    git_commit "Add file$i" "dir/file$i.txt" "content $i"
+done
+
+# Delete 3 files in one commit (like the CI migration in hyperfine)
+git rm --quiet dir/file1.txt dir/file3.txt dir/file5.txt
+git commit --quiet -m "Remove odd files"
+
+atomic init >/dev/null 2>&1
+assert_success "import bulk deletion succeeds" atomic git import
+assert_clean "clean after bulk deletion import"
+
+assert_file_not_exists "file1 deleted" "dir/file1.txt"
+assert_file_exists     "file2 survives" "dir/file2.txt"
+assert_file_not_exists "file3 deleted" "dir/file3.txt"
+assert_file_exists     "file4 survives" "dir/file4.txt"
+assert_file_not_exists "file5 deleted" "dir/file5.txt"
+
+# ════════════════════════════════════════════════════════════════════════════
+# Section 2: Binary File Modifications
+# ════════════════════════════════════════════════════════════════════════════
+
+begin_section "Import Fidelity: Binary File Add"
+
+make_temp_repo "fidelity-binary-add"
+init_git_repo
+
+# Create a binary file (PNG-like header + random bytes)
+printf '\x89PNG\r\n\x1a\n' > image.png
+dd if=/dev/urandom bs=1 count=256 >> image.png 2>/dev/null
+git add image.png
+git commit --quiet -m "Add binary image"
+
+atomic init >/dev/null 2>&1
+assert_success "import with binary add succeeds" atomic git import
+assert_clean "clean after binary add import"
+
+# ────────────────────────────────────────────────────────────────────────────
+
+begin_section "Import Fidelity: Binary File Modification"
+
+make_temp_repo "fidelity-binary-mod"
+init_git_repo
+
+# Create initial binary file
+printf '\x89PNG\r\n\x1a\n' > image.png
+dd if=/dev/urandom bs=1 count=512 >> image.png 2>/dev/null
+original_size=$(wc -c < image.png | tr -d ' ')
+git add image.png
+git commit --quiet -m "Add binary image"
+
+# Modify the binary file (completely different content)
+printf '\x89PNG\r\n\x1a\n' > image.png
+dd if=/dev/urandom bs=1 count=128 >> image.png 2>/dev/null
+modified_size=$(wc -c < image.png | tr -d ' ')
+git add image.png
+git commit --quiet -m "Update binary image"
+
+atomic init >/dev/null 2>&1
+assert_success "import with binary modification succeeds" atomic git import
+assert_clean "clean after binary modification import"
+
+# Also verify diff shows nothing
+diff_out="$(atomic diff 2>/dev/null || true)"
+if echo "$diff_out" | grep -qE '^diff --atomic'; then
+    _fail "no diff after binary modification import" "atomic diff shows changes for binary file"
+else
+    _pass "no diff after binary modification import"
+fi
+
+# ────────────────────────────────────────────────────────────────────────────
+
+begin_section "Import Fidelity: Multiple Binary Modifications"
+
+make_temp_repo "fidelity-binary-multi"
+init_git_repo
+
+# Create binary file, then modify it several times (like execution-order.png)
+printf '\x89PNG\r\n\x1a\n' > icon.png
+dd if=/dev/urandom bs=1 count=1024 >> icon.png 2>/dev/null
+git add icon.png
+git commit --quiet -m "Add icon"
+
+for i in 1 2 3 4; do
+    printf '\x89PNG\r\n\x1a\n' > icon.png
+    dd if=/dev/urandom bs=1 count=$((256 * i)) >> icon.png 2>/dev/null
+    git add icon.png
+    git commit --quiet -m "Update icon v$i"
+done
+
+final_size=$(wc -c < icon.png | tr -d ' ')
+
+atomic init >/dev/null 2>&1
+assert_success "import with multiple binary mods succeeds" atomic git import
+assert_clean "clean after multiple binary modifications"
+
+# ────────────────────────────────────────────────────────────────────────────
+
+begin_section "Import Fidelity: Binary File Deletion"
+
+make_temp_repo "fidelity-binary-delete"
+init_git_repo
+
+printf '\x89PNG\r\n\x1a\n' > logo.png
+dd if=/dev/urandom bs=1 count=256 >> logo.png 2>/dev/null
+git add logo.png
+git commit --quiet -m "Add logo"
+
+git rm --quiet logo.png
+git commit --quiet -m "Remove logo"
+
+atomic init >/dev/null 2>&1
+assert_success "import with binary deletion succeeds" atomic git import
+assert_clean "clean after binary deletion"
+assert_file_not_exists "logo.png deleted" "logo.png"
+
+# ════════════════════════════════════════════════════════════════════════════
+# Section 3: Rewrite Misclassification (Spurious Renames)
+# ════════════════════════════════════════════════════════════════════════════
+
+begin_section "Import Fidelity: Rewrite + New File (No Spurious Rename)"
+
+make_temp_repo "fidelity-rewrite"
+init_git_repo
+
+# Create a file with substantial content
+cat > tests.rs << 'EOF'
+fn test_addition() {
+    assert_eq!(2 + 2, 4);
+}
+
+fn test_subtraction() {
+    assert_eq!(5 - 3, 2);
+}
+
+fn test_multiplication() {
+    assert_eq!(3 * 4, 12);
+}
+
+fn test_division() {
+    assert_eq!(10 / 2, 5);
+}
+
+fn test_modulo() {
+    assert_eq!(10 % 3, 1);
+}
+EOF
+git add tests.rs
+git commit --quiet -m "Add tests.rs"
+
+# In a single commit: heavily rewrite tests.rs AND add a new file
+# The new file shares some keywords with the old file (the trigger for
+# renames_from_rewrites), but this should NOT be classified as a rename.
+cat > tests.rs << 'EOF'
+use insta::assert_snapshot;
+
+#[test]
+fn snapshot_basic() {
+    assert_snapshot!("hello", @"hello");
+}
+
+#[test]
+fn snapshot_math() {
+    let result = 42;
+    assert_snapshot!(result.to_string(), @"42");
+}
+EOF
+
+cat > helpers.rs << 'EOF'
+pub fn setup() {
+    // Test setup helper
+    println!("setting up test environment");
+}
+
+pub fn teardown() {
+    println!("tearing down");
+}
+
+pub fn assert_close(a: f64, b: f64) {
+    assert!((a - b).abs() < 1e-6);
+}
+EOF
+
+git add tests.rs helpers.rs
+git commit --quiet -m "Rewrite tests, add helpers"
+
+# More commits on top to exercise continued tracking
+git_commit "Update helpers" "helpers.rs" "$(cat helpers.rs)
+pub fn extra() {}"
+
+atomic init >/dev/null 2>&1
+assert_success "import rewrite+add succeeds" atomic git import
+assert_clean "clean after rewrite+add import"
+
+# Both files must be tracked
+assert_file_exists "tests.rs exists" "tests.rs"
+assert_file_exists "helpers.rs exists" "helpers.rs"
+
+# Verify status doesn't show either as untracked
+status_out="$(atomic status 2>/dev/null || true)"
+if echo "$status_out" | grep -qF "tests.rs"; then
+    _fail "tests.rs not listed in status" "tests.rs appears in status output"
+else
+    _pass "tests.rs not listed in status"
+fi
+if echo "$status_out" | grep -qF "helpers.rs"; then
+    _fail "helpers.rs not listed in status" "helpers.rs appears in status output"
+else
+    _pass "helpers.rs not listed in status"
+fi
+
+# ────────────────────────────────────────────────────────────────────────────
+
+begin_section "Import Fidelity: Rename + Modify vs Rewrite + Add"
+
+make_temp_repo "fidelity-rename-vs-rewrite"
+init_git_repo
+
+# True rename: git mv + small content change (should be tracked as rename)
+cat > original.txt << 'EOF'
+This is the original file with some content.
+It has multiple lines to give rename detection
+enough material to work with for similarity.
+Line four.
+Line five.
+EOF
+git add original.txt
+git commit --quiet -m "Add original.txt"
+
+git mv original.txt renamed.txt
+# Small modification (rename + edit)
+echo "Added a new line." >> renamed.txt
+git add renamed.txt
+git commit --quiet -m "Rename original to renamed"
+
+# Now: delete + add with very different content (should NOT be a rename)
+cat > brand_new.txt << 'EOF'
+Completely different content here.
+Nothing like what was in original.txt.
+This is a fresh file with its own purpose.
+EOF
+git add brand_new.txt
+git commit --quiet -m "Add brand_new.txt"
+
+atomic init >/dev/null 2>&1
+assert_success "import rename-vs-rewrite succeeds" atomic git import
+assert_clean "clean after rename-vs-rewrite import"
+
+assert_file_not_exists "original.txt removed" "original.txt"
+assert_file_exists     "renamed.txt exists" "renamed.txt"
+assert_file_exists     "brand_new.txt exists" "brand_new.txt"
+
+# ════════════════════════════════════════════════════════════════════════════
+# Section 4: Combined Stress Test
+# ════════════════════════════════════════════════════════════════════════════
+
+begin_section "Import Fidelity: Combined Stress Test"
+
+make_temp_repo "fidelity-stress"
+init_git_repo
+
+# Phase 1: Create a mix of text and binary files
+git_commit "Add readme"   "README.md"      "# Project\nInitial readme"
+git_commit "Add config"   "config.yml"     "key: value\nport: 8080"
+git_commit "Add source"   "src/main.rs"    "fn main() { println!(\"hello\"); }"
+git_commit "Add module"   "src/lib.rs"     "pub mod utils;"
+git_commit "Add utils"    "src/utils.rs"   "pub fn helper() -> i32 { 42 }"
+
+printf '\x89PNG\r\n\x1a\n' > logo.png
+dd if=/dev/urandom bs=1 count=500 >> logo.png 2>/dev/null
+git add logo.png
+git commit --quiet -m "Add logo"
+
+printf '\x89PNG\r\n\x1a\n' > banner.png
+dd if=/dev/urandom bs=1 count=300 >> banner.png 2>/dev/null
+git add banner.png
+git commit --quiet -m "Add banner"
+
+# Phase 2: Modify some, delete others, rename one
+git_commit "Update readme" "README.md" "# Project\nUpdated readme with more info"
+
+# Modify binary
+printf '\x89PNG\r\n\x1a\n' > logo.png
+dd if=/dev/urandom bs=1 count=200 >> logo.png 2>/dev/null
+git add logo.png
+git commit --quiet -m "Resize logo"
+
+# Delete config and banner
+git rm --quiet config.yml banner.png
+git commit --quiet -m "Remove config and banner"
+
+# Rename utils
+git mv src/utils.rs src/helpers.rs
+git commit --quiet -m "Rename utils to helpers"
+
+# Phase 3: More churn
+git_commit "Update lib"  "src/lib.rs"     "pub mod helpers;"
+git_commit "Add tests"   "tests/test.rs"  "#[test] fn it_works() { assert!(true); }"
+
+# Heavily rewrite main.rs AND add a new file in the same commit
+cat > src/main.rs << 'EOF'
+use std::io;
+fn main() -> io::Result<()> {
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+    println!("Got: {}", input.trim());
+    Ok(())
+}
+EOF
+cat > src/cli.rs << 'EOF'
+pub fn parse_args() -> Vec<String> {
+    std::env::args().collect()
+}
+EOF
+git add src/main.rs src/cli.rs
+git commit --quiet -m "Rewrite main, add cli module"
+
+# Final deletion
+git rm --quiet src/lib.rs
+git commit --quiet -m "Remove lib.rs"
+
+# Record expected final state
+expected_files=(
+    "README.md"
+    "logo.png"
+    "src/main.rs"
+    "src/helpers.rs"
+    "src/cli.rs"
+    "tests/test.rs"
+)
+deleted_files=(
+    "config.yml"
+    "banner.png"
+    "src/utils.rs"
+    "src/lib.rs"
+)
+
+# Import
+atomic init >/dev/null 2>&1
+assert_success "stress test import succeeds" atomic git import
+assert_clean "clean after stress test import"
+
+# Verify expected files exist
+for f in "${expected_files[@]}"; do
+    assert_file_exists "$f exists" "$f"
+done
+
+# Verify deleted files are gone
+for f in "${deleted_files[@]}"; do
+    assert_file_not_exists "$f deleted" "$f"
+done
+
+# Final consistency check: atomic diff should be empty
+diff_out="$(atomic diff 2>/dev/null || true)"
+if echo "$diff_out" | grep -qE '^diff --atomic'; then
+    _fail "no diff in stress test" "atomic diff shows unexpected changes"
+else
+    _pass "no diff in stress test"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+# Summary
+# ════════════════════════════════════════════════════════════════════════════
+
+print_summary


### PR DESCRIPTION
This pull request introduces improved support for file moves/renames in the workflow globalization pipeline and refines the CRDT operation generation for modified files. The main changes include handling file move events as first-class operations, ensuring correct dependency tracking and graph updates, and enhancing the logic for generating CRDT operations for line replacements. Additional improvements clarify code comments and streamline content handling for hunks.

**File move/rename support:**

* Added logic in `pipeline.rs` to handle file moves (`DetectionKind::Moved`) as a dedicated `FileMove` graph operation, which updates graph edges, records dependencies, and manages content for the new filename.

**CRDT operation generation improvements:**

* Refined the logic for generating CRDT operations for modified files in `crdt.rs`, now emitting `BranchOp::Modify` for 1:1 line replacements and falling back to delete/insert for unequal line counts, with clearer code and comments. [[1]](diffhunk://#diff-d070d18260c0dc0ec12cc6d5e849af121ab291257702485eb89998c891fbc634L224-R242) [[2]](diffhunk://#diff-d070d18260c0dc0ec12cc6d5e849af121ab291257702485eb89998c891fbc634L272-R267) [[3]](diffhunk://#diff-d070d18260c0dc0ec12cc6d5e849af121ab291257702485eb89998c891fbc634L295-R295) [[4]](diffhunk://#diff-d070d18260c0dc0ec12cc6d5e849af121ab291257702485eb89998c891fbc634L326-R313)

**Hunk and content handling:**

* Improved handling of hunk content slices in `pipeline.rs`, ensuring that replace hunks use the full file content, insert hunks use their own slice, and delete hunks carry no content. [[1]](diffhunk://#diff-e97bdee4060e5505e73bc5fd1569ed0d8215136018766e7f180fefba56823a16L187-R302) [[2]](diffhunk://#diff-e97bdee4060e5505e73bc5fd1569ed0d8215136018766e7f180fefba56823a16R313-R315)
* Updated tracking of content ranges for hunks, simplifying the logic for determining when the full content is used.

**Exports and API:**

* Re-exported new types and functions (`build_crdt_ops_from_git_diff`, `GitDiffLine`) for broader use in the workflow module.Port all 7 commits from chore/roundtirp-fidelity-test onto dev's restructured codebase:

- Fix hunk consolidation: collapse any combination of Replace, Delete, or middle-Insert hunks into a single whole-file Replace to prevent N× content duplication in the graph
- Remove NeedsReplace fallback from globalize_hunk; middle insertions are now caught by upstream consolidation
- Add GitDiffLine type and build_crdt_ops_from_git_diff for exact git diff parity in CRDT ops
- Rewrite git import write_commit to use in-memory working copies (Memory) instead of git checkout_tree, eliminating filesystem I/O
- Add FileMove GraphOp support in record, globalize, and insert pipelines for proper rename tracking
- Fix binary file modifications (create Replace hunk when binary content differs)
- Fix deleted file cleanup (explicit repo.remove after insert)
- Add double-deletion guard for FileMove in insert_change
- Use Phase 1 old_content instead of repo.get_file_content to avoid O(N) graph scans per commit during import
- Add content roundtrip fidelity tests
- Add harness suites 11-13 (diff parity, full repo parity, import fidelity)
- Extend harness suite 10 with status parity tests

Known issue: assemble_and_hash calls retrieve_graph per file per commit, which is O(graph_size). For large imports (1000+ commits), this causes progressive slowdown. Tracked for separate optimization (in-memory content vertex cache).