### PR TITLE
feat(agent): add discovery foundation for trace import (#13)

### DIFF
--- a/atomic-agent/src/discovery/mod.rs
+++ b/atomic-agent/src/discovery/mod.rs
@@ -1,0 +1,376 @@
+//! Discovery adapters for reading agent storage on the provenance import path.
+//!
+//! This module defines the [`TraceDiscovery`] trait that each discovery adapter
+//! implements, and the [`DiscoveryRegistry`] that manages available adapters.
+//! Where [`crate::hooks`] is the **write path** — normalizing live hook callbacks
+//! into [`crate::event::TurnEvent`] values as an agent runs — the discovery
+//! module is the **read path**: adapters scan agent storage already on disk
+//! (JSONL transcripts, JSON session files, SQLite databases) and produce
+//! normalized [`DiscoveredTrace`] and [`DiscoveredEvent`] values that feed the
+//! provenance import pipeline.
+//!
+//! # Architecture
+//!
+//! ```text
+//! Agent storage on disk
+//!   (JSONL / JSON / SQLite)
+//!         │
+//!         ▼
+//!  TraceDiscovery adapter
+//!  (list_traces / read_events)
+//!         │
+//!         ▼
+//!  DiscoveredTrace / DiscoveredEvent
+//!         │
+//!         ▼
+//!  Provenance import pipeline
+//! ```
+//!
+//! # Adding a New Adapter
+//!
+//! 1. Create a new file `discovery/<agent_name>.rs`
+//! 2. Implement [`TraceDiscovery`] for your adapter struct
+//! 3. Register it in the default registry via [`DiscoveryRegistry::with_defaults`]
+//!    (see the comment there for the relevant issue numbers)
+//! 4. Add a `pub mod <agent_name>;` declaration to this file
+//!
+//! # Example
+//!
+//! ```rust
+//! use atomic_agent::discovery::DiscoveryRegistry;
+//!
+//! let registry = DiscoveryRegistry::with_defaults();
+//! // No adapters wired yet — they land in follow-up issues.
+//! let _ = registry;
+//! ```
+
+pub mod types;
+
+pub use types::{DiscoveredEvent, DiscoveredEventType, DiscoveredTrace, StorageKind};
+
+use std::fmt;
+
+use crate::error::{AgentError, AgentResult};
+
+// TraceDiscovery Trait
+
+/// Read-path counterpart to [`crate::hooks::AgentHook`]. Each adapter knows how
+/// to scan a specific agent's on-disk storage and produce normalized traces and
+/// events for the provenance import pipeline.
+pub trait TraceDiscovery: Send + Sync + fmt::Debug {
+    /// Unique adapter id used in registry lookups (kebab-case, e.g., `"claude-code"`).
+    fn agent_id(&self) -> &str;
+
+    /// Human-readable display name (e.g., `"Claude Code"`).
+    fn display_name(&self) -> &str;
+
+    /// Whether this adapter's storage is currently present on the host.
+    ///
+    /// Cheap probe (existence check); should not open files or DBs.
+    fn is_available(&self) -> bool;
+
+    /// Enumerate all traces this adapter can see. Order is adapter-defined.
+    fn list_traces(&self) -> AgentResult<Vec<DiscoveredTrace>>;
+
+    /// Read all events for a single trace, in monotonic order.
+    fn read_events(&self, trace_id: &str) -> AgentResult<Vec<DiscoveredEvent>>;
+
+    /// Storage backend this adapter reads from.
+    fn storage_kind(&self) -> StorageKind;
+}
+
+// DiscoveryRegistry
+
+/// Registry of available discovery adapters.
+///
+/// The registry holds all known adapters and provides lookup by agent id,
+/// listing, and filtering to adapters whose storage is currently present on
+/// the host.
+///
+/// # Thread Safety
+///
+/// Adapters are stored as `Box<dyn TraceDiscovery>` which is `Send + Sync`.
+/// The registry itself requires `&mut self` for `register()`; share across
+/// threads via `Arc<Mutex<DiscoveryRegistry>>` or freeze before sharing.
+///
+/// # Example
+///
+/// ```rust
+/// use atomic_agent::discovery::DiscoveryRegistry;
+///
+/// let registry = DiscoveryRegistry::with_defaults();
+///
+/// // List all registered adapter ids
+/// for id in registry.list() {
+///     println!("Registered adapter: {}", id);
+/// }
+/// ```
+pub struct DiscoveryRegistry {
+    adapters: Vec<Box<dyn TraceDiscovery>>,
+}
+
+impl DiscoveryRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            adapters: Vec::new(),
+        }
+    }
+
+    /// Create a registry pre-populated with all built-in discovery adapters.
+    ///
+    /// Currently returns an empty registry — adapters are wired in follow-up
+    /// issues (#18–#28).
+    pub fn with_defaults() -> Self {
+        // Adapters are wired in follow-up issues (#18–#28).
+        Self::new()
+    }
+
+    /// Register a new discovery adapter.
+    ///
+    /// If an adapter with the same `agent_id()` is already registered, the new
+    /// one replaces it.
+    pub fn register(&mut self, adapter: Box<dyn TraceDiscovery>) {
+        // Replace existing adapter with the same agent_id
+        self.adapters.retain(|a| a.agent_id() != adapter.agent_id());
+        self.adapters.push(adapter);
+    }
+
+    /// Look up a discovery adapter by agent id.
+    ///
+    /// Returns `None` if no adapter with the given id is registered.
+    pub fn get(&self, agent_id: &str) -> Option<&dyn TraceDiscovery> {
+        self.adapters
+            .iter()
+            .find(|a| a.agent_id() == agent_id)
+            .map(|a| a.as_ref())
+    }
+
+    /// Look up a discovery adapter by agent id, returning an error if not found.
+    ///
+    /// Returns [`AgentError::AdapterNotFound`] with the sorted list of registered ids
+    /// when the given id is not present.
+    pub fn require(&self, agent_id: &str) -> AgentResult<&dyn TraceDiscovery> {
+        self.get(agent_id).ok_or_else(|| {
+            let mut names = self.list();
+            names.sort_unstable();
+            AgentError::AdapterNotFound {
+                name: agent_id.to_string(),
+                available: names.join(", "),
+            }
+        })
+    }
+
+    /// Returns the agent ids of all registered adapters, in registration order.
+    pub fn list(&self) -> Vec<&str> {
+        self.adapters.iter().map(|a| a.agent_id()).collect()
+    }
+
+    /// Returns the agent ids of adapters whose storage is currently present on
+    /// the host (`is_available() == true`), in registration order.
+    pub fn available(&self) -> Vec<&str> {
+        self.adapters
+            .iter()
+            .filter(|a| a.is_available())
+            .map(|a| a.agent_id())
+            .collect()
+    }
+
+    /// Returns the number of registered adapters.
+    pub fn count(&self) -> usize {
+        self.adapters.len()
+    }
+
+    /// Returns `true` if no adapters are registered.
+    pub fn is_empty(&self) -> bool {
+        self.adapters.is_empty()
+    }
+
+    /// Returns an iterator over all registered adapters.
+    pub fn iter(&self) -> impl Iterator<Item = &dyn TraceDiscovery> {
+        self.adapters.iter().map(|a| a.as_ref())
+    }
+}
+
+impl Default for DiscoveryRegistry {
+    fn default() -> Self {
+        Self::with_defaults()
+    }
+}
+
+impl fmt::Debug for DiscoveryRegistry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DiscoveryRegistry")
+            .field("adapters", &self.list())
+            .finish()
+    }
+}
+
+// Tests
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::AgentError;
+
+    #[derive(Debug)]
+    struct MockDiscovery {
+        agent_id: String,
+        available: bool,
+    }
+
+    impl MockDiscovery {
+        fn new(agent_id: &str) -> Self {
+            Self {
+                agent_id: agent_id.to_string(),
+                available: true,
+            }
+        }
+
+        fn with_available(agent_id: &str, available: bool) -> Self {
+            Self {
+                agent_id: agent_id.to_string(),
+                available,
+            }
+        }
+    }
+
+    impl TraceDiscovery for MockDiscovery {
+        fn agent_id(&self) -> &str {
+            &self.agent_id
+        }
+
+        fn display_name(&self) -> &str {
+            "Mock"
+        }
+
+        fn is_available(&self) -> bool {
+            self.available
+        }
+
+        fn list_traces(&self) -> AgentResult<Vec<DiscoveredTrace>> {
+            Ok(Vec::new())
+        }
+
+        fn read_events(&self, _trace_id: &str) -> AgentResult<Vec<DiscoveredEvent>> {
+            Ok(Vec::new())
+        }
+
+        fn storage_kind(&self) -> StorageKind {
+            StorageKind::Jsonl
+        }
+    }
+
+    #[test]
+    fn test_registry_new_is_empty() {
+        let registry = DiscoveryRegistry::new();
+        assert!(registry.is_empty());
+        assert_eq!(registry.count(), 0);
+        assert!(registry.list().is_empty());
+    }
+
+    #[test]
+    fn test_registry_with_defaults_is_empty() {
+        let registry = DiscoveryRegistry::with_defaults();
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn test_registry_register_and_get() {
+        let mut registry = DiscoveryRegistry::new();
+        registry.register(Box::new(MockDiscovery::new("mock-a")));
+        let adapter = registry.get("mock-a");
+        assert!(adapter.is_some());
+        assert_eq!(adapter.unwrap().agent_id(), "mock-a");
+    }
+
+    #[test]
+    fn test_registry_get_nonexistent() {
+        let registry = DiscoveryRegistry::new();
+        assert!(registry.get("nope").is_none());
+    }
+
+    #[test]
+    fn test_registry_require_success() {
+        let mut registry = DiscoveryRegistry::new();
+        registry.register(Box::new(MockDiscovery::new("mock-a")));
+        assert!(registry.require("mock-a").is_ok());
+    }
+
+    #[test]
+    fn test_registry_require_not_found() {
+        let mut registry = DiscoveryRegistry::new();
+        registry.register(Box::new(MockDiscovery::new("mock-a")));
+        let err = registry.require("missing").unwrap_err();
+        match err {
+            AgentError::AdapterNotFound { name, available } => {
+                assert_eq!(name, "missing");
+                assert!(available.contains("mock-a"));
+            }
+            other => panic!("Expected AdapterNotFound, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_registry_register_replaces_duplicate() {
+        let mut registry = DiscoveryRegistry::new();
+        registry.register(Box::new(MockDiscovery::new("mock-a")));
+        registry.register(Box::new(MockDiscovery::new("mock-a")));
+        assert_eq!(registry.count(), 1);
+        assert_eq!(registry.get("mock-a").unwrap().agent_id(), "mock-a");
+    }
+
+    #[test]
+    fn test_registry_list_preserves_order() {
+        let mut registry = DiscoveryRegistry::new();
+        registry.register(Box::new(MockDiscovery::new("a")));
+        registry.register(Box::new(MockDiscovery::new("b")));
+        registry.register(Box::new(MockDiscovery::new("c")));
+        assert_eq!(registry.list(), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_registry_available_filters_unavailable() {
+        let mut registry = DiscoveryRegistry::new();
+        registry.register(Box::new(MockDiscovery::new("present")));
+        registry.register(Box::new(MockDiscovery::with_available("absent", false)));
+
+        let available = registry.available();
+        assert!(available.contains(&"present"));
+        assert!(!available.contains(&"absent"));
+
+        let all = registry.list();
+        assert!(all.contains(&"present"));
+        assert!(all.contains(&"absent"));
+    }
+
+    #[test]
+    fn test_registry_iter() {
+        let mut registry = DiscoveryRegistry::new();
+        registry.register(Box::new(MockDiscovery::new("x")));
+        registry.register(Box::new(MockDiscovery::new("y")));
+        assert_eq!(registry.iter().count(), 2);
+    }
+
+    #[test]
+    fn test_registry_debug_format() {
+        let mut registry = DiscoveryRegistry::new();
+        registry.register(Box::new(MockDiscovery::new("claude-code")));
+        registry.register(Box::new(MockDiscovery::new("gemini-cli")));
+        let debug = format!("{:?}", registry);
+        assert!(debug.contains("DiscoveryRegistry"));
+        assert!(debug.contains("claude-code"));
+        assert!(debug.contains("gemini-cli"));
+    }
+
+    #[test]
+    fn test_trace_discovery_is_object_safe() {
+        let _: Box<dyn TraceDiscovery> = Box::new(MockDiscovery::new("x"));
+    }
+
+    #[test]
+    fn test_trace_discovery_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<Box<dyn TraceDiscovery>>();
+    }
+}

--- a/atomic-agent/src/discovery/types.rs
+++ b/atomic-agent/src/discovery/types.rs
@@ -1,0 +1,202 @@
+//! Shared data types for the `TraceDiscovery` trait.
+//!
+//! Mirrors the wire-format produced by all discovery adapters (JSONL, JSON,
+//! SQLite) into a normalized representation that feeds the provenance import
+//! pipeline. Adapters implement [`super::TraceDiscovery`] and emit these types;
+//! consumers read only these types, never adapter-specific structs.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::path::PathBuf;
+
+/// Backing storage format an adapter reads from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StorageKind {
+    /// JSON Lines — one object per line. Used by Claude Code, Codex, Gemini CLI, Copilot.
+    Jsonl,
+    /// Single JSON document per trace. Used by Cline, Amp, OpenClaw, Pi.
+    Json,
+    /// SQLite database. Used by Cursor, Hermes, OpenCode.
+    Sqlite,
+}
+
+/// Normalized event category. Discovery adapters classify each agent event into
+/// one of these variants so downstream provenance accumulation is uniform.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiscoveredEventType {
+    UserMessage,
+    AssistantText,
+    AssistantThinking,
+    ToolCall,
+    ToolResult,
+    Error,
+}
+
+/// Metadata about a single trace (session) found on disk.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoveredTrace {
+    /// Adapter-defined unique id for the trace within this agent.
+    pub trace_id: String,
+    /// Owning agent id (matches `TraceDiscovery::agent_id()`).
+    pub agent_id: String,
+    /// Optional human-readable title (often the first user message).
+    pub title: Option<String>,
+    /// Optional short preview snippet for listing UIs.
+    pub preview: Option<String>,
+    /// Most recent activity time on the trace.
+    pub timestamp: DateTime<Utc>,
+    /// Working directory the trace was associated with, if recorded.
+    pub directory: Option<PathBuf>,
+    /// On-disk path the trace was loaded from (file or DB).
+    pub source_path: PathBuf,
+}
+
+/// A single normalized event read from a trace.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoveredEvent {
+    /// Classification of this event within the trace.
+    pub event_type: DiscoveredEventType,
+    /// Optional speaker role (e.g., "user", "assistant", "system"). Some adapters
+    /// store this redundantly with `event_type`; preserve it when available.
+    pub role: Option<String>,
+    /// Text payload for message/result events.
+    pub text: Option<String>,
+    /// Tool name for `ToolCall` / `ToolResult` events.
+    pub tool_name: Option<String>,
+    /// Correlation id linking a `ToolResult` to its preceding `ToolCall`.
+    pub tool_call_id: Option<String>,
+    /// Model identifier (e.g., "claude-sonnet-4-5") when known.
+    pub model_id: Option<String>,
+    /// Event timestamp when available. Many adapters only have trace-level ts.
+    pub timestamp: Option<DateTime<Utc>>,
+    /// Monotonic ordering index within a trace (0-based). Required.
+    pub order: u64,
+    /// The original adapter-specific JSON payload, preserved for debugging.
+    pub raw_json: Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_storage_kind_serde_roundtrip() {
+        let variants = [StorageKind::Jsonl, StorageKind::Json, StorageKind::Sqlite];
+        for variant in &variants {
+            let json = serde_json::to_string(variant).unwrap();
+            let parsed: StorageKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(&parsed, variant, "round-trip failed for {:?}", variant);
+        }
+    }
+
+    #[test]
+    fn test_storage_kind_serde_format() {
+        assert_eq!(
+            serde_json::to_string(&StorageKind::Jsonl).unwrap(),
+            "\"jsonl\""
+        );
+        assert_eq!(
+            serde_json::to_string(&StorageKind::Json).unwrap(),
+            "\"json\""
+        );
+        assert_eq!(
+            serde_json::to_string(&StorageKind::Sqlite).unwrap(),
+            "\"sqlite\""
+        );
+    }
+
+    #[test]
+    fn test_event_type_serde_roundtrip() {
+        let variants = [
+            DiscoveredEventType::UserMessage,
+            DiscoveredEventType::AssistantText,
+            DiscoveredEventType::AssistantThinking,
+            DiscoveredEventType::ToolCall,
+            DiscoveredEventType::ToolResult,
+            DiscoveredEventType::Error,
+        ];
+        for variant in &variants {
+            let json = serde_json::to_string(variant).unwrap();
+            let parsed: DiscoveredEventType = serde_json::from_str(&json).unwrap();
+            assert_eq!(&parsed, variant, "round-trip failed for {:?}", variant);
+        }
+    }
+
+    #[test]
+    fn test_event_type_serde_format() {
+        assert_eq!(
+            serde_json::to_string(&DiscoveredEventType::AssistantText).unwrap(),
+            "\"assistant_text\""
+        );
+    }
+
+    #[test]
+    fn test_discovered_trace_serde_roundtrip() {
+        let ts = Utc::now();
+        let trace = DiscoveredTrace {
+            trace_id: "trace-abc-123".to_string(),
+            agent_id: "claude-code".to_string(),
+            title: Some("Fix the auth bug".to_string()),
+            preview: Some("Let me look at the login module...".to_string()),
+            timestamp: ts,
+            directory: Some(PathBuf::from("/home/user/project")),
+            source_path: PathBuf::from("/home/user/.claude/projects/trace.jsonl"),
+        };
+
+        let json = serde_json::to_string(&trace).unwrap();
+        let parsed: DiscoveredTrace = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.trace_id, trace.trace_id);
+        assert_eq!(parsed.agent_id, trace.agent_id);
+        assert_eq!(parsed.title, trace.title);
+        assert_eq!(parsed.timestamp, trace.timestamp);
+    }
+
+    #[test]
+    fn test_discovered_event_serde_roundtrip() {
+        let event = DiscoveredEvent {
+            event_type: DiscoveredEventType::ToolCall,
+            role: Some("assistant".to_string()),
+            text: None,
+            tool_name: Some("Edit".to_string()),
+            tool_call_id: Some("tu-999".to_string()),
+            model_id: Some("claude-sonnet-4-5".to_string()),
+            timestamp: Some(Utc::now()),
+            order: 7,
+            raw_json: serde_json::json!({"k": "v"}),
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: DiscoveredEvent = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.event_type, event.event_type);
+        assert_eq!(parsed.order, event.order);
+        assert_eq!(parsed.raw_json, serde_json::json!({"k": "v"}));
+    }
+
+    #[test]
+    fn test_discovered_trace_optional_fields_none() {
+        let ts = Utc::now();
+        let trace = DiscoveredTrace {
+            trace_id: "trace-minimal".to_string(),
+            agent_id: "gemini-cli".to_string(),
+            title: None,
+            preview: None,
+            timestamp: ts,
+            directory: None,
+            source_path: PathBuf::from("/tmp/trace.json"),
+        };
+
+        let json = serde_json::to_string(&trace).unwrap();
+        let parsed: DiscoveredTrace = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.trace_id, trace.trace_id);
+        assert!(parsed.title.is_none());
+        assert!(parsed.preview.is_none());
+        assert!(parsed.directory.is_none());
+        assert_eq!(parsed.source_path, trace.source_path);
+    }
+}

