### PR TITLE
fix: attestation covers only agent-recorded changes

### DIFF
--- a/atomic-agent/src/turn/orchestrator/attestation.rs
+++ b/atomic-agent/src/turn/orchestrator/attestation.rs
@@ -11,12 +11,16 @@ impl TurnOrchestrator {
     // Attestation
     // =========================================================================
 
-    /// Create an attestation covering changes in a session's agent view.
+    /// Create an attestation covering changes this session actually recorded.
     ///
-    /// On a fresh session, this covers all changes in the view. On a
-    /// resumed session (`claude --resume`), this only covers the NEW
-    /// changes that aren't already covered by a previous attestation,
-    /// and chains to that attestation via `previous_attestation`.
+    /// Coverage is based on `session.recorded_change_hashes`, not the full
+    /// agent-view history. Agent views inherit parent-view changes, so scanning
+    /// the view would over-attribute inherited baseline work to the agent.
+    ///
+    /// If this same session was already attested before, only newly recorded
+    /// hashes not covered by a same-session attestation are included and chained
+    /// via `previous_attestation`. Legacy sessions with no recorded hashes are
+    /// skipped.
     ///
     /// The attestation is enriched with data from the provenance entries
     /// embedded in each covered change: model name, token counts, cost,

--- a/atomic-agent/src/turn/orchestrator/attestation.rs
+++ b/atomic-agent/src/turn/orchestrator/attestation.rs
@@ -45,31 +45,27 @@ impl TurnOrchestrator {
             }
         };
 
-        // Query the agent view for all change hashes
-        let history = match repo
-            .log(atomic_repository::history::HistoryOptions::default().view(&session.view_name))
-        {
-            Ok(h) => h,
-            Err(e) => {
-                log::debug!(
-                    "Could not read history for view '{}': {} (no attestation created)",
-                    session.view_name,
-                    e,
-                );
-                return;
-            }
-        };
-
-        if history.is_empty() {
+        // Use the change hashes the orchestrator actually recorded for THIS
+        // session — not the full agent-view history. The agent view is a
+        // fork of the parent view and inherits the parent's baseline
+        // changes; scanning the full history would (incorrectly) attribute
+        // those inherited baseline changes to the agent.
+        //
+        // For sessions that pre-date this field (or that recorded zero
+        // changes), `recorded_change_hashes` is empty — we skip rather
+        // than fall back to the old "scan whole view" path, which would
+        // resurrect the over-counting bug.
+        if session.recorded_change_hashes.is_empty() {
             log::debug!(
-                "View '{}' has no changes — skipping attestation",
-                session.view_name,
+                "Session {} has no recorded change hashes — skipping attestation \
+                 (legacy session or no turns recorded)",
+                session.session_id,
             );
             return;
         }
 
         let all_change_hashes: Vec<atomic_core::types::Hash> =
-            history.iter().map(|e| e.hash).collect();
+            session.recorded_change_hashes.clone();
 
         // Handle resumed sessions: find existing attestations and determine
         // which changes are new (not yet covered by any attestation).

--- a/atomic-agent/src/turn/orchestrator/tests.rs
+++ b/atomic-agent/src/turn/orchestrator/tests.rs
@@ -272,6 +272,163 @@ async fn test_turn_end_records_untracked_only_files() {
         .contains(&"package.json".to_string()));
 }
 
