### PR TITLE
feat(agent): add Hermes discovery adapter (#27)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +142,7 @@ dependencies = [
  "ignore",
  "log",
  "postcard",
+ "rusqlite",
  "serde",
  "serde_json",
  "serial_test",
@@ -827,6 +840,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastcdc"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,6 +1136,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1123,6 +1157,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heapless"
@@ -1561,6 +1604,17 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags",
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2227,6 +2281,20 @@ checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/atomic-agent/Cargo.toml
+++ b/atomic-agent/Cargo.toml
@@ -48,6 +48,9 @@ ignore = { workspace = true }
 # File locking (flock-based advisory locks for concurrent hook processes)
 fs2 = "0.4"
 
+# SQLite read-only access for discovery adapters (Cursor, Hermes, OpenCode)
+rusqlite = { version = "0.31", features = ["bundled"] }
+
 # Home directory resolution (for ~/.atomic/identities/)
 dirs = { workspace = true }
 

--- a/atomic-agent/src/discovery/hermes.rs
+++ b/atomic-agent/src/discovery/hermes.rs
@@ -1,0 +1,972 @@
+//! Hermes discovery adapter.
+//!
+//! Reads conversation history from a Hermes agent's local SQLite store
+//! at `~/.hermes/state.db`. Schema verified against NousResearch/hermes-agent
+//! (see `hermes_state.py`, schema version 6).
+//!
+//! # Schema (quoted from upstream `hermes_state.py`)
+//!
+//! ```sql
+//! CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT NOT NULL, ...,
+//!     started_at REAL NOT NULL, ended_at REAL, ...,  title TEXT, ...);
+//! CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT,
+//!     session_id TEXT NOT NULL, role TEXT NOT NULL, content TEXT,
+//!     tool_call_id TEXT, tool_calls TEXT, tool_name TEXT,
+//!     timestamp REAL NOT NULL, ...,
+//!     reasoning TEXT, reasoning_details TEXT, codex_reasoning_items TEXT);
+//! ```
+//!
+//! Tool calls are embedded in `messages.tool_calls` as a JSON array. Tool
+//! results arrive as separate rows with `role = 'tool'`, populating
+//! `tool_call_id`, `tool_name`, and `content`. There is no `part` table.
+//!
+//! Top-level sessions are filtered with `parent_session_id IS NULL`
+//! (subagent runs / compression continuations are children and are
+//! excluded from default discovery, matching Hermes' own
+//! `list_sessions_rich`).
+//!
+//! Hermes deduplicates messages at write time via `_last_flushed_db_idx`,
+//! so the database itself does not contain consecutive duplicates under
+//! normal operation. This adapter still applies a defensive consecutive-
+//! equivalence pass on read to tolerate hand-edited or replayed DBs.
+
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use rusqlite::Connection;
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::discovery::reader::open_sqlite_readonly;
+use crate::discovery::types::{DiscoveredEvent, DiscoveredEventType, DiscoveredTrace, StorageKind};
+use crate::discovery::TraceDiscovery;
+use crate::error::{AgentError, AgentResult};
+
+/// Agent identifier used in registry lookups.
+pub const HERMES_AGENT_ID: &str = "hermes";
+
+/// Name of the SQLite database file inside the Hermes root directory.
+const HERMES_DB_FILENAME: &str = "state.db";
+
+// HermesDiscovery
+
+/// Discovery adapter for the Hermes AI agent.
+///
+/// Reads from the SQLite database at `<root>/state.db` (default root:
+/// `~/.hermes`). Implements [`TraceDiscovery`] and produces normalized
+/// [`DiscoveredTrace`] and [`DiscoveredEvent`] values.
+///
+/// # Thread safety
+///
+/// This struct is `Send + Sync`. Database connections are opened fresh in each
+/// method call — no `Connection` is stored in the struct (per the contract in
+/// [`crate::discovery::reader::open_sqlite_readonly`]).
+#[derive(Debug, Clone)]
+pub struct HermesDiscovery {
+    /// Directory containing `state.db` (typically `~/.hermes`).
+    root: PathBuf,
+}
+
+impl HermesDiscovery {
+    /// Construct an adapter rooted at the default Hermes path (`~/.hermes`).
+    ///
+    /// If the home directory cannot be resolved, falls back to a relative
+    /// `.hermes/` path; `is_available()` will report `false` until the path
+    /// is populated.
+    pub fn new() -> Self {
+        let root = dirs::home_dir()
+            .map(|home| home.join(".hermes"))
+            .unwrap_or_else(|| PathBuf::from(".hermes"));
+        Self { root }
+    }
+
+    /// Construct an adapter against a custom root directory.
+    ///
+    /// Used for tests and for alternative install locations. The path need not
+    /// exist at construction time; [`TraceDiscovery::is_available`] checks
+    /// existence lazily.
+    pub fn with_root(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// Returns the expected path to the Hermes SQLite database.
+    fn db_path(&self) -> PathBuf {
+        self.root.join(HERMES_DB_FILENAME)
+    }
+}
+
+impl Default for HermesDiscovery {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// TraceDiscovery impl
+
+impl TraceDiscovery for HermesDiscovery {
+    fn agent_id(&self) -> &str {
+        HERMES_AGENT_ID
+    }
+
+    fn display_name(&self) -> &str {
+        "Hermes"
+    }
+
+    /// Returns `true` when both the root directory and the `state.db` file
+    /// exist. Does not open the database.
+    fn is_available(&self) -> bool {
+        self.root.is_dir() && self.db_path().is_file()
+    }
+
+    fn storage_kind(&self) -> StorageKind {
+        StorageKind::Sqlite
+    }
+
+    /// List all top-level Hermes sessions (those with `parent_session_id IS NULL`),
+    /// ordered most-recent first by last message timestamp.
+    ///
+    /// Child sessions (subagent runs, compression continuations) are excluded,
+    /// matching the behaviour of Hermes' own `list_sessions_rich` function.
+    fn list_traces(&self) -> AgentResult<Vec<DiscoveredTrace>> {
+        let db = self.db_path();
+        let conn = open_sqlite_readonly(&db)?;
+
+        let mut stmt = conn
+            .prepare(
+                "SELECT \
+                    s.id           AS session_id, \
+                    s.title        AS title, \
+                    s.source       AS source, \
+                    s.model        AS model, \
+                    s.started_at   AS started_at, \
+                    COALESCE( \
+                        (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = s.id), \
+                        s.started_at \
+                    ) AS last_ts, \
+                    (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 120) \
+                       FROM messages m \
+                      WHERE m.session_id = s.id \
+                        AND m.role = 'user' \
+                        AND m.content IS NOT NULL \
+                      ORDER BY m.timestamp, m.id \
+                      LIMIT 1) AS preview \
+                FROM sessions s \
+                WHERE s.parent_session_id IS NULL \
+                ORDER BY last_ts DESC",
+            )
+            .map_err(|e| AgentError::DiscoveryReadFailed {
+                path: db.clone(),
+                reason: e.to_string(),
+            })?;
+
+        let traces: Vec<DiscoveredTrace> = stmt
+            .query_map([], |row| {
+                let session_id: String = row.get(0)?;
+                let title: Option<String> = row.get(1)?;
+                let last_ts: f64 = row.get(5)?;
+                let preview: Option<String> = row.get(6)?;
+                Ok((session_id, title, last_ts, preview))
+            })
+            .map_err(|e| AgentError::DiscoveryReadFailed {
+                path: db.clone(),
+                reason: e.to_string(),
+            })?
+            .map(|row| {
+                let (session_id, title, last_ts, preview) =
+                    row.map_err(|e| AgentError::DiscoveryReadFailed {
+                        path: db.clone(),
+                        reason: e.to_string(),
+                    })?;
+
+                let timestamp = seconds_to_datetime(last_ts);
+
+                // Treat NULL or empty title as absent.
+                let title = title.filter(|t| !t.is_empty());
+                let preview = preview
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty());
+
+                Ok(DiscoveredTrace {
+                    trace_id: session_id,
+                    agent_id: HERMES_AGENT_ID.to_string(),
+                    title,
+                    preview,
+                    timestamp,
+                    directory: None,
+                    source_path: db.clone(),
+                })
+            })
+            .collect::<AgentResult<Vec<_>>>()?;
+
+        Ok(traces)
+    }
+
+    /// Read all events for a single Hermes session, in chronological order.
+    ///
+    /// Wraps both reads in `BEGIN DEFERRED ... ROLLBACK` for WAL snapshot
+    /// consistency. Applies a defensive consecutive-equivalence dedup pass
+    /// after collecting all events (Hermes already deduplicates on write via
+    /// `_last_flushed_db_idx`; the pass here guards against hand-edited or
+    /// replayed databases).
+    fn read_events(&self, trace_id: &str) -> AgentResult<Vec<DiscoveredEvent>> {
+        let db = self.db_path();
+        let conn = open_sqlite_readonly(&db)?;
+
+        // Lock a read snapshot so queries see the same WAL state.
+        conn.execute_batch("BEGIN DEFERRED")
+            .map_err(|e| AgentError::DiscoveryReadFailed {
+                path: db.clone(),
+                reason: e.to_string(),
+            })?;
+
+        let result = read_session_events(&conn, &db, trace_id);
+
+        // Always end the transaction — read-only, so rollback to release.
+        let _ = conn.execute_batch("ROLLBACK");
+
+        result
+    }
+}
+
+// Private helpers
+
+/// Read and assemble all events for `session_id` from the `messages` table.
+fn read_session_events(
+    conn: &Connection,
+    db: &Path,
+    session_id: &str,
+) -> AgentResult<Vec<DiscoveredEvent>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, role, content, tool_call_id, tool_calls, tool_name, \
+                    timestamp, reasoning, reasoning_details, finish_reason \
+             FROM messages \
+             WHERE session_id = ?1 \
+             ORDER BY timestamp, id",
+        )
+        .map_err(|e| AgentError::DiscoveryReadFailed {
+            path: db.to_path_buf(),
+            reason: e.to_string(),
+        })?;
+
+    let rows = stmt
+        .query_map([session_id], |row| {
+            let id: i64 = row.get(0)?;
+            let role: String = row.get(1)?;
+            let content: Option<String> = row.get(2)?;
+            let tool_call_id: Option<String> = row.get(3)?;
+            let tool_calls: Option<String> = row.get(4)?;
+            let tool_name: Option<String> = row.get(5)?;
+            let timestamp: f64 = row.get(6)?;
+            let reasoning: Option<String> = row.get(7)?;
+            let reasoning_details: Option<String> = row.get(8)?;
+            let finish_reason: Option<String> = row.get(9)?;
+            Ok((
+                id,
+                role,
+                content,
+                tool_call_id,
+                tool_calls,
+                tool_name,
+                timestamp,
+                reasoning,
+                reasoning_details,
+                finish_reason,
+            ))
+        })
+        .map_err(|e| AgentError::DiscoveryReadFailed {
+            path: db.to_path_buf(),
+            reason: e.to_string(),
+        })?;
+
+    let mut events: Vec<DiscoveredEvent> = Vec::new();
+
+    for row_result in rows {
+        let (
+            id,
+            role,
+            content,
+            tool_call_id,
+            tool_calls,
+            tool_name,
+            timestamp_secs,
+            reasoning,
+            reasoning_details,
+            finish_reason,
+        ) = row_result.map_err(|e| AgentError::DiscoveryReadFailed {
+            path: db.to_path_buf(),
+            reason: e.to_string(),
+        })?;
+
+        let ts = Some(seconds_to_datetime(timestamp_secs));
+
+        // Build the raw_json snapshot of the source row.
+        let row_raw = json!({
+            "source": "messages",
+            "id": id,
+            "role": role,
+            "content": content,
+            "tool_call_id": tool_call_id,
+            "tool_calls": tool_calls,
+            "tool_name": tool_name,
+            "timestamp": timestamp_secs,
+            "reasoning": reasoning,
+            "reasoning_details": reasoning_details,
+            "finish_reason": finish_reason,
+        });
+
+        // 1. Emit AssistantThinking if reasoning is present.
+        //    Prefer reasoning_details if both are set.
+        let thinking_text = match (&reasoning_details, &reasoning) {
+            (Some(rd), _) if !rd.is_empty() => Some(rd.clone()),
+            (None, Some(r)) if !r.is_empty() => Some(r.clone()),
+            _ => None,
+        };
+        if let Some(thinking) = thinking_text {
+            events.push(DiscoveredEvent {
+                event_type: DiscoveredEventType::AssistantThinking,
+                role: Some("assistant".to_string()),
+                text: Some(thinking),
+                tool_name: None,
+                tool_call_id: None,
+                model_id: None,
+                timestamp: ts,
+                order: 0,
+                raw_json: row_raw.clone(),
+            });
+        }
+
+        // 2. Emit the role-derived event.
+        match role.as_str() {
+            "user" => {
+                events.push(DiscoveredEvent {
+                    event_type: DiscoveredEventType::UserMessage,
+                    role: Some("user".to_string()),
+                    text: content.clone(),
+                    tool_name: None,
+                    tool_call_id: None,
+                    model_id: None,
+                    timestamp: ts,
+                    order: 0,
+                    raw_json: row_raw.clone(),
+                });
+            }
+            "assistant" => {
+                // Omit AssistantText when content is absent AND tool_calls is present.
+                let has_tool_calls = tool_calls
+                    .as_deref()
+                    .map(|s| !s.trim().is_empty())
+                    .unwrap_or(false);
+                let has_content = content.as_ref().map(|s| !s.is_empty()).unwrap_or(false);
+                if has_content || !has_tool_calls {
+                    events.push(DiscoveredEvent {
+                        event_type: DiscoveredEventType::AssistantText,
+                        role: Some("assistant".to_string()),
+                        text: content.clone(),
+                        tool_name: None,
+                        tool_call_id: None,
+                        model_id: None,
+                        timestamp: ts,
+                        order: 0,
+                        raw_json: row_raw.clone(),
+                    });
+                }
+            }
+            "tool" => {
+                events.push(DiscoveredEvent {
+                    event_type: DiscoveredEventType::ToolResult,
+                    role: Some("tool".to_string()),
+                    text: content.clone(),
+                    tool_name: tool_name.clone(),
+                    tool_call_id: tool_call_id.clone(),
+                    model_id: None,
+                    timestamp: ts,
+                    order: 0,
+                    raw_json: row_raw.clone(),
+                });
+            }
+            "system" => {
+                // Documented limitation: DiscoveredEventType has no SystemPrompt variant.
+                // Map to UserMessage but preserve role for downstream filters.
+                events.push(DiscoveredEvent {
+                    event_type: DiscoveredEventType::UserMessage,
+                    role: Some("system".to_string()),
+                    text: content.clone(),
+                    tool_name: None,
+                    tool_call_id: None,
+                    model_id: None,
+                    timestamp: ts,
+                    order: 0,
+                    raw_json: row_raw.clone(),
+                });
+            }
+            other => {
+                log::warn!(
+                    "hermes discovery: unknown message role '{}' in session {}, emitting Error event",
+                    other,
+                    session_id
+                );
+                events.push(DiscoveredEvent {
+                    event_type: DiscoveredEventType::Error,
+                    role: Some(other.to_string()),
+                    text: Some(format!("unknown role: {}", other)),
+                    tool_name: None,
+                    tool_call_id: None,
+                    model_id: None,
+                    timestamp: ts,
+                    order: 0,
+                    raw_json: row_raw.clone(),
+                });
+            }
+        }
+
+        // 3. Parse tool_calls JSON and emit ToolCall events.
+        if let Some(ref tc_json) = tool_calls {
+            let trimmed = tc_json.trim();
+            if !trimmed.is_empty() {
+                match serde_json::from_str::<Vec<HermesToolCall>>(trimmed) {
+                    Ok(calls) => {
+                        for call in calls {
+                            let call_id = call.id.clone();
+                            let fn_name = call.function.as_ref().and_then(|f| f.name.clone());
+                            let fn_args = call.function.as_ref().and_then(|f| f.arguments.clone());
+
+                            let raw_call = json!({
+                                "source": "tool_calls",
+                                "id": call_id,
+                                "function": {
+                                    "name": fn_name,
+                                    "arguments": fn_args,
+                                },
+                            });
+
+                            events.push(DiscoveredEvent {
+                                event_type: DiscoveredEventType::ToolCall,
+                                role: Some("assistant".to_string()),
+                                text: fn_args,
+                                tool_name: fn_name,
+                                tool_call_id: call_id,
+                                model_id: None,
+                                timestamp: ts,
+                                order: 0,
+                                raw_json: raw_call,
+                            });
+                        }
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "hermes discovery: malformed tool_calls JSON in session {} row {}: {}",
+                            session_id,
+                            id,
+                            e
+                        );
+                        events.push(DiscoveredEvent {
+                            event_type: DiscoveredEventType::Error,
+                            role: None,
+                            text: Some(format!("malformed tool_calls JSON: {}", e)),
+                            tool_name: None,
+                            tool_call_id: None,
+                            model_id: None,
+                            timestamp: ts,
+                            order: 0,
+                            raw_json: row_raw.clone(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    // Defensive dedup pass (Hermes already deduplicates on write).
+    let events = dedupe_consecutive(events);
+
+    // Assign monotonic order after dedup.
+    let events: Vec<DiscoveredEvent> = events
+        .into_iter()
+        .enumerate()
+        .map(|(i, mut ev)| {
+            ev.order = i as u64;
+            ev
+        })
+        .collect();
+
+    Ok(events)
+}
+
+/// Convert a Hermes `REAL` timestamp (seconds since Unix epoch, possibly
+/// fractional) to a [`DateTime<Utc>`].
+///
+/// Non-finite or negative values produce an epoch-sentinel timestamp (1970-01-01
+/// 00:00:00 UTC) and a `log::warn!`. Timestamps outside the `DateTime` range
+/// also fall back to the sentinel.
+fn seconds_to_datetime(secs: f64) -> DateTime<Utc> {
+    if !secs.is_finite() || secs < 0.0 {
+        log::warn!(
+            "hermes: non-finite or negative timestamp ({}), using epoch sentinel",
+            secs
+        );
+        return DateTime::<Utc>::from_timestamp(0, 0).expect("epoch must be valid");
+    }
+    let whole = secs.trunc() as i64;
+    let frac_nanos = (secs.fract() * 1_000_000_000.0).round().max(0.0) as u32;
+    DateTime::<Utc>::from_timestamp(whole, frac_nanos.min(999_999_999)).unwrap_or_else(|| {
+        log::warn!(
+            "hermes: timestamp {} out of DateTime range, using epoch sentinel",
+            secs
+        );
+        DateTime::<Utc>::from_timestamp(0, 0).expect("epoch must be valid")
+    })
+}
+
+/// OpenAI/OpenRouter-compatible tool-call entry stored in `messages.tool_calls`.
+///
+/// All fields are optional to tolerate null or missing fields in hand-edited or
+/// future-schema databases.
+#[derive(Debug, Deserialize)]
+struct HermesToolCall {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    function: Option<HermesToolFunction>,
+}
+
+/// The `function` sub-object of a [`HermesToolCall`].
+#[derive(Debug, Deserialize)]
+struct HermesToolFunction {
+    #[serde(default)]
+    name: Option<String>,
+    /// Arguments stored as a JSON string per OpenAI/OpenRouter convention.
+    #[serde(default)]
+    arguments: Option<String>,
+}
+
+/// Returns `true` when two events carry equivalent conversational content.
+///
+/// Used to deduplicate consecutive identical events that may appear in
+/// hand-edited or replayed databases. Compares event type, role, text,
+/// tool name, and tool call id. Hermes normally prevents duplicates at
+/// write time via `_last_flushed_db_idx`; this is a defensive read-side pass.
+fn are_hermes_messages_equivalent(a: &DiscoveredEvent, b: &DiscoveredEvent) -> bool {
+    a.event_type == b.event_type
+        && a.role == b.role
+        && a.text == b.text
+        && a.tool_name == b.tool_name
+        && a.tool_call_id == b.tool_call_id
+}
+
+/// Remove consecutive duplicate events from `events`.
+fn dedupe_consecutive(events: Vec<DiscoveredEvent>) -> Vec<DiscoveredEvent> {
+    let mut out: Vec<DiscoveredEvent> = Vec::with_capacity(events.len());
+    for ev in events {
+        if let Some(prev) = out.last() {
+            if are_hermes_messages_equivalent(prev, &ev) {
+                continue;
+            }
+        }
+        out.push(ev);
+    }
+    out
+}
+
+// Tests
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// Create the canonical Hermes schema in `conn` and return it for seeding.
+    fn make_fixture(root: &Path) -> Connection {
+        std::fs::create_dir_all(root).unwrap();
+        let db_path = root.join(HERMES_DB_FILENAME);
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE sessions (
+                id                  TEXT PRIMARY KEY,
+                source              TEXT NOT NULL,
+                user_id             TEXT,
+                model               TEXT,
+                model_config        TEXT,
+                system_prompt       TEXT,
+                parent_session_id   TEXT,
+                started_at          REAL NOT NULL,
+                ended_at            REAL,
+                end_reason          TEXT,
+                message_count       INTEGER DEFAULT 0,
+                tool_call_count     INTEGER DEFAULT 0,
+                input_tokens        INTEGER DEFAULT 0,
+                output_tokens       INTEGER DEFAULT 0,
+                cache_read_tokens   INTEGER DEFAULT 0,
+                cache_write_tokens  INTEGER DEFAULT 0,
+                reasoning_tokens    INTEGER DEFAULT 0,
+                billing_provider    TEXT,
+                billing_base_url    TEXT,
+                billing_mode        TEXT,
+                estimated_cost_usd  REAL,
+                actual_cost_usd     REAL,
+                cost_status         TEXT,
+                cost_source         TEXT,
+                pricing_version     TEXT,
+                title               TEXT,
+                FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
+            );
+            CREATE TABLE messages (
+                id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id              TEXT NOT NULL REFERENCES sessions(id),
+                role                    TEXT NOT NULL,
+                content                 TEXT,
+                tool_call_id            TEXT,
+                tool_calls              TEXT,
+                tool_name               TEXT,
+                timestamp               REAL NOT NULL,
+                token_count             INTEGER,
+                finish_reason           TEXT,
+                reasoning               TEXT,
+                reasoning_details       TEXT,
+                codex_reasoning_items   TEXT
+            );
+            CREATE INDEX idx_messages_session ON messages(session_id, timestamp);",
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn test_agent_id_and_display_name() {
+        let dir = tempdir().unwrap();
+        let adapter = HermesDiscovery::with_root(dir.path());
+        assert_eq!(adapter.agent_id(), "hermes");
+        assert_eq!(adapter.display_name(), "Hermes");
+    }
+
+    #[test]
+    fn test_storage_kind_is_sqlite() {
+        let dir = tempdir().unwrap();
+        let adapter = HermesDiscovery::with_root(dir.path());
+        assert_eq!(adapter.storage_kind(), StorageKind::Sqlite);
+    }
+
+    #[test]
+    fn test_is_available_missing_root() {
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("nonexistent");
+        let adapter = HermesDiscovery::with_root(missing);
+        assert!(!adapter.is_available());
+    }
+
+    #[test]
+    fn test_is_available_root_without_db() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path()).unwrap();
+        let adapter = HermesDiscovery::with_root(dir.path());
+        assert!(!adapter.is_available());
+    }
+
+    #[test]
+    fn test_is_available_with_db() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join(HERMES_DB_FILENAME);
+        std::fs::write(&db_path, b"").unwrap();
+        let adapter = HermesDiscovery::with_root(dir.path());
+        assert!(adapter.is_available());
+    }
+
+    #[test]
+    fn test_list_traces_empty_db_no_sessions() {
+        let dir = tempdir().unwrap();
+        make_fixture(dir.path());
+        let adapter = HermesDiscovery::with_root(dir.path());
+        let traces = adapter.list_traces().unwrap();
+        assert!(traces.is_empty());
+    }
+
+    #[test]
+    fn test_list_traces_excludes_child_sessions() {
+        let dir = tempdir().unwrap();
+        let conn = make_fixture(dir.path());
+
+        // Parent session
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES ('parent-1', 'cli', 100.0)",
+            [],
+        )
+        .unwrap();
+
+        // Child session with parent_session_id set
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at, parent_session_id) VALUES ('child-1', 'cli', 200.0, 'parent-1')",
+            [],
+        )
+        .unwrap();
+
+        let adapter = HermesDiscovery::with_root(dir.path());
+        let traces = adapter.list_traces().unwrap();
+        assert_eq!(traces.len(), 1);
+        assert_eq!(traces[0].trace_id, "parent-1");
+    }
+
+    #[test]
+    fn test_list_traces_uses_session_title_when_present() {
+        let dir = tempdir().unwrap();
+        let conn = make_fixture(dir.path());
+
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at, title) VALUES ('sess-title', 'cli', 100.0, 'Refactor auth')",
+            [],
+        )
+        .unwrap();
+
+        let adapter = HermesDiscovery::with_root(dir.path());
+        let traces = adapter.list_traces().unwrap();
+        assert_eq!(traces.len(), 1);
+        assert_eq!(traces[0].title.as_deref(), Some("Refactor auth"));
+    }
+
+    #[test]
+    fn test_list_traces_preview_is_first_user_message() {
+        let dir = tempdir().unwrap();
+        let conn = make_fixture(dir.path());
+
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES ('sess-p', 'cli', 1.0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES ('sess-p', 'user', 'Open the PR description', 1.0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES ('sess-p', 'assistant', 'OK', 2.0)",
+            [],
+        )
+        .unwrap();
+
+        let adapter = HermesDiscovery::with_root(dir.path());
+        let traces = adapter.list_traces().unwrap();
+        assert_eq!(traces.len(), 1);
+        assert_eq!(
+            traces[0].preview.as_deref(),
+            Some("Open the PR description")
+        );
+    }
+
+    #[test]
+    fn test_list_traces_timestamp_uses_max_message_timestamp() {
+        let dir = tempdir().unwrap();
+        let conn = make_fixture(dir.path());
+
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES ('sess-ts', 'cli', 100.0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES ('sess-ts', 'user', 'hi', 200.0)",
+            [],
+        )
+        .unwrap();
+
+        let adapter = HermesDiscovery::with_root(dir.path());
+        let traces = adapter.list_traces().unwrap();
+        assert_eq!(traces.len(), 1);
+        assert_eq!(traces[0].timestamp.timestamp(), 200);
+    }
+
+    #[test]
+    fn test_read_events_returns_messages_in_order() {
+        let dir = tempdir().unwrap();
+        let conn = make_fixture(dir.path());
+
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES ('sess-x', 'cli', 1.0)",
+            [],
+        )
+        .unwrap();
+
+        for (ts, role, text) in [
+            (1.0f64, "user", "first message"),
+            (2.0f64, "assistant", "second message"),
+            (3.0f64, "user", "third message"),
+        ] {
+            conn.execute(
+                "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params!["sess-x", role, text, ts],
+            )
+            .unwrap();
+        }
+
+        let adapter = HermesDiscovery::with_root(dir.path());
+        let events = adapter.read_events("sess-x").unwrap();
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].order, 0);
+        assert_eq!(events[1].order, 1);
+        assert_eq!(events[2].order, 2);
+        assert_eq!(events[0].event_type, DiscoveredEventType::UserMessage);
+        assert_eq!(events[1].event_type, DiscoveredEventType::AssistantText);
+        assert_eq!(events[2].event_type, DiscoveredEventType::UserMessage);
+        assert_eq!(events[0].text.as_deref(), Some("first message"));
+        assert_eq!(events[1].text.as_deref(), Some("second message"));
+        assert_eq!(events[2].text.as_deref(), Some("third message"));
+    }
+
+    #[test]
+    fn test_read_events_emits_tool_calls_from_json() {
+        let dir = tempdir().unwrap();
+        let conn = make_fixture(dir.path());
+
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES ('sess-tc', 'cli', 1.0)",
+            [],
+        )
+        .unwrap();
+
+        // Assistant message with no content text but with tool_calls JSON.
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, tool_calls, timestamp) \
+             VALUES ('sess-tc', 'assistant', NULL, '[{\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"read\",\"arguments\":\"{}\"}}]', 1.0)",
+            [],
+        )
+        .unwrap();
+
+        let adapter = HermesDiscovery::with_root(dir.path());
+        let events = adapter.read_events("sess-tc").unwrap();
+
+        // Content is NULL and tool_calls is present: no AssistantText, just ToolCall.
+        let tool_calls: Vec<_> = events
+            .iter()
+            .filter(|e| e.event_type == DiscoveredEventType::ToolCall)
+            .collect();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].tool_name.as_deref(), Some("read"));
+        assert_eq!(tool_calls[0].tool_call_id.as_deref(), Some("call_1"));
+        assert_eq!(tool_calls[0].text.as_deref(), Some("{}"));
+    }
+
+    #[test]
+    fn test_read_events_tool_role_emits_tool_result() {
+        let dir = tempdir().unwrap();
+        let conn = make_fixture(dir.path());
+
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES ('sess-tr', 'cli', 1.0)",
+            [],
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, tool_call_id, tool_name, timestamp) \
+             VALUES ('sess-tr', 'tool', 'ok', 'call_1', 'read', 1.0)",
+            [],
+        )
+        .unwrap();
+
+        let adapter = HermesDiscovery::with_root(dir.path());
+        let events = adapter.read_events("sess-tr").unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, DiscoveredEventType::ToolResult);
+        assert_eq!(events[0].tool_name.as_deref(), Some("read"));
+        assert_eq!(events[0].tool_call_id.as_deref(), Some("call_1"));
+        assert_eq!(events[0].text.as_deref(), Some("ok"));
+    }
+
+    #[test]
+    fn test_read_events_emits_thinking_from_reasoning_column() {
+        let dir = tempdir().unwrap();
+        let conn = make_fixture(dir.path());
+
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES ('sess-think', 'cli', 1.0)",
+            [],
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, reasoning, timestamp) \
+             VALUES ('sess-think', 'assistant', 'answer', 'thinking out loud...', 1.0)",
+            [],
+        )
+        .unwrap();
+
+        let adapter = HermesDiscovery::with_root(dir.path());
+        let events = adapter.read_events("sess-think").unwrap();
+
+        // Expect: AssistantThinking BEFORE AssistantText
+        assert!(events.len() >= 2);
+        assert_eq!(events[0].event_type, DiscoveredEventType::AssistantThinking);
+        assert_eq!(events[0].text.as_deref(), Some("thinking out loud..."));
+        assert_eq!(events[1].event_type, DiscoveredEventType::AssistantText);
+    }
+
+    #[test]
+    fn test_read_events_unknown_session_returns_empty() {
+        let dir = tempdir().unwrap();
+        make_fixture(dir.path());
+        let adapter = HermesDiscovery::with_root(dir.path());
+        let events = adapter.read_events("no-such-session").unwrap();
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_read_events_dedupes_consecutive_identical_messages() {
+        let dir = tempdir().unwrap();
+        let conn = make_fixture(dir.path());
+
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES ('sess-d', 'cli', 1.0)",
+            [],
+        )
+        .unwrap();
+
+        // Two adjacent rows with identical role/content at different timestamps.
+        for ts in [1.0f64, 2.0f64] {
+            conn.execute(
+                "INSERT INTO messages (session_id, role, content, timestamp) \
+                 VALUES ('sess-d', 'user', 'duplicate text', ?1)",
+                rusqlite::params![ts],
+            )
+            .unwrap();
+        }
+
+        let adapter = HermesDiscovery::with_root(dir.path());
+        let events = adapter.read_events("sess-d").unwrap();
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn test_read_events_handles_malformed_tool_calls_json() {
+        let dir = tempdir().unwrap();
+        let conn = make_fixture(dir.path());
+
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES ('sess-bad', 'cli', 1.0)",
+            [],
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, tool_calls, timestamp) \
+             VALUES ('sess-bad', 'assistant', NULL, '{not json', 1.0)",
+            [],
+        )
+        .unwrap();
+
+        let adapter = HermesDiscovery::with_root(dir.path());
+        // Must not panic; must return Ok with an Error event.
+        let events = adapter.read_events("sess-bad").unwrap();
+        let error_events: Vec<_> = events
+            .iter()
+            .filter(|e| e.event_type == DiscoveredEventType::Error)
+            .collect();
+        assert!(
+            !error_events.is_empty(),
+            "expected at least one Error event for malformed tool_calls JSON"
+        );
+        assert!(error_events[0]
+            .text
+            .as_deref()
+            .unwrap_or("")
+            .contains("malformed tool_calls JSON"));
+    }
+}

