### PR TITLE
feat(identity): add sign and verify subcommands

### DIFF
--- a/atomic-cli/src/commands/identity/mod.rs
+++ b/atomic-cli/src/commands/identity/mod.rs
@@ -43,6 +43,8 @@ pub mod list;
 pub mod new;
 pub mod register;
 pub mod show;
+pub mod sign;
+pub mod verify;
 pub mod whoami;
 
 // Re-export command structs
@@ -51,6 +53,8 @@ pub use list::List;
 pub use new::New;
 pub use register::Register;
 pub use show::Show;
+pub use sign::Sign;
+pub use verify::Verify;
 pub use whoami::WhoAmI;
 
 use clap::Subcommand;
@@ -197,6 +201,38 @@ pub enum IdentityCommands {
     /// atomic identity register https://atomic.storage --identity alice-work
     /// ```
     Register(Register),
+
+    /// Sign bytes from stdin and output a JSON signature object.
+    ///
+    /// Reads raw bytes from stdin, signs them with the identity's Ed25519
+    /// secret key, and prints a JSON object containing the signature,
+    /// public key, identity name, and algorithm.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// # Sign with the default identity
+    /// atomic identity sign < file.bin
+    ///
+    /// # Sign with a specific identity
+    /// echo -n "hello" | atomic identity sign --identity alice-work
+    /// ```
+    Sign(Sign),
+
+    /// Verify an Ed25519 signature against bytes from stdin.
+    ///
+    /// Reads raw bytes from stdin and checks the provided signature
+    /// against the provided public key. Exits 0 if valid, 1 if invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// atomic identity verify \
+    ///   --signature <base64-sig> \
+    ///   --public-key <base32-key> \
+    ///   < file.bin
+    /// ```
+    Verify(Verify),
 }
 
 impl Command for Identity {
@@ -209,6 +245,8 @@ impl Command for Identity {
             IdentityCommands::Delete(cmd) => cmd.run(),
             IdentityCommands::WhoAmI(cmd) => cmd.run(),
             IdentityCommands::Register(cmd) => cmd.run(),
+            IdentityCommands::Sign(cmd) => cmd.run(),
+            IdentityCommands::Verify(cmd) => cmd.run(),
         }
     }
 }

--- a/atomic-cli/src/commands/identity/sign.rs
+++ b/atomic-cli/src/commands/identity/sign.rs
@@ -1,0 +1,86 @@
+use clap::Parser;
+use data_encoding::BASE64;
+use std::io::Read;
+
+use atomic_identity::IdentityStore;
+
+use crate::commands::Command;
+use crate::error::{CliError, CliResult};
+
+/// Sign bytes from stdin using an identity's Ed25519 key.
+///
+/// Reads raw bytes from stdin and outputs a JSON object with the
+/// signature, public key, identity name, and algorithm.
+///
+/// # Examples
+///
+/// ```text
+/// # Sign a file with the default identity
+/// atomic identity sign < file.bin
+///
+/// # Sign with a specific identity
+/// atomic identity sign --identity alice-work < file.bin
+///
+/// # Sign a string
+/// echo -n "hello world" | atomic identity sign
+/// ```
+#[derive(Debug, Parser)]
+pub struct Sign {
+    /// Identity to sign with. Defaults to the current default identity.
+    #[arg(short, long)]
+    pub identity: Option<String>,
+}
+
+impl Command for Sign {
+    fn run(&self) -> CliResult<()> {
+        let store = IdentityStore::open_default().map_err(|e| {
+            CliError::Internal(anyhow::anyhow!("Failed to open identity store: {}", e))
+        })?;
+
+        let identity = if let Some(name) = &self.identity {
+            store
+                .load_by_name(name)
+                .map_err(|_| CliError::IdentityNotFound(name.clone()))?
+        } else {
+            store
+                .get_default()
+                .map_err(|e| {
+                    CliError::Internal(anyhow::anyhow!("Failed to load default identity: {}", e))
+                })?
+                .ok_or_else(|| {
+                    CliError::Internal(anyhow::anyhow!(
+                        "No default identity set. Create one first:\n  \
+                         atomic identity new <name> --email <email> --set-default"
+                    ))
+                })?
+        };
+
+        let keypair = store.load_keypair(&identity.id, None).map_err(|e| {
+            CliError::Internal(anyhow::anyhow!(
+                "Failed to load keypair for '{}': {}",
+                identity.name,
+                e
+            ))
+        })?;
+
+        let mut data = Vec::new();
+        std::io::stdin().read_to_end(&mut data).map_err(|e| {
+            CliError::Internal(anyhow::anyhow!("Failed to read stdin: {}", e))
+        })?;
+
+        let sig_bytes = keypair.sign(&data);
+        let signature = BASE64.encode(&sig_bytes);
+        let public_key = identity.public_key_base32();
+        let name = &identity.name;
+
+        let output = serde_json::json!({
+            "signature": signature,
+            "public_key": public_key,
+            "identity": name,
+            "alg": "ed25519",
+        });
+
+        println!("{}", serde_json::to_string_pretty(&output).unwrap());
+        Ok(())
+    }
+}