--- a/atomic-agent/src/error.rs
+++ b/atomic-agent/src/error.rs
@@ -109,6 +109,15 @@ pub enum AgentError {
         available: String,
     },
 
+    /// The requested adapter id is not registered in the [`crate::discovery::DiscoveryRegistry`].
+    #[error("Unknown discovery adapter: '{name}' (available adapters: {available})")]
+    AdapterNotFound {
+        /// The adapter id that was requested.
+        name: String,
+        /// Comma-separated list of available adapter ids.
+        available: String,
+    },
+
     /// Hooks are already installed for this agent.
     #[error("Hooks already installed for {agent} (use --force to reinstall)")]
     AlreadyInstalled {
@@ -353,6 +362,9 @@ impl AgentError {
             ),
             AgentError::AgentNotFound { .. } => {
                 Some("Use `atomic agent enable --help` to see available agents.")
+            }
+            AgentError::AdapterNotFound { .. } => {
+                Some("Run `atomic agent discover --list` to see available discovery adapters.")
             }
             _ => None,
         }

--- a/atomic-agent/src/lib.rs
+++ b/atomic-agent/src/lib.rs
@@ -60,6 +60,7 @@
 //!
 //! - [`error`] — Error types for all agent operations
 //! - [`event`] — Turn lifecycle event types (`HookType`, `TurnEvent`, `TurnChanges`)
