### PR TITLE
docs: add Installation section with Homebrew tap as macOS path

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ curl -sSf https://atomic.storage/install.sh | ATOMIC_INSTALL="$HOME/.local/bin" 
 ```
 
 The installer detects your platform, downloads the matching GitHub release,
-verifies checksums, and installs the `atomic` binary.
+verifies checksums when available, and installs the `atomic` binary.
 
 ### Manual — release tarball
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,57 @@ The `ask` command gives the LLM six tools (`kg_search`, `kg_neighbors`, `read_fi
 
 No API key required for `search`, `code`, `entities`, `neighbors`, `graph`, or `enrich`.
 
+## Installation
+
+Pick the path that matches your environment.
+
+### macOS — Homebrew (recommended)
+
+```bash
+brew install atomicdotdev/tap/atomic
+```
+
+Upgrade later with:
+
+```bash
+brew upgrade atomicdotdev/tap/atomic
+```
+
+After installation, `brew upgrade atomic` also works in normal Homebrew setups.
+
+### Linux, CI, or no Homebrew — hosted installer
+
+```bash
+curl -sSf https://atomic.storage/install.sh | sh
+```
+
+Pin a specific version or install to a user-writable directory:
+
+```bash
+curl -sSf https://atomic.storage/install.sh | ATOMIC_VERSION=0.6.0 sh
+curl -sSf https://atomic.storage/install.sh | ATOMIC_INSTALL="$HOME/.local/bin" sh
+```
+
+The installer detects your platform, downloads the matching GitHub release,
+verifies checksums, and installs the `atomic` binary.
+
+### Manual — release tarball
+
+For air-gapped, audited, or one-off installs, download the archive for your
+platform directly from the [latest release](https://github.com/atomicdotdev/atomic/releases/latest)
+and place `atomic` somewhere on your `PATH`.
+
+### From source — development builds
+
+See the [installation docs](https://docs.atomic.dev/getting-started/installation#source-install-development)
+for the source build path (rustup, system dependencies, `cargo install`).
+
+### Verify
+
+```bash
+atomic --version
+```
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary
Adds an Installation section in Quick Start.

1. **macOS — Homebrew** (\`atomicdotdev/tap/atomic\`, new tap)
2. **Linux / CI / no Homebrew** — hosted installer (\`curl | sh\`)
3. **Manual** — release tarball for air-gapped or audited installs
4. **From source** — links to docs for the cargo install path

Homebrew is positioned as the macOS recommended path, not the only official channel. The hosted installer remains the cross-platform default.

## Companion PR

Same content lands in atomic-docs \`getting-started/installation\` — Distribution Packages section moves from "COMING SOON" to real Homebrew commands.
