### PR TITLE
fix(cli): correct two onboarding hints (register next-steps, vault init)

### DIFF
--- a/atomic-cli/src/commands/identity/register.rs
+++ b/atomic-cli/src/commands/identity/register.rs
@@ -215,16 +215,16 @@ impl Register {
                 );
             }
 
-            println!();
-            println!("{}", crate::output::hint("Next steps:"));
-            println!(
-                "  {}  Push a project",
-                crate::output::command("atomic push")
-            );
-            println!(
-                "  {}  Clone from the server",
-                crate::output::command(format!("atomic clone {base_url}/<project>"))
-            );
+            crate::output::print_next_steps(&[
+                (
+                    "atomic workspace create <name>",
+                    "Create your first workspace",
+                ),
+                (
+                    "atomic project create <name> --workspace <workspace>",
+                    "Create a project (prints the clone/push URL)",
+                ),
+            ]);
         } else {
             // Parse error response.
             let error_msg = serde_json::from_str::<serde_json::Value>(&response_text)

--- a/atomic-repository/src/repository/vault_goal.rs
+++ b/atomic-repository/src/repository/vault_goal.rs
@@ -84,7 +84,7 @@ impl Repository {
     ) -> Result<GoalStartResult, RepositoryError> {
         if !self.has_vault()? {
             return Err(RepositoryError::InvalidOperation {
-                message: "Vault not initialized. Run `atomic init --vault` first.".to_string(),
+                message: "Vault not initialized. Run `atomic vault init` first.".to_string(),
             });
         }
 

--- a/atomic-repository/src/repository/vault_intent.rs
+++ b/atomic-repository/src/repository/vault_intent.rs
@@ -76,7 +76,7 @@ impl Repository {
     ) -> Result<IntentCreateResult, RepositoryError> {
         if !self.has_vault()? {
             return Err(RepositoryError::InvalidOperation {
-                message: "Vault not initialized. Run `atomic init --vault` first.".to_string(),
+                message: "Vault not initialized. Run `atomic vault init` first.".to_string(),
             });
         }
 


### PR DESCRIPTION
Two unrelated but small CLI hint fixes, bundled on one branch.

## 1. `atomic identity register` next steps
- The `atomic clone {base_url}/<project>` hint didn't match the URL scheme used everywhere else (`{base_url}/workspaces/<workspace>/projects/<project>/code` per `project/create.rs:138`, `project/show.rs:99`, `project/init.rs:167`). Following the printed example produced an unusable URL.
- A freshly registered identity has no workspace and no project, so `atomic push` / `atomic clone` aren't actionable next steps.
- Replaced the block with the standard `print_next_steps` helper and walk users through the real first steps. `atomic project create` already prints the correct VCS URL, so we don't fabricate one here.

## 2. Vault not-initialized hint
- `Repository::vault_intent_create` and `Repository::vault_goal_start` returned the message *"Vault not initialized. Run \`atomic init --vault\` first."* — that command doesn't exist. The real command is `atomic vault init`.
- Updated both error messages.

## Test plan
- [x] `cargo build -p atomic-cli`
- [x] `cargo build -p atomic-repository`
- [ ] Manually: `atomic identity register …` shows the new workspace/project hints
- [ ] Manually: `atomic vault intent create` (with no vault) prints the corrected hint