+//! - [`discovery`] — Read-path adapters (`TraceDiscovery` trait, `DiscoveryRegistry`) for importing historical agent traces (foundation only — concrete adapters land in follow-up issues)
 //! - [`hooks`] — Agent hook adapters (`AgentHook` trait, `AgentRegistry`, Claude Code adapter)
 //! - [`provenance`] — Causal decision DAG for agent sessions
 //! - [`watcher`] — Watchman file watching integration (planned)
@@ -83,6 +84,7 @@
 //! assert_eq!(event.session_id, "abc-123");
 //! ```
 
+pub mod discovery;
 pub mod envelope;
 pub mod error;
 pub mod event;
@@ -97,6 +99,10 @@ pub mod turn;
 pub mod watcher;
 
 // Re-export primary types for convenience
+pub use discovery::{
+    DiscoveredEvent, DiscoveredEventType, DiscoveredTrace, DiscoveryRegistry, StorageKind,
+    TraceDiscovery,
+};
 pub use envelope::SessionEnvelope;
 pub use error::{AgentError, AgentResult};
 pub use event::{HookType, TurnChanges, TurnEvent};

--- a/docs/ATOMIC-AGENT-TASKS.md
+++ b/docs/ATOMIC-AGENT-TASKS.md
@@ -115,6 +115,24 @@ See **Phase 18.5** for full implementation details.
     - `detect(repo_root)`, `installed(repo_root)`, `iter()`
   - [x] Unit tests: 40 tests (MockAgent, registry CRUD, detect/installed filtering, trait object safety, Send+Sync)
 
