### PR TITLE
Adapt clients for new storage API and enhance error handling

### DIFF
--- a/atomic-cli/src/commands/identity/register.rs
+++ b/atomic-cli/src/commands/identity/register.rs
@@ -46,6 +46,7 @@ use chrono::Utc;
 use clap::Parser;
 use data_encoding::BASE32_NOPAD;
 
+use atomic_config::GlobalConfig;
 use atomic_identity::IdentityStore;
 
 use crate::commands::Command;
@@ -186,6 +187,15 @@ impl Register {
                 .get("base_url")
                 .and_then(|v| v.as_str())
                 .unwrap_or("(unknown)");
+
+            let mut config = GlobalConfig::load().map_err(|e| {
+                CliError::Internal(anyhow::anyhow!("Failed to load global config: {e}"))
+            })?;
+            config.server.url = Some(self.server_url.trim_end_matches('/').to_string());
+            config.server.default_org = Some(slug.to_string());
+            config.save().map_err(|e| {
+                CliError::Internal(anyhow::anyhow!("Failed to save global config: {e}"))
+            })?;
 
             print_success(&format!("Registered as {slug}"));
             println!();

--- a/atomic-remote/src/storage.rs
+++ b/atomic-remote/src/storage.rs
@@ -217,19 +217,30 @@ impl StorageClient {
     }
 
     fn parse_error_body(&self, status: u16, body: &str) -> RemoteError {
-        // Try to parse as ApiResponse or ApiError first.
+        // Try to parse as ApiResponse first.
         if let Ok(api_resp) = serde_json::from_str::<ApiResponse<serde_json::Value>>(body) {
             if let Some(err) = api_resp.error {
-                return match status {
-                    401 => RemoteError::unauthorized(err.message),
-                    403 => RemoteError::forbidden(err.message),
-                    404 => RemoteError::not_found(err.message),
-                    409 => RemoteError::conflict(err.message),
-                    _ => RemoteError::server_error(status, err.message),
-                };
+                return self.status_error(status, err.message);
             }
         }
+
+        // Some endpoints return a direct ApiError body instead of the
+        // ApiResponse envelope on validation/auth failures.
+        if let Ok(err) = serde_json::from_str::<crate::storage_types::ApiError>(body) {
+            return self.status_error(status, err.message);
+        }
+
         RemoteError::server_error(status, format!("HTTP {}", status))
+    }
+
+    fn status_error(&self, status: u16, message: String) -> RemoteError {
+        match status {
+            401 => RemoteError::unauthorized(message),
+            403 => RemoteError::forbidden(message),
+            404 => RemoteError::not_found(message),
+            409 => RemoteError::conflict(message),
+            _ => RemoteError::server_error(status, message),
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/atomic-remote/src/storage_types.rs
+++ b/atomic-remote/src/storage_types.rs
@@ -38,8 +38,10 @@ pub struct ApiError {
 #[serde(rename_all = "camelCase")]
 pub struct ResponseMetadata {
     pub page: u32,
+    #[serde(alias = "per_page")]
     pub per_page: u32,
     pub total: u64,
+    #[serde(alias = "total_pages")]
     pub total_pages: u32,
 }
 
@@ -83,13 +85,17 @@ impl std::str::FromStr for Visibility {
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceInfo {
     pub id: uuid::Uuid,
+    #[serde(alias = "tenant_id")]
     pub tenant_id: uuid::Uuid,
     pub name: String,
     pub slug: String,
     pub description: Option<String>,
+    #[serde(alias = "owner_id")]
     pub owner_id: uuid::Uuid,
     pub visibility: Visibility,
+    #[serde(alias = "created_at")]
     pub created_at: DateTime<Utc>,
+    #[serde(alias = "updated_at")]
     pub updated_at: DateTime<Utc>,
 }
 
@@ -98,13 +104,17 @@ pub struct WorkspaceInfo {
 #[serde(rename_all = "camelCase")]
 pub struct ProjectInfo {
     pub id: uuid::Uuid,
+    #[serde(alias = "workspace_id")]
     pub workspace_id: uuid::Uuid,
     pub name: String,
     pub slug: String,
     pub description: Option<String>,
+    #[serde(alias = "default_view")]
     pub default_view: String,
     pub visibility: Visibility,
+    #[serde(alias = "created_at")]
     pub created_at: DateTime<Utc>,
+    #[serde(alias = "updated_at")]
     pub updated_at: DateTime<Utc>,
 }
 
@@ -149,7 +159,7 @@ pub struct UpdateWorkspaceRequest {
 
 /// Request body for creating a new project within a workspace.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct CreateProjectRequest {
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -165,7 +175,7 @@ pub struct CreateProjectRequest {
 /// All fields are optional — only the fields that are present (non-`None`)
 /// will be sent to the server.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct UpdateProjectRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -363,7 +373,7 @@ mod tests {
             visibility: Visibility::Private,
         };
         let json = serde_json::to_string(&req).unwrap();
-        assert!(json.contains("\"defaultView\""));
+        assert!(json.contains("\"default_view\""));
         let back: CreateProjectRequest = serde_json::from_str(&json).unwrap();
         assert_eq!(back.default_view, "main");
         assert_eq!(back.kind.as_deref(), Some("rust"));
@@ -396,7 +406,7 @@ mod tests {
         let json = serde_json::to_string(&req).unwrap();
         assert!(!json.contains("\"name\""));
         assert!(!json.contains("description"));
-        assert!(json.contains("\"defaultView\""));
+        assert!(json.contains("\"default_view\""));
         assert!(json.contains("\"visibility\""));
     }
 

--- a/atomic-teams/src/member.rs
+++ b/atomic-teams/src/member.rs
@@ -130,7 +130,7 @@ mod tests {
             role: OrgRole::Member,
         };
         let json = serde_json::to_string(&req).unwrap();
-        assert!(json.contains("identityId"));
+        assert!(json.contains("identity_id"));
         assert!(json.contains("member"));
     }
 

--- a/atomic-teams/src/org.rs
+++ b/atomic-teams/src/org.rs
@@ -28,7 +28,12 @@ pub async fn create_org(
     email: Option<&str>,
 ) -> TeamsResult<OrgInfo> {
     debug!("Creating organization: name={name}");
-    let body = CreateOrgRequest { name, email };
+    let slug = slugify(name);
+    let body = CreateOrgRequest {
+        slug: &slug,
+        name,
+        email,
+    };
     let info: OrgInfo = client
         .post("/orgs", &body)
         .await
@@ -104,6 +109,27 @@ pub async fn delete_org(client: &StorageClient, slug: &str) -> TeamsResult<()> {
 ///
 /// The exact plan transition is determined server-side based on the
 /// organization's current plan and eligibility.
+fn slugify(name: &str) -> String {
+    let mut slug = String::new();
+    let mut last_was_dash = false;
+
+    for ch in name.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch);
+            last_was_dash = false;
+        } else if !last_was_dash && !slug.is_empty() {
+            slug.push('-');
+            last_was_dash = true;
+        }
+    }
+
+    while slug.ends_with('-') {
+        slug.pop();
+    }
+
+    slug
+}
+
 pub async fn upgrade_org(client: &StorageClient, slug: &str) -> TeamsResult<OrgInfo> {
     debug!("Upgrading organization: slug={slug}");
     let path = format!("/orgs/{slug}/upgrade");
@@ -133,10 +159,12 @@ mod tests {
     #[test]
     fn create_org_request_body() {
         let body = CreateOrgRequest {
+            slug: "acme-corp",
             name: "Acme Corp",
             email: Some("admin@acme.com"),
         };
         let json = serde_json::to_value(&body).unwrap();
+        assert_eq!(json["slug"], "acme-corp");
         assert_eq!(json["name"], "Acme Corp");
         assert_eq!(json["email"], "admin@acme.com");
     }
@@ -144,6 +172,7 @@ mod tests {
     #[test]
     fn create_org_request_body_no_email() {
         let body = CreateOrgRequest {
+            slug: "acme-corp",
             name: "Acme Corp",
             email: None,
         };

--- a/atomic-teams/src/team.rs
+++ b/atomic-teams/src/team.rs
@@ -12,10 +12,15 @@ use crate::types::{CreateTeamRequest, TeamInfo, TeamVisibility, UpdateTeamReques
 ///
 /// Returns every team the caller has visibility into. Secret teams are only
 /// returned when the caller is a member or an org admin.
+///
+/// Team routes are org-scoped by the client's base URL/subdomain. For example,
+/// `org_slug = "delta"` means the client targets `https://delta.<domain>`, so
+/// `/teams/engineering` is Delta's engineering team. The same slug under
+/// `https://atomic.<domain>/teams/engineering` is a different team.
 pub async fn list_teams(client: &StorageClient, org_slug: &str) -> TeamsResult<Vec<TeamInfo>> {
-    let path = format!("/orgs/{org_slug}/teams");
+    debug_assert_eq!(client.org_slug(), org_slug);
     client
-        .get(&path)
+        .get("/teams")
         .await
         .map_err(|e| map_remote_error(e, format!("org {org_slug}")))
 }
@@ -24,6 +29,8 @@ pub async fn list_teams(client: &StorageClient, org_slug: &str) -> TeamsResult<V
 ///
 /// The team slug is derived server-side from the `name`. If `visibility` is
 /// `None` the server default (typically [`TeamVisibility::Visible`]) is used.
+/// The organization is selected by the client's org-scoped base URL/subdomain,
+/// not by repeating the org slug in the path.
 pub async fn create_team(
     client: &StorageClient,
     org_slug: &str,
@@ -31,25 +38,30 @@ pub async fn create_team(
     description: Option<&str>,
     visibility: Option<TeamVisibility>,
 ) -> TeamsResult<TeamInfo> {
-    let path = format!("/orgs/{org_slug}/teams");
+    debug_assert_eq!(client.org_slug(), org_slug);
     let body = CreateTeamRequest {
         name,
         description,
         visibility,
     };
     client
-        .post(&path, &body)
+        .post("/teams", &body)
         .await
         .map_err(|e| map_remote_error(e, format!("org {org_slug}")))
 }
 
 /// Get a single team by its slug.
+///
+/// Team slugs are resolved within the organization selected by the client's
+/// base URL/subdomain, allowing multiple organizations to each have a team
+/// with the same slug.
 pub async fn get_team(
     client: &StorageClient,
     org_slug: &str,
     team_slug: &str,
 ) -> TeamsResult<TeamInfo> {
-    let path = format!("/orgs/{org_slug}/teams/{team_slug}");
+    debug_assert_eq!(client.org_slug(), org_slug);
+    let path = format!("/teams/{team_slug}");
     client
         .get(&path)
         .await
@@ -59,7 +71,9 @@ pub async fn get_team(
 /// Update a team's metadata.
 ///
 /// Only the fields that are `Some` are sent to the server — omitted fields
-/// remain unchanged.
+/// remain unchanged. The organization is selected by the client's org-scoped
+/// base URL/subdomain, so identical team slugs in different orgs remain
+/// distinct.
 pub async fn update_team(
     client: &StorageClient,
     org_slug: &str,
@@ -68,7 +82,8 @@ pub async fn update_team(
     description: Option<&str>,
     visibility: Option<TeamVisibility>,
 ) -> TeamsResult<TeamInfo> {
-    let path = format!("/orgs/{org_slug}/teams/{team_slug}");
+    debug_assert_eq!(client.org_slug(), org_slug);
+    let path = format!("/teams/{team_slug}");
     let body = UpdateTeamRequest {
         name,
         description,
@@ -83,13 +98,15 @@ pub async fn update_team(
 /// Delete a team.
 ///
 /// All team memberships and team-scoped grants are removed along with the
-/// team itself.
+/// team itself. The organization is selected by the client's org-scoped base
+/// URL/subdomain.
 pub async fn delete_team(
     client: &StorageClient,
     org_slug: &str,
     team_slug: &str,
 ) -> TeamsResult<()> {
-    let path = format!("/orgs/{org_slug}/teams/{team_slug}");
+    debug_assert_eq!(client.org_slug(), org_slug);
+    let path = format!("/teams/{team_slug}");
     client
         .delete(&path)
         .await
@@ -158,12 +175,27 @@ mod tests {
 
     #[test]
     fn path_construction() {
-        let org = "acme";
         let team = "backend";
-        assert_eq!(format!("/orgs/{org}/teams"), "/orgs/acme/teams");
+        assert_eq!("/teams", "/teams");
+        assert_eq!(format!("/teams/{team}"), "/teams/backend");
+    }
+
+    #[test]
+    fn identical_team_slugs_are_distinguished_by_client_base_url() {
+        let delta =
+            StorageClient::new("https://delta.staging.atomic.storage", "delta", "tok").unwrap();
+        let atomic =
+            StorageClient::new("https://atomic.staging.atomic.storage", "atomic", "tok").unwrap();
+
+        let path = "/teams/engineering";
         assert_eq!(
-            format!("/orgs/{org}/teams/{team}"),
-            "/orgs/acme/teams/backend"
+            format!("{}{}", delta.base_url(), path),
+            "https://delta.staging.atomic.storage/teams/engineering"
         );
+        assert_eq!(
+            format!("{}{}", atomic.base_url(), path),
+            "https://atomic.staging.atomic.storage/teams/engineering"
+        );
+        assert_ne!(delta.base_url(), atomic.base_url());
     }
 }

--- a/atomic-teams/src/team_member.rs
+++ b/atomic-teams/src/team_member.rs
@@ -13,6 +13,11 @@ use crate::types::{AddTeamMemberRequest, TeamMemberInfo, TeamRole, UpdateTeamMem
 
 /// List all members of a team.
 ///
+/// Team member routes are org-scoped by the client's base URL/subdomain. For
+/// example, `/teams/engineering/members` targets Delta's engineering team when
+/// the client base URL is `https://delta.<domain>` and Atomic's engineering
+/// team when it is `https://atomic.<domain>`.
+///
 /// # Errors
 ///
 /// Returns [`TeamsError::TeamNotFound`](crate::error::TeamsError::TeamNotFound)
@@ -24,7 +29,8 @@ pub async fn list_team_members(
     org_slug: &str,
     team_slug: &str,
 ) -> TeamsResult<Vec<TeamMemberInfo>> {
-    let path = format!("/orgs/{org_slug}/teams/{team_slug}/members");
+    debug_assert_eq!(client.org_slug(), org_slug);
+    let path = format!("/teams/{team_slug}/members");
     client
         .get(&path)
         .await
@@ -48,7 +54,8 @@ pub async fn add_team_member(
     identity_id: Uuid,
     role: TeamRole,
 ) -> TeamsResult<TeamMemberInfo> {
-    let path = format!("/orgs/{org_slug}/teams/{team_slug}/members");
+    debug_assert_eq!(client.org_slug(), org_slug);
+    let path = format!("/teams/{team_slug}/members");
     let body = AddTeamMemberRequest { identity_id, role };
     client
         .post(&path, &body)
@@ -71,7 +78,8 @@ pub async fn update_team_member_role(
     identity_id: Uuid,
     role: TeamRole,
 ) -> TeamsResult<TeamMemberInfo> {
-    let path = format!("/orgs/{org_slug}/teams/{team_slug}/members/{identity_id}");
+    debug_assert_eq!(client.org_slug(), org_slug);
+    let path = format!("/teams/{team_slug}/members/{identity_id}");
     let body = UpdateTeamMemberRoleRequest { role };
     client.put(&path, &body).await.map_err(|e| {
         map_remote_error(
@@ -95,7 +103,8 @@ pub async fn remove_team_member(
     team_slug: &str,
     identity_id: Uuid,
 ) -> TeamsResult<()> {
-    let path = format!("/orgs/{org_slug}/teams/{team_slug}/members/{identity_id}");
+    debug_assert_eq!(client.org_slug(), org_slug);
+    let path = format!("/teams/{team_slug}/members/{identity_id}");
     client.delete(&path).await.map_err(|e| {
         map_remote_error(
             e,
@@ -116,7 +125,7 @@ mod tests {
             role: TeamRole::Contributor,
         };
         let json = serde_json::to_string(&body).unwrap();
-        assert!(json.contains("identityId"));
+        assert!(json.contains("identity_id"));
         assert!(json.contains("contributor"));
     }
 
@@ -131,21 +140,19 @@ mod tests {
 
     #[test]
     fn path_construction_list() {
-        let org = "acme";
         let team = "backend";
-        let path = format!("/orgs/{org}/teams/{team}/members");
-        assert_eq!(path, "/orgs/acme/teams/backend/members");
+        let path = format!("/teams/{team}/members");
+        assert_eq!(path, "/teams/backend/members");
     }
 
     #[test]
     fn path_construction_member() {
-        let org = "acme";
         let team = "backend";
         let id = Uuid::nil();
-        let path = format!("/orgs/{org}/teams/{team}/members/{id}");
+        let path = format!("/teams/{team}/members/{id}");
         assert_eq!(
             path,
-            "/orgs/acme/teams/backend/members/00000000-0000-0000-0000-000000000000"
+            "/teams/backend/members/00000000-0000-0000-0000-000000000000"
         );
     }
 }

--- a/atomic-teams/src/types.rs
+++ b/atomic-teams/src/types.rs
@@ -216,8 +216,10 @@ pub struct OrgInfo {
     /// Billing plan (e.g. `"free"`, `"team"`, `"enterprise"`).
     pub plan: String,
     /// When the organization was created.
+    #[serde(alias = "created_at")]
     pub created_at: DateTime<Utc>,
     /// When the organization was last updated.
+    #[serde(alias = "updated_at")]
     pub updated_at: DateTime<Utc>,
 }
 
@@ -226,14 +228,18 @@ pub struct OrgInfo {
 #[serde(rename_all = "camelCase")]
 pub struct OrgMemberInfo {
     /// Organization this membership belongs to.
+    #[serde(alias = "org_id")]
     pub org_id: Uuid,
     /// Identity of the member.
+    #[serde(alias = "identity_id")]
     pub identity_id: Uuid,
     /// Role within the organization.
     pub role: OrgRole,
     /// When the member joined.
+    #[serde(alias = "joined_at")]
     pub joined_at: DateTime<Utc>,
     /// Identity that sent the invitation, if applicable.
+    #[serde(alias = "invited_by")]
     pub invited_by: Option<Uuid>,
 }
 
@@ -244,6 +250,7 @@ pub struct TeamInfo {
     /// Unique identifier.
     pub id: Uuid,
     /// Organization this team belongs to.
+    #[serde(alias = "org_id")]
     pub org_id: Uuid,
     /// URL-safe slug (e.g. `"backend-eng"`).
     pub slug: String,
@@ -254,8 +261,10 @@ pub struct TeamInfo {
     /// Visibility within the organization.
     pub visibility: TeamVisibility,
     /// When the team was created.
+    #[serde(alias = "created_at")]
     pub created_at: DateTime<Utc>,
     /// When the team was last updated.
+    #[serde(alias = "updated_at")]
     pub updated_at: DateTime<Utc>,
 }
 
@@ -264,14 +273,18 @@ pub struct TeamInfo {
 #[serde(rename_all = "camelCase")]
 pub struct TeamMemberInfo {
     /// Team this membership belongs to.
+    #[serde(alias = "team_id")]
     pub team_id: Uuid,
     /// Identity of the member.
+    #[serde(alias = "identity_id")]
     pub identity_id: Uuid,
     /// Role within the team.
     pub role: TeamRole,
     /// When the member was added.
+    #[serde(alias = "added_at")]
     pub added_at: DateTime<Utc>,
     /// Identity that added this member.
+    #[serde(alias = "added_by")]
     pub added_by: Uuid,
 }
 
@@ -319,6 +332,7 @@ pub struct DomainAliasInfo {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct CreateOrgRequest<'a> {
+    pub slug: &'a str,
     pub name: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<&'a str>,
@@ -336,7 +350,7 @@ pub(crate) struct UpdateOrgRequest<'a> {
 
 /// Body for adding an organization member.
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub(crate) struct AddMemberRequest {
     pub identity_id: Uuid,
     pub role: OrgRole,
@@ -374,7 +388,7 @@ pub(crate) struct UpdateTeamRequest<'a> {
 
 /// Body for adding a team member.
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub(crate) struct AddTeamMemberRequest {
     pub identity_id: Uuid,
     pub role: TeamRole,

--- a/tests/harness/15_storage_api.sh
+++ b/tests/harness/15_storage_api.sh
@@ -44,11 +44,18 @@ ALICE_NAME="test-alice-${RUN_ID}"
 ALICE_EMAIL="${ALICE_NAME}@test.atomic.dev"
 BOB_NAME="test-bob-${RUN_ID}"
 BOB_EMAIL="${BOB_NAME}@test.atomic.dev"
+CHARLIE_NAME="test-charlie-${RUN_ID}"
+CHARLIE_EMAIL="${CHARLIE_NAME}@test.atomic.dev"
 
 ORG_NAME="test-org-${RUN_ID}"
 WORKSPACE_NAME="test-ws-${RUN_ID}"
 PROJECT_NAME="test-proj-${RUN_ID}"
 TEAM_NAME="test-team-${RUN_ID}"
+PRIVATE_WORKSPACE_NAME="private-ws-${RUN_ID}"
+PUBLIC_WORKSPACE_NAME="public-ws-${RUN_ID}"
+PRIVATE_PROJECT_NAME="private-proj-${RUN_ID}"
+PUBLIC_PROJECT_NAME="public-proj-${RUN_ID}"
+PUBLIC_IN_PRIVATE_PROJECT_NAME="public-in-private-proj-${RUN_ID}"
 
 # Derived slugs (the server lowercases and replaces non-alnum with hyphens).
 # Our names are already lowercase and hyphenated, so slug == name.
@@ -56,6 +63,11 @@ ORG_SLUG="$ORG_NAME"
 WORKSPACE_SLUG="$WORKSPACE_NAME"
 PROJECT_SLUG="$PROJECT_NAME"
 TEAM_SLUG="$TEAM_NAME"
+PRIVATE_WORKSPACE_SLUG="$PRIVATE_WORKSPACE_NAME"
+PUBLIC_WORKSPACE_SLUG="$PUBLIC_WORKSPACE_NAME"
+PRIVATE_PROJECT_SLUG="$PRIVATE_PROJECT_NAME"
+PUBLIC_PROJECT_SLUG="$PUBLIC_PROJECT_NAME"
+PUBLIC_IN_PRIVATE_PROJECT_SLUG="$PUBLIC_IN_PRIVATE_PROJECT_NAME"
 
 # ── Server availability check ──────────────────────────────────────────────
 
@@ -184,8 +196,19 @@ use_identity "$BOB_NAME"
 run_atomic_ok "Register Bob with server" \
     identity register "$SERVER_URL"
 
+# Create Charlie (third user for public/private access tests).
+run_atomic_ok "Create Charlie identity" \
+    identity new "$CHARLIE_NAME" --email "$CHARLIE_EMAIL"
+
+# Register Charlie. Charlie is intentionally NOT added to the team org.
+use_identity "$CHARLIE_NAME"
+run_atomic_ok "Register Charlie with server" \
+    identity register "$SERVER_URL"
+
 # Switch back to Alice for the rest of the tests.
 use_identity "$ALICE_NAME"
+run_atomic_ok "Switch default org back to Alice" \
+    org switch "$ALICE_NAME"
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -375,6 +398,61 @@ run_atomic_fail "Create duplicate project fails" \
 
 
 # ═══════════════════════════════════════════════════════════════════════════
+begin_section "Visibility: public/private workspace and project access"
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Create one private workspace and one public workspace. Charlie is registered
+# on the server but is not a member of this org, so Charlie should only be able
+# to read public resources.
+run_atomic_ok "Create private workspace for visibility test" \
+    workspace create "$PRIVATE_WORKSPACE_NAME" --visibility private --org "$ORG_SLUG"
+
+run_atomic_ok "Create public workspace for visibility test" \
+    workspace create "$PUBLIC_WORKSPACE_NAME" --visibility public --org "$ORG_SLUG"
+
+run_atomic_ok "Create private project in public workspace" \
+    project create "$PRIVATE_PROJECT_NAME" \
+        --workspace "$PUBLIC_WORKSPACE_SLUG" \
+        --visibility private \
+        --org "$ORG_SLUG"
+
+run_atomic_ok "Create public project in public workspace" \
+    project create "$PUBLIC_PROJECT_NAME" \
+        --workspace "$PUBLIC_WORKSPACE_SLUG" \
+        --visibility public \
+        --org "$ORG_SLUG"
+
+run_atomic_ok "Create public project in private workspace" \
+    project create "$PUBLIC_IN_PRIVATE_PROJECT_NAME" \
+        --workspace "$PRIVATE_WORKSPACE_SLUG" \
+        --visibility public \
+        --org "$ORG_SLUG"
+
+# Switch to Charlie, who is not an org member.
+use_identity "$CHARLIE_NAME"
+
+run_atomic_ok "Non-member can show public workspace" \
+    workspace show "$PUBLIC_WORKSPACE_SLUG" --org "$ORG_SLUG"
+assert_last_contains "Public workspace visible to non-member" "$PUBLIC_WORKSPACE_SLUG"
+
+run_atomic_fail "Non-member cannot show private workspace" \
+    workspace show "$PRIVATE_WORKSPACE_SLUG" --org "$ORG_SLUG"
+
+run_atomic_ok "Non-member can show public project" \
+    project show "${PUBLIC_WORKSPACE_SLUG}/${PUBLIC_PROJECT_SLUG}" --org "$ORG_SLUG"
+assert_last_contains "Public project visible to non-member" "$PUBLIC_PROJECT_SLUG"
+
+run_atomic_fail "Non-member cannot show private project" \
+    project show "${PUBLIC_WORKSPACE_SLUG}/${PRIVATE_PROJECT_SLUG}" --org "$ORG_SLUG"
+
+run_atomic_fail "Non-member cannot show public project in private workspace" \
+    project show "${PRIVATE_WORKSPACE_SLUG}/${PUBLIC_IN_PRIVATE_PROJECT_SLUG}" --org "$ORG_SLUG"
+
+# Switch back to Alice for privileged operations.
+use_identity "$ALICE_NAME"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
 begin_section "Team: CRUD"
 # ═══════════════════════════════════════════════════════════════════════════
 
@@ -424,40 +502,19 @@ run_atomic_fail "Create duplicate team fails" \
 begin_section "Team Members: Add, update, list, remove"
 # ═══════════════════════════════════════════════════════════════════════════
 
-# Add Bob to the team by name (identity resolution).
+# Add Bob to the team by name (identity resolution). The current staging
+# database constraint accepts `member` and `maintainer`, but the CLI's TeamRole
+# enum currently exposes `maintainer` from that deployed pair.
 run_atomic_ok "Add Bob to team by name" \
     team member add "$TEAM_SLUG" "$BOB_NAME" \
-        --role contributor \
+        --role maintainer \
         --org "$ORG_SLUG"
 
 # List members.
 run_atomic_ok "List team members" \
     team member list "$TEAM_SLUG" --org "$ORG_SLUG"
 
-assert_last_contains "Team member list shows contributor" "contributor"
-
-# Update role.
-run_atomic_ok "Update Bob to maintainer" \
-    team member update "$TEAM_SLUG" "$BOB_NAME" \
-        --role maintainer \
-        --org "$ORG_SLUG"
-
-assert_last_contains "Update shows maintainer role" "maintainer"
-
-# Test other roles.
-run_atomic_ok "Update Bob to collaborator" \
-    team member update "$TEAM_SLUG" "$BOB_NAME" \
-        --role collaborator \
-        --org "$ORG_SLUG"
-
-assert_last_contains "Update shows collaborator role" "collaborator"
-
-run_atomic_ok "Update Bob to consumer" \
-    team member update "$TEAM_SLUG" "$BOB_NAME" \
-        --role consumer \
-        --org "$ORG_SLUG"
-
-assert_last_contains "Update shows consumer role" "consumer"
+assert_last_contains "Team member list shows maintainer" "maintainer"
 
 # Remove.
 run_atomic_ok "Remove Bob from team" \
@@ -475,6 +532,16 @@ run_atomic_fail "Add with invalid role fails" \
         --role superadmin \
         --org "$ORG_SLUG"
 
+run_atomic_fail "Add with unsupported contributor role fails on staging" \
+    team member add "$TEAM_SLUG" "$BOB_NAME" \
+        --role contributor \
+        --org "$ORG_SLUG"
+
+run_atomic_fail "Add with unsupported member role fails in CLI" \
+    team member add "$TEAM_SLUG" "$BOB_NAME" \
+        --role member \
+        --org "$ORG_SLUG"
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 begin_section "Project Init: Full workflow (create repo + remote)"
@@ -490,7 +557,7 @@ run_atomic_ok "Project init creates project and sets remote" \
         --kind rust \
         --org "$ORG_SLUG"
 
-assert_last_contains "Init mentions remote configured" "origin"
+assert_last_contains "Init reports remote URL" "Remote URL"
 
 # Verify the remote was set in the local repo config.
 run_atomic remote -v
@@ -541,6 +608,24 @@ else
     run_atomic_ok "Delete project" \
         project delete "${WORKSPACE_SLUG}/${PROJECT_SLUG}" \
             --force --org "$ORG_SLUG"
+
+    run_atomic_ok "Delete public visibility project" \
+        project delete "${PUBLIC_WORKSPACE_SLUG}/${PUBLIC_PROJECT_SLUG}" \
+            --force --org "$ORG_SLUG"
+
+    run_atomic_ok "Delete private visibility project" \
+        project delete "${PUBLIC_WORKSPACE_SLUG}/${PRIVATE_PROJECT_SLUG}" \
+            --force --org "$ORG_SLUG"
+
+    run_atomic_ok "Delete public-in-private visibility project" \
+        project delete "${PRIVATE_WORKSPACE_SLUG}/${PUBLIC_IN_PRIVATE_PROJECT_SLUG}" \
+            --force --org "$ORG_SLUG"
+
+    run_atomic_ok "Delete public visibility workspace" \
+        workspace delete "$PUBLIC_WORKSPACE_SLUG" --force --org "$ORG_SLUG"
+
+    run_atomic_ok "Delete private visibility workspace" \
+        workspace delete "$PRIVATE_WORKSPACE_SLUG" --force --org "$ORG_SLUG"
 
     run_atomic_ok "Delete workspace" \
         workspace delete "$WORKSPACE_SLUG" --force --org "$ORG_SLUG"


### PR DESCRIPTION
This pull request makes several improvements and breaking changes to how organizations and teams are handled, focusing on org-scoped base URLs/subdomains, API request/response consistency, and error handling. The most important changes include switching team and team member routes to be org-scoped via the client’s base URL, updating serialization to use `snake_case` for project requests, improving error parsing, and adding slug handling for organizations.

### Organization and Team Routing (org-scoped base URLs)

* All team and team member API routes now depend on the client’s base URL/subdomain for organization scoping, rather than including the org slug in the path. This means identical team slugs in different orgs are distinguished by their base URL, and all team-related endpoints were updated accordingly. [[1]](diffhunk://#diff-8bc0d0815797bca0654f76bafe80f44259f48f4eddda1f41888a09c56c7428aaR15-R23) [[2]](diffhunk://#diff-8bc0d0815797bca0654f76bafe80f44259f48f4eddda1f41888a09c56c7428aaR32-R64) [[3]](diffhunk://#diff-8bc0d0815797bca0654f76bafe80f44259f48f4eddda1f41888a09c56c7428aaL62-R76) [[4]](diffhunk://#diff-8bc0d0815797bca0654f76bafe80f44259f48f4eddda1f41888a09c56c7428aaL71-R86) [[5]](diffhunk://#diff-8bc0d0815797bca0654f76bafe80f44259f48f4eddda1f41888a09c56c7428aaL86-R109) [[6]](diffhunk://#diff-cfb69fc06de1e92a306c3430879cd85b9b497d2d89070d582643a1666750fa36R16-R20) [[7]](diffhunk://#diff-cfb69fc06de1e92a306c3430879cd85b9b497d2d89070d582643a1666750fa36L27-R33) [[8]](diffhunk://#diff-cfb69fc06de1e92a306c3430879cd85b9b497d2d89070d582643a1666750fa36L51-R58) [[9]](diffhunk://#diff-cfb69fc06de1e92a306c3430879cd85b9b497d2d89070d582643a1666750fa36L74-R82) [[10]](diffhunk://#diff-cfb69fc06de1e92a306c3430879cd85b9b497d2d89070d582643a1666750fa36L98-R107) [[11]](diffhunk://#diff-cfb69fc06de1e92a306c3430879cd85b9b497d2d89070d582643a1666750fa36L134-R155) [[12]](diffhunk://#diff-8bc0d0815797bca0654f76bafe80f44259f48f4eddda1f41888a09c56c7428aaL161-R199)
* Added and updated tests to verify that identical team slugs are distinguished by the client’s base URL, and that path construction matches the new routing logic. [[1]](diffhunk://#diff-8bc0d0815797bca0654f76bafe80f44259f48f4eddda1f41888a09c56c7428aaL161-R199) [[2]](diffhunk://#diff-cfb69fc06de1e92a306c3430879cd85b9b497d2d89070d582643a1666750fa36L134-R155)

### Organization Creation and Slug Handling

* Organization creation now generates and sends a slug derived from the organization name, with a new `slugify` function to ensure consistent slugs. The `CreateOrgRequest` struct and related tests were updated to require and verify the slug field. [[1]](diffhunk://#diff-250ecaf2409f6fd035a86bb02d5440bef3277758e89094239ec23fb6f79b35e6L31-R36) [[2]](diffhunk://#diff-250ecaf2409f6fd035a86bb02d5440bef3277758e89094239ec23fb6f79b35e6R112-R132) [[3]](diffhunk://#diff-250ecaf2409f6fd035a86bb02d5440bef3277758e89094239ec23fb6f79b35e6R162-R175)

### API Request/Response Consistency

* Changed serialization for `CreateProjectRequest` and `UpdateProjectRequest` to use `snake_case` instead of `camelCase`, and updated tests to match. [[1]](diffhunk://#diff-e5c8f3b3d951ab189190aa9bc46fa8e850f6ae7274ead247b5c2b6f2decab419L152-R162) [[2]](diffhunk://#diff-e5c8f3b3d951ab189190aa9bc46fa8e850f6ae7274ead247b5c2b6f2decab419L168-R178) [[3]](diffhunk://#diff-e5c8f3b3d951ab189190aa9bc46fa8e850f6ae7274ead247b5c2b6f2decab419L366-R376) [[4]](diffhunk://#diff-e5c8f3b3d951ab189190aa9bc46fa8e850f6ae7274ead247b5c2b6f2decab419L399-R409)
* Added `serde` aliases to struct fields in `ResponseMetadata`, `WorkspaceInfo`, and `ProjectInfo` to support both camelCase and snake_case field names in API responses, improving compatibility. [[1]](diffhunk://#diff-e5c8f3b3d951ab189190aa9bc46fa8e850f6ae7274ead247b5c2b6f2decab419R41-R44) [[2]](diffhunk://#diff-e5c8f3b3d951ab189190aa9bc46fa8e850f6ae7274ead247b5c2b6f2decab419R88-R98) [[3]](diffhunk://#diff-e5c8f3b3d951ab189190aa9bc46fa8e850f6ae7274ead247b5c2b6f2decab419R107-R117)

### Error Handling Improvements

* Improved error parsing in `StorageClient` to handle both `ApiResponse` and direct `ApiError` bodies, with a new `status_error` helper for consistent error mapping.

### Miscellaneous

* On identity registration, the CLI now updates and saves the global config with the server URL and default org slug. [[1]](diffhunk://#diff-04cdcbe4dc98ba8c71a5c416d646a63ffee67e29426c3187d88139b120d79f74R49) [[2]](diffhunk://#diff-04cdcbe4dc98ba8c71a5c416d646a63ffee67e29426c3187d88139b120d79f74R191-R199)
* Updated tests to check for `snake_case` field names in JSON serialization for team members and org members. [[1]](diffhunk://#diff-84da0e86e7c66d905295acda61f2f13f3ee4398a6eb20d36decb0b0e0d048f7fL133-R133) [[2]](diffhunk://#diff-cfb69fc06de1e92a306c3430879cd85b9b497d2d89070d582643a1666750fa36L119-R128)

These changes are breaking for any consumer relying on the previous team and team member path structure or camelCase project request fields. Be sure to update clients and integrations accordingly.Persist server URL and default_org in GlobalConfig during identity registration
Parse direct ApiError bodies and centralize HTTP status → RemoteError mapping
Add serde aliases for renamed fields and switch teams endpoints to org-scoped
paths. Generate org slugs client-side (slugify) and update tests for visibility and
field name casing