### PR TITLE
fix(agent): record turns that only create new files

### DIFF
--- a/atomic-agent/src/record/mod.rs
+++ b/atomic-agent/src/record/mod.rs
@@ -146,11 +146,11 @@ pub fn record_turn(
         })?;
 
     // Step 2: Status — find out what the agent changed.
-    // Use fast mode + tracked only: mtime-based detection, no content
-    // hashing, no filesystem walk for untracked. The full hash check
-    // happens inside record() itself.
+    // Fast mode (no content hashing — record() itself does the full hash check)
+    // but include untracked files: agents create new files all the time and we
+    // need to see them here to add+record them in Step 3.
     let status = repo
-        .status(atomic_repository::status::StatusOptions::fast().with_untracked(false))
+        .status(atomic_repository::status::StatusOptions::fast().with_untracked(true))
         .map_err(|e| AgentError::RecordFailed {
             session_id: options.session.session_id.clone(),
             turn_number: options.turn_number,

--- a/atomic-agent/src/turn/orchestrator/mod.rs
+++ b/atomic-agent/src/turn/orchestrator/mod.rs
@@ -341,19 +341,20 @@ pub(crate) fn truncate_prompt(prompt: &str, max_len: usize) -> String {
 impl TurnOrchestrator {
     /// Fast check for working copy changes.
     ///
-    /// Uses `StatusOptions::fast().with_untracked(false)` — mtime-based
-    /// detection on tracked files only, no content hashing, no filesystem
-    /// walk for untracked files. This is O(tracked files) with just stat
-    /// calls, no hashing.
+    /// Uses `StatusOptions::fast()` (mtime-based, no content hashing) with
+    /// `with_untracked(true)` so the gate also detects new files the agent
+    /// created — the most common case. Without untracked detection, turns
+    /// that only create new files (e.g., a fresh `Foo.tsx`) would be skipped
+    /// silently, never reaching `record_turn`.
     pub(crate) fn has_working_copy_changes(&self) -> bool {
         let repo = match atomic_repository::Repository::open(&self.repo_root) {
             Ok(r) => r,
             Err(_) => return true, // can't check — assume changes
         };
 
-        let opts = atomic_repository::status::StatusOptions::fast().with_untracked(false);
+        let opts = atomic_repository::status::StatusOptions::fast().with_untracked(true);
         match repo.status(opts) {
-            Ok(status) => !status.is_clean(),
+            Ok(status) => !status.is_clean() || status.untracked_count() > 0,
             Err(_) => true, // can't check — assume changes
         }
     }


### PR DESCRIPTION
## Summary

Agent turns that only create new files were being silently dropped instead of recorded. Two `with_untracked(false)` calls in the recording path caused the working copy to look "clean" whenever no tracked file was modified — which is the common case for code-generation turns (`Foo.tsx`, `new_module.rs`, etc.).

## What was broken

1. **`TurnOrchestrator::has_working_copy_changes`** (`atomic-agent/src/turn/orchestrator/mod.rs`) is the early gate at the top of `handle_turn_end`. With `with_untracked(false)`, `RepositoryStatus` contained no entries for new files, `is_clean()` returned `true`, and the function short-circuited before `record_turn` was ever called.

2. **`record_turn`** (`atomic-agent/src/record/mod.rs`) ran its own status query with the same flag. Even when called directly, `status.untracked()` returned an empty iterator and the existing add-then-record loop had no paths to add.

Net effect: agents that wrote new files saw their work persist on disk as untracked, with no Atomic change recorded for the turn. `files_touched` stayed empty, `turn_count` didn't increment, and `atomic log` showed nothing.

## Fix

Both call sites now pass `with_untracked(true)`. The orchestrator's gate also reads `untracked_count()` so a clean tracked tree with new files isn't treated as a no-op.

```rust
// orchestrator/mod.rs
let opts = StatusOptions::fast().with_untracked(true);
match repo.status(opts) {
    Ok(status) => !status.is_clean() || status.untracked_count() > 0,
    Err(_) => true,
}
```

```rust
// record/mod.rs (Step 2)
let status = repo.status(StatusOptions::fast().with_untracked(true))...
```

Performance: bounded by `.atomicignore` (`respect_ignore_files` is on by default). `record_turn` already performed this walk via a separate status call before recording — this is consolidation, not extra work.

## Verification

End-to-end with the OpenCode hooks plugin against a fresh repo. A turn creating `src/cli_probe.txt` plus several `GraphView/*.tsx` files:

**Before fix:**
- `phase: idle`, `turn_count: 0`, `files_touched: []`
- `atomic log` showed no new change
- Files lingered as untracked

**After fix:**
- `phase: idle`, `turn_count: 1`, `files_touched: [...]` populated with all 7 paths
- `atomic log` shows the new change `QBHZG2LCIQPF` authored by `opencode+sesc <aaron.ogle@atomic.dev>` with the prompt as the message
- `atomic status` reports working tree clean

`cargo test --release -p atomic-agent` — 108 passed, 0 failed.

## Test plan

- [ ] CI green
- [ ] Manual: real OpenCode session writing new files produces one Atomic change per turn
- [ ] Manual: real OpenCode session editing only existing tracked files still records (regression check)
- [ ] Manual: turn with no file changes still produces no record (`EmptyTurn` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)