+### 14.4 Discovery Module Foundation ✅
+_Issue #13. Read-path counterpart to hooks — adapters scan agent storage already on disk and feed the provenance import pipeline._
+
+- [x] Create `atomic-agent/src/discovery/mod.rs`
+  - [x] `TraceDiscovery` trait (dyn-compatible, `Send + Sync + Debug`): `agent_id()`, `display_name()`, `is_available()`, `list_traces()`, `read_events()`, `storage_kind()`
+  - [x] `DiscoveryRegistry` struct: `new()`, `with_defaults()` (currently empty — adapters land in #18–#28), `register()`, `get()`, `require()` (returns `AgentError::AdapterNotFound`), `list()`, `available()`, `count()`, `is_empty()`, `iter()`, `Default`, `Debug`
+- [x] Create `atomic-agent/src/discovery/types.rs`
+  - [x] `DiscoveredTrace` struct: `trace_id`, `agent_id`, `title`, `preview`, `timestamp`, `directory`, `source_path`
+  - [x] `DiscoveredEvent` struct: `event_type`, `role`, `text`, `tool_name`, `tool_call_id`, `model_id`, `timestamp`, `order`, `raw_json`
+  - [x] `DiscoveredEventType` enum: `UserMessage`, `AssistantText`, `AssistantThinking`, `ToolCall`, `ToolResult`, `Error`
+  - [x] `StorageKind` enum: `Jsonl`, `Json`, `Sqlite`
+- [x] Unit tests: 20 tests total (13 in `mod.rs` covering registry CRUD, ordering, replace semantics, `available()` filter, `Debug` format, trait object-safety, `Send + Sync`; 7 in `types.rs` covering serde round-trip and rename_all formats)
+- [ ] Concrete adapters — deferred to follow-up issues:
+  - [ ] Claude Code JSONL adapter (#18)
+  - [ ] Gemini CLI JSON adapter (#19)
+  - [ ] Codex adapter (#20)
+  - [ ] Reader helpers per issue #14
+
 ---
 
 ## Phase 15: Agent Hook Adapters


### PR DESCRIPTION
## Summary

Adds the foundation for the agent trace **discovery** subsystem in `atomic-agent`: the `TraceDiscovery` trait, shared data types, and the `DiscoveryRegistry` that manages adapters. This is the read-path counterpart to the existing write-path `AgentHook` / `AgentRegistry`.

Foundation only — concrete adapters land in follow-up PRs (readers in #14, Hermes in #27, others in #18–#28).

## What's new

- `atomic-agent/src/discovery/types.rs` — `DiscoveredTrace`, `DiscoveredEvent`, `DiscoveredEventType`, `StorageKind`. All serde round-trip; `rename_all = "lowercase"` / `"snake_case"` matches the wire format used by adapters.
- `atomic-agent/src/discovery/mod.rs` — object-safe `TraceDiscovery` trait (`Send + Sync + Debug`) and `DiscoveryRegistry` (`Vec<Box<dyn TraceDiscovery>>`). API surface mirrors `AgentRegistry` (`new`, `with_defaults`, `register`, `get`, `require`, `list`, `available`, `iter`, `Default`, `Debug`).
- `atomic-agent/src/error.rs` — new `AgentError::AdapterNotFound { name, available }` variant with a discovery-specific `suggestion()`. The hook-side `AgentNotFound` variant is untouched.
- `atomic-agent/src/lib.rs` — re-exports the public types at the crate root; the `# Modules` doc bullet is flagged \"foundation only — concrete adapters land in follow-up issues\".
- `docs/ATOMIC-AGENT-TASKS.md` — new Phase 14.4 entry listing what landed and what is deferred.

## Design notes

- `DiscoveryRegistry::list()` returns adapters in **registration order** (deliberate divergence from `AgentRegistry::list()` which sorts). Issue #13 specifies registration-order semantics; the test `test_registry_list_preserves_order` pins this.
- `DiscoveryRegistry::with_defaults()` is currently empty; adapters are wired in #14/#27 and the rest of the #18–#28 series.
- `Connection: !Sync` is acknowledged in the trait documentation — future SQLite adapters open per-call rather than holding a `Connection` field.

## Test plan

- [x] \`cargo fmt -p atomic-agent --check\`
- [x] \`cargo check -p atomic-agent --all-targets\` under \`RUSTFLAGS=-Dwarnings\`
- [x] \`cargo test -p atomic-agent --lib discovery\` — 20 new tests (13 in \`mod.rs\` + 7 in \`types.rs\`)
- [x] \`cargo test -p atomic-agent --doc discovery\` — 2 new doctests
- [x] \`cargo test -p atomic-agent --lib\` — no regressions
- [x] \`cargo clippy -p atomic-agent --all-targets\` — no new lints in \`discovery/\`

## Deferred (planned follow-ups)

- Reader helpers for JSONL/JSON/SQLite — #14
- Concrete adapters — #18 (Claude Code), #19 (Codex), #20 (Gemini CLI), #21 (Copilot), #22 (Cline), #23 (Amp), #24 (OpenClaw), #25 (Pi), #26 (Cursor), #27 (Hermes), #28 (OpenCode)
- CLI \`atomic agent discover\` / \`import\` — #29
- Import pipeline (discovery events → ProvenanceAccumulator → redb) — #17

Closes #13.