--- a/atomic-cli/src/commands/identity/sign.rs
+++ b/atomic-cli/src/commands/identity/sign.rs
@@ -64,9 +64,9 @@ impl Command for Sign {
         })?;
 
         let mut data = Vec::new();
-        std::io::stdin().read_to_end(&mut data).map_err(|e| {
-            CliError::Internal(anyhow::anyhow!("Failed to read stdin: {}", e))
-        })?;
+        std::io::stdin()
+            .read_to_end(&mut data)
+            .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to read stdin: {}", e)))?;
 
         let sig_bytes = keypair.sign(&data);
         let signature = BASE64.encode(&sig_bytes);

--- a/atomic-cli/src/commands/identity/verify.rs
+++ b/atomic-cli/src/commands/identity/verify.rs
@@ -1,0 +1,71 @@
+use clap::Parser;
+use data_encoding::BASE64;
+use std::io::Read;
+
+use atomic_identity::keypair::PublicKey;
+
+use crate::commands::Command;
+use crate::error::{CliError, CliResult};
+
+/// Verify an Ed25519 signature against bytes from stdin.
+///
+/// Reads raw bytes from stdin and checks the signature. Exits 0 if
+/// valid, 1 if invalid.
+///
+/// # Examples
+///
+/// ```text
+/// # Verify a signature
+/// atomic identity verify \
+///   --signature <base64-sig> \
+///   --public-key <base32-key> \
+///   < file.bin
+/// ```
+#[derive(Debug, Parser)]
+pub struct Verify {
+    /// Base64-encoded signature to verify.
+    #[arg(long)]
+    pub signature: String,
+
+    /// Base32-encoded public key to verify against.
+    #[arg(long)]
+    pub public_key: String,
+}
+
+impl Command for Verify {
+    fn run(&self) -> CliResult<()> {
+        let sig_bytes = BASE64.decode(self.signature.as_bytes()).map_err(|e| {
+            CliError::Internal(anyhow::anyhow!("Invalid signature encoding: {}", e))
+        })?;
+
+        if sig_bytes.len() != 64 {
+            return Err(CliError::Internal(anyhow::anyhow!(
+                "Invalid signature: expected 64 bytes, got {}",
+                sig_bytes.len()
+            )));
+        }
+
+        let mut sig_arr = [0u8; 64];
+        sig_arr.copy_from_slice(&sig_bytes);
+
+        let public_key = PublicKey::from_base32(&self.public_key).map_err(|e| {
+            CliError::Internal(anyhow::anyhow!("Invalid public key: {}", e))
+        })?;
+
+        let mut data = Vec::new();
+        std::io::stdin().read_to_end(&mut data).map_err(|e| {
+            CliError::Internal(anyhow::anyhow!("Failed to read stdin: {}", e))
+        })?;
+
+        match public_key.verify(&data, &sig_arr) {
+            Ok(()) => {
+                eprintln!("Signature valid");
+                std::process::exit(0);
+            }
+            Err(_) => {
+                eprintln!("Signature invalid");
+                std::process::exit(1);
+            }
+        }
+    }
+}

--- a/atomic-cli/src/commands/identity/verify.rs
+++ b/atomic-cli/src/commands/identity/verify.rs
@@ -48,14 +48,13 @@ impl Command for Verify {
         let mut sig_arr = [0u8; 64];
         sig_arr.copy_from_slice(&sig_bytes);
 
-        let public_key = PublicKey::from_base32(&self.public_key).map_err(|e| {
-            CliError::Internal(anyhow::anyhow!("Invalid public key: {}", e))
-        })?;
+        let public_key = PublicKey::from_base32(&self.public_key)
+            .map_err(|e| CliError::Internal(anyhow::anyhow!("Invalid public key: {}", e)))?;
 
         let mut data = Vec::new();
-        std::io::stdin().read_to_end(&mut data).map_err(|e| {
-            CliError::Internal(anyhow::anyhow!("Failed to read stdin: {}", e))
-        })?;
+        std::io::stdin()
+            .read_to_end(&mut data)
+            .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to read stdin: {}", e)))?;
 
         match public_key.verify(&data, &sig_arr) {
             Ok(()) => {


### PR DESCRIPTION
## Summary

- `atomic identity sign [--identity <name>] < data` — reads stdin, signs with the identity's Ed25519 key, outputs JSON with `signature` (base64), `public_key` (base32), `identity` name, and `alg: "ed25519"`
- `atomic identity verify --signature <base64> --public-key <base32> < data` — exits 0 on valid, 1 on invalid
- `--identity` on sign defaults to `whoami`; both commands plug into the existing `IdentityStore` / `KeyPair` / `PublicKey` primitives with no new crypto code

## Test plan

- [ ] `echo -n "hello" | atomic identity sign` produces valid JSON with expected fields
- [ ] Round-trip: sign output pipes into verify and exits 0
- [ ] Tampered data causes verify to exit 1
- [ ] `--identity <name>` selects a non-default identity on sign
- [ ] Missing/no-default identity produces a clear error message