### PR TITLE
Add per-org default workspace and rename switch to set, fix missing validation on server for org/workspace

### DIFF
--- a/atomic-cli/src/commands/client.rs
+++ b/atomic-cli/src/commands/client.rs
@@ -45,24 +45,28 @@ use crate::error::{CliError, CliResult};
 /// - Identity store cannot be opened or no default identity set.
 /// - HTTP client construction failure.
 pub fn build_client(org_override: Option<&str>) -> CliResult<StorageClient> {
+    let (client, _org_slug) = build_client_with_org(org_override)?;
+    Ok(client)
+}
+
+/// Build a [`StorageClient`] and return the resolved org slug alongside it.
+///
+/// Useful for commands that also need to resolve org-scoped state (e.g.
+/// per-org default workspace lookup). Avoids resolving the org twice.
+pub fn build_client_with_org(
+    org_override: Option<&str>,
+) -> CliResult<(StorageClient, String)> {
     let config = GlobalConfig::load()
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load global config: {}", e)))?;
 
     let server = &config.server;
-    if !server.is_configured() {
+    if server.url.is_none() {
         return Err(CliError::Internal(anyhow::anyhow!(
             "Server not configured. Run 'atomic identity register <server-url>' first."
         )));
     }
 
-    let org_slug = org_override
-        .map(|s| s.to_string())
-        .or_else(|| server.default_org.clone())
-        .ok_or_else(|| {
-            CliError::Internal(anyhow::anyhow!(
-                "No organization specified. Use --org or set a default with 'atomic org switch'."
-            ))
-        })?;
+    let org_slug = resolve_org(org_override)?;
 
     let base_url = server.org_base_url(&org_slug).ok_or_else(|| {
         CliError::Internal(anyhow::anyhow!(
@@ -86,8 +90,11 @@ pub fn build_client(org_override: Option<&str>) -> CliResult<StorageClient> {
 
     let bearer_token = identity.public_key_base32();
 
-    StorageClient::new(&base_url, &org_slug, &bearer_token)
-        .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to create storage client: {}", e)))
+    let client = StorageClient::new(&base_url, &org_slug, &bearer_token).map_err(|e| {
+        CliError::Internal(anyhow::anyhow!("Failed to create storage client: {}", e))
+    })?;
+
+    Ok((client, org_slug))
 }
 
 /// Convenience: map a [`atomic_remote::RemoteError`] to a [`CliError`].
@@ -96,6 +103,82 @@ pub fn remote_err(e: atomic_remote::RemoteError) -> CliError {
         message: e.to_string(),
         url: None,
     }
+}
+
+/// Resolve the org slug for a command, with fallback to the configured default.
+///
+/// Resolution order:
+/// 1. `--org` override (if `Some(non-empty)`)
+/// 2. `server.default_org` from global config
+/// 3. Error with a hint to run `atomic org switch`
+///
+/// An explicit empty string (`--org ""`) is an error: the user asked for "no
+/// org" which never makes sense.
+pub fn resolve_org(org_override: Option<&str>) -> CliResult<String> {
+    if let Some(s) = org_override {
+        if s.is_empty() {
+            return Err(CliError::InvalidArgument {
+                message: "Organization slug cannot be empty.".to_string(),
+            });
+        }
+        return Ok(s.to_string());
+    }
+
+    let config = GlobalConfig::load()
+        .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load global config: {}", e)))?;
+
+    config.server.default_org.ok_or_else(|| {
+        CliError::InvalidArgument {
+            message: "No organization specified.\n  \
+                      Use --org or set a default with: atomic org switch <slug>"
+                .to_string(),
+        }
+    })
+}
+
+/// Resolve the workspace slug for a command, with fallback to the
+/// org-scoped default workspace from global config.
+///
+/// Workspaces are org-scoped, so the lookup is keyed by `org_slug`. The
+/// caller is responsible for resolving the org first (typically with
+/// [`resolve_org`]).
+///
+/// Resolution order:
+/// 1. `--workspace` override (if `Some(non-empty)`)
+/// 2. `server.default_workspaces[org_slug]` from global config
+/// 3. Error with a hint to run `atomic workspace switch`
+///
+/// An explicit empty string (`--workspace ""`) is an error: the user
+/// explicitly asked for "no workspace", which is meaningless. Distinguishing
+/// `None` (not provided → fall back to default) from `Some("")` (provided
+/// empty → error) prevents a class of confusing bugs.
+pub fn resolve_workspace(
+    org_slug: &str,
+    workspace_override: Option<&str>,
+) -> CliResult<String> {
+    if let Some(s) = workspace_override {
+        if s.is_empty() {
+            return Err(CliError::InvalidArgument {
+                message: "Workspace slug cannot be empty.".to_string(),
+            });
+        }
+        return Ok(s.to_string());
+    }
+
+    let config = GlobalConfig::load()
+        .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load global config: {}", e)))?;
+
+    config
+        .server
+        .default_workspaces
+        .get(org_slug)
+        .cloned()
+        .ok_or_else(|| CliError::InvalidArgument {
+            message: format!(
+                "No workspace specified for org '{org_slug}'.\n  \
+                 Use --workspace or set a default with: atomic workspace switch <slug>"
+            ),
+        })
 }
 
 /// Resolve a flexible identity reference to a UUID.
@@ -209,5 +292,43 @@ mod tests {
         // An identifier containing '@' should be treated as an email.
         assert!("alice@example.com".contains('@'));
         assert!(!"alice".contains('@'));
+    }
+
+    // -- resolve_org / resolve_workspace (override-branch only;
+    //    the config-fallback branch touches disk and is exercised by
+    //    integration tests). --
+
+    #[test]
+    fn resolve_org_passes_through_explicit_override() {
+        let result = resolve_org(Some("acme")).unwrap();
+        assert_eq!(result, "acme");
+    }
+
+    #[test]
+    fn resolve_org_rejects_explicit_empty_override() {
+        let err = resolve_org(Some("")).unwrap_err();
+        match err {
+            CliError::InvalidArgument { message } => {
+                assert!(message.contains("cannot be empty"));
+            }
+            other => panic!("expected InvalidArgument, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn resolve_workspace_passes_through_explicit_override() {
+        let result = resolve_workspace("acme", Some("backend")).unwrap();
+        assert_eq!(result, "backend");
+    }
+
+    #[test]
+    fn resolve_workspace_rejects_explicit_empty_override() {
+        let err = resolve_workspace("acme", Some("")).unwrap_err();
+        match err {
+            CliError::InvalidArgument { message } => {
+                assert!(message.contains("cannot be empty"));
+            }
+            other => panic!("expected InvalidArgument, got {:?}", other),
+        }
     }
 }

--- a/atomic-cli/src/commands/client.rs
+++ b/atomic-cli/src/commands/client.rs
@@ -108,7 +108,7 @@ pub fn remote_err(e: atomic_remote::RemoteError) -> CliError {
 /// Resolution order:
 /// 1. `--org` override (if `Some(non-empty)`)
 /// 2. `server.default_org` from global config
-/// 3. Error with a hint to run `atomic org switch`
+/// 3. Error with a hint to run `atomic org set`
 ///
 /// An explicit empty string (`--org ""`) is an error: the user asked for "no
 /// org" which never makes sense.
@@ -130,7 +130,7 @@ pub fn resolve_org(org_override: Option<&str>) -> CliResult<String> {
         .default_org
         .ok_or_else(|| CliError::InvalidArgument {
             message: "No organization specified.\n  \
-                      Use --org or set a default with: atomic org switch <slug>"
+                      Use --org or set a default with: atomic org set <slug>"
                 .to_string(),
         })
 }
@@ -145,7 +145,7 @@ pub fn resolve_org(org_override: Option<&str>) -> CliResult<String> {
 /// Resolution order:
 /// 1. `--workspace` override (if `Some(non-empty)`)
 /// 2. `server.default_workspaces[org_slug]` from global config
-/// 3. Error with a hint to run `atomic workspace switch`
+/// 3. Error with a hint to run `atomic workspace set`
 ///
 /// An explicit empty string (`--workspace ""`) is an error: the user
 /// explicitly asked for "no workspace", which is meaningless. Distinguishing
@@ -172,7 +172,7 @@ pub fn resolve_workspace(org_slug: &str, workspace_override: Option<&str>) -> Cl
         .ok_or_else(|| CliError::InvalidArgument {
             message: format!(
                 "No workspace specified for org '{org_slug}'.\n  \
-                 Use --workspace or set a default with: atomic workspace switch <slug>"
+                 Use --workspace or set a default with: atomic workspace set <slug>"
             ),
         })
 }

--- a/atomic-cli/src/commands/client.rs
+++ b/atomic-cli/src/commands/client.rs
@@ -53,9 +53,7 @@ pub fn build_client(org_override: Option<&str>) -> CliResult<StorageClient> {
 ///
 /// Useful for commands that also need to resolve org-scoped state (e.g.
 /// per-org default workspace lookup). Avoids resolving the org twice.
-pub fn build_client_with_org(
-    org_override: Option<&str>,
-) -> CliResult<(StorageClient, String)> {
+pub fn build_client_with_org(org_override: Option<&str>) -> CliResult<(StorageClient, String)> {
     let config = GlobalConfig::load()
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load global config: {}", e)))?;
 
@@ -127,13 +125,14 @@ pub fn resolve_org(org_override: Option<&str>) -> CliResult<String> {
     let config = GlobalConfig::load()
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load global config: {}", e)))?;
 
-    config.server.default_org.ok_or_else(|| {
-        CliError::InvalidArgument {
+    config
+        .server
+        .default_org
+        .ok_or_else(|| CliError::InvalidArgument {
             message: "No organization specified.\n  \
                       Use --org or set a default with: atomic org switch <slug>"
                 .to_string(),
-        }
-    })
+        })
 }
 
 /// Resolve the workspace slug for a command, with fallback to the
@@ -152,10 +151,7 @@ pub fn resolve_org(org_override: Option<&str>) -> CliResult<String> {
 /// explicitly asked for "no workspace", which is meaningless. Distinguishing
 /// `None` (not provided → fall back to default) from `Some("")` (provided
 /// empty → error) prevents a class of confusing bugs.
-pub fn resolve_workspace(
-    org_slug: &str,
-    workspace_override: Option<&str>,
-) -> CliResult<String> {
+pub fn resolve_workspace(org_slug: &str, workspace_override: Option<&str>) -> CliResult<String> {
     if let Some(s) = workspace_override {
         if s.is_empty() {
             return Err(CliError::InvalidArgument {

--- a/atomic-cli/src/commands/identity/register.rs
+++ b/atomic-cli/src/commands/identity/register.rs
@@ -221,7 +221,11 @@ impl Register {
                     "Create your first workspace",
                 ),
                 (
-                    "atomic project create <name> --workspace <workspace>",
+                    "atomic workspace switch <name>",
+                    "Set as your default workspace",
+                ),
+                (
+                    "atomic project create <project-name>",
                     "Create a project (prints the clone/push URL)",
                 ),
             ]);

--- a/atomic-cli/src/commands/identity/register.rs
+++ b/atomic-cli/src/commands/identity/register.rs
@@ -221,7 +221,7 @@ impl Register {
                     "Create your first workspace",
                 ),
                 (
-                    "atomic workspace switch <name>",
+                    "atomic workspace set <name>",
                     "Set as your default workspace",
                 ),
                 (

--- a/atomic-cli/src/commands/org/create.rs
+++ b/atomic-cli/src/commands/org/create.rs
@@ -28,7 +28,7 @@
 //!   Plan:  free
 //!
 //! Next steps:
-//!   atomic org switch acme-corp    Set as your default org
+//!   atomic org set acme-corp    Set as your default org
 //!   atomic org member add <id>     Add members to the org
 //!   atomic team create <name>      Create a team
 //!
@@ -109,7 +109,7 @@ impl OrgCreate {
 
         print_next_steps(&[
             (
-                &format!("atomic org switch {}", info.slug),
+                &format!("atomic org set {}", info.slug),
                 "Set as your default org",
             ),
             ("atomic org member add <id>", "Add members to the org"),

--- a/atomic-cli/src/commands/org/delete.rs
+++ b/atomic-cli/src/commands/org/delete.rs
@@ -134,9 +134,8 @@ impl OrgDelete {
 ///   - If `server.default_org == Some(slug)`, set it to `None` and hint.
 ///   - Remove `server.default_workspaces[slug]` if present.
 fn clean_up_local_config(deleted_slug: &str) -> CliResult<()> {
-    let mut config = GlobalConfig::load().map_err(|e| {
-        CliError::Internal(anyhow::anyhow!("Failed to load global config: {e}"))
-    })?;
+    let mut config = GlobalConfig::load()
+        .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load global config: {e}")))?;
 
     let mut changed = false;
     let was_default_org = config.server.default_org.as_deref() == Some(deleted_slug);
@@ -157,9 +156,9 @@ fn clean_up_local_config(deleted_slug: &str) -> CliResult<()> {
         return Ok(());
     }
 
-    config.save().map_err(|e| {
-        CliError::Internal(anyhow::anyhow!("Failed to save global config: {e}"))
-    })?;
+    config
+        .save()
+        .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to save global config: {e}")))?;
 
     if was_default_org {
         print_hint(&format!(

--- a/atomic-cli/src/commands/org/delete.rs
+++ b/atomic-cli/src/commands/org/delete.rs
@@ -33,10 +33,12 @@
 
 use clap::Parser;
 
+use atomic_config::GlobalConfig;
+
 use crate::commands::client::build_client;
 use crate::commands::Command;
 use crate::error::{CliError, CliResult};
-use crate::output::{print_success, print_warning};
+use crate::output::{print_hint, print_success, print_warning};
 
 /// Delete an organization.
 ///
@@ -112,8 +114,61 @@ impl OrgDelete {
 
         print_success(&format!("Deleted organization: {}", self.slug));
 
+        // Clean up local config: if the deleted org was the current default
+        // or had a configured default workspace, those entries are now stale
+        // and would surface as confusing errors on subsequent commands.
+        // We log but do not fail on config errors here — the server-side
+        // deletion has already succeeded.
+        if let Err(e) = clean_up_local_config(&self.slug) {
+            log::warn!("Failed to clean up local config after org delete: {e}");
+        }
+
         Ok(())
     }
+}
+
+/// Remove references to a deleted org from the local global config.
+///
+/// Returns the side effects performed so the caller can print appropriate
+/// hints. Specifically:
+///   - If `server.default_org == Some(slug)`, set it to `None` and hint.
+///   - Remove `server.default_workspaces[slug]` if present.
+fn clean_up_local_config(deleted_slug: &str) -> CliResult<()> {
+    let mut config = GlobalConfig::load().map_err(|e| {
+        CliError::Internal(anyhow::anyhow!("Failed to load global config: {e}"))
+    })?;
+
+    let mut changed = false;
+    let was_default_org = config.server.default_org.as_deref() == Some(deleted_slug);
+    if was_default_org {
+        config.server.default_org = None;
+        changed = true;
+    }
+    if config
+        .server
+        .default_workspaces
+        .remove(deleted_slug)
+        .is_some()
+    {
+        changed = true;
+    }
+
+    if !changed {
+        return Ok(());
+    }
+
+    config.save().map_err(|e| {
+        CliError::Internal(anyhow::anyhow!("Failed to save global config: {e}"))
+    })?;
+
+    if was_default_org {
+        print_hint(&format!(
+            "Default org was '{deleted_slug}' — run 'atomic org switch <slug>' \
+             to pick a new one."
+        ));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/atomic-cli/src/commands/org/delete.rs
+++ b/atomic-cli/src/commands/org/delete.rs
@@ -162,7 +162,7 @@ fn clean_up_local_config(deleted_slug: &str) -> CliResult<()> {
 
     if was_default_org {
         print_hint(&format!(
-            "Default org was '{deleted_slug}' — run 'atomic org switch <slug>' \
+            "Default org was '{deleted_slug}' — run 'atomic org set <slug>' \
              to pick a new one."
         ));
     }

--- a/atomic-cli/src/commands/org/list.rs
+++ b/atomic-cli/src/commands/org/list.rs
@@ -25,7 +25,7 @@
 //!   Slug:  acme-corp
 //!   Plan:  team
 //!
-//!   Hint: Use 'atomic org switch <slug>' to change the default organization.
+//!   Hint: Use 'atomic org set <slug>' to change the default organization.
 //!
 //! $ atomic org list --format json
 //! ```
@@ -41,7 +41,7 @@ use crate::output::{print_hint, print_section, KeyValueTable};
 ///
 /// Currently shows the default organization's info, since the server
 /// does not yet support listing all organizations for a user. Use
-/// `atomic org switch <slug>` to change which organization is active.
+/// `atomic org set <slug>` to change which organization is active.
 #[derive(Debug, Parser)]
 #[command(name = "list")]
 pub struct OrgList {
@@ -112,7 +112,7 @@ impl OrgList {
 
             println!("{table}");
             println!();
-            print_hint("Use 'atomic org switch <slug>' to change the default organization.");
+            print_hint("Use 'atomic org set <slug>' to change the default organization.");
         }
 
         Ok(())

--- a/atomic-cli/src/commands/org/mod.rs
+++ b/atomic-cli/src/commands/org/mod.rs
@@ -249,6 +249,7 @@ mod tests {
 
         let set = set::OrgSet {
             slug: "test".to_string(),
+            no_verify: false,
         };
         assert_eq!(check_variant(&OrgCommands::Set(set)), "set");
     }

--- a/atomic-cli/src/commands/org/mod.rs
+++ b/atomic-cli/src/commands/org/mod.rs
@@ -9,7 +9,7 @@
 //! - Updating organization settings
 //! - Deleting organizations
 //! - Upgrading personal orgs to team orgs
-//! - Switching the default organization
+//! - Setting the default organization
 //! - Managing organization members (nested subcommands)
 //!
 //! # Usage
@@ -24,7 +24,7 @@
 //!   update   Update organization settings
 //!   delete   Delete an organization
 //!   upgrade  Upgrade a personal org to a team org
-//!   switch   Switch the default organization
+//!   set      Set the default organization
 //!   member   Manage organization members
 //! ```
 //!
@@ -37,8 +37,8 @@
 //! # Create a new team org
 //! $ atomic org create "Acme Corp" --email admin@acme.com
 //!
-//! # Switch default org
-//! $ atomic org switch acme-corp
+//! # Set default org (accepts `switch` as a hidden alias for back-compat)
+//! $ atomic org set acme-corp
 //!
 //! # Add a member
 //! $ atomic org member add 550e8400-e29b-41d4-a716-446655440000 --role admin
@@ -53,9 +53,9 @@ pub mod list;
 #[cfg(feature = "teams")]
 pub mod member;
 #[cfg(feature = "teams")]
-pub mod show;
+pub mod set;
 #[cfg(feature = "teams")]
-pub mod switch;
+pub mod show;
 #[cfg(feature = "teams")]
 pub mod update;
 #[cfg(feature = "teams")]
@@ -155,17 +155,18 @@ pub enum OrgCommands {
     /// ```
     Upgrade(upgrade::OrgUpgrade),
 
-    /// Switch the default organization.
+    /// Set the default organization.
     ///
     /// Changes which organization is used by default for all commands
-    /// that interact with the remote server.
+    /// that interact with the remote server. Accepts `switch` as a
+    /// hidden alias for backward compatibility.
     ///
     /// # Examples
     ///
     /// ```text
-    /// atomic org switch acme-corp
+    /// atomic org set acme-corp
     /// ```
-    Switch(switch::OrgSwitch),
+    Set(set::OrgSet),
 
     /// Manage organization members.
     ///
@@ -206,7 +207,7 @@ impl Command for OrgCmd {
             OrgCommands::Update(cmd) => cmd.run(),
             OrgCommands::Delete(cmd) => cmd.run(),
             OrgCommands::Upgrade(cmd) => cmd.run(),
-            OrgCommands::Switch(cmd) => cmd.run(),
+            OrgCommands::Set(cmd) => cmd.run(),
             OrgCommands::Member(cmd) => cmd.run(),
         }
     }
@@ -227,7 +228,7 @@ mod tests {
                 OrgCommands::Update(_) => "update",
                 OrgCommands::Delete(_) => "delete",
                 OrgCommands::Upgrade(_) => "upgrade",
-                OrgCommands::Switch(_) => "switch",
+                OrgCommands::Set(_) => "set",
                 OrgCommands::Member(_) => "member",
             }
         }
@@ -246,9 +247,9 @@ mod tests {
         };
         assert_eq!(check_variant(&OrgCommands::Create(create)), "create");
 
-        let switch = switch::OrgSwitch {
+        let set = set::OrgSet {
             slug: "test".to_string(),
         };
-        assert_eq!(check_variant(&OrgCommands::Switch(switch)), "switch");
+        assert_eq!(check_variant(&OrgCommands::Set(set)), "set");
     }
 }

--- a/atomic-cli/src/commands/org/set.rs
+++ b/atomic-cli/src/commands/org/set.rs
@@ -5,8 +5,10 @@
 //! subsequent commands that interact with the remote server will use the
 //! new default organization.
 //!
-//! Accepts `switch` as a hidden alias for backward compatibility with
-//! the previous command name.
+//! The slug is validated against the server before being written to
+//! config — typos fail immediately instead of self-locking subsequent
+//! commands. Accepts `switch` as a hidden alias for backward compatibility
+//! with the previous command name.
 //!
 //! # Usage
 //!
@@ -17,27 +19,30 @@
 //!   <SLUG>  Organization slug to set as the new default
 //!
 //! Options:
-//!   -h, --help  Print help information
+//!       --no-verify  Skip server-side slug validation (advanced)
+//!   -h, --help       Print help information
 //! ```
 //!
 //! # Examples
 //!
 //! ```text
-//! # Set the default org
+//! # Set the default org (validated against the server)
 //! $ atomic org set acme-corp
 //! ✓ Default organization set to: acme-corp
 //!
-//! # Verify
-//! $ atomic org show
-//!   Name:  Acme Corp
-//!   Slug:  acme-corp
-//!   ...
+//! # Typo: fails before any config change
+//! $ atomic org set acme-corpz
+//! ✗ Organization 'acme-corpz' not found on the server.
+//!
+//! # Skip validation (e.g. pre-configuring before the org exists)
+//! $ atomic org set acme-corp --no-verify
 //! ```
 
 use clap::Parser;
 
 use atomic_config::GlobalConfig;
 
+use crate::commands::client::build_client_with_org;
 use crate::commands::Command;
 use crate::error::{CliError, CliResult};
 use crate::output::{print_hint, print_success};
@@ -48,10 +53,10 @@ use crate::output::{print_hint, print_success};
 /// file (`~/.atomic/config.toml`). All subsequent commands that interact
 /// with the remote server will scope their requests to this organization.
 ///
-/// This command does **not** validate that the slug exists on the server.
-/// If the slug is invalid, subsequent commands will fail with a "not found"
-/// error.
-#[derive(Debug, Parser)]
+/// Validates the slug against the server before saving (the server
+/// responds with 404 if no tenant matches the subdomain). Pass
+/// `--no-verify` to skip the network round-trip.
+#[derive(Debug, Parser, Default)]
 #[command(name = "set", alias = "switch")]
 pub struct OrgSet {
     /// Organization slug to set as the new default.
@@ -60,21 +65,36 @@ pub struct OrgSet {
     /// to on the remote server (e.g. `"acme-corp"`).
     #[arg(required = true, value_name = "SLUG")]
     pub slug: String,
+
+    /// Skip server-side slug validation.
+    ///
+    /// Useful for pre-configuring an org slug before the org exists on
+    /// the server, or for offline workflows. Without this flag, the
+    /// command fails fast if the slug does not resolve to a tenant.
+    #[arg(long)]
+    pub no_verify: bool,
 }
 
 impl Command for OrgSet {
     fn run(&self) -> CliResult<()> {
-        // Load the current global config (or defaults if none exists).
+        if self.slug.is_empty() {
+            return Err(CliError::InvalidArgument {
+                message: "Organization slug cannot be empty.".to_string(),
+            });
+        }
+
+        // Validate against the server first so a bad slug fails fast
+        // rather than self-locking subsequent commands.
+        if !self.no_verify {
+            verify_org_exists(&self.slug)?;
+        }
+
         let mut config = GlobalConfig::load().map_err(|e| {
             CliError::Internal(anyhow::anyhow!("Failed to load global config: {e}"))
         })?;
 
         let previous = config.server.default_org.clone();
-
-        // Update the default org.
         config.server.default_org = Some(self.slug.clone());
-
-        // Persist to disk.
         config.save().map_err(|e| {
             CliError::Internal(anyhow::anyhow!("Failed to save global config: {e}"))
         })?;
@@ -91,6 +111,43 @@ impl Command for OrgSet {
     }
 }
 
+/// Confirm the slug resolves to an org on the server.
+///
+/// Returns a [`CliError::InvalidArgument`] with a clean, slug-specific
+/// message on 404 so the user sees the actual problem (typo) rather than
+/// a raw HTTP response. Other failures (network, auth) bubble up so the
+/// user can distinguish "wrong slug" from "server unreachable".
+fn verify_org_exists(slug: &str) -> CliResult<()> {
+    let rt = tokio::runtime::Runtime::new()
+        .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to create async runtime: {e}")))?;
+
+    rt.block_on(async {
+        let (client, _resolved) = build_client_with_org(Some(slug))?;
+        match atomic_teams::org::get_org(&client, slug).await {
+            Ok(_) => Ok(()),
+            Err(e) if is_org_not_found(&e) => Err(CliError::InvalidArgument {
+                message: format!(
+                    "Organization '{slug}' not found on the server.\n  \
+                     Check the slug with: atomic org list\n  \
+                     Or pass --no-verify to set the value without checking."
+                ),
+            }),
+            Err(e) => Err(CliError::RemoteError {
+                message: e.to_string(),
+                url: None,
+            }),
+        }
+    })
+}
+
+fn is_org_not_found(err: &atomic_teams::TeamsError) -> bool {
+    matches!(err, atomic_teams::TeamsError::OrgNotFound(_))
+        || matches!(
+            err,
+            atomic_teams::TeamsError::Remote(re) if re.is_not_found()
+        )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -99,6 +156,7 @@ mod tests {
     fn required_slug() {
         let cmd = OrgSet {
             slug: "acme-corp".to_string(),
+            no_verify: false,
         };
         assert_eq!(cmd.slug, "acme-corp");
     }
@@ -107,6 +165,7 @@ mod tests {
     fn slug_with_hyphens() {
         let cmd = OrgSet {
             slug: "my-cool-org-123".to_string(),
+            no_verify: false,
         };
         assert_eq!(cmd.slug, "my-cool-org-123");
     }
@@ -115,7 +174,23 @@ mod tests {
     fn slug_simple() {
         let cmd = OrgSet {
             slug: "alice".to_string(),
+            no_verify: false,
         };
         assert_eq!(cmd.slug, "alice");
+    }
+
+    #[test]
+    fn empty_slug_rejected() {
+        let cmd = OrgSet {
+            slug: "".to_string(),
+            no_verify: true, // skip network so the check is the only failure
+        };
+        let err = cmd.run().unwrap_err();
+        match err {
+            CliError::InvalidArgument { message } => {
+                assert!(message.contains("cannot be empty"));
+            }
+            other => panic!("expected InvalidArgument, got {other:?}"),
+        }
     }
 }

--- a/atomic-cli/src/commands/org/set.rs
+++ b/atomic-cli/src/commands/org/set.rs
@@ -1,14 +1,17 @@
-//! The `org switch` command for changing the default organization.
+//! The `org set` command for changing the default organization.
 //!
-//! This module implements the `atomic org switch` command, which updates
+//! This module implements the `atomic org set` command, which updates
 //! the `server.default_org` field in the global configuration file. All
 //! subsequent commands that interact with the remote server will use the
 //! new default organization.
 //!
+//! Accepts `switch` as a hidden alias for backward compatibility with
+//! the previous command name.
+//!
 //! # Usage
 //!
 //! ```text
-//! atomic org switch <SLUG>
+//! atomic org set <SLUG>
 //!
 //! Arguments:
 //!   <SLUG>  Organization slug to set as the new default
@@ -20,11 +23,11 @@
 //! # Examples
 //!
 //! ```text
-//! # Switch to a different org
-//! $ atomic org switch acme-corp
+//! # Set the default org
+//! $ atomic org set acme-corp
 //! ✓ Default organization set to: acme-corp
 //!
-//! # Verify the switch
+//! # Verify
 //! $ atomic org show
 //!   Name:  Acme Corp
 //!   Slug:  acme-corp
@@ -39,19 +42,18 @@ use crate::commands::Command;
 use crate::error::{CliError, CliResult};
 use crate::output::{print_hint, print_success};
 
-/// Switch the default organization.
+/// Set the default organization.
 ///
 /// Updates the `[server] default_org` field in the global configuration
-/// file (`~/.config/atomic/config.toml`). All subsequent commands that
-/// interact with the remote server will scope their requests to this
-/// organization.
+/// file (`~/.atomic/config.toml`). All subsequent commands that interact
+/// with the remote server will scope their requests to this organization.
 ///
 /// This command does **not** validate that the slug exists on the server.
 /// If the slug is invalid, subsequent commands will fail with a "not found"
 /// error.
 #[derive(Debug, Parser)]
-#[command(name = "switch")]
-pub struct OrgSwitch {
+#[command(name = "set", alias = "switch")]
+pub struct OrgSet {
     /// Organization slug to set as the new default.
     ///
     /// This should be the URL-safe slug of an organization you belong
@@ -60,7 +62,7 @@ pub struct OrgSwitch {
     pub slug: String,
 }
 
-impl Command for OrgSwitch {
+impl Command for OrgSet {
     fn run(&self) -> CliResult<()> {
         // Load the current global config (or defaults if none exists).
         let mut config = GlobalConfig::load().map_err(|e| {
@@ -95,7 +97,7 @@ mod tests {
 
     #[test]
     fn required_slug() {
-        let cmd = OrgSwitch {
+        let cmd = OrgSet {
             slug: "acme-corp".to_string(),
         };
         assert_eq!(cmd.slug, "acme-corp");
@@ -103,7 +105,7 @@ mod tests {
 
     #[test]
     fn slug_with_hyphens() {
-        let cmd = OrgSwitch {
+        let cmd = OrgSet {
             slug: "my-cool-org-123".to_string(),
         };
         assert_eq!(cmd.slug, "my-cool-org-123");
@@ -111,7 +113,7 @@ mod tests {
 
     #[test]
     fn slug_simple() {
-        let cmd = OrgSwitch {
+        let cmd = OrgSet {
             slug: "alice".to_string(),
         };
         assert_eq!(cmd.slug, "alice");

--- a/atomic-cli/src/commands/org/set.rs
+++ b/atomic-cli/src/commands/org/set.rs
@@ -77,6 +77,21 @@ pub struct OrgSet {
 
 impl Command for OrgSet {
     fn run(&self) -> CliResult<()> {
+        self.run_with_verifier(verify_org_exists)
+    }
+}
+
+impl OrgSet {
+    /// Inner runner that takes the slug-verification step as a parameter.
+    ///
+    /// Splitting this out lets tests inject a deterministic verifier
+    /// (succeed / fail) without making a real network call, so we can
+    /// assert the load-bearing invariant: **when verification fails, the
+    /// config file is not modified**.
+    fn run_with_verifier<F>(&self, verify: F) -> CliResult<()>
+    where
+        F: FnOnce(&str) -> CliResult<()>,
+    {
         if self.slug.is_empty() {
             return Err(CliError::InvalidArgument {
                 message: "Organization slug cannot be empty.".to_string(),
@@ -84,9 +99,10 @@ impl Command for OrgSet {
         }
 
         // Validate against the server first so a bad slug fails fast
-        // rather than self-locking subsequent commands.
+        // rather than self-locking subsequent commands. The `?` here is
+        // load-bearing: if it returns Err, config is not touched.
         if !self.no_verify {
-            verify_org_exists(&self.slug)?;
+            verify(&self.slug)?;
         }
 
         let mut config = GlobalConfig::load().map_err(|e| {
@@ -192,5 +208,133 @@ mod tests {
             }
             other => panic!("expected InvalidArgument, got {other:?}"),
         }
+    }
+
+    // -----------------------------------------------------------------
+    // Regression invariant: when the verifier fails, config must NOT be
+    // mutated. This protects against accidentally reordering the verify /
+    // save steps in future refactors.
+    //
+    // Tests touch HOME to redirect `GlobalConfig::{load,save}` at an
+    // isolated config dir, so `#[serial]` is required.
+    // -----------------------------------------------------------------
+
+    use serial_test::serial;
+
+    /// Save the current `HOME` value and point it at a tempdir for the
+    /// lifetime of the guard. Restores on drop. Wraps the tempdir so the
+    /// directory lives as long as `HOME` points at it.
+    struct HomeGuard {
+        _tmp: tempfile::TempDir,
+        original: Option<std::ffi::OsString>,
+    }
+
+    impl HomeGuard {
+        fn new() -> Self {
+            let tmp = tempfile::tempdir().unwrap();
+            let original = std::env::var_os("HOME");
+            // SAFETY: env mutation is technically UB if accessed
+            // concurrently from another thread. `#[serial]` serializes
+            // these tests against each other but does NOT prevent
+            // unmarked tests elsewhere in the workspace from reading
+            // HOME concurrently. No other test in this crate currently
+            // mutates or reads HOME outside its own `#[serial]` block,
+            // so the race window is empty today. A path-aware
+            // GlobalConfig API would eliminate this — tracked as a
+            // follow-up.
+            unsafe {
+                std::env::set_var("HOME", tmp.path());
+            }
+            Self {
+                _tmp: tmp,
+                original,
+            }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            // SAFETY: see HomeGuard::new.
+            unsafe {
+                match &self.original {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
+        }
+    }
+
+    fn seed_config(default_org: &str) {
+        let mut cfg = GlobalConfig::load().unwrap();
+        cfg.server.default_org = Some(default_org.to_string());
+        cfg.save().unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn config_unchanged_when_verifier_fails() {
+        let _guard = HomeGuard::new();
+        seed_config("old-org");
+
+        let cmd = OrgSet {
+            slug: "new-org".to_string(),
+            no_verify: false,
+        };
+
+        let result = cmd.run_with_verifier(|slug| {
+            // Simulate "slug not found on server".
+            Err(CliError::InvalidArgument {
+                message: format!("Organization '{slug}' not found on the server."),
+            })
+        });
+
+        assert!(result.is_err(), "verifier failure should propagate");
+
+        // Critical invariant: config on disk still has the old default.
+        let after = GlobalConfig::load().unwrap();
+        assert_eq!(
+            after.server.default_org.as_deref(),
+            Some("old-org"),
+            "default_org must not change when verification fails"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn config_written_when_verifier_succeeds() {
+        let _guard = HomeGuard::new();
+        seed_config("old-org");
+
+        let cmd = OrgSet {
+            slug: "new-org".to_string(),
+            no_verify: false,
+        };
+
+        let result = cmd.run_with_verifier(|_| Ok(()));
+        assert!(result.is_ok(), "verifier success path should succeed");
+
+        let after = GlobalConfig::load().unwrap();
+        assert_eq!(after.server.default_org.as_deref(), Some("new-org"));
+    }
+
+    #[test]
+    #[serial]
+    fn no_verify_skips_verifier_entirely() {
+        let _guard = HomeGuard::new();
+        seed_config("old-org");
+
+        // The verifier panics if called — `--no-verify` must short-circuit
+        // before reaching it.
+        let cmd = OrgSet {
+            slug: "new-org".to_string(),
+            no_verify: true,
+        };
+
+        let result =
+            cmd.run_with_verifier(|_| panic!("verifier must not be called when no_verify is true"));
+        assert!(result.is_ok());
+
+        let after = GlobalConfig::load().unwrap();
+        assert_eq!(after.server.default_org.as_deref(), Some("new-org"));
     }
 }

--- a/atomic-cli/src/commands/project/create.rs
+++ b/atomic-cli/src/commands/project/create.rs
@@ -5,13 +5,15 @@
 //! # Usage
 //!
 //! ```text
-//! atomic project create <NAME> --workspace <SLUG> [OPTIONS]
+//! atomic project create <NAME> [--workspace <SLUG>] [OPTIONS]
 //!
 //! Arguments:
 //!   <NAME>  Name of the project to create
 //!
 //! Options:
-//!   -w, --workspace <SLUG>     Workspace to create the project in (required)
+//!   -w, --workspace <SLUG>     Workspace to create the project in.
+//!                              Falls back to the default workspace for the
+//!                              current org if omitted.
 //!       --description <TEXT>   Optional description
 //!       --kind <KIND>          Project kind (rust, python, node, go, java, ruby, zig)
 //!       --default-view <NAME>  Default view name (default: "dev")
@@ -22,7 +24,13 @@
 //! # Examples
 //!
 //! ```text
+//! # Explicit workspace
 //! $ atomic project create my-service --workspace backend
+//! ✓ Created project: my-service (slug: my-service)
+//!
+//! # Uses the default workspace for the current org
+//! $ atomic workspace switch backend
+//! $ atomic project create my-service
 //! ✓ Created project: my-service (slug: my-service)
 //!
 //!   Workspace:    backend
@@ -39,7 +47,7 @@ use clap::Parser;
 
 use atomic_remote::storage_types::{CreateProjectRequest, Visibility};
 
-use crate::commands::client::{build_client, remote_err};
+use crate::commands::client::{build_client_with_org, remote_err, resolve_workspace};
 use crate::commands::Command;
 use crate::error::{CliError, CliResult};
 use crate::output::{print_next_steps, print_success, KeyValueTable};
@@ -48,6 +56,9 @@ use crate::output::{print_next_steps, print_success, KeyValueTable};
 ///
 /// The project will be created on the configured atomic-storage server
 /// and can then be linked to a local repository with `atomic project init`.
+///
+/// If `--workspace` is not given, falls back to the default workspace for
+/// the current org (set via `atomic workspace switch <slug>`).
 #[derive(Debug, Parser, Default)]
 #[command(name = "create")]
 pub struct ProjectCreate {
@@ -56,8 +67,10 @@ pub struct ProjectCreate {
     pub name: String,
 
     /// Workspace slug to create the project in.
-    #[arg(long, short = 'w', default_value = "")]
-    pub workspace: String,
+    ///
+    /// Falls back to the default workspace for the current org if omitted.
+    #[arg(long, short = 'w')]
+    pub workspace: Option<String>,
 
     /// Optional description for the project.
     #[arg(long)]
@@ -102,18 +115,13 @@ impl Command for ProjectCreate {
             });
         }
 
-        if self.workspace.is_empty() {
-            return Err(CliError::InvalidArgument {
-                message: "Workspace slug is required (--workspace).".to_string(),
-            });
-        }
-
         let rt = tokio::runtime::Runtime::new().map_err(|e| {
             CliError::Internal(anyhow::anyhow!("Failed to create async runtime: {}", e))
         })?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref())?;
+            let (client, org_slug) = build_client_with_org(self.org.as_deref())?;
+            let workspace = resolve_workspace(&org_slug, self.workspace.as_deref())?;
             let visibility = self.parse_visibility()?;
 
             let req = CreateProjectRequest {
@@ -125,7 +133,7 @@ impl Command for ProjectCreate {
             };
 
             let project = client
-                .create_project(&self.workspace, &req)
+                .create_project(&workspace, &req)
                 .await
                 .map_err(remote_err)?;
 
@@ -138,12 +146,12 @@ impl Command for ProjectCreate {
             let vcs_url = format!(
                 "{}/workspaces/{}/projects/{}/code",
                 client.base_url(),
-                self.workspace,
+                workspace,
                 project.slug,
             );
 
             let details = KeyValueTable::new()
-                .add("Workspace", &self.workspace)
+                .add("Workspace", &workspace)
                 .add("Default view", &project.default_view)
                 .add("Visibility", project.visibility.to_string())
                 .add("VCS URL", &vcs_url);
@@ -154,7 +162,7 @@ impl Command for ProjectCreate {
                 (
                     &format!(
                         "atomic project init {} --workspace {}",
-                        project.slug, self.workspace
+                        project.slug, workspace
                     ),
                     "Link a local repo to this project",
                 ),
@@ -174,7 +182,7 @@ mod tests {
     fn default_has_empty_fields() {
         let cmd = ProjectCreate::default();
         assert_eq!(cmd.name, "");
-        assert_eq!(cmd.workspace, "");
+        assert!(cmd.workspace.is_none());
         assert_eq!(cmd.default_view, "");
         assert!(cmd.description.is_none());
         assert!(cmd.kind.is_none());
@@ -185,7 +193,7 @@ mod tests {
     fn with_all_options() {
         let cmd = ProjectCreate {
             name: "svc".to_string(),
-            workspace: "backend".to_string(),
+            workspace: Some("backend".to_string()),
             description: Some("A microservice".to_string()),
             kind: Some("rust".to_string()),
             default_view: "main".to_string(),
@@ -193,7 +201,7 @@ mod tests {
             org: Some("acme".to_string()),
         };
         assert_eq!(cmd.name, "svc");
-        assert_eq!(cmd.workspace, "backend");
+        assert_eq!(cmd.workspace.as_deref(), Some("backend"));
         assert_eq!(cmd.description.as_deref(), Some("A microservice"));
         assert_eq!(cmd.kind.as_deref(), Some("rust"));
         assert_eq!(cmd.default_view, "main");
@@ -205,7 +213,7 @@ mod tests {
     fn parse_visibility_valid() {
         let cmd = ProjectCreate {
             name: "p".to_string(),
-            workspace: "w".to_string(),
+            workspace: Some("w".to_string()),
             visibility: "private".to_string(),
             ..Default::default()
         };
@@ -217,7 +225,7 @@ mod tests {
     fn parse_visibility_invalid() {
         let cmd = ProjectCreate {
             name: "p".to_string(),
-            workspace: "w".to_string(),
+            workspace: Some("w".to_string()),
             visibility: "bogus".to_string(),
             ..Default::default()
         };
@@ -232,22 +240,6 @@ mod tests {
         match result.unwrap_err() {
             CliError::InvalidArgument { message } => {
                 assert!(message.contains("required"));
-            }
-            other => panic!("expected InvalidArgument, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn empty_workspace_rejected() {
-        let cmd = ProjectCreate {
-            name: "proj".to_string(),
-            ..Default::default()
-        };
-        let result = cmd.run();
-        assert!(result.is_err());
-        match result.unwrap_err() {
-            CliError::InvalidArgument { message } => {
-                assert!(message.contains("Workspace"));
             }
             other => panic!("expected InvalidArgument, got {:?}", other),
         }

--- a/atomic-cli/src/commands/project/create.rs
+++ b/atomic-cli/src/commands/project/create.rs
@@ -24,10 +24,6 @@
 //! # Examples
 //!
 //! ```text
-//! # Explicit workspace
-//! $ atomic project create my-service --workspace backend
-//! ✓ Created project: my-service (slug: my-service)
-//!
 //! # Uses the default workspace for the current org
 //! $ atomic workspace set backend
 //! $ atomic project create my-service
@@ -38,6 +34,14 @@
 //!   Visibility:   private
 //!   VCS URL:      https://alice.atomic.storage/workspaces/backend/projects/my-service/code
 //!
+//! Next steps:
+//!   atomic project init my-service  Link a local repo to this project
+//!   atomic push                     Push changes to the remote
+//!
+//! # Explicit workspace — Next steps repeats the flag
+//! $ atomic project create my-service --workspace backend
+//! ✓ Created project: my-service (slug: my-service)
+//!   ...
 //! Next steps:
 //!   atomic project init my-service --workspace backend  Link a local repo to this project
 //!   atomic push                                         Push changes to the remote
@@ -158,14 +162,19 @@ impl Command for ProjectCreate {
 
             println!("{}", details);
 
+            // Mirror what the user typed when building the follow-up hint.
+            // Omitting flags that fell back to defaults reinforces that the
+            // default-workspace / default-org config is in effect.
+            let mut init_cmd = format!("atomic project init {}", project.slug);
+            if self.workspace.is_some() {
+                init_cmd.push_str(&format!(" --workspace {workspace}"));
+            }
+            if let Some(org) = self.org.as_deref() {
+                init_cmd.push_str(&format!(" --org {org}"));
+            }
+
             print_next_steps(&[
-                (
-                    &format!(
-                        "atomic project init {} --workspace {}",
-                        project.slug, workspace
-                    ),
-                    "Link a local repo to this project",
-                ),
+                (&init_cmd, "Link a local repo to this project"),
                 ("atomic push", "Push changes to the remote"),
             ]);
 

--- a/atomic-cli/src/commands/project/create.rs
+++ b/atomic-cli/src/commands/project/create.rs
@@ -29,7 +29,7 @@
 //! ✓ Created project: my-service (slug: my-service)
 //!
 //! # Uses the default workspace for the current org
-//! $ atomic workspace switch backend
+//! $ atomic workspace set backend
 //! $ atomic project create my-service
 //! ✓ Created project: my-service (slug: my-service)
 //!
@@ -58,7 +58,7 @@ use crate::output::{print_next_steps, print_success, KeyValueTable};
 /// and can then be linked to a local repository with `atomic project init`.
 ///
 /// If `--workspace` is not given, falls back to the default workspace for
-/// the current org (set via `atomic workspace switch <slug>`).
+/// the current org (set via `atomic workspace set <slug>`).
 #[derive(Debug, Parser, Default)]
 #[command(name = "create")]
 pub struct ProjectCreate {

--- a/atomic-cli/src/commands/project/init.rs
+++ b/atomic-cli/src/commands/project/init.rs
@@ -56,7 +56,7 @@ use crate::output::{print_info, print_next_steps, print_success};
 /// then stores the remote URL in the local repository configuration.
 ///
 /// If `--workspace` is omitted, falls back to the default workspace for
-/// the current org (set via `atomic workspace switch <slug>`).
+/// the current org (set via `atomic workspace set <slug>`).
 #[derive(Debug, Parser)]
 #[command(name = "init")]
 pub struct ProjectInit {

--- a/atomic-cli/src/commands/project/init.rs
+++ b/atomic-cli/src/commands/project/init.rs
@@ -11,13 +11,14 @@
 //! # Usage
 //!
 //! ```text
-//! atomic project init <NAME> --workspace <SLUG> [OPTIONS]
+//! atomic project init <NAME> [--workspace <SLUG>] [OPTIONS]
 //!
 //! Arguments:
 //!   <NAME>  Name of the project to create on the server
 //!
 //! Options:
-//!   -w, --workspace <SLUG>    Workspace slug (required)
+//!   -w, --workspace <SLUG>    Workspace slug. Falls back to the default
+//!                             workspace for the current org if omitted.
 //!       --kind <KIND>         Project kind (rust, python, node, go, java, ruby, zig)
 //!       --description <DESC>  Project description
 //!       --visibility <VIS>    Visibility (private or public) [default: private]
@@ -44,15 +45,18 @@ use clap::Parser;
 use atomic_remote::storage_types::{CreateProjectRequest, CreateWorkspaceRequest, Visibility};
 use atomic_repository::Repository;
 
-use crate::commands::client::{build_client, remote_err};
+use crate::commands::client::{build_client_with_org, remote_err, resolve_workspace};
 use crate::commands::{find_repository_root, Command};
 use crate::error::{CliError, CliResult};
-use crate::output::{print_hint, print_info, print_next_steps, print_success};
+use crate::output::{print_info, print_next_steps, print_success};
 
 /// Initialise a remote project from the current Atomic repository.
 ///
 /// Creates the project (and optionally the workspace) on the server,
 /// then stores the remote URL in the local repository configuration.
+///
+/// If `--workspace` is omitted, falls back to the default workspace for
+/// the current org (set via `atomic workspace switch <slug>`).
 #[derive(Debug, Parser)]
 #[command(name = "init")]
 pub struct ProjectInit {
@@ -63,9 +67,10 @@ pub struct ProjectInit {
     /// Workspace slug to create the project in.
     ///
     /// If the workspace does not exist on the server it will be created
-    /// automatically (with default settings).
-    #[arg(short = 'w', long, required = true)]
-    pub workspace: String,
+    /// automatically (with default settings). Falls back to the default
+    /// workspace for the current org if omitted.
+    #[arg(short = 'w', long)]
+    pub workspace: Option<String>,
 
     /// Project kind hint (rust, python, node, go, java, ruby, zig).
     ///
@@ -108,19 +113,20 @@ impl ProjectInit {
             other => CliError::Repository(other),
         })?;
 
-        // 2. Build the storage client.
-        let client = build_client(self.org.as_deref())?;
+        // 2. Build the storage client and resolve the workspace.
+        let (client, org_slug) = build_client_with_org(self.org.as_deref())?;
+        let workspace = resolve_workspace(&org_slug, self.workspace.as_deref())?;
 
         // 3. Ensure the workspace exists — create it if necessary.
         //    A 409 (Conflict) means it already exists, which is fine.
-        match client.get_workspace(&self.workspace).await {
+        match client.get_workspace(&workspace).await {
             Ok(_ws) => {
                 // Already exists — nothing to do.
             }
             Err(_) => {
                 // Try to create it. If the server returns 409 we ignore it.
                 let ws_req = CreateWorkspaceRequest {
-                    name: self.workspace.clone(),
+                    name: workspace.clone(),
                     description: None,
                     visibility: self.visibility,
                 };
@@ -138,7 +144,7 @@ impl ProjectInit {
                         {
                             print_info(&format!(
                                 "Workspace '{}' already exists, using it.",
-                                self.workspace
+                                workspace
                             ));
                         } else {
                             return Err(remote_err(e));
@@ -158,7 +164,7 @@ impl ProjectInit {
         };
 
         let project = client
-            .create_project(&self.workspace, &proj_req)
+            .create_project(&workspace, &proj_req)
             .await
             .map_err(remote_err)?;
 
@@ -166,7 +172,7 @@ impl ProjectInit {
         let vcs_url = format!(
             "{}/workspaces/{}/projects/{}/code",
             client.base_url(),
-            self.workspace,
+            workspace,
             project.slug,
         );
 
@@ -200,7 +206,7 @@ mod tests {
     fn command_fields() {
         let cmd = ProjectInit {
             name: "my-app".to_string(),
-            workspace: "my-ws".to_string(),
+            workspace: Some("my-ws".to_string()),
             kind: Some("rust".to_string()),
             description: Some("My app".to_string()),
             visibility: Visibility::Private,
@@ -208,7 +214,7 @@ mod tests {
         };
 
         assert_eq!(cmd.name, "my-app");
-        assert_eq!(cmd.workspace, "my-ws");
+        assert_eq!(cmd.workspace.as_deref(), Some("my-ws"));
         assert_eq!(cmd.kind.as_deref(), Some("rust"));
         assert_eq!(cmd.description.as_deref(), Some("My app"));
         assert_eq!(cmd.visibility, Visibility::Private);
@@ -219,7 +225,7 @@ mod tests {
     fn default_visibility_is_private() {
         let cmd = ProjectInit {
             name: "proj".to_string(),
-            workspace: "ws".to_string(),
+            workspace: Some("ws".to_string()),
             kind: None,
             description: None,
             visibility: Visibility::Private,
@@ -229,12 +235,25 @@ mod tests {
     }
 
     #[test]
+    fn workspace_can_be_omitted() {
+        let cmd = ProjectInit {
+            name: "proj".to_string(),
+            workspace: None,
+            kind: None,
+            description: None,
+            visibility: Visibility::Private,
+            org: None,
+        };
+        assert!(cmd.workspace.is_none());
+    }
+
+    #[test]
     fn run_outside_repo_fails() {
         // Running outside a repository should produce an error before
         // any network calls happen.
         let cmd = ProjectInit {
             name: "proj".to_string(),
-            workspace: "ws".to_string(),
+            workspace: Some("ws".to_string()),
             kind: None,
             description: None,
             visibility: Visibility::Private,

--- a/atomic-cli/src/commands/project/list.rs
+++ b/atomic-cli/src/commands/project/list.rs
@@ -6,10 +6,11 @@
 //! # Usage
 //!
 //! ```text
-//! atomic project list --workspace <SLUG> [OPTIONS]
+//! atomic project list [--workspace <SLUG>] [OPTIONS]
 //!
 //! Options:
-//!   -w, --workspace <SLUG>  Workspace slug (required)
+//!   -w, --workspace <SLUG>  Workspace slug. Falls back to the default
+//!                           workspace for the current org if omitted.
 //!       --org <ORG>         Organization override
 //!       --format <FORMAT>   Output format: table or json (default: table)
 //!   -h, --help              Print help information
@@ -18,18 +19,20 @@
 //! # Examples
 //!
 //! ```text
+//! # Explicit workspace
 //! $ atomic project list --workspace my-ws
 //! NAME          SLUG          VIEW   VISIBILITY  CREATED
 //! ─────────────────────────────────────────────────────────
 //! my-project    my-project    dev    private     2025-01-15 10:30:00
 //!
-//! $ atomic project list --workspace my-ws --format json
-//! [{"name":"my-project", ...}]
+//! # Uses the default workspace for the current org
+//! $ atomic workspace switch my-ws
+//! $ atomic project list
 //! ```
 
 use clap::Parser;
 
-use crate::commands::client::{build_client, remote_err};
+use crate::commands::client::{build_client_with_org, remote_err, resolve_workspace};
 use crate::commands::{format_timestamp, Command};
 use crate::error::{CliError, CliResult};
 use crate::output::{print_hint, Column, Table};
@@ -37,13 +40,16 @@ use crate::output::{print_hint, Column, Table};
 /// List all projects in a remote workspace.
 ///
 /// Shows projects with their name, slug, default view, visibility, and
-/// creation date. Requires the workspace slug to scope the listing.
+/// creation date. If `--workspace` is omitted, falls back to the default
+/// workspace for the current org.
 #[derive(Debug, Parser)]
 #[command(name = "list")]
 pub struct ProjectList {
     /// Workspace slug to list projects from.
-    #[arg(short, long, required = true)]
-    pub workspace: String,
+    ///
+    /// Falls back to the default workspace for the current org if omitted.
+    #[arg(short, long)]
+    pub workspace: Option<String>,
 
     /// Organization override (defaults to configured org).
     #[arg(long)]
@@ -61,9 +67,11 @@ impl Command for ProjectList {
         })?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref())?;
+            let (client, org_slug) = build_client_with_org(self.org.as_deref())?;
+            let workspace = resolve_workspace(&org_slug, self.workspace.as_deref())?;
+
             let projects = client
-                .list_projects(&self.workspace)
+                .list_projects(&workspace)
                 .await
                 .map_err(remote_err)?;
 
@@ -79,7 +87,7 @@ impl Command for ProjectList {
                 print_hint(&format!(
                     "No projects found in workspace '{}'. Create one with \
                      'atomic project create <name> --workspace {}'.",
-                    self.workspace, self.workspace
+                    workspace, workspace
                 ));
                 return Ok(());
             }
@@ -116,7 +124,7 @@ mod tests {
     #[test]
     fn default_format_is_table() {
         let cmd = ProjectList {
-            workspace: "ws".to_string(),
+            workspace: Some("ws".to_string()),
             org: None,
             format: "table".to_string(),
         };
@@ -126,12 +134,22 @@ mod tests {
     #[test]
     fn workspace_is_stored() {
         let cmd = ProjectList {
-            workspace: "my-workspace".to_string(),
+            workspace: Some("my-workspace".to_string()),
             org: Some("acme".to_string()),
             format: "json".to_string(),
         };
-        assert_eq!(cmd.workspace, "my-workspace");
+        assert_eq!(cmd.workspace.as_deref(), Some("my-workspace"));
         assert_eq!(cmd.org.as_deref(), Some("acme"));
         assert_eq!(cmd.format, "json");
+    }
+
+    #[test]
+    fn workspace_can_be_omitted() {
+        let cmd = ProjectList {
+            workspace: None,
+            org: None,
+            format: "table".to_string(),
+        };
+        assert!(cmd.workspace.is_none());
     }
 }

--- a/atomic-cli/src/commands/project/list.rs
+++ b/atomic-cli/src/commands/project/list.rs
@@ -81,10 +81,19 @@ impl Command for ProjectList {
             }
 
             if projects.is_empty() {
+                // Mirror the flags the user typed so the suggested follow-up
+                // resolves to the same org/workspace they were just looking
+                // at — not whatever the current defaults are.
+                let mut create_hint = String::from("atomic project create <name>");
+                if let Some(ws) = self.workspace.as_deref() {
+                    create_hint.push_str(&format!(" --workspace {ws}"));
+                }
+                if let Some(org) = self.org.as_deref() {
+                    create_hint.push_str(&format!(" --org {org}"));
+                }
                 print_hint(&format!(
-                    "No projects found in workspace '{}'. Create one with \
-                     'atomic project create <name> --workspace {}'.",
-                    workspace, workspace
+                    "No projects found in workspace '{workspace}'. \
+                     Create one with '{create_hint}'."
                 ));
                 return Ok(());
             }

--- a/atomic-cli/src/commands/project/list.rs
+++ b/atomic-cli/src/commands/project/list.rs
@@ -26,7 +26,7 @@
 //! my-project    my-project    dev    private     2025-01-15 10:30:00
 //!
 //! # Uses the default workspace for the current org
-//! $ atomic workspace switch my-ws
+//! $ atomic workspace set my-ws
 //! $ atomic project list
 //! ```
 

--- a/atomic-cli/src/commands/project/list.rs
+++ b/atomic-cli/src/commands/project/list.rs
@@ -70,10 +70,7 @@ impl Command for ProjectList {
             let (client, org_slug) = build_client_with_org(self.org.as_deref())?;
             let workspace = resolve_workspace(&org_slug, self.workspace.as_deref())?;
 
-            let projects = client
-                .list_projects(&workspace)
-                .await
-                .map_err(remote_err)?;
+            let projects = client.list_projects(&workspace).await.map_err(remote_err)?;
 
             if self.format == "json" {
                 println!(

--- a/atomic-cli/src/commands/project/mod.rs
+++ b/atomic-cli/src/commands/project/mod.rs
@@ -217,7 +217,7 @@ mod tests {
         }
 
         let list = list::ProjectList {
-            workspace: "ws".to_string(),
+            workspace: Some("ws".to_string()),
             org: None,
             format: "table".to_string(),
         };
@@ -225,7 +225,7 @@ mod tests {
 
         let create = create::ProjectCreate {
             name: "proj".to_string(),
-            workspace: "ws".to_string(),
+            workspace: Some("ws".to_string()),
             description: None,
             kind: None,
             default_view: "dev".to_string(),

--- a/atomic-cli/src/commands/project/mod.rs
+++ b/atomic-cli/src/commands/project/mod.rs
@@ -66,11 +66,14 @@ pub fn parse_project_path(path: &str) -> CliResult<(&str, &str)> {
 pub enum ProjectCommands {
     /// List projects in a workspace.
     ///
-    /// Shows all projects within the specified workspace.
+    /// Shows all projects within a workspace. If `--workspace` is omitted,
+    /// uses the default workspace for the current org (set via
+    /// `atomic workspace switch`).
     ///
     /// # Examples
     ///
     /// ```text
+    /// atomic project list
     /// atomic project list --workspace my-ws
     /// atomic project list --workspace my-ws --format json
     /// ```
@@ -78,11 +81,14 @@ pub enum ProjectCommands {
 
     /// Create a new remote project.
     ///
-    /// Creates a project inside an existing workspace on the server.
+    /// Creates a project inside a workspace on the server. If `--workspace`
+    /// is omitted, uses the default workspace for the current org (set via
+    /// `atomic workspace switch`).
     ///
     /// # Examples
     ///
     /// ```text
+    /// atomic project create my-project
     /// atomic project create my-project --workspace my-ws
     /// atomic project create my-project --workspace my-ws --kind rust
     /// ```
@@ -128,11 +134,14 @@ pub enum ProjectCommands {
     /// Initialize a local repo as a remote project.
     ///
     /// Creates the project on the server and configures the local
-    /// repository with the remote URL.
+    /// repository with the remote URL. If `--workspace` is omitted, uses
+    /// the default workspace for the current org (set via
+    /// `atomic workspace switch`).
     ///
     /// # Examples
     ///
     /// ```text
+    /// atomic project init my-project
     /// atomic project init my-project --workspace my-ws
     /// atomic project init my-project --workspace my-ws --kind rust
     /// ```

--- a/atomic-cli/src/commands/project/mod.rs
+++ b/atomic-cli/src/commands/project/mod.rs
@@ -68,7 +68,7 @@ pub enum ProjectCommands {
     ///
     /// Shows all projects within a workspace. If `--workspace` is omitted,
     /// uses the default workspace for the current org (set via
-    /// `atomic workspace switch`).
+    /// `atomic workspace set`).
     ///
     /// # Examples
     ///
@@ -83,7 +83,7 @@ pub enum ProjectCommands {
     ///
     /// Creates a project inside a workspace on the server. If `--workspace`
     /// is omitted, uses the default workspace for the current org (set via
-    /// `atomic workspace switch`).
+    /// `atomic workspace set`).
     ///
     /// # Examples
     ///
@@ -136,7 +136,7 @@ pub enum ProjectCommands {
     /// Creates the project on the server and configures the local
     /// repository with the remote URL. If `--workspace` is omitted, uses
     /// the default workspace for the current org (set via
-    /// `atomic workspace switch`).
+    /// `atomic workspace set`).
     ///
     /// # Examples
     ///

--- a/atomic-cli/src/commands/record/tests.rs
+++ b/atomic-cli/src/commands/record/tests.rs
@@ -6,7 +6,49 @@ use super::*;
 mod tests {
     use super::*;
     use serial_test::serial;
+    use std::ffi::OsString;
     use std::path::PathBuf;
+
+    const AI_ENV_KEYS: &[&str] = &[
+        "ATOMIC_AI_ENABLED",
+        "ATOMIC_AI_PROVIDER",
+        "ATOMIC_AI_MODEL",
+        "ATOMIC_AI_TOOL",
+        "ATOMIC_AI_SUGGESTION_TYPE",
+        "ATOMIC_AI_INPUT_TOKENS",
+        "ATOMIC_AI_OUTPUT_TOKENS",
+        "ATOMIC_AI_COST_USD",
+        "ATOMIC_AI_REQUEST_ID",
+        "ATOMIC_AI_SESSION_ID",
+    ];
+
+    struct AiEnvGuard {
+        original: Vec<(&'static str, Option<OsString>)>,
+    }
+
+    impl AiEnvGuard {
+        fn clear() -> Self {
+            let original = AI_ENV_KEYS
+                .iter()
+                .map(|&key| (key, std::env::var_os(key)))
+                .collect();
+            for key in AI_ENV_KEYS {
+                std::env::remove_var(key);
+            }
+            Self { original }
+        }
+    }
+
+    impl Drop for AiEnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in &self.original {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
 
     // Record Command Construction Tests
 
@@ -632,14 +674,18 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_build_provenance_disabled() {
+        let _env = AiEnvGuard::clear();
         let record = Record::new();
         let provenance = record.build_provenance();
         assert!(provenance.is_none());
     }
 
     #[test]
+    #[serial]
     fn test_build_provenance_enabled_without_provider() {
+        let _env = AiEnvGuard::clear();
         let record = Record::new().with_ai_assisted(true);
         // Without provider, provenance should be None
         let provenance = record.build_provenance();
@@ -785,7 +831,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_build_options_without_provenance() {
+        let _env = AiEnvGuard::clear();
         let record = Record::new();
         let options = record.build_options().unwrap();
         assert!(!options.has_provenance());
@@ -795,6 +843,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_build_provenance_from_env_var() {
+        let _env = AiEnvGuard::clear();
         // Set environment variables
         std::env::set_var("ATOMIC_AI_ENABLED", "true");
         std::env::set_var("ATOMIC_AI_PROVIDER", "openai");
@@ -817,6 +866,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_build_provenance_cli_overrides_env() {
+        let _env = AiEnvGuard::clear();
         // Set environment variables
         std::env::set_var("ATOMIC_AI_ENABLED", "true");
         std::env::set_var("ATOMIC_AI_PROVIDER", "openai");

--- a/atomic-cli/src/commands/workspace/create.rs
+++ b/atomic-cli/src/commands/workspace/create.rs
@@ -109,7 +109,7 @@ impl Command for WorkspaceCreate {
 
             print_next_steps(&[
                 (
-                    &format!("atomic workspace switch {}", ws.slug),
+                    &format!("atomic workspace set {}", ws.slug),
                     "Set as your default workspace",
                 ),
                 (

--- a/atomic-cli/src/commands/workspace/create.rs
+++ b/atomic-cli/src/commands/workspace/create.rs
@@ -109,10 +109,14 @@ impl Command for WorkspaceCreate {
 
             print_next_steps(&[
                 (
-                    &format!("atomic project create <name> --workspace {}", ws.slug),
+                    &format!("atomic workspace switch {}", ws.slug),
+                    "Set as your default workspace",
+                ),
+                (
+                    "atomic project create <project-name>",
                     "Create a project in this workspace",
                 ),
-                ("atomic workspace list", "List all workspaces"),
+                ("atomic workspace list", "View all workspaces"),
             ]);
 
             Ok(())

--- a/atomic-cli/src/commands/workspace/delete.rs
+++ b/atomic-cli/src/commands/workspace/delete.rs
@@ -115,9 +115,8 @@ impl Command for WorkspaceDelete {
 /// Remove a deleted workspace from `[server.default_workspaces]` if it was
 /// the configured default for its org.
 fn clean_up_local_config(org_slug: &str, deleted_workspace: &str) -> CliResult<()> {
-    let mut config = GlobalConfig::load().map_err(|e| {
-        CliError::Internal(anyhow::anyhow!("Failed to load global config: {e}"))
-    })?;
+    let mut config = GlobalConfig::load()
+        .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load global config: {e}")))?;
 
     let was_default = config
         .server
@@ -131,9 +130,9 @@ fn clean_up_local_config(org_slug: &str, deleted_workspace: &str) -> CliResult<(
     }
 
     config.server.default_workspaces.remove(org_slug);
-    config.save().map_err(|e| {
-        CliError::Internal(anyhow::anyhow!("Failed to save global config: {e}"))
-    })?;
+    config
+        .save()
+        .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to save global config: {e}")))?;
 
     print_hint(&format!(
         "Default workspace for '{org_slug}' was '{deleted_workspace}' — \

--- a/atomic-cli/src/commands/workspace/delete.rs
+++ b/atomic-cli/src/commands/workspace/delete.rs
@@ -136,7 +136,7 @@ fn clean_up_local_config(org_slug: &str, deleted_workspace: &str) -> CliResult<(
 
     print_hint(&format!(
         "Default workspace for '{org_slug}' was '{deleted_workspace}' — \
-         run 'atomic workspace switch <slug>' to pick a new one."
+         run 'atomic workspace set <slug>' to pick a new one."
     ));
 
     Ok(())

--- a/atomic-cli/src/commands/workspace/delete.rs
+++ b/atomic-cli/src/commands/workspace/delete.rs
@@ -34,10 +34,12 @@
 
 use clap::Parser;
 
-use crate::commands::client::{build_client, remote_err};
+use atomic_config::GlobalConfig;
+
+use crate::commands::client::{build_client_with_org, remote_err};
 use crate::commands::Command;
 use crate::error::{CliError, CliResult};
-use crate::output::{print_error, print_success, print_warning};
+use crate::output::{print_error, print_hint, print_success, print_warning};
 
 /// Delete a remote workspace.
 ///
@@ -88,7 +90,7 @@ impl Command for WorkspaceDelete {
                 }
             }
 
-            let client = build_client(self.org.as_deref())?;
+            let (client, org_slug) = build_client_with_org(self.org.as_deref())?;
 
             client
                 .delete_workspace(&self.slug)
@@ -97,9 +99,48 @@ impl Command for WorkspaceDelete {
 
             print_success(&format!("Deleted workspace: {}", self.slug));
 
+            // If this workspace was the default for the org we just operated
+            // in, remove the stale entry so subsequent commands don't hit a
+            // confusing 404. Server-side deletion succeeded; config cleanup
+            // is best-effort.
+            if let Err(e) = clean_up_local_config(&org_slug, &self.slug) {
+                log::warn!("Failed to clean up local config after workspace delete: {e}");
+            }
+
             Ok(())
         })
     }
+}
+
+/// Remove a deleted workspace from `[server.default_workspaces]` if it was
+/// the configured default for its org.
+fn clean_up_local_config(org_slug: &str, deleted_workspace: &str) -> CliResult<()> {
+    let mut config = GlobalConfig::load().map_err(|e| {
+        CliError::Internal(anyhow::anyhow!("Failed to load global config: {e}"))
+    })?;
+
+    let was_default = config
+        .server
+        .default_workspaces
+        .get(org_slug)
+        .map(|v| v == deleted_workspace)
+        .unwrap_or(false);
+
+    if !was_default {
+        return Ok(());
+    }
+
+    config.server.default_workspaces.remove(org_slug);
+    config.save().map_err(|e| {
+        CliError::Internal(anyhow::anyhow!("Failed to save global config: {e}"))
+    })?;
+
+    print_hint(&format!(
+        "Default workspace for '{org_slug}' was '{deleted_workspace}' — \
+         run 'atomic workspace switch <slug>' to pick a new one."
+    ));
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/atomic-cli/src/commands/workspace/mod.rs
+++ b/atomic-cli/src/commands/workspace/mod.rs
@@ -15,7 +15,7 @@
 //!   show    Show workspace details
 //!   update  Update a workspace
 //!   delete  Delete a workspace
-//!   switch  Set the default workspace for an org
+//!   set     Set the default workspace for an org
 //!
 //! Options:
 //!   -h, --help  Print help information
@@ -47,15 +47,15 @@
 //! ✓ Deleted workspace: my-team
 //!
 //! # Set the default workspace for the current org
-//! $ atomic workspace switch my-team
+//! $ atomic workspace set my-team
 //! ✓ Default workspace for 'acme' set to: my-team
 //! ```
 
 pub mod create;
 pub mod delete;
 pub mod list;
+pub mod set;
 pub mod show;
-pub mod switch;
 pub mod update;
 
 use clap::Subcommand;
@@ -63,8 +63,8 @@ use clap::Subcommand;
 pub use create::WorkspaceCreate;
 pub use delete::WorkspaceDelete;
 pub use list::WorkspaceList;
+pub use set::WorkspaceSet;
 pub use show::WorkspaceShow;
-pub use switch::WorkspaceSwitch;
 pub use update::WorkspaceUpdate;
 
 use crate::commands::Command;
@@ -148,10 +148,10 @@ pub enum WorkspaceCommands {
     /// # Examples
     ///
     /// ```text
-    /// atomic workspace switch my-team
-    /// atomic workspace switch personal --org alice
+    /// atomic workspace set my-team
+    /// atomic workspace set personal --org alice
     /// ```
-    Switch(WorkspaceSwitch),
+    Set(WorkspaceSet),
 }
 
 /// Workspace management command.
@@ -173,7 +173,7 @@ impl Command for WorkspaceCmd {
             WorkspaceCommands::Show(cmd) => cmd.run(),
             WorkspaceCommands::Update(cmd) => cmd.run(),
             WorkspaceCommands::Delete(cmd) => cmd.run(),
-            WorkspaceCommands::Switch(cmd) => cmd.run(),
+            WorkspaceCommands::Set(cmd) => cmd.run(),
         }
     }
 }
@@ -191,7 +191,7 @@ mod tests {
                 WorkspaceCommands::Show(_) => "show",
                 WorkspaceCommands::Update(_) => "update",
                 WorkspaceCommands::Delete(_) => "delete",
-                WorkspaceCommands::Switch(_) => "switch",
+                WorkspaceCommands::Set(_) => "set",
             }
         }
 
@@ -200,13 +200,13 @@ mod tests {
         let show = WorkspaceShow::default();
         let update = WorkspaceUpdate::default();
         let delete = WorkspaceDelete::default();
-        let switch = WorkspaceSwitch::default();
+        let set = WorkspaceSet::default();
 
         assert_eq!(check_variant(&WorkspaceCommands::List(list)), "list");
         assert_eq!(check_variant(&WorkspaceCommands::Create(create)), "create");
         assert_eq!(check_variant(&WorkspaceCommands::Show(show)), "show");
         assert_eq!(check_variant(&WorkspaceCommands::Update(update)), "update");
         assert_eq!(check_variant(&WorkspaceCommands::Delete(delete)), "delete");
-        assert_eq!(check_variant(&WorkspaceCommands::Switch(switch)), "switch");
+        assert_eq!(check_variant(&WorkspaceCommands::Set(set)), "set");
     }
 }

--- a/atomic-cli/src/commands/workspace/mod.rs
+++ b/atomic-cli/src/commands/workspace/mod.rs
@@ -15,6 +15,7 @@
 //!   show    Show workspace details
 //!   update  Update a workspace
 //!   delete  Delete a workspace
+//!   switch  Set the default workspace for an org
 //!
 //! Options:
 //!   -h, --help  Print help information
@@ -44,12 +45,17 @@
 //! # Delete a workspace
 //! $ atomic workspace delete my-team --force
 //! ✓ Deleted workspace: my-team
+//!
+//! # Set the default workspace for the current org
+//! $ atomic workspace switch my-team
+//! ✓ Default workspace for 'acme' set to: my-team
 //! ```
 
 pub mod create;
 pub mod delete;
 pub mod list;
 pub mod show;
+pub mod switch;
 pub mod update;
 
 use clap::Subcommand;
@@ -58,6 +64,7 @@ pub use create::WorkspaceCreate;
 pub use delete::WorkspaceDelete;
 pub use list::WorkspaceList;
 pub use show::WorkspaceShow;
+pub use switch::WorkspaceSwitch;
 pub use update::WorkspaceUpdate;
 
 use crate::commands::Command;
@@ -131,6 +138,20 @@ pub enum WorkspaceCommands {
     /// atomic workspace delete my-team --force
     /// ```
     Delete(WorkspaceDelete),
+
+    /// Set the default workspace for an org.
+    ///
+    /// Stores the chosen workspace slug in `[server.default_workspaces]`
+    /// keyed by the target org. Subsequent commands that take an optional
+    /// `--workspace` parameter fall back to this default.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// atomic workspace switch my-team
+    /// atomic workspace switch personal --org alice
+    /// ```
+    Switch(WorkspaceSwitch),
 }
 
 /// Workspace management command.
@@ -152,6 +173,7 @@ impl Command for WorkspaceCmd {
             WorkspaceCommands::Show(cmd) => cmd.run(),
             WorkspaceCommands::Update(cmd) => cmd.run(),
             WorkspaceCommands::Delete(cmd) => cmd.run(),
+            WorkspaceCommands::Switch(cmd) => cmd.run(),
         }
     }
 }
@@ -169,6 +191,7 @@ mod tests {
                 WorkspaceCommands::Show(_) => "show",
                 WorkspaceCommands::Update(_) => "update",
                 WorkspaceCommands::Delete(_) => "delete",
+                WorkspaceCommands::Switch(_) => "switch",
             }
         }
 
@@ -177,11 +200,13 @@ mod tests {
         let show = WorkspaceShow::default();
         let update = WorkspaceUpdate::default();
         let delete = WorkspaceDelete::default();
+        let switch = WorkspaceSwitch::default();
 
         assert_eq!(check_variant(&WorkspaceCommands::List(list)), "list");
         assert_eq!(check_variant(&WorkspaceCommands::Create(create)), "create");
         assert_eq!(check_variant(&WorkspaceCommands::Show(show)), "show");
         assert_eq!(check_variant(&WorkspaceCommands::Update(update)), "update");
         assert_eq!(check_variant(&WorkspaceCommands::Delete(delete)), "delete");
+        assert_eq!(check_variant(&WorkspaceCommands::Switch(switch)), "switch");
     }
 }

--- a/atomic-cli/src/commands/workspace/set.rs
+++ b/atomic-cli/src/commands/workspace/set.rs
@@ -45,9 +45,8 @@
 use clap::Parser;
 
 use atomic_config::GlobalConfig;
-use atomic_remote::RemoteError;
 
-use crate::commands::client::build_client_with_org;
+use crate::commands::client::{build_client_with_org, remote_err};
 use crate::commands::Command;
 use crate::error::{CliError, CliResult};
 use crate::output::{print_hint, print_success};
@@ -88,6 +87,21 @@ pub struct WorkspaceSet {
 
 impl Command for WorkspaceSet {
     fn run(&self) -> CliResult<()> {
+        self.run_with_verifier(verify_workspace_exists)
+    }
+}
+
+impl WorkspaceSet {
+    /// Inner runner that takes the slug-verification step as a parameter.
+    ///
+    /// Splitting this out lets tests inject a deterministic verifier
+    /// (succeed / fail) without making a real network call, so we can
+    /// assert the load-bearing invariant: **when verification fails, the
+    /// config file is not modified**.
+    fn run_with_verifier<F>(&self, verify: F) -> CliResult<()>
+    where
+        F: FnOnce(&str, &str) -> CliResult<()>,
+    {
         if self.slug.is_empty() {
             return Err(CliError::InvalidArgument {
                 message: "Workspace slug cannot be empty.".to_string(),
@@ -122,8 +136,10 @@ impl Command for WorkspaceSet {
 
         // Validate against the server first so a bad slug fails fast
         // rather than producing confusing 404s on subsequent commands.
+        // The `?` here is load-bearing: if it returns Err, the mutation
+        // and save below never execute.
         if !self.no_verify {
-            verify_workspace_exists(&target_org, &self.slug)?;
+            verify(&target_org, &self.slug)?;
         }
 
         let previous = config
@@ -180,16 +196,9 @@ fn verify_workspace_exists(org_slug: &str, workspace_slug: &str) -> CliResult<()
                      Or pass --no-verify to set the value without checking."
                 ),
             }),
-            Err(e) => Err(map_remote(e)),
+            Err(e) => Err(remote_err(e)),
         }
     })
-}
-
-fn map_remote(e: RemoteError) -> CliError {
-    CliError::RemoteError {
-        message: e.to_string(),
-        url: None,
-    }
 }
 
 #[cfg(test)]
@@ -239,5 +248,172 @@ mod tests {
         assert_eq!(cmd.slug, "backend");
         assert_eq!(cmd.org.as_deref(), Some("acme"));
         assert!(!cmd.no_verify);
+    }
+
+    // -----------------------------------------------------------------
+    // Regression invariant: when the verifier fails, config must NOT be
+    // mutated. Protects against accidentally reordering verify / save in
+    // future refactors.
+    //
+    // Tests touch HOME to redirect `GlobalConfig::{load,save}` at an
+    // isolated config dir, so `#[serial]` is required.
+    // -----------------------------------------------------------------
+
+    use serial_test::serial;
+
+    struct HomeGuard {
+        _tmp: tempfile::TempDir,
+        original: Option<std::ffi::OsString>,
+    }
+
+    impl HomeGuard {
+        fn new() -> Self {
+            let tmp = tempfile::tempdir().unwrap();
+            let original = std::env::var_os("HOME");
+            // SAFETY: env mutation is technically UB if accessed
+            // concurrently from another thread. `#[serial]` serializes
+            // these tests against each other but does NOT prevent
+            // unmarked tests elsewhere in the workspace from reading
+            // HOME concurrently. No other test in this crate currently
+            // mutates or reads HOME outside its own `#[serial]` block,
+            // so the race window is empty today. A path-aware
+            // GlobalConfig API would eliminate this — tracked as a
+            // follow-up.
+            unsafe {
+                std::env::set_var("HOME", tmp.path());
+            }
+            Self {
+                _tmp: tmp,
+                original,
+            }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            // SAFETY: see HomeGuard::new.
+            unsafe {
+                match &self.original {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
+        }
+    }
+
+    fn seed_config(default_org: &str, existing_workspace: Option<(&str, &str)>) {
+        let mut cfg = GlobalConfig::load().unwrap();
+        cfg.server.default_org = Some(default_org.to_string());
+        if let Some((org, ws)) = existing_workspace {
+            cfg.server
+                .default_workspaces
+                .insert(org.to_string(), ws.to_string());
+        }
+        cfg.save().unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn config_unchanged_when_verifier_fails() {
+        let _guard = HomeGuard::new();
+        seed_config("acme", Some(("acme", "old-ws")));
+
+        let cmd = WorkspaceSet {
+            slug: "new-ws".to_string(),
+            org: None, // use default org "acme"
+            no_verify: false,
+        };
+
+        let result = cmd.run_with_verifier(|org, ws| {
+            Err(CliError::InvalidArgument {
+                message: format!("Workspace '{ws}' not found in org '{org}'."),
+            })
+        });
+
+        assert!(result.is_err(), "verifier failure should propagate");
+
+        // Critical invariant: the old workspace mapping is still there,
+        // unchanged.
+        let after = GlobalConfig::load().unwrap();
+        assert_eq!(
+            after.server.default_workspaces.get("acme"),
+            Some(&"old-ws".to_string()),
+            "default_workspaces[acme] must not change when verification fails"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn config_written_when_verifier_succeeds() {
+        let _guard = HomeGuard::new();
+        seed_config("acme", Some(("acme", "old-ws")));
+
+        let cmd = WorkspaceSet {
+            slug: "new-ws".to_string(),
+            org: None,
+            no_verify: false,
+        };
+
+        let result = cmd.run_with_verifier(|_, _| Ok(()));
+        assert!(result.is_ok(), "verifier success path should succeed");
+
+        let after = GlobalConfig::load().unwrap();
+        assert_eq!(
+            after.server.default_workspaces.get("acme"),
+            Some(&"new-ws".to_string()),
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn no_verify_skips_verifier_entirely() {
+        let _guard = HomeGuard::new();
+        seed_config("acme", None);
+
+        // Verifier panics if called — `--no-verify` must short-circuit.
+        let cmd = WorkspaceSet {
+            slug: "new-ws".to_string(),
+            org: None,
+            no_verify: true,
+        };
+
+        let result = cmd
+            .run_with_verifier(|_, _| panic!("verifier must not be called when no_verify is true"));
+        assert!(result.is_ok());
+
+        let after = GlobalConfig::load().unwrap();
+        assert_eq!(
+            after.server.default_workspaces.get("acme"),
+            Some(&"new-ws".to_string()),
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn explicit_org_overrides_default_for_target() {
+        // Side-benefit test: writing to a non-default org leaves the
+        // default org's workspace alone.
+        let _guard = HomeGuard::new();
+        seed_config("acme", Some(("acme", "acme-ws")));
+
+        let cmd = WorkspaceSet {
+            slug: "alice-ws".to_string(),
+            org: Some("alice".to_string()),
+            no_verify: false,
+        };
+
+        let result = cmd.run_with_verifier(|_, _| Ok(()));
+        assert!(result.is_ok());
+
+        let after = GlobalConfig::load().unwrap();
+        assert_eq!(
+            after.server.default_workspaces.get("acme"),
+            Some(&"acme-ws".to_string()),
+            "acme's workspace must not change when writing to alice"
+        );
+        assert_eq!(
+            after.server.default_workspaces.get("alice"),
+            Some(&"alice-ws".to_string()),
+        );
     }
 }

--- a/atomic-cli/src/commands/workspace/set.rs
+++ b/atomic-cli/src/commands/workspace/set.rs
@@ -5,10 +5,14 @@
 //! updates that map for the current default org, or for an explicit org
 //! passed via `--org`.
 //!
+//! The slug is validated against the server before being written to
+//! config — typos fail immediately instead of surfacing as confusing
+//! 404s on the next `project create / list / init`.
+//!
 //! # Usage
 //!
 //! ```text
-//! atomic workspace set <SLUG> [--org <ORG>]
+//! atomic workspace set <SLUG> [--org <ORG>] [--no-verify]
 //!
 //! Arguments:
 //!   <SLUG>  Workspace slug to set as the default for the target org
@@ -16,26 +20,34 @@
 //! Options:
 //!       --org <ORG>  Set the default workspace for this org instead
 //!                    of the current default org
+//!       --no-verify  Skip server-side slug validation (advanced)
 //!   -h, --help       Print help information
 //! ```
 //!
 //! # Examples
 //!
 //! ```text
-//! # Set default workspace for the current org
+//! # Set default workspace for the current org (validated against the server)
 //! $ atomic workspace set backend
 //! ✓ Default workspace for 'acme' set to: backend
 //!
-//! # Set default workspace for a different org (does not change current org)
+//! # Typo: fails before any config change
+//! $ atomic workspace set backendz
+//! ✗ Workspace 'backendz' not found in org 'acme'.
+//!
+//! # Set default workspace for a different org
 //! $ atomic workspace set personal --org alice
-//! ✓ Default workspace for 'alice' set to: personal
-//!   (current default org is 'acme' — run 'atomic org set alice' to use it)
+//!
+//! # Skip validation (e.g. pre-configuring before the workspace exists)
+//! $ atomic workspace set new-ws --no-verify
 //! ```
 
 use clap::Parser;
 
 use atomic_config::GlobalConfig;
+use atomic_remote::RemoteError;
 
+use crate::commands::client::build_client_with_org;
 use crate::commands::Command;
 use crate::error::{CliError, CliResult};
 use crate::output::{print_hint, print_success};
@@ -46,9 +58,8 @@ use crate::output::{print_hint, print_success};
 /// All subsequent commands that take an optional `--workspace` parameter
 /// fall back to this slug for the target org.
 ///
-/// This command does **not** validate that the slug exists on the server.
-/// If the slug is invalid, subsequent commands will fail with a "not found"
-/// error. This matches the behavior of `atomic org set`.
+/// Validates the slug against the server before saving. Pass `--no-verify`
+/// to skip the network round-trip.
 #[derive(Debug, Parser, Default)]
 #[command(name = "set")]
 pub struct WorkspaceSet {
@@ -66,6 +77,13 @@ pub struct WorkspaceSet {
     /// are not currently using as the default.
     #[arg(long, value_name = "ORG")]
     pub org: Option<String>,
+
+    /// Skip server-side slug validation.
+    ///
+    /// Useful for pre-configuring a workspace slug before the workspace
+    /// exists on the server, or for offline workflows.
+    #[arg(long)]
+    pub no_verify: bool,
 }
 
 impl Command for WorkspaceSet {
@@ -80,9 +98,10 @@ impl Command for WorkspaceSet {
             CliError::Internal(anyhow::anyhow!("Failed to load global config: {e}"))
         })?;
 
-        // Determine the target org. Explicit --org wins; otherwise fall back
-        // to the configured default. We don't go through `resolve_org` here
-        // because we want a distinct error message tied to *this* command.
+        // Determine the target org. Explicit --org wins; otherwise fall
+        // back to the configured default. We don't go through `resolve_org`
+        // here because we want a distinct error message tied to *this*
+        // command's flow.
         let target_org = match self.org.as_deref() {
             Some(o) if !o.is_empty() => o.to_string(),
             Some(_) => {
@@ -100,6 +119,12 @@ impl Command for WorkspaceSet {
                         .to_string(),
                 })?,
         };
+
+        // Validate against the server first so a bad slug fails fast
+        // rather than producing confusing 404s on subsequent commands.
+        if !self.no_verify {
+            verify_workspace_exists(&target_org, &self.slug)?;
+        }
 
         let previous = config
             .server
@@ -136,6 +161,37 @@ impl Command for WorkspaceSet {
     }
 }
 
+/// Confirm the workspace slug resolves on the server under the target org.
+///
+/// 404s surface as a clean slug-specific message; other failures (network,
+/// auth, wrong org) bubble through so the user can distinguish problems.
+fn verify_workspace_exists(org_slug: &str, workspace_slug: &str) -> CliResult<()> {
+    let rt = tokio::runtime::Runtime::new()
+        .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to create async runtime: {e}")))?;
+
+    rt.block_on(async {
+        let (client, _resolved) = build_client_with_org(Some(org_slug))?;
+        match client.get_workspace(workspace_slug).await {
+            Ok(_) => Ok(()),
+            Err(e) if e.is_not_found() => Err(CliError::InvalidArgument {
+                message: format!(
+                    "Workspace '{workspace_slug}' not found in org '{org_slug}'.\n  \
+                     Check the slug with: atomic workspace list --org {org_slug}\n  \
+                     Or pass --no-verify to set the value without checking."
+                ),
+            }),
+            Err(e) => Err(map_remote(e)),
+        }
+    })
+}
+
+fn map_remote(e: RemoteError) -> CliError {
+    CliError::RemoteError {
+        message: e.to_string(),
+        url: None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -145,13 +201,14 @@ mod tests {
         let cmd = WorkspaceSet {
             slug: "".to_string(),
             org: None,
+            no_verify: true, // skip network so the empty-slug check is the only failure
         };
         let err = cmd.run().unwrap_err();
         match err {
             CliError::InvalidArgument { message } => {
                 assert!(message.contains("cannot be empty"));
             }
-            other => panic!("expected InvalidArgument, got {:?}", other),
+            other => panic!("expected InvalidArgument, got {other:?}"),
         }
     }
 
@@ -160,6 +217,7 @@ mod tests {
         let cmd = WorkspaceSet {
             slug: "backend".to_string(),
             org: Some("".to_string()),
+            no_verify: true,
         };
         let err = cmd.run().unwrap_err();
         match err {
@@ -167,7 +225,7 @@ mod tests {
                 assert!(message.contains("Organization"));
                 assert!(message.contains("empty"));
             }
-            other => panic!("expected InvalidArgument, got {:?}", other),
+            other => panic!("expected InvalidArgument, got {other:?}"),
         }
     }
 
@@ -176,8 +234,10 @@ mod tests {
         let cmd = WorkspaceSet {
             slug: "backend".to_string(),
             org: Some("acme".to_string()),
+            no_verify: false,
         };
         assert_eq!(cmd.slug, "backend");
         assert_eq!(cmd.org.as_deref(), Some("acme"));
+        assert!(!cmd.no_verify);
     }
 }

--- a/atomic-cli/src/commands/workspace/set.rs
+++ b/atomic-cli/src/commands/workspace/set.rs
@@ -1,4 +1,4 @@
-//! The `workspace switch` command for setting a default workspace per org.
+//! The `workspace set` command for setting a default workspace per org.
 //!
 //! Workspaces are org-scoped, so the default is stored per org in
 //! `server.default_workspaces` (a map keyed by org slug). This command
@@ -8,7 +8,7 @@
 //! # Usage
 //!
 //! ```text
-//! atomic workspace switch <SLUG> [--org <ORG>]
+//! atomic workspace set <SLUG> [--org <ORG>]
 //!
 //! Arguments:
 //!   <SLUG>  Workspace slug to set as the default for the target org
@@ -23,13 +23,13 @@
 //!
 //! ```text
 //! # Set default workspace for the current org
-//! $ atomic workspace switch backend
+//! $ atomic workspace set backend
 //! ✓ Default workspace for 'acme' set to: backend
 //!
 //! # Set default workspace for a different org (does not change current org)
-//! $ atomic workspace switch personal --org alice
+//! $ atomic workspace set personal --org alice
 //! ✓ Default workspace for 'alice' set to: personal
-//!   (current default org is 'acme' — run 'atomic org switch alice' to use it)
+//!   (current default org is 'acme' — run 'atomic org set alice' to use it)
 //! ```
 
 use clap::Parser;
@@ -40,7 +40,7 @@ use crate::commands::Command;
 use crate::error::{CliError, CliResult};
 use crate::output::{print_hint, print_success};
 
-/// Switch the default workspace for an org.
+/// Set the default workspace for an org.
 ///
 /// Updates `[server.default_workspaces]` in the global configuration file.
 /// All subsequent commands that take an optional `--workspace` parameter
@@ -48,10 +48,10 @@ use crate::output::{print_hint, print_success};
 ///
 /// This command does **not** validate that the slug exists on the server.
 /// If the slug is invalid, subsequent commands will fail with a "not found"
-/// error. This matches the behavior of `atomic org switch`.
+/// error. This matches the behavior of `atomic org set`.
 #[derive(Debug, Parser, Default)]
-#[command(name = "switch")]
-pub struct WorkspaceSwitch {
+#[command(name = "set")]
+pub struct WorkspaceSet {
     /// Workspace slug to set as the new default.
     ///
     /// This should be the URL-safe slug of a workspace that exists on
@@ -68,7 +68,7 @@ pub struct WorkspaceSwitch {
     pub org: Option<String>,
 }
 
-impl Command for WorkspaceSwitch {
+impl Command for WorkspaceSet {
     fn run(&self) -> CliResult<()> {
         if self.slug.is_empty() {
             return Err(CliError::InvalidArgument {
@@ -96,7 +96,7 @@ impl Command for WorkspaceSwitch {
                 .clone()
                 .ok_or_else(|| CliError::InvalidArgument {
                     message: "No default org set. Use --org or first run: \
-                              atomic org switch <slug>"
+                              atomic org set <slug>"
                         .to_string(),
                 })?,
         };
@@ -127,7 +127,7 @@ impl Command for WorkspaceSwitch {
             if current_org != target_org {
                 print_hint(&format!(
                     "Current default org is '{current_org}' — \
-                     run 'atomic org switch {target_org}' to use this workspace."
+                     run 'atomic org set {target_org}' to use this workspace."
                 ));
             }
         }
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn empty_slug_rejected() {
-        let cmd = WorkspaceSwitch {
+        let cmd = WorkspaceSet {
             slug: "".to_string(),
             org: None,
         };
@@ -157,7 +157,7 @@ mod tests {
 
     #[test]
     fn empty_org_override_rejected() {
-        let cmd = WorkspaceSwitch {
+        let cmd = WorkspaceSet {
             slug: "backend".to_string(),
             org: Some("".to_string()),
         };
@@ -173,7 +173,7 @@ mod tests {
 
     #[test]
     fn fields_stored() {
-        let cmd = WorkspaceSwitch {
+        let cmd = WorkspaceSet {
             slug: "backend".to_string(),
             org: Some("acme".to_string()),
         };

--- a/atomic-cli/src/commands/workspace/switch.rs
+++ b/atomic-cli/src/commands/workspace/switch.rs
@@ -1,0 +1,181 @@
+//! The `workspace switch` command for setting a default workspace per org.
+//!
+//! Workspaces are org-scoped, so the default is stored per org in
+//! `server.default_workspaces` (a map keyed by org slug). This command
+//! updates that map for the current default org, or for an explicit org
+//! passed via `--org`.
+//!
+//! # Usage
+//!
+//! ```text
+//! atomic workspace switch <SLUG> [--org <ORG>]
+//!
+//! Arguments:
+//!   <SLUG>  Workspace slug to set as the default for the target org
+//!
+//! Options:
+//!       --org <ORG>  Set the default workspace for this org instead
+//!                    of the current default org
+//!   -h, --help       Print help information
+//! ```
+//!
+//! # Examples
+//!
+//! ```text
+//! # Set default workspace for the current org
+//! $ atomic workspace switch backend
+//! ✓ Default workspace for 'acme' set to: backend
+//!
+//! # Set default workspace for a different org (does not change current org)
+//! $ atomic workspace switch personal --org alice
+//! ✓ Default workspace for 'alice' set to: personal
+//!   (current default org is 'acme' — run 'atomic org switch alice' to use it)
+//! ```
+
+use clap::Parser;
+
+use atomic_config::GlobalConfig;
+
+use crate::commands::Command;
+use crate::error::{CliError, CliResult};
+use crate::output::{print_hint, print_success};
+
+/// Switch the default workspace for an org.
+///
+/// Updates `[server.default_workspaces]` in the global configuration file.
+/// All subsequent commands that take an optional `--workspace` parameter
+/// fall back to this slug for the target org.
+///
+/// This command does **not** validate that the slug exists on the server.
+/// If the slug is invalid, subsequent commands will fail with a "not found"
+/// error. This matches the behavior of `atomic org switch`.
+#[derive(Debug, Parser, Default)]
+#[command(name = "switch")]
+pub struct WorkspaceSwitch {
+    /// Workspace slug to set as the new default.
+    ///
+    /// This should be the URL-safe slug of a workspace that exists on
+    /// the remote server under the target org.
+    #[arg(required = true, value_name = "SLUG")]
+    pub slug: String,
+
+    /// Org to set the default workspace for.
+    ///
+    /// If omitted, uses the current default org from global config.
+    /// Passing this lets you pre-configure a workspace for an org you
+    /// are not currently using as the default.
+    #[arg(long, value_name = "ORG")]
+    pub org: Option<String>,
+}
+
+impl Command for WorkspaceSwitch {
+    fn run(&self) -> CliResult<()> {
+        if self.slug.is_empty() {
+            return Err(CliError::InvalidArgument {
+                message: "Workspace slug cannot be empty.".to_string(),
+            });
+        }
+
+        let mut config = GlobalConfig::load().map_err(|e| {
+            CliError::Internal(anyhow::anyhow!("Failed to load global config: {e}"))
+        })?;
+
+        // Determine the target org. Explicit --org wins; otherwise fall back
+        // to the configured default. We don't go through `resolve_org` here
+        // because we want a distinct error message tied to *this* command.
+        let target_org = match self.org.as_deref() {
+            Some(o) if !o.is_empty() => o.to_string(),
+            Some(_) => {
+                return Err(CliError::InvalidArgument {
+                    message: "Organization slug cannot be empty.".to_string(),
+                });
+            }
+            None => config.server.default_org.clone().ok_or_else(|| {
+                CliError::InvalidArgument {
+                    message: "No default org set. Use --org or first run: \
+                              atomic org switch <slug>"
+                        .to_string(),
+                }
+            })?,
+        };
+
+        let previous = config
+            .server
+            .default_workspaces
+            .insert(target_org.clone(), self.slug.clone());
+
+        config.save().map_err(|e| {
+            CliError::Internal(anyhow::anyhow!("Failed to save global config: {e}"))
+        })?;
+
+        print_success(&format!(
+            "Default workspace for '{}' set to: {}",
+            target_org, self.slug
+        ));
+
+        if let Some(prev) = previous.as_ref() {
+            if prev != &self.slug {
+                print_hint(&format!("Previous default was: {prev}"));
+            }
+        }
+
+        // If the user set a workspace for a non-current org, remind them
+        // that it won't take effect until they switch orgs.
+        if let Some(current_org) = config.server.default_org.as_deref() {
+            if current_org != target_org {
+                print_hint(&format!(
+                    "Current default org is '{current_org}' — \
+                     run 'atomic org switch {target_org}' to use this workspace."
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_slug_rejected() {
+        let cmd = WorkspaceSwitch {
+            slug: "".to_string(),
+            org: None,
+        };
+        let err = cmd.run().unwrap_err();
+        match err {
+            CliError::InvalidArgument { message } => {
+                assert!(message.contains("cannot be empty"));
+            }
+            other => panic!("expected InvalidArgument, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn empty_org_override_rejected() {
+        let cmd = WorkspaceSwitch {
+            slug: "backend".to_string(),
+            org: Some("".to_string()),
+        };
+        let err = cmd.run().unwrap_err();
+        match err {
+            CliError::InvalidArgument { message } => {
+                assert!(message.contains("Organization"));
+                assert!(message.contains("empty"));
+            }
+            other => panic!("expected InvalidArgument, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn fields_stored() {
+        let cmd = WorkspaceSwitch {
+            slug: "backend".to_string(),
+            org: Some("acme".to_string()),
+        };
+        assert_eq!(cmd.slug, "backend");
+        assert_eq!(cmd.org.as_deref(), Some("acme"));
+    }
+}

--- a/atomic-cli/src/commands/workspace/switch.rs
+++ b/atomic-cli/src/commands/workspace/switch.rs
@@ -90,13 +90,15 @@ impl Command for WorkspaceSwitch {
                     message: "Organization slug cannot be empty.".to_string(),
                 });
             }
-            None => config.server.default_org.clone().ok_or_else(|| {
-                CliError::InvalidArgument {
+            None => config
+                .server
+                .default_org
+                .clone()
+                .ok_or_else(|| CliError::InvalidArgument {
                     message: "No default org set. Use --org or first run: \
                               atomic org switch <slug>"
                         .to_string(),
-                }
-            })?,
+                })?,
         };
 
         let previous = config

--- a/atomic-cli/src/main.rs
+++ b/atomic-cli/src/main.rs
@@ -493,12 +493,12 @@ enum Commands {
     /// Projects live inside workspaces and represent a single Atomic VCS
     /// repository hosted on a remote server. When `--workspace` is omitted,
     /// commands fall back to the default workspace for the current org
-    /// (set with `atomic workspace switch`).
+    /// (set with `atomic workspace set`).
     ///
     /// # Examples
     ///
     /// ```text
-    /// atomic workspace switch my-ws
+    /// atomic workspace set my-ws
     ///
     /// atomic project list
     /// atomic project create my-app
@@ -524,7 +524,7 @@ enum Commands {
     /// atomic org create "Acme Corp"
     ///
     /// # Switch default org
-    /// atomic org switch acme-corp
+    /// atomic org set acme-corp
     ///
     /// # Manage members
     /// atomic org member list

--- a/atomic-cli/src/main.rs
+++ b/atomic-cli/src/main.rs
@@ -491,19 +491,20 @@ enum Commands {
     /// Manage remote projects.
     ///
     /// Projects live inside workspaces and represent a single Atomic VCS
-    /// repository hosted on a remote server.
+    /// repository hosted on a remote server. When `--workspace` is omitted,
+    /// commands fall back to the default workspace for the current org
+    /// (set with `atomic workspace switch`).
     ///
     /// # Examples
     ///
     /// ```text
-    /// # List projects
-    /// atomic project list --workspace my-ws
+    /// atomic workspace switch my-ws
     ///
-    /// # Create a project
-    /// atomic project create my-app --workspace my-ws
+    /// atomic project list
+    /// atomic project create my-app
+    /// atomic project init my-app
     ///
-    /// # Initialize local repo as remote project
-    /// atomic project init my-app --workspace my-ws
+    /// atomic project create my-app --workspace other-ws
     /// ```
     Project(ProjectCmd),
 

--- a/atomic-config/src/lib.rs
+++ b/atomic-config/src/lib.rs
@@ -83,7 +83,7 @@ pub struct ServerConfig {
     /// Default organization slug for management commands.
     ///
     /// Set automatically during registration (personal org = identity name).
-    /// Can be switched with `atomic org switch`.
+    /// Can be switched with `atomic org set`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_org: Option<String>,
 
@@ -93,7 +93,7 @@ pub struct ServerConfig {
     /// a management command needs a workspace and none is given on the
     /// CLI, the resolver looks up the current org in this map.
     ///
-    /// Set with `atomic workspace switch <slug> [--org <slug>]`.
+    /// Set with `atomic workspace set <slug> [--org <slug>]`.
     /// Uses `BTreeMap` so the serialized TOML is alphabetically ordered
     /// and produces stable diffs.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]

--- a/atomic-config/src/lib.rs
+++ b/atomic-config/src/lib.rs
@@ -10,6 +10,7 @@
 //! Configuration is merged with later levels overriding earlier ones.
 
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -65,6 +66,10 @@ pub struct Author {
 /// [server]
 /// url = "https://atomic.storage"
 /// default_org = "alice"
+///
+/// [server.default_workspaces]
+/// alice = "personal"
+/// acme = "backend"
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ServerConfig {
@@ -81,6 +86,18 @@ pub struct ServerConfig {
     /// Can be switched with `atomic org switch`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_org: Option<String>,
+
+    /// Default workspace slug per organization.
+    ///
+    /// Workspaces are org-scoped, so the default is stored per org. When
+    /// a management command needs a workspace and none is given on the
+    /// CLI, the resolver looks up the current org in this map.
+    ///
+    /// Set with `atomic workspace switch <slug> [--org <slug>]`.
+    /// Uses `BTreeMap` so the serialized TOML is alphabetically ordered
+    /// and produces stable diffs.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub default_workspaces: BTreeMap<String, String>,
 }
 
 impl ServerConfig {
@@ -352,6 +369,7 @@ mod tests {
         let config = ServerConfig {
             url: Some("https://atomic.storage".to_string()),
             default_org: Some("alice".to_string()),
+            default_workspaces: BTreeMap::new(),
         };
         assert!(config.is_configured());
 
@@ -359,6 +377,7 @@ mod tests {
         let partial = ServerConfig {
             url: Some("https://atomic.storage".to_string()),
             default_org: None,
+            default_workspaces: BTreeMap::new(),
         };
         assert!(!partial.is_configured());
 
@@ -366,6 +385,7 @@ mod tests {
         let partial = ServerConfig {
             url: None,
             default_org: Some("alice".to_string()),
+            default_workspaces: BTreeMap::new(),
         };
         assert!(!partial.is_configured());
     }
@@ -375,6 +395,7 @@ mod tests {
         let config = ServerConfig {
             url: Some("https://atomic.storage".to_string()),
             default_org: Some("alice".to_string()),
+            default_workspaces: BTreeMap::new(),
         };
         assert_eq!(
             config.org_base_url("alice"),
@@ -391,6 +412,7 @@ mod tests {
         let config = ServerConfig {
             url: Some("http://localhost:8080".to_string()),
             default_org: None,
+            default_workspaces: BTreeMap::new(),
         };
         assert_eq!(
             config.org_base_url("alice"),
@@ -403,6 +425,7 @@ mod tests {
         let config = ServerConfig {
             url: Some("https://atomic.storage".to_string()),
             default_org: Some("alice".to_string()),
+            default_workspaces: BTreeMap::new(),
         };
         assert_eq!(
             config.default_org_base_url(),
@@ -413,6 +436,7 @@ mod tests {
         let config = ServerConfig {
             url: Some("https://atomic.storage".to_string()),
             default_org: None,
+            default_workspaces: BTreeMap::new(),
         };
         assert!(config.default_org_base_url().is_none());
     }
@@ -422,6 +446,7 @@ mod tests {
         let config = ServerConfig {
             url: Some("https://atomic.storage".to_string()),
             default_org: Some("alice".to_string()),
+            default_workspaces: BTreeMap::new(),
         };
 
         let toml_str = toml::to_string_pretty(&config).unwrap();
@@ -444,6 +469,7 @@ mod tests {
             server: ServerConfig {
                 url: Some("https://atomic.storage".to_string()),
                 default_org: Some("alice".to_string()),
+                default_workspaces: BTreeMap::new(),
             },
             ..GlobalConfig::default()
         };
@@ -459,6 +485,60 @@ mod tests {
         );
         assert_eq!(parsed.server.default_org, Some("alice".to_string()));
         assert!(parsed.server.is_configured());
+    }
+
+    #[test]
+    fn test_default_workspaces_skipped_when_empty() {
+        let config = ServerConfig {
+            url: Some("https://atomic.storage".to_string()),
+            default_org: Some("alice".to_string()),
+            default_workspaces: BTreeMap::new(),
+        };
+        let toml_str = toml::to_string_pretty(&config).unwrap();
+        assert!(!toml_str.contains("default_workspaces"));
+    }
+
+    #[test]
+    fn test_default_workspaces_roundtrip() {
+        let mut workspaces = BTreeMap::new();
+        workspaces.insert("alice".to_string(), "personal".to_string());
+        workspaces.insert("acme".to_string(), "backend".to_string());
+
+        let config = ServerConfig {
+            url: Some("https://atomic.storage".to_string()),
+            default_org: Some("alice".to_string()),
+            default_workspaces: workspaces,
+        };
+
+        let toml_str = toml::to_string_pretty(&config).unwrap();
+        assert!(toml_str.contains("[default_workspaces]"));
+
+        // BTreeMap → alphabetical, so "acme" appears before "alice"
+        let acme_pos = toml_str.find("acme = \"backend\"").unwrap();
+        let alice_pos = toml_str.find("alice = \"personal\"").unwrap();
+        assert!(acme_pos < alice_pos);
+
+        let parsed: ServerConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(
+            parsed.default_workspaces.get("alice"),
+            Some(&"personal".to_string())
+        );
+        assert_eq!(
+            parsed.default_workspaces.get("acme"),
+            Some(&"backend".to_string())
+        );
+    }
+
+    #[test]
+    fn test_default_workspaces_backward_compatibility() {
+        // Old configs without default_workspaces should still parse.
+        let toml_str = r#"
+url = "https://atomic.storage"
+default_org = "alice"
+"#;
+        let parsed: ServerConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(parsed.default_org.as_deref(), Some("alice"));
+        assert!(parsed.default_workspaces.is_empty());
     }
 
     #[test]

--- a/atomic-teams/README.md
+++ b/atomic-teams/README.md
@@ -155,7 +155,7 @@ atomic org update acme-corp --name "Acme Corporation" --email new@acme.com
 atomic org upgrade
 
 # Switch your default org context
-atomic org switch acme-corp
+atomic org set acme-corp
 
 # Delete an org (owner only, interactive confirmation)
 atomic org delete acme-corp
@@ -674,7 +674,7 @@ atomic org create "Dev Team" --email team@dev.local
 #   Plan:  free
 
 # Switch to the new org
-atomic org switch dev-team
+atomic org set dev-team
 ```
 
 #### 4. Add Bob to the organization

--- a/tests/harness/15_storage_api.sh
+++ b/tests/harness/15_storage_api.sh
@@ -208,7 +208,7 @@ run_atomic_ok "Register Charlie with server" \
 # Switch back to Alice for the rest of the tests.
 use_identity "$ALICE_NAME"
 run_atomic_ok "Switch default org back to Alice" \
-    org switch "$ALICE_NAME"
+    org set "$ALICE_NAME"
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -232,7 +232,7 @@ assert_last_contains "Create response includes org slug" "$ORG_SLUG"
 
 # Switch to the new org so subsequent commands target it.
 run_atomic_ok "Switch to team org" \
-    org switch "$ORG_SLUG"
+    org set "$ORG_SLUG"
 
 # Verify the switch persisted.
 run_atomic_ok "Show team org after switch" \


### PR DESCRIPTION
# Fix in this PR
1. Add per-org default workspace and rename `switch` → `set` (org + workspace), 
2. Fix the bug missing validation on server for org/workspace.


## Motivation

```
$ atomic project create vince-project-1
✗ Invalid argument: Workspace slug is required (--workspace).
```


Workspaces are org-scoped (the URL is literally
`<org>.atomic.storage/workspaces/<workspace>/...`), but the CLI required
the slug on every call. This PR mirrors what `default_org` +
`atomic org switch` already did at the org level, one tier down.


## Why a per-org map, not a flat `default_workspace`

A flat string would create an obvious footgun:

```
atomic org set personal
atomic workspace set vince          # defaults workspace to "vince"
atomic org set acme
atomic project create api           # would try acme + vince → 404
```


So `default_workspaces` is a `BTreeMap<String, String>` keyed by org slug.
`BTreeMap` (not `HashMap`) gives alphabetical TOML output for stable
config diffs.


## Why server-side validation on `set`

After team review (#engineering, 5/14): without validation, feels like a bug: 

```
❯ atomic org show
Name   : vince
Slug   : vince
Kind   : personal
Plan   : free
ID     : f2a9d104-7914-48d4-af25-66c0d60a68f4
Created: 2026-05-13T19:30:28.760914+00:00
Updated: 2026-05-13T19:30:28.760914+00:00
❯ atomic org switch vince-new-123
✓ Default organization set to: vince-new-123
Previous default was: vince
❯ atomic workspace create vince-workspace
✗ Remote operation failed: HTTP error 404: No tenant found for subdomain 'vince-new-123'
```

After the fix: 

```
❯ atest org set vince-o
✗ Invalid argument: Organization 'vince-o' not found on the server.
  Check the slug with: atomic org list
  Or pass --no-verify to set the value without checking.

Hint: Run 'atomic <command> --help' for usage information.
```





## End-to-end against a local `atomic-storage`: 

1. First I make a new local dev binary:
```

❯ export TMPHOME=$(mktemp -d)

❯ echo "Test home: $TMPHOME"

Test home: /var/folders/q9/b56yc8h16sdfyvs7dn8h5c480000gn/T/tmp.6NYIXTbvAC
❯ alias atest='HOME=$TMPHOME ./target/debug/atomic'

❯ ~/.cargo/bin/cargo build

    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.33s
```

2. I ran the test against this new atest (my local atomic alias):

```
❯ atest org set personal
✓ Default organization set to: personal
Previous default was: vince-el

```

3. I try create a new org, and I verify that the next step is correct:)
```
❯ atest org create test123
✓ Created organization: test123

Name: test123
Slug: test123
Kind: team
Plan: free
ID  : fe007e8d-eb8d-4bda-b7f5-7cc564215c75

Next steps:
  atomic org set test123      Set as your default org
  atomic org member add <id>  Add members to the org
  atomic team create <name>   Create a team
```

4. Set to default above test123 as default org and create a test workspace:

```
❯ atest org set test123
✓ Default organization set to: test123
Previous default was: vince-el


❯ atest workspace create test_workspace

✓ Created workspace: test_workspace (slug: test-workspace)

Name      : test_workspace
Slug      : test-workspace
Visibility: private
Created   : 2026-05-14 10:50:50

Next steps:
  atomic workspace set test-workspace   Set as your default workspace
  atomic project create <project-name>  Create a project in this workspace
  atomic workspace list                 View all workspaces
```

Try create a new workspace and set:

```
❯ atest workspace create diff-workspace
✓ Created workspace: diff-workspace (slug: diff-workspace)

Name      : diff-workspace
Slug      : diff-workspace
Visibility: private
Created   : 2026-05-14 10:52:12

Next steps:
  atomic workspace set diff-workspace   Set as your default workspace
  atomic project create <project-name>  Create a project in this workspace
  atomic workspace list                 View all workspaces
❯ atest workspace set diff-workspace
✓ Default workspace for 'test123' set to: diff-workspace
Previous default was: test-workspace
```


5. Try create a new project without passing workspace

```
❯ atest project create my-project

✓ Created project: my-project (slug: my-project)

Workspace   : diff-workspace
Default view: dev
Visibility  : private
VCS URL     : http://test123.localhost:8080/workspaces/diff-workspace/projects/my-project/code
```

6. Try create a new project with workspace passed:

```
❯ atest project create another-proj --workspace test-workspace

✓ Created project: another-proj (slug: another-proj)

Workspace   : test-workspace
Default view: dev
Visibility  : private
VCS URL     : http://test123.localhost:8080/workspaces/test-workspace/projects/another-proj/code

Next steps:
  atomic project init another-proj  Link a local repo to this project
  atomic push
```

## Test change

**Refactor**: extracted verification on `OrgSet::run` / `WorkspaceSet::run` into a private `run_with_verifier<F>(&self, verify: F)` taking the verifier as a closure. `Command::run` dispatches the real network-bound verifier; tests inject deterministic ones. No HTTP mocking needed.

**Three new tests per command** (6 total):
- `config_unchanged_when_verifier_fails` — seed old value, inject `Err`-returning verifier, assert on-disk config unchanged. The critical one.
- `config_written_when_verifier_succeeds` — happy path locked down.
- `no_verify_skips_verifier_entirely` — injects a verifier that **panics**; `--no-verify` short-circuits before reaching it.