--- a/atomic-agent/src/discovery/mod.rs
+++ b/atomic-agent/src/discovery/mod.rs
@@ -40,10 +40,10 @@
 //! use atomic_agent::discovery::DiscoveryRegistry;
 //!
 //! let registry = DiscoveryRegistry::with_defaults();
-//! // No adapters wired yet — they land in follow-up issues.
 //! let _ = registry;
 //! ```
 
+pub mod hermes;
 pub mod reader;
 pub mod types;
 
@@ -120,11 +120,12 @@ impl DiscoveryRegistry {
 
     /// Create a registry pre-populated with all built-in discovery adapters.
     ///
-    /// Currently returns an empty registry — adapters are wired in follow-up
-    /// issues (#18–#28).
+    /// Registers all built-in discovery adapters. Currently: Hermes (#27).
+    /// Additional adapters land in follow-up issues (#18–#26, #28).
     pub fn with_defaults() -> Self {
-        // Adapters are wired in follow-up issues (#18–#28).
-        Self::new()
+        let mut registry = Self::new();
+        registry.register(Box::new(crate::discovery::hermes::HermesDiscovery::new()));
+        registry
     }
 
     /// Register a new discovery adapter.
@@ -271,9 +272,10 @@ mod tests {
     }
 
     #[test]
-    fn test_registry_with_defaults_is_empty() {
+    fn test_registry_with_defaults_has_hermes() {
         let registry = DiscoveryRegistry::with_defaults();
-        assert!(registry.is_empty());
+        assert!(!registry.is_empty());
+        assert!(registry.list().contains(&"hermes"));
     }
 
     #[test]

--- a/atomic-agent/src/discovery/mod.rs
+++ b/atomic-agent/src/discovery/mod.rs
@@ -44,6 +44,7 @@
 //! let _ = registry;
 //! ```
 
+pub mod reader;
 pub mod types;
 
 pub use types::{DiscoveredEvent, DiscoveredEventType, DiscoveredTrace, StorageKind};

--- a/atomic-agent/src/discovery/mod.rs
+++ b/atomic-agent/src/discovery/mod.rs
@@ -1,0 +1,376 @@
+//! Discovery adapters for reading agent storage on the provenance import path.
+//!
+//! This module defines the [`TraceDiscovery`] trait that each discovery adapter
+//! implements, and the [`DiscoveryRegistry`] that manages available adapters.
+//! Where [`crate::hooks`] is the **write path** — normalizing live hook callbacks
+//! into [`crate::event::TurnEvent`] values as an agent runs — the discovery
+//! module is the **read path**: adapters scan agent storage already on disk
+//! (JSONL transcripts, JSON session files, SQLite databases) and produce
+//! normalized [`DiscoveredTrace`] and [`DiscoveredEvent`] values that feed the
+//! provenance import pipeline.
+//!
+//! # Architecture
+//!
+//! ```text
+//! Agent storage on disk
+//!   (JSONL / JSON / SQLite)
+//!         │
+//!         ▼
+//!  TraceDiscovery adapter
+//!  (list_traces / read_events)
+//!         │
+//!         ▼
+//!  DiscoveredTrace / DiscoveredEvent
+//!         │
+//!         ▼
+//!  Provenance import pipeline
+//! ```
+//!
+//! # Adding a New Adapter
+//!
+//! 1. Create a new file `discovery/<agent_name>.rs`
+//! 2. Implement [`TraceDiscovery`] for your adapter struct
+//! 3. Register it in the default registry via [`DiscoveryRegistry::with_defaults`]
+//!    (see the comment there for the relevant issue numbers)
+//! 4. Add a `pub mod <agent_name>;` declaration to this file
+//!
+//! # Example
+//!
+//! ```rust
+//! use atomic_agent::discovery::DiscoveryRegistry;
+//!
+//! let registry = DiscoveryRegistry::with_defaults();
+//! // No adapters wired yet — they land in follow-up issues.
+//! let _ = registry;
+//! ```
+
+pub mod types;
+
+pub use types::{DiscoveredEvent, DiscoveredEventType, DiscoveredTrace, StorageKind};
+
+use std::fmt;
+
+use crate::error::{AgentError, AgentResult};
+
+// TraceDiscovery Trait
+
+/// Read-path counterpart to [`crate::hooks::AgentHook`]. Each adapter knows how
+/// to scan a specific agent's on-disk storage and produce normalized traces and
+/// events for the provenance import pipeline.
+pub trait TraceDiscovery: Send + Sync + fmt::Debug {
+    /// Unique adapter id used in registry lookups (kebab-case, e.g., `"claude-code"`).
+    fn agent_id(&self) -> &str;
+
+    /// Human-readable display name (e.g., `"Claude Code"`).
+    fn display_name(&self) -> &str;
+
+    /// Whether this adapter's storage is currently present on the host.
+    ///
+    /// Cheap probe (existence check); should not open files or DBs.
+    fn is_available(&self) -> bool;
+
+    /// Enumerate all traces this adapter can see. Order is adapter-defined.
+    fn list_traces(&self) -> AgentResult<Vec<DiscoveredTrace>>;
+
+    /// Read all events for a single trace, in monotonic order.
+    fn read_events(&self, trace_id: &str) -> AgentResult<Vec<DiscoveredEvent>>;
+
+    /// Storage backend this adapter reads from.
+    fn storage_kind(&self) -> StorageKind;
+}
+
+// DiscoveryRegistry
+
+/// Registry of available discovery adapters.
+///
+/// The registry holds all known adapters and provides lookup by agent id,
+/// listing, and filtering to adapters whose storage is currently present on
+/// the host.
+///
+/// # Thread Safety
+///
+/// Adapters are stored as `Box<dyn TraceDiscovery>` which is `Send + Sync`.
+/// The registry itself requires `&mut self` for `register()`; share across
+/// threads via `Arc<Mutex<DiscoveryRegistry>>` or freeze before sharing.
+///
+/// # Example
+///
+/// ```rust
+/// use atomic_agent::discovery::DiscoveryRegistry;
+///
+/// let registry = DiscoveryRegistry::with_defaults();
+///
+/// // List all registered adapter ids
+/// for id in registry.list() {
+///     println!("Registered adapter: {}", id);
+/// }
+/// ```
+pub struct DiscoveryRegistry {
+    adapters: Vec<Box<dyn TraceDiscovery>>,
+}
+
+impl DiscoveryRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            adapters: Vec::new(),
+        }
+    }
+
+    /// Create a registry pre-populated with all built-in discovery adapters.
+    ///
+    /// Currently returns an empty registry — adapters are wired in follow-up
+    /// issues (#18–#28).
+    pub fn with_defaults() -> Self {
+        // Adapters are wired in follow-up issues (#18–#28).
+        Self::new()
+    }
+
+    /// Register a new discovery adapter.
+    ///
+    /// If an adapter with the same `agent_id()` is already registered, the new
+    /// one replaces it.
+    pub fn register(&mut self, adapter: Box<dyn TraceDiscovery>) {
+        // Replace existing adapter with the same agent_id
+        self.adapters.retain(|a| a.agent_id() != adapter.agent_id());
+        self.adapters.push(adapter);
+    }
+
+    /// Look up a discovery adapter by agent id.
+    ///
+    /// Returns `None` if no adapter with the given id is registered.
+    pub fn get(&self, agent_id: &str) -> Option<&dyn TraceDiscovery> {
+        self.adapters
+            .iter()
+            .find(|a| a.agent_id() == agent_id)
+            .map(|a| a.as_ref())
+    }
+
+    /// Look up a discovery adapter by agent id, returning an error if not found.
+    ///
+    /// Returns [`AgentError::AdapterNotFound`] with the sorted list of registered ids
+    /// when the given id is not present.
+    pub fn require(&self, agent_id: &str) -> AgentResult<&dyn TraceDiscovery> {
+        self.get(agent_id).ok_or_else(|| {
+            let mut names = self.list();
+            names.sort_unstable();
+            AgentError::AdapterNotFound {
+                name: agent_id.to_string(),
+                available: names.join(", "),
+            }
+        })
+    }
+
+    /// Returns the agent ids of all registered adapters, in registration order.
+    pub fn list(&self) -> Vec<&str> {
+        self.adapters.iter().map(|a| a.agent_id()).collect()
+    }
+
+    /// Returns the agent ids of adapters whose storage is currently present on
+    /// the host (`is_available() == true`), in registration order.
+    pub fn available(&self) -> Vec<&str> {
+        self.adapters
+            .iter()
+            .filter(|a| a.is_available())
+            .map(|a| a.agent_id())
+            .collect()
+    }
+
+    /// Returns the number of registered adapters.
+    pub fn count(&self) -> usize {
+        self.adapters.len()
+    }
+
+    /// Returns `true` if no adapters are registered.
+    pub fn is_empty(&self) -> bool {
+        self.adapters.is_empty()
+    }
+
+    /// Returns an iterator over all registered adapters.
+    pub fn iter(&self) -> impl Iterator<Item = &dyn TraceDiscovery> {
+        self.adapters.iter().map(|a| a.as_ref())
+    }
+}
+
+impl Default for DiscoveryRegistry {
+    fn default() -> Self {
+        Self::with_defaults()
+    }
+}
+
+impl fmt::Debug for DiscoveryRegistry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DiscoveryRegistry")
+            .field("adapters", &self.list())
+            .finish()
+    }
+}
+
+// Tests
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::AgentError;
+
+    #[derive(Debug)]
+    struct MockDiscovery {
+        agent_id: String,
+        available: bool,
+    }
+
+    impl MockDiscovery {
+        fn new(agent_id: &str) -> Self {
+            Self {
+                agent_id: agent_id.to_string(),
+                available: true,
+            }
+        }
+
+        fn with_available(agent_id: &str, available: bool) -> Self {
+            Self {
+                agent_id: agent_id.to_string(),
+                available,
+            }
+        }
+    }
+
+    impl TraceDiscovery for MockDiscovery {
+        fn agent_id(&self) -> &str {
+            &self.agent_id
+        }
+
+        fn display_name(&self) -> &str {
+            "Mock"
+        }
+
+        fn is_available(&self) -> bool {
+            self.available
+        }
+
+        fn list_traces(&self) -> AgentResult<Vec<DiscoveredTrace>> {
+            Ok(Vec::new())
+        }
+
+        fn read_events(&self, _trace_id: &str) -> AgentResult<Vec<DiscoveredEvent>> {
+            Ok(Vec::new())
+        }
+
+        fn storage_kind(&self) -> StorageKind {
+            StorageKind::Jsonl
+        }
+    }
+
+    #[test]
+    fn test_registry_new_is_empty() {
+        let registry = DiscoveryRegistry::new();
+        assert!(registry.is_empty());
+        assert_eq!(registry.count(), 0);
+        assert!(registry.list().is_empty());
+    }
+
+    #[test]
+    fn test_registry_with_defaults_is_empty() {
+        let registry = DiscoveryRegistry::with_defaults();
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn test_registry_register_and_get() {
+        let mut registry = DiscoveryRegistry::new();
+        registry.register(Box::new(MockDiscovery::new("mock-a")));
+        let adapter = registry.get("mock-a");
+        assert!(adapter.is_some());
+        assert_eq!(adapter.unwrap().agent_id(), "mock-a");
+    }
+
+    #[test]
+    fn test_registry_get_nonexistent() {
+        let registry = DiscoveryRegistry::new();
+        assert!(registry.get("nope").is_none());
+    }
+
+    #[test]
+    fn test_registry_require_success() {
+        let mut registry = DiscoveryRegistry::new();
+        registry.register(Box::new(MockDiscovery::new("mock-a")));
+        assert!(registry.require("mock-a").is_ok());
+    }
+
+    #[test]
+    fn test_registry_require_not_found() {
+        let mut registry = DiscoveryRegistry::new();
+        registry.register(Box::new(MockDiscovery::new("mock-a")));
+        let err = registry.require("missing").unwrap_err();
+        match err {
+            AgentError::AdapterNotFound { name, available } => {
+                assert_eq!(name, "missing");
+                assert!(available.contains("mock-a"));
+            }
+            other => panic!("Expected AdapterNotFound, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_registry_register_replaces_duplicate() {
+        let mut registry = DiscoveryRegistry::new();
+        registry.register(Box::new(MockDiscovery::new("mock-a")));
+        registry.register(Box::new(MockDiscovery::new("mock-a")));
+        assert_eq!(registry.count(), 1);
+        assert_eq!(registry.get("mock-a").unwrap().agent_id(), "mock-a");
+    }
+
+    #[test]
+    fn test_registry_list_preserves_order() {
+        let mut registry = DiscoveryRegistry::new();
+        registry.register(Box::new(MockDiscovery::new("a")));
+        registry.register(Box::new(MockDiscovery::new("b")));
+        registry.register(Box::new(MockDiscovery::new("c")));
+        assert_eq!(registry.list(), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_registry_available_filters_unavailable() {
+        let mut registry = DiscoveryRegistry::new();
+        registry.register(Box::new(MockDiscovery::new("present")));
+        registry.register(Box::new(MockDiscovery::with_available("absent", false)));
+
+        let available = registry.available();
+        assert!(available.contains(&"present"));
+        assert!(!available.contains(&"absent"));
+
+        let all = registry.list();
+        assert!(all.contains(&"present"));
+        assert!(all.contains(&"absent"));
+    }
+
+    #[test]
+    fn test_registry_iter() {
+        let mut registry = DiscoveryRegistry::new();
+        registry.register(Box::new(MockDiscovery::new("x")));
+        registry.register(Box::new(MockDiscovery::new("y")));
+        assert_eq!(registry.iter().count(), 2);
+    }
+
+    #[test]
+    fn test_registry_debug_format() {
+        let mut registry = DiscoveryRegistry::new();
+        registry.register(Box::new(MockDiscovery::new("claude-code")));
+        registry.register(Box::new(MockDiscovery::new("gemini-cli")));
+        let debug = format!("{:?}", registry);
+        assert!(debug.contains("DiscoveryRegistry"));
+        assert!(debug.contains("claude-code"));
+        assert!(debug.contains("gemini-cli"));
+    }
+
+    #[test]
+    fn test_trace_discovery_is_object_safe() {
+        let _: Box<dyn TraceDiscovery> = Box::new(MockDiscovery::new("x"));
+    }
+
+    #[test]
+    fn test_trace_discovery_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<Box<dyn TraceDiscovery>>();
+    }
+}

--- a/atomic-agent/src/discovery/reader.rs
+++ b/atomic-agent/src/discovery/reader.rs
@@ -1,0 +1,528 @@
+//! Low-level I/O helpers for reading agent storage during discovery.
+//!
+//! These functions handle JSONL streaming, single-document JSON, and
+//! read-only SQLite access.
+
+use std::fs;
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
+use std::path::Path;
+
+use rusqlite::{Connection, OpenFlags};
+
+use crate::error::{AgentError, AgentResult};
+
+/// Maximum JSON file size accepted by [`read_json`] to prevent OOM on oversized files.
+pub const MAX_JSON_BYTES: u64 = 64 * 1024 * 1024; // 64 MiB
+
+// JSONL Helpers
+
+/// Read every line of a JSONL file, parsing each as a [`serde_json::Value`].
+///
+/// Streams via `BufReader::lines()` — does not load the full file at once.
+/// Empty and whitespace-only lines are skipped silently; malformed lines are
+/// logged via `log::warn!` and skipped (parse errors do not abort the read).
+/// Lines with invalid UTF-8 encoding are logged via `log::warn!` and skipped;
+/// all other I/O errors are propagated as [`AgentError::DiscoveryReadFailed`].
+/// A leading UTF-8 BOM (`\u{FEFF}`) on the first line is stripped automatically.
+pub fn read_jsonl(path: &Path) -> AgentResult<Vec<serde_json::Value>> {
+    let file = fs::File::open(path).map_err(|e| AgentError::DiscoveryReadFailed {
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })?;
+    let reader = BufReader::new(file);
+    let mut values = Vec::new();
+    let mut bom_stripped = false;
+
+    for line_result in reader.lines() {
+        let line = match line_result {
+            Ok(line) => line,
+            Err(err) if err.kind() == std::io::ErrorKind::InvalidData => {
+                log::warn!(
+                    "discovery reader: skipping line with invalid UTF-8 in {}: {}",
+                    path.display(),
+                    err
+                );
+                continue;
+            }
+            Err(err) => {
+                return Err(AgentError::DiscoveryReadFailed {
+                    path: path.to_path_buf(),
+                    reason: err.to_string(),
+                });
+            }
+        };
+
+        let trimmed = line.trim();
+        let trimmed = if !bom_stripped {
+            bom_stripped = true;
+            trimmed.strip_prefix('\u{FEFF}').unwrap_or(trimmed)
+        } else {
+            trimmed
+        };
+
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        match serde_json::from_str(trimmed) {
+            Ok(value) => values.push(value),
+            Err(err) => {
+                log::warn!(
+                    "discovery reader: skipping malformed JSONL line in {}: {}",
+                    path.display(),
+                    err
+                );
+            }
+        }
+    }
+
+    Ok(values)
+}
+
+/// Read a JSONL file starting at byte `offset` for cursor-based scanning.
+///
+/// Returns `(parsed values, new byte offset)` where the new offset is the
+/// stream position after the read, capped at the file's current size. The
+/// returned offset is a valid input for a subsequent call to resume reading.
+/// If `offset` is at or past EOF, returns `(vec![], file_size)` without error.
+/// Same malformed-line and invalid-UTF-8 tolerance as [`read_jsonl`].
+/// A leading UTF-8 BOM (`\u{FEFF}`) on the first line is stripped automatically.
+///
+/// **Offset contract**: `offset` MUST be `0` or a value previously returned by
+/// `read_jsonl_since` on the same file. Hand-constructed offsets that land
+/// mid-line will cause the partial line to be skipped as malformed without
+/// recovery. After file truncation or rotation, treat the cursor as invalidated
+/// and restart from `0`.
+pub fn read_jsonl_since(path: &Path, offset: u64) -> AgentResult<(Vec<serde_json::Value>, u64)> {
+    let file = fs::File::open(path).map_err(|e| AgentError::DiscoveryReadFailed {
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })?;
+
+    let file_size =
+        file.metadata()
+            .map(|m| m.len())
+            .map_err(|e| AgentError::DiscoveryReadFailed {
+                path: path.to_path_buf(),
+                reason: e.to_string(),
+            })?;
+
+    if offset >= file_size {
+        return Ok((Vec::new(), file_size));
+    }
+
+    let mut file = file;
+    file.seek(SeekFrom::Start(offset))
+        .map_err(|e| AgentError::DiscoveryReadFailed {
+            path: path.to_path_buf(),
+            reason: e.to_string(),
+        })?;
+
+    let mut reader = BufReader::new(file);
+    let mut values = Vec::new();
+    let mut bom_stripped = false;
+
+    for line_result in reader.by_ref().lines() {
+        let line = match line_result {
+            Ok(line) => line,
+            Err(err) if err.kind() == std::io::ErrorKind::InvalidData => {
+                log::warn!(
+                    "discovery reader: skipping line with invalid UTF-8 in {}: {}",
+                    path.display(),
+                    err
+                );
+                continue;
+            }
+            Err(err) => {
+                return Err(AgentError::DiscoveryReadFailed {
+                    path: path.to_path_buf(),
+                    reason: err.to_string(),
+                });
+            }
+        };
+
+        let trimmed = line.trim();
+        let trimmed = if !bom_stripped {
+            bom_stripped = true;
+            trimmed.strip_prefix('\u{FEFF}').unwrap_or(trimmed)
+        } else {
+            trimmed
+        };
+
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        match serde_json::from_str(trimmed) {
+            Ok(value) => values.push(value),
+            Err(err) => {
+                log::warn!(
+                    "discovery reader: skipping malformed JSONL line in {}: {}",
+                    path.display(),
+                    err
+                );
+            }
+        }
+    }
+
+    // Recover the underlying file to get its current stream position, capped
+    // at the file's size so the returned offset is always a valid resume point.
+    let new_offset = reader
+        .into_inner()
+        .stream_position()
+        .map_err(|e| AgentError::DiscoveryReadFailed {
+            path: path.to_path_buf(),
+            reason: e.to_string(),
+        })?
+        .min(file_size);
+
+    Ok((values, new_offset))
+}
+
+// JSON Helper
+
+/// Read a single JSON document from `path`.
+///
+/// Rejects files larger than [`MAX_JSON_BYTES`] (64 MiB) to prevent OOM.
+/// Strips an optional UTF-8 BOM (`\u{FEFF}`) from the start of the file
+/// before parsing. Any I/O or parse error is returned as
+/// [`AgentError::DiscoveryReadFailed`].
+pub fn read_json(path: &Path) -> AgentResult<serde_json::Value> {
+    let metadata = fs::metadata(path).map_err(|e| AgentError::DiscoveryReadFailed {
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })?;
+
+    if metadata.len() > MAX_JSON_BYTES {
+        return Err(AgentError::DiscoveryReadFailed {
+            path: path.to_path_buf(),
+            reason: format!(
+                "JSON file too large ({} bytes, max {} bytes)",
+                metadata.len(),
+                MAX_JSON_BYTES
+            ),
+        });
+    }
+
+    let raw = fs::read_to_string(path).map_err(|e| AgentError::DiscoveryReadFailed {
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })?;
+
+    let content = raw.strip_prefix('\u{FEFF}').unwrap_or(&raw);
+
+    serde_json::from_str(content).map_err(|e| AgentError::DiscoveryReadFailed {
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })
+}
+
+// SQLite Helper
+
+/// Open a SQLite database in strictly read-only mode (no file creation).
+///
+/// Returns [`AgentError::DiscoveryReadFailed`] if the file does not exist or
+/// cannot be opened. The `SQLITE_OPEN_CREATE` flag is intentionally absent so
+/// that a missing file surfaces as an error rather than an empty database.
+///
+/// **Thread safety**: `rusqlite::Connection` is `Send` but NOT `Sync`. Adapters
+/// implementing [`crate::discovery::TraceDiscovery`] (which is `Send + Sync`)
+/// MUST NOT store a `Connection` in their struct directly. Instead, open a fresh
+/// connection in each `list_traces` / `read_events` call, OR store the database
+/// path and wrap any cached connection in `std::sync::Mutex`.
+pub fn open_sqlite_readonly(path: &Path) -> AgentResult<Connection> {
+    Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY).map_err(|e| {
+        AgentError::DiscoveryReadFailed {
+            path: path.to_path_buf(),
+            reason: e.to_string(),
+        }
+    })
+}
+
+// Tests
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::error::AgentError;
+
+    // --- read_jsonl ---
+
+    #[test]
+    fn test_read_jsonl_happy_path() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.jsonl");
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, r#"{{"a":1}}"#).unwrap();
+        writeln!(f, r#"{{"b":2}}"#).unwrap();
+        writeln!(f, r#"{{"c":3}}"#).unwrap();
+
+        let values = read_jsonl(&path).unwrap();
+        assert_eq!(values.len(), 3);
+        assert_eq!(values[0]["a"], 1);
+        assert_eq!(values[1]["b"], 2);
+        assert_eq!(values[2]["c"], 3);
+    }
+
+    #[test]
+    fn test_read_jsonl_skips_empty_and_whitespace_lines() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.jsonl");
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, r#"{{"a":1}}"#).unwrap();
+        writeln!(f).unwrap(); // empty line
+        writeln!(f, "   ").unwrap(); // whitespace-only line
+        writeln!(f, r#"{{"b":2}}"#).unwrap();
+
+        let values = read_jsonl(&path).unwrap();
+        assert_eq!(values.len(), 2);
+        assert_eq!(values[0]["a"], 1);
+        assert_eq!(values[1]["b"], 2);
+    }
+
+    #[test]
+    fn test_read_jsonl_skips_malformed_lines() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.jsonl");
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, r#"{{"a":1}}"#).unwrap();
+        writeln!(f, "this is not json").unwrap();
+        writeln!(f, r#"{{"b":2}}"#).unwrap();
+        writeln!(f, r#"{{"c":3}}"#).unwrap();
+
+        let values = read_jsonl(&path).unwrap();
+        assert_eq!(values.len(), 3);
+        assert_eq!(values[0]["a"], 1);
+        assert_eq!(values[1]["b"], 2);
+        assert_eq!(values[2]["c"], 3);
+    }
+
+    #[test]
+    fn test_read_jsonl_file_not_found() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nonexistent.jsonl");
+
+        let err = read_jsonl(&path).unwrap_err();
+        assert!(matches!(err, AgentError::DiscoveryReadFailed { .. }));
+    }
+
+    #[test]
+    fn test_read_jsonl_skips_invalid_utf8() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("invalid_utf8.jsonl");
+        // Build the file as raw bytes: valid JSON line, invalid UTF-8 line, valid JSON line.
+        let mut content: Vec<u8> = Vec::new();
+        content.extend_from_slice(b"{\"a\":1}\n");
+        content.extend_from_slice(&[0xC3, 0x28, b'\n']); // invalid UTF-8 continuation
+        content.extend_from_slice(b"{\"b\":2}\n");
+        fs::write(&path, &content).unwrap();
+
+        let values = read_jsonl(&path).unwrap();
+        assert_eq!(values.len(), 2, "invalid UTF-8 line should be skipped");
+        assert_eq!(values[0]["a"], 1);
+        assert_eq!(values[1]["b"], 2);
+    }
+
+    #[test]
+    fn test_read_jsonl_strips_leading_bom() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("bom.jsonl");
+        // Write UTF-8 BOM followed by a valid JSON line.
+        let mut content: Vec<u8> = vec![0xEF, 0xBB, 0xBF]; // UTF-8 BOM bytes
+        content.extend_from_slice(b"{\"k\":\"v\"}\n");
+        fs::write(&path, &content).unwrap();
+
+        let values = read_jsonl(&path).unwrap();
+        assert_eq!(
+            values.len(),
+            1,
+            "BOM-prefixed line should parse successfully"
+        );
+        assert_eq!(values[0]["k"], "v");
+    }
+
+    // --- read_jsonl_since ---
+
+    #[test]
+    fn test_read_jsonl_since_offset_zero_matches_read_jsonl() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.jsonl");
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, r#"{{"a":1}}"#).unwrap();
+        writeln!(f, r#"{{"b":2}}"#).unwrap();
+        writeln!(f, r#"{{"c":3}}"#).unwrap();
+
+        let expected = read_jsonl(&path).unwrap();
+        let (values, _offset) = read_jsonl_since(&path, 0).unwrap();
+        assert_eq!(values, expected);
+    }
+
+    #[test]
+    fn test_read_jsonl_since_resumes_from_offset() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.jsonl");
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, r#"{{"a":1}}"#).unwrap();
+        writeln!(f, r#"{{"b":2}}"#).unwrap();
+
+        // Read the whole file, capturing the final offset.
+        let (_values, final_offset) = read_jsonl_since(&path, 0).unwrap();
+
+        // Reading again from that offset should return no new values.
+        let (values2, offset2) = read_jsonl_since(&path, final_offset).unwrap();
+        assert!(values2.is_empty());
+        assert_eq!(offset2, final_offset);
+    }
+
+    #[test]
+    fn test_read_jsonl_since_past_eof() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.jsonl");
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, r#"{{"a":1}}"#).unwrap();
+
+        let past_eof = 99_999u64;
+        let (values, returned_offset) = read_jsonl_since(&path, past_eof).unwrap();
+        assert!(values.is_empty());
+        let file_size = fs::metadata(&path).unwrap().len();
+        assert_eq!(
+            returned_offset, file_size,
+            "past-EOF offset must clamp to file size"
+        );
+    }
+
+    // --- read_json ---
+
+    #[test]
+    fn test_read_json_happy_path() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.json");
+        fs::write(&path, r#"{"k":"v"}"#).unwrap();
+
+        let value = read_json(&path).unwrap();
+        assert_eq!(value["k"], "v");
+    }
+
+    #[test]
+    fn test_read_json_strips_bom() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("bom.json");
+        // Write UTF-8 BOM followed by valid JSON.
+        let mut content = vec![0xEF, 0xBB, 0xBF]; // UTF-8 BOM bytes
+        content.extend_from_slice(r#"{"k":"v"}"#.as_bytes());
+        fs::write(&path, &content).unwrap();
+
+        let value = read_json(&path).unwrap();
+        assert_eq!(value["k"], "v");
+    }
+
+    #[test]
+    fn test_read_json_trailing_comma_errors() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("bad.json");
+        fs::write(&path, r#"{"k":"v",}"#).unwrap();
+
+        let err = read_json(&path).unwrap_err();
+        assert!(matches!(err, AgentError::DiscoveryReadFailed { .. }));
+    }
+
+    #[test]
+    fn test_read_json_file_not_found() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nonexistent.json");
+
+        let err = read_json(&path).unwrap_err();
+        assert!(matches!(err, AgentError::DiscoveryReadFailed { .. }));
+    }
+
+    #[test]
+    fn test_read_json_rejects_oversize() {
+        use std::fs::OpenOptions;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("huge.json");
+
+        // Create a sparse file one byte over the limit — no actual disk allocation needed.
+        let file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(&path)
+            .unwrap();
+        file.set_len(MAX_JSON_BYTES + 1).unwrap();
+
+        let err = read_json(&path).unwrap_err();
+        assert!(
+            matches!(err, AgentError::DiscoveryReadFailed { .. }),
+            "expected DiscoveryReadFailed, got: {:?}",
+            err
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("too large"),
+            "error message should mention 'too large', got: {msg}"
+        );
+    }
+
+    // --- open_sqlite_readonly ---
+
+    #[test]
+    fn test_open_sqlite_readonly_happy_path() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        // Create a DB and write a row via a writable connection.
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT);
+                 INSERT INTO items (name) VALUES ('hello');",
+            )
+            .unwrap();
+        }
+
+        // Open read-only and confirm we can query the row.
+        let conn = open_sqlite_readonly(&db_path).unwrap();
+        let name: String = conn
+            .query_row("SELECT name FROM items WHERE id = 1", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(name, "hello");
+    }
+
+    #[test]
+    fn test_open_sqlite_readonly_rejects_missing_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("missing.db");
+
+        let err = open_sqlite_readonly(&path).unwrap_err();
+        assert!(matches!(err, AgentError::DiscoveryReadFailed { .. }));
+        // Confirm no file was auto-created.
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn test_open_sqlite_readonly_blocks_writes() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        // Create the DB with a table via a writable connection.
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch("CREATE TABLE items (id INTEGER PRIMARY KEY);")
+                .unwrap();
+        }
+
+        // Open read-only and attempt a write — must fail.
+        let conn = open_sqlite_readonly(&db_path).unwrap();
+        let result = conn.execute("INSERT INTO items (id) VALUES (1)", []);
+        assert!(result.is_err(), "write on read-only connection should fail");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("readonly"),
+            "expected 'readonly' in error, got: {err_msg}"
+        );
+    }
+}