+// PR0 — Attestation coverage correctness
+//
+// Regression guard: the session-end attestation must cover only the changes
+// the orchestrator actually recorded for this session — NOT the inherited
+// baseline (init) changes that the agent view picked up from its parent view.
+//
+// Before this fix, `create_session_attestation` scanned the full agent-view
+// history and reported every change as "covered by the agent". On a fresh
+// repo with 2 init changes + 1 agent file, it incorrectly reported 3 changes.
+// See: notes/2026-05-26-standup.md §3 + development/atomic-attest-fixes.md (B0).
+#[tokio::test]
+async fn test_session_attestation_covers_only_agent_recorded_changes() {
+    use atomic_core::change::ChangeHeader;
+
+    let dir = TempDir::new().unwrap();
+    Repository::init(dir.path()).unwrap();
+
+    // Pre-existing baseline: record a "human" change BEFORE the agent
+    // session starts. This change will be inherited by the agent view
+    // when the session forks. The bug we're guarding against is that
+    // this baseline used to get attributed to the agent.
+    let repo_for_baseline = Repository::open(dir.path()).unwrap();
+    fs::write(dir.path().join("baseline.txt"), "baseline content\n").unwrap();
+    repo_for_baseline
+        .add(
+            "baseline.txt",
+            atomic_repository::tracking::TrackingOptions::default(),
+        )
+        .expect("track baseline.txt");
+    let baseline_outcome = repo_for_baseline
+        .record(
+            ChangeHeader::new("baseline change"),
+            atomic_repository::record::RecordOptions::new().with_all(true),
+        )
+        .expect("baseline record should succeed");
+    let baseline_hash = *baseline_outcome.hash();
+    drop(repo_for_baseline);
+
+    let mut orch = make_orchestrator(&dir);
+    orch.set_agent("claude-code", "Claude Code");
+
+    orch.dispatch(session_start_event("sess-cov-1"))
+        .await
+        .unwrap();
+    orch.dispatch(turn_start_event("sess-cov-1", "Create agent-p0.txt"))
+        .await
+        .unwrap();
+
+    fs::write(dir.path().join("agent-p0.txt"), "agent p0 test\n").unwrap();
+
+    let turn_result = orch
+        .dispatch(turn_end_event("sess-cov-1"))
+        .await
+        .unwrap();
+
+    let recorded = turn_result
+        .change_recorded
+        .as_ref()
+        .expect("turn with new file must record a change");
+    let agent_hash = recorded.hash;
+    assert_ne!(agent_hash, baseline_hash);
+
+    // The session must remember the exact hash(es) it just recorded —
+    // and NOT the baseline that the agent view inherited.
+    let session_after_turn = orch.session_store.load("sess-cov-1").unwrap().unwrap();
+    assert_eq!(
+        session_after_turn.recorded_change_hashes,
+        vec![agent_hash],
+        "session must track exactly the agent's recorded changes, not inherited baseline",
+    );
+
+    // Confirm the agent view DID inherit the baseline (otherwise the test
+    // isn't exercising the regression scenario). We must drop this repo
+    // handle before dispatching session_end — `create_session_attestation`
+    // opens its own handle and the lock is exclusive.
+    {
+        let repo = Repository::open(dir.path()).unwrap();
+        let agent_view_history = repo
+            .log(
+                atomic_repository::history::HistoryOptions::default()
+                    .view(&session_after_turn.view_name),
+            )
+            .unwrap();
+        let inherited_hashes: Vec<_> = agent_view_history.iter().map(|e| e.hash).collect();
+        assert!(
+            inherited_hashes.contains(&baseline_hash),
+            "agent view should inherit the baseline change from parent",
+        );
+        assert!(
+            inherited_hashes.contains(&agent_hash),
+            "agent view should also contain the agent's own change",
+        );
+    }
+
+    // Session end triggers create_session_attestation.
+    orch.dispatch(session_end_event("sess-cov-1"))
+        .await
+        .unwrap();
+
+    let repo = Repository::open(dir.path()).unwrap();
+
+    let attestation_hashes: Vec<_> = repo
+        .change_store()
+        .iter_attestations()
+        .filter_map(|r| r.ok())
+        .collect();
+    assert_eq!(
+        attestation_hashes.len(),
+        1,
+        "expected exactly one attestation after session end",
+    );
+    let attest = repo.load_attestation(&attestation_hashes[0]).unwrap();
+    assert_eq!(
+        attest.changes_covered,
+        vec![agent_hash],
+        "attestation must cover only what the agent recorded ({:?}) — not the inherited baseline ({:?})",
+        agent_hash,
+        baseline_hash,
+    );
+    assert!(
+        !attest.changes_covered.contains(&baseline_hash),
+        "regression: attestation should never include the pre-session baseline change",
+    );
+}
+
+// PR0 — early-return guard
+//
+// A session that never recorded any changes (e.g. agent opened then exited
+// without doing work) must NOT create a virtual attestation by falling back
+// to the full view history.
+#[tokio::test]
+async fn test_session_end_skips_attestation_when_no_recorded_changes() {
+    let dir = TempDir::new().unwrap();
+    Repository::init(dir.path()).unwrap();
+    let mut orch = make_orchestrator(&dir);
+    orch.set_agent("claude-code", "Claude Code");
+
+    orch.dispatch(session_start_event("sess-empty"))
+        .await
+        .unwrap();
+    // No turn_end → no record_turn → recorded_change_hashes stays empty.
+    orch.dispatch(session_end_event("sess-empty"))
+        .await
+        .unwrap();
+
+    let repo = Repository::open(dir.path()).unwrap();
+    let attestations: Vec<_> = repo
+        .change_store()
+        .iter_attestations()
+        .filter_map(|r| r.ok())
+        .collect();
+    assert!(
+        attestations.is_empty(),
+        "session with zero recorded turns must not produce an attestation",
+    );
+}
+
 #[tokio::test]
 async fn test_turn_end_with_file_changes() {
     let dir = TempDir::new().unwrap();

--- a/atomic-agent/src/turn/orchestrator/tests.rs
+++ b/atomic-agent/src/turn/orchestrator/tests.rs
@@ -322,10 +322,7 @@ async fn test_session_attestation_covers_only_agent_recorded_changes() {
 
     fs::write(dir.path().join("agent-p0.txt"), "agent p0 test\n").unwrap();
 
-    let turn_result = orch
-        .dispatch(turn_end_event("sess-cov-1"))
-        .await
-        .unwrap();
+    let turn_result = orch.dispatch(turn_end_event("sess-cov-1")).await.unwrap();
 
     let recorded = turn_result
         .change_recorded

--- a/atomic-agent/src/turn/orchestrator/turn.rs
+++ b/atomic-agent/src/turn/orchestrator/turn.rs
@@ -245,6 +245,11 @@ impl TurnOrchestrator {
                             let recorded_files: Vec<String> = outcome.recorded_file_list().to_vec();
                             session.add_files_touched(&recorded_files);
 
+                            // Track the change hash so the session-end attestation
+                            // covers only what the agent actually recorded — not
+                            // inherited baseline changes from the parent view.
+                            session.recorded_change_hashes.push(outcome.hash);
+
                             // Clear current_prompt so the next turn doesn't
                             // reuse this turn's prompt as the change message.
                             session.clear_current_prompt();

--- a/atomic-agent/src/turn/session.rs
+++ b/atomic-agent/src/turn/session.rs
@@ -179,6 +179,18 @@ pub struct AgentSession {
     /// for the `SessionEnvelope`.
     #[serde(default)]
     pub current_turn_started_at: Option<DateTime<Utc>>,
+
+    /// Change hashes the orchestrator actually recorded for this session.
+    ///
+    /// Appended on each successful `record_turn()` (see `handle_turn_end`).
+    /// Used by `create_session_attestation` as the authoritative coverage set
+    /// — replaces the previous "scan the whole agent-view history" path, which
+    /// over-counted inherited baseline changes from the parent view.
+    ///
+    /// `#[serde(default)]` keeps existing session JSON files (written before
+    /// this field existed) loadable as an empty vec.
+    #[serde(default)]
+    pub recorded_change_hashes: Vec<atomic_core::types::Hash>,
 }
 
 impl AgentSession {
@@ -219,6 +231,7 @@ impl AgentSession {
             current_prompt: None,
             files_touched: Vec::new(),
             current_turn_started_at: None,
+            recorded_change_hashes: Vec::new(),
         }
     }
 
@@ -978,6 +991,24 @@ mod tests {
         assert!(loaded.transcript_path.is_none());
         assert!(loaded.first_prompt.is_none());
         assert!(loaded.files_touched.is_empty());
+        // recorded_change_hashes was added later — old session files must
+        // still load with this field as an empty vec (#[serde(default)])
+        assert!(loaded.recorded_change_hashes.is_empty());
+    }
+
+    #[test]
+    fn test_serde_roundtrip_with_recorded_hashes() {
+        use atomic_core::types::Hash;
+
+        let mut s = make_session();
+        // Push a couple of hashes (use deterministic content for stability)
+        s.recorded_change_hashes.push(Hash::of(b"change-a"));
+        s.recorded_change_hashes.push(Hash::of(b"change-b"));
+
+        let json = serde_json::to_string_pretty(&s).unwrap();
+        let loaded: AgentSession = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.recorded_change_hashes.len(), 2);
+        assert_eq!(loaded.recorded_change_hashes, s.recorded_change_hashes);
     }
 
     // Validation


### PR DESCRIPTION
## Problem
My understanding:

attestation.changes_covered = this agent session actually recorded but NOT attestation.changes_covered = everything visible from the agent view.

The previous session-end attestations scanned the **full agent-view history**. An agent view is forked from its parent view, so that history includes the parent's inherited baseline changes. Result: a session that recorded **1** change on a repo with 2 baseline changes produced an attestation claiming **"3 changes covered"** — over-attributing inherited work to the agent.

## What changed

- `AgentSession` gains `recorded_change_hashes`, appended on each successful `record_turn()` in `handle_turn_end`.
- `create_session_attestation` now uses that set as the coverage list instead of scanning the whole view.
- Sessions with no recorded changes are **skipped** (no attestation) rather than falling back to the full view.
- `#[serde(default)]` keeps existing session JSON files loadable.

## Tests

- Regression: attestation covers only the agent's recorded change, **not** the inherited baseline (sets up a human baseline change, forks an agent view, records 1 agent change, asserts coverage == [agent change]).
- Empty session → no attestation created.
- Serde backward-compat for the new field + round-trip.

Verified end-to-end on a fresh repo: a 1-file Claude session now reports `1 change` (was `3`).

## Scope

Bug-fix only. Independent of the provenance-summary feature PR. Codex `SessionEnd` attestation generation is intentionally **not** included. Will try fix in a separate PR.


## Local smoke test

```bash
  BIN=/Users/dev-vincent/Documents/atomic/dev/atomic/target/debug/atomic
  DEBUG_DIR=/Users/dev-vincent/Documents/atomic/dev/atomic/target/debug

  mkdir /tmp/attest-pr0-fresh && cd /tmp/attest-pr0-fresh
  $BIN init
  $BIN agent enable --agent claude-code --force

  echo "baseline" > human.txt
  $BIN add human.txt
  $BIN record -m "human baseline change"

  PATH="$DEBUG_DIR:$PATH" claude
  # Prompt: create exactly one file foo.txt with "hi"

  $BIN agent attest

  Result:

  1 attestation

    MFHLKPBLLLS7 Claude Code · 1m 5s · 1 change
  ──────────────────────────────────────────
  Total: 1 change covered

  This confirms the session attestation covers only the agent-recorded foo.txt change, not the
  inherited dev history (Initialize repository, Initialize vault, or human baseline change).


  ```


  Before this fix, the same class of repo reported inherited view history as agent coverage, e.g. `3
  changes covered` for a session that recorded only 1 agent change.