--- a/atomic-agent/src/discovery/types.rs
+++ b/atomic-agent/src/discovery/types.rs
@@ -1,0 +1,202 @@
+//! Shared data types for the `TraceDiscovery` trait.
+//!
+//! Mirrors the wire-format produced by all discovery adapters (JSONL, JSON,
+//! SQLite) into a normalized representation that feeds the provenance import
+//! pipeline. Adapters implement [`super::TraceDiscovery`] and emit these types;
+//! consumers read only these types, never adapter-specific structs.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::path::PathBuf;
+
+/// Backing storage format an adapter reads from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StorageKind {
+    /// JSON Lines — one object per line. Used by Claude Code, Codex, Gemini CLI, Copilot.
+    Jsonl,
+    /// Single JSON document per trace. Used by Cline, Amp, OpenClaw, Pi.
+    Json,
+    /// SQLite database. Used by Cursor, Hermes, OpenCode.
+    Sqlite,
+}
+
+/// Normalized event category. Discovery adapters classify each agent event into
+/// one of these variants so downstream provenance accumulation is uniform.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiscoveredEventType {
+    UserMessage,
+    AssistantText,
+    AssistantThinking,
+    ToolCall,
+    ToolResult,
+    Error,
+}
+
+/// Metadata about a single trace (session) found on disk.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoveredTrace {
+    /// Adapter-defined unique id for the trace within this agent.
+    pub trace_id: String,
+    /// Owning agent id (matches `TraceDiscovery::agent_id()`).
+    pub agent_id: String,
+    /// Optional human-readable title (often the first user message).
+    pub title: Option<String>,
+    /// Optional short preview snippet for listing UIs.
+    pub preview: Option<String>,
+    /// Most recent activity time on the trace.
+    pub timestamp: DateTime<Utc>,
+    /// Working directory the trace was associated with, if recorded.
+    pub directory: Option<PathBuf>,
+    /// On-disk path the trace was loaded from (file or DB).
+    pub source_path: PathBuf,
+}
+
+/// A single normalized event read from a trace.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoveredEvent {
+    /// Classification of this event within the trace.
+    pub event_type: DiscoveredEventType,
+    /// Optional speaker role (e.g., "user", "assistant", "system"). Some adapters
+    /// store this redundantly with `event_type`; preserve it when available.
+    pub role: Option<String>,
+    /// Text payload for message/result events.
+    pub text: Option<String>,
+    /// Tool name for `ToolCall` / `ToolResult` events.
+    pub tool_name: Option<String>,
+    /// Correlation id linking a `ToolResult` to its preceding `ToolCall`.
+    pub tool_call_id: Option<String>,
+    /// Model identifier (e.g., "claude-sonnet-4-5") when known.
+    pub model_id: Option<String>,
+    /// Event timestamp when available. Many adapters only have trace-level ts.
+    pub timestamp: Option<DateTime<Utc>>,
+    /// Monotonic ordering index within a trace (0-based). Required.
+    pub order: u64,
+    /// The original adapter-specific JSON payload, preserved for debugging.
+    pub raw_json: Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_storage_kind_serde_roundtrip() {
+        let variants = [StorageKind::Jsonl, StorageKind::Json, StorageKind::Sqlite];
+        for variant in &variants {
+            let json = serde_json::to_string(variant).unwrap();
+            let parsed: StorageKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(&parsed, variant, "round-trip failed for {:?}", variant);
+        }
+    }
+
+    #[test]
+    fn test_storage_kind_serde_format() {
+        assert_eq!(
+            serde_json::to_string(&StorageKind::Jsonl).unwrap(),
+            "\"jsonl\""
+        );
+        assert_eq!(
+            serde_json::to_string(&StorageKind::Json).unwrap(),
+            "\"json\""
+        );
+        assert_eq!(
+            serde_json::to_string(&StorageKind::Sqlite).unwrap(),
+            "\"sqlite\""
+        );
+    }
+
+    #[test]
+    fn test_event_type_serde_roundtrip() {
+        let variants = [
+            DiscoveredEventType::UserMessage,
+            DiscoveredEventType::AssistantText,
+            DiscoveredEventType::AssistantThinking,
+            DiscoveredEventType::ToolCall,
+            DiscoveredEventType::ToolResult,
+            DiscoveredEventType::Error,
+        ];
+        for variant in &variants {
+            let json = serde_json::to_string(variant).unwrap();
+            let parsed: DiscoveredEventType = serde_json::from_str(&json).unwrap();
+            assert_eq!(&parsed, variant, "round-trip failed for {:?}", variant);
+        }
+    }
+
+    #[test]
+    fn test_event_type_serde_format() {
+        assert_eq!(
+            serde_json::to_string(&DiscoveredEventType::AssistantText).unwrap(),
+            "\"assistant_text\""
+        );
+    }
+
+    #[test]
+    fn test_discovered_trace_serde_roundtrip() {
+        let ts = Utc::now();
+        let trace = DiscoveredTrace {
+            trace_id: "trace-abc-123".to_string(),
+            agent_id: "claude-code".to_string(),
+            title: Some("Fix the auth bug".to_string()),
+            preview: Some("Let me look at the login module...".to_string()),
+            timestamp: ts,
+            directory: Some(PathBuf::from("/home/user/project")),
+            source_path: PathBuf::from("/home/user/.claude/projects/trace.jsonl"),
+        };
+
+        let json = serde_json::to_string(&trace).unwrap();
+        let parsed: DiscoveredTrace = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.trace_id, trace.trace_id);
+        assert_eq!(parsed.agent_id, trace.agent_id);
+        assert_eq!(parsed.title, trace.title);
+        assert_eq!(parsed.timestamp, trace.timestamp);
+    }
+
+    #[test]
+    fn test_discovered_event_serde_roundtrip() {
+        let event = DiscoveredEvent {
+            event_type: DiscoveredEventType::ToolCall,
+            role: Some("assistant".to_string()),
+            text: None,
+            tool_name: Some("Edit".to_string()),
+            tool_call_id: Some("tu-999".to_string()),
+            model_id: Some("claude-sonnet-4-5".to_string()),
+            timestamp: Some(Utc::now()),
+            order: 7,
+            raw_json: serde_json::json!({"k": "v"}),
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: DiscoveredEvent = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.event_type, event.event_type);
+        assert_eq!(parsed.order, event.order);
+        assert_eq!(parsed.raw_json, serde_json::json!({"k": "v"}));
+    }
+
+    #[test]
+    fn test_discovered_trace_optional_fields_none() {
+        let ts = Utc::now();
+        let trace = DiscoveredTrace {
+            trace_id: "trace-minimal".to_string(),
+            agent_id: "gemini-cli".to_string(),
+            title: None,
+            preview: None,
+            timestamp: ts,
+            directory: None,
+            source_path: PathBuf::from("/tmp/trace.json"),
+        };
+
+        let json = serde_json::to_string(&trace).unwrap();
+        let parsed: DiscoveredTrace = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.trace_id, trace.trace_id);
+        assert!(parsed.title.is_none());
+        assert!(parsed.preview.is_none());
+        assert!(parsed.directory.is_none());
+        assert_eq!(parsed.source_path, trace.source_path);
+    }
+}

--- a/atomic-agent/src/error.rs
+++ b/atomic-agent/src/error.rs
@@ -276,6 +276,15 @@ pub enum AgentError {
         reason: String,
     },
 
+    /// I/O or parse failure while reading agent storage during discovery.
+    #[error("Failed to read discovery source at {path}: {reason}")]
+    DiscoveryReadFailed {
+        /// Path to the discovery source file.
+        path: PathBuf,
+        /// What went wrong.
+        reason: String,
+    },
+
     /// Failed to encode or decode a `SessionEnvelope`.
     #[error("Session envelope codec error: {reason}")]
     EnvelopeCodecError {

--- a/atomic-agent/src/error.rs
+++ b/atomic-agent/src/error.rs
@@ -109,6 +109,15 @@ pub enum AgentError {
         available: String,
     },
 
+    /// The requested adapter id is not registered in the [`crate::discovery::DiscoveryRegistry`].
+    #[error("Unknown discovery adapter: '{name}' (available adapters: {available})")]
+    AdapterNotFound {
+        /// The adapter id that was requested.
+        name: String,
+        /// Comma-separated list of available adapter ids.
+        available: String,
+    },
+
     /// Hooks are already installed for this agent.
     #[error("Hooks already installed for {agent} (use --force to reinstall)")]
     AlreadyInstalled {
@@ -353,6 +362,9 @@ impl AgentError {
             ),
             AgentError::AgentNotFound { .. } => {
                 Some("Use `atomic agent enable --help` to see available agents.")
+            }
+            AgentError::AdapterNotFound { .. } => {
+                Some("Run `atomic agent discover --list` to see available discovery adapters.")
             }
             _ => None,
         }

--- a/atomic-agent/src/lib.rs
+++ b/atomic-agent/src/lib.rs
@@ -60,6 +60,7 @@
 //!
 //! - [`error`] — Error types for all agent operations
 //! - [`event`] — Turn lifecycle event types (`HookType`, `TurnEvent`, `TurnChanges`)
+//! - [`discovery`] — Read-path adapters (`TraceDiscovery` trait, `DiscoveryRegistry`) for importing historical agent traces (foundation only — concrete adapters land in follow-up issues)
 //! - [`hooks`] — Agent hook adapters (`AgentHook` trait, `AgentRegistry`, Claude Code adapter)
 //! - [`provenance`] — Causal decision DAG for agent sessions
 //! - [`watcher`] — Watchman file watching integration (planned)
@@ -83,6 +84,7 @@
 //! assert_eq!(event.session_id, "abc-123");
 //! ```
 
+pub mod discovery;
 pub mod envelope;
 pub mod error;
 pub mod event;
@@ -97,6 +99,10 @@ pub mod turn;
 pub mod watcher;
 
 // Re-export primary types for convenience
+pub use discovery::{
+    DiscoveredEvent, DiscoveredEventType, DiscoveredTrace, DiscoveryRegistry, StorageKind,
+    TraceDiscovery,
+};
 pub use envelope::SessionEnvelope;
 pub use error::{AgentError, AgentResult};
 pub use event::{HookType, TurnChanges, TurnEvent};

--- a/docs/ATOMIC-AGENT-TASKS.md
+++ b/docs/ATOMIC-AGENT-TASKS.md
@@ -115,6 +115,24 @@ See **Phase 18.5** for full implementation details.
     - `detect(repo_root)`, `installed(repo_root)`, `iter()`
   - [x] Unit tests: 40 tests (MockAgent, registry CRUD, detect/installed filtering, trait object safety, Send+Sync)
 
+### 14.4 Discovery Module Foundation ✅
+_Issue #13. Read-path counterpart to hooks — adapters scan agent storage already on disk and feed the provenance import pipeline._
+
+- [x] Create `atomic-agent/src/discovery/mod.rs`
+  - [x] `TraceDiscovery` trait (dyn-compatible, `Send + Sync + Debug`): `agent_id()`, `display_name()`, `is_available()`, `list_traces()`, `read_events()`, `storage_kind()`
+  - [x] `DiscoveryRegistry` struct: `new()`, `with_defaults()` (currently empty — adapters land in #18–#28), `register()`, `get()`, `require()` (returns `AgentError::AdapterNotFound`), `list()`, `available()`, `count()`, `is_empty()`, `iter()`, `Default`, `Debug`
+- [x] Create `atomic-agent/src/discovery/types.rs`
+  - [x] `DiscoveredTrace` struct: `trace_id`, `agent_id`, `title`, `preview`, `timestamp`, `directory`, `source_path`
+  - [x] `DiscoveredEvent` struct: `event_type`, `role`, `text`, `tool_name`, `tool_call_id`, `model_id`, `timestamp`, `order`, `raw_json`
+  - [x] `DiscoveredEventType` enum: `UserMessage`, `AssistantText`, `AssistantThinking`, `ToolCall`, `ToolResult`, `Error`
+  - [x] `StorageKind` enum: `Jsonl`, `Json`, `Sqlite`
+- [x] Unit tests: 20 tests total (13 in `mod.rs` covering registry CRUD, ordering, replace semantics, `available()` filter, `Debug` format, trait object-safety, `Send + Sync`; 7 in `types.rs` covering serde round-trip and rename_all formats)
+- [ ] Concrete adapters — deferred to follow-up issues:
+  - [ ] Claude Code JSONL adapter (#18)
+  - [ ] Gemini CLI JSON adapter (#19)
+  - [ ] Codex adapter (#20)
+  - [ ] Reader helpers per issue #14
+
 ---
 
 ## Phase 15: Agent Hook Adapters


### PR DESCRIPTION
## Summary

Implements \`TraceDiscovery\` for the Hermes agent (NousResearch/hermes-agent, schema version 6) and wires it into \`DiscoveryRegistry::with_defaults()\` so the import pipeline picks it up automatically. Built on the discovery foundation (#66) and reader helpers (#67).

## Canonical schema

Verified against the upstream source — see [\`hermes_state.py\` lines 36–90](https://github.com/NousResearch/hermes-agent/blob/main/hermes_state.py) (schema version 6, May 2026):

\`\`\`sql
CREATE TABLE sessions (
    id TEXT PRIMARY KEY,
    source TEXT NOT NULL,
    user_id TEXT,
    model TEXT,
    model_config TEXT,
    system_prompt TEXT,
    parent_session_id TEXT,
    started_at REAL NOT NULL,
    ended_at REAL,
    ...,
    title TEXT,
    ...
);

CREATE TABLE messages (
    id INTEGER PRIMARY KEY AUTOINCREMENT,
    session_id TEXT NOT NULL REFERENCES sessions(id),
    role TEXT NOT NULL,
    content TEXT,
    tool_call_id TEXT,
    tool_calls TEXT,        -- JSON array of OpenAI-style tool calls
    tool_name TEXT,
    timestamp REAL NOT NULL,
    token_count INTEGER,
    finish_reason TEXT,
    reasoning TEXT,
    reasoning_details TEXT,
    codex_reasoning_items TEXT
);
\`\`\`

Two important deltas from the issue body's initial description:

- **There is no \`part\` table.** Tool calls are JSON-encoded on \`messages.tool_calls\`; tool results arrive as \`messages\` rows with \`role = 'tool'\` (carrying \`tool_call_id\`, \`tool_name\`, and \`content\`).
- **Timestamps are \`REAL\` seconds** since epoch with sub-second precision, not integer milliseconds.

## Adapter behavior

- \`list_traces()\` reads from \`sessions\`, filters \`parent_session_id IS NULL\` (matching upstream \`list_sessions_rich\` — subagent runs and compression continuations stay hidden by default), uses the \`sessions.title\` column as the title source, and builds the preview via a correlated subquery against the first user message (capped at 120 chars, newlines stripped).
- \`read_events()\` reads from \`messages\` under \`BEGIN DEFERRED ... ROLLBACK\` so concurrent writers under SQLite WAL can't split the view across the read. Per row, emits:
  - \`AssistantThinking\` **before** the role-derived event when \`reasoning\` or \`reasoning_details\` is set (prefers \`reasoning_details\`);
  - the role-derived event (\`UserMessage\` / \`AssistantText\` / \`ToolResult\` / \`UserMessage\` for system rows with the \`role\` field preserved / \`Error\` for unknown roles);
  - one \`ToolCall\` event per entry in the parsed \`tool_calls\` JSON array (tolerant deserialization — missing fields are fine, malformed JSON emits a single \`Error\` event without aborting the read).
- A new \`seconds_to_datetime(f64)\` helper preserves fractional-second precision and clamps non-finite/negative values to an epoch sentinel with a \`log::warn!\`.
- \`HermesDiscovery::new()\` is infallible — it falls back to a relative \`.hermes/\` path when the home directory can't be resolved (\`is_available()\` then reports \`false\` until the path is populated). \`is_available()\` is a cheap probe: \`root.is_dir() && db.is_file()\`. No I/O beyond a stat.
- Defensive \`are_hermes_messages_equivalent\` adjacency dedup runs after the merge — Hermes already dedupes on write via \`_last_flushed_db_idx\`, so this is belt-and-braces for replayed or hand-edited databases.

## Test plan

- [x] \`cargo fmt -p atomic-agent --check\`
- [x] \`cargo check -p atomic-agent --all-targets\` under \`RUSTFLAGS=-Dwarnings\`
- [x] \`cargo test -p atomic-agent --lib discovery::hermes\` — 17 tests covering trait shape, availability probing, parent-session filtering, title sourcing, chronological preview, \`MAX(timestamp)\` trace time, ordering with \`AssistantThinking\` before \`AssistantText\`, tool-call JSON parsing, tool-role → ToolResult mapping, malformed-JSON tolerance, dedup, unknown-session behavior
- [x] \`cargo test -p atomic-agent --lib discovery\` — 54 tests (20 foundation + 17 reader + 17 hermes)
- [x] \`cargo test -p atomic-agent --lib\` — 1178 tests, no regressions
- [x] \`cargo test -p atomic-agent --doc discovery\` — 2 doctests

## Deferred (planned follow-ups)

- JSON session exports — the issue body mentions them, but they're not part of the acceptance criteria; revisit when the import pipeline (#17) needs them.
- File truncation/rotation detection — the read snapshot is consistent under WAL; rotation handling is a polling-adapter concern.
- \`SystemPrompt\` variant in \`DiscoveredEventType\` — \`role = 'system'\` currently maps to \`UserMessage\` with the \`role\` field preserved so downstream filtering can distinguish.

Stacked on #66 and #67. Closes #27.