### PR TITLE
feat: project-level AI provenance summary (atomic agent attest --summary)

### DIFF
--- a/atomic-cli/src/commands/agent/attest.rs
+++ b/atomic-cli/src/commands/agent/attest.rs
@@ -43,7 +43,10 @@ use crate::output::print_warning;
 #[derive(Debug, Args)]
 pub struct Attest {
     /// Show details for a specific attestation by hash (or prefix).
-    #[arg(long, value_name = "HASH")]
+    ///
+    /// Cannot be combined with `--summary` / `--pending` (those are
+    /// provenance-summary modes, not attestation lookups).
+    #[arg(long, value_name = "HASH", conflicts_with_all = ["summary", "pending"])]
     hash: Option<String>,
 
     /// Filter to attestations covering changes in this view.
@@ -53,6 +56,26 @@ pub struct Attest {
     /// Show verbose output with model breakdown and coverage.
     #[arg(short, long)]
     verbose: bool,
+
+    /// Show a project-level AI provenance summary instead of the attestation list.
+    ///
+    /// Classifies each change in the view as AI / Human / Needs-attention / System
+    /// based on embedded change provenance, and reports `AI / (AI + Human)`.
+    /// Independent of attestations — works even if attestations are missing.
+    ///
+    /// Scans the full history of the selected view (good for canonical views
+    /// like `dev`). For an agent / draft view that inherits from a parent,
+    /// use `--pending <parent_view>` to summarize only the delta — otherwise
+    /// inherited human/system changes will be counted in the denominator.
+    #[arg(short, long)]
+    summary: bool,
+
+    /// Summarize the **pending delta** of `--view` relative to the given
+    /// parent view (e.g., `--pending dev`). Only changes that are in
+    /// `--view` but not in `<parent>` are classified. Implies `--summary`
+    /// and requires `--view` to be set.
+    #[arg(long, value_name = "PARENT_VIEW")]
+    pending: Option<String>,
 }
 
 impl Attest {
@@ -62,6 +85,8 @@ impl Attest {
             hash: None,
             view: None,
             verbose: false,
+            summary: false,
+            pending: None,
         }
     }
 }
@@ -75,6 +100,22 @@ impl Command for Attest {
             },
             other => CliError::Repository(other),
         })?;
+
+        // Project-level AI provenance summary (independent of attestations).
+        // `--pending <parent>` implies summary mode.
+        if self.summary || self.pending.is_some() {
+            // `--pending` compares a specific agent view against its parent;
+            // defaulting the agent view to the current view would produce a
+            // meaningless "X relative to X" empty delta, so require it.
+            if self.pending.is_some() && self.view.is_none() {
+                return Err(CliError::InvalidArgument {
+                    message:
+                        "--pending <parent_view> requires --view <agent_view> (the forked view to summarize)"
+                            .to_string(),
+                });
+            }
+            return self.show_summary(&repo);
+        }
 
         // Show details for a specific attestation
         if let Some(ref hash_prefix) = self.hash {
@@ -92,6 +133,129 @@ impl Command for Attest {
 }
 
 impl Attest {
+    /// Print a project-level AI provenance summary.
+    ///
+    /// Reads each change's embedded provenance (independent of attestations)
+    /// and classifies as AI / Human / Needs-attention / System. The headline
+    /// metric is `ai_authored_pct = AI / (AI + Human)`.
+    ///
+    /// Default output is terse and product-facing: the headline %, the human
+    /// count, and the AI source / tool breakdown. Implementation detail
+    /// (system/bootstrap exclusions, model breakdown, zero-count data-quality
+    /// lines) is shown only under `--verbose`. Non-zero data-quality
+    /// conditions (needs-attention, unreadable) always surface as warnings.
+    fn show_summary(&self, repo: &Repository) -> CliResult<()> {
+        let view_name = self
+            .view
+            .clone()
+            .unwrap_or_else(|| repo.current_view().to_string());
+
+        let (summary, header_line) = if let Some(parent_view) = self.pending.as_deref() {
+            let s = repo
+                .provenance_summary_pending(&view_name, parent_view)
+                .map_err(CliError::Repository)?;
+            (s, format!("Pending work: {} → {}", view_name, parent_view))
+        } else {
+            let s = repo
+                .provenance_summary(&view_name)
+                .map_err(CliError::Repository)?;
+            (s, format!("Project: {}", view_name))
+        };
+
+        println!("{}", header_line);
+        println!();
+
+        // Headline.
+        match summary.ai_authored_pct() {
+            None => {
+                println!("No authored changes in this view yet.");
+            }
+            Some(pct) => {
+                let denom = summary.authored_denominator();
+                println!(
+                    "AI-authored: {:.0}% ({} of {} authored change{})",
+                    pct,
+                    summary.ai_changes,
+                    denom,
+                    if denom == 1 { "" } else { "s" },
+                );
+                if summary.human_changes > 0 {
+                    println!(
+                        "Human-authored: {} change{}",
+                        summary.human_changes,
+                        if summary.human_changes == 1 { "" } else { "s" },
+                    );
+                }
+                if !summary.by_vendor.is_empty() {
+                    let parts: Vec<String> = summary
+                        .by_vendor
+                        .iter()
+                        .map(|(v, n)| format!("{} {}", pretty_vendor(v), n))
+                        .collect();
+                    println!("AI sources: {}", parts.join(" · "));
+                }
+                if !summary.by_tool.is_empty() {
+                    let parts: Vec<String> = summary
+                        .by_tool
+                        .iter()
+                        .map(|(t, n)| format!("{} {}", pretty_tool(t), n))
+                        .collect();
+                    println!("Tools: {}", parts.join(" · "));
+                }
+            }
+        }
+
+        // Verbose: internal accounting.
+        if self.verbose {
+            println!();
+            println!("System/bootstrap changes excluded: {}", summary.system_changes);
+            println!("Needs attention: {}", summary.needs_attention_changes);
+            println!("Unreadable: {}", summary.unreadable_changes);
+            if !summary.by_model.is_empty() {
+                let parts: Vec<String> = summary
+                    .by_model
+                    .iter()
+                    .map(|(m, n)| format!("{} {}", m, n))
+                    .collect();
+                println!("Models: {}", parts.join(" · "));
+            }
+        }
+
+        // Non-zero data-quality conditions always surface (even without -v).
+        if summary.needs_attention_changes > 0 {
+            println!();
+            print_warning(&format!(
+                "{} change(s) have an agent-identity author but no embedded provenance — possible recording pipeline issue. Excluded from the percentage.",
+                summary.needs_attention_changes,
+            ));
+        }
+        if summary.unreadable_changes > 0 {
+            println!();
+            print_warning(&format!(
+                "{} change(s) could not be loaded and are excluded from the percentage.",
+                summary.unreadable_changes,
+            ));
+        }
+
+        // On the canonical path, if the user actually selected a forked /
+        // draft view, point them at --pending. Detection is exact (via the
+        // view's recorded parent), so this never fires for canonical views.
+        if self.pending.is_none() {
+            if let Ok(info) = repo.get_view_info(&view_name) {
+                if let Some(parent) = info.parent_name {
+                    println!();
+                    println!("This looks like a draft view. To summarize only pending work:");
+                    println!(
+                        "  atomic agent attest --pending {} --view {}",
+                        parent, view_name,
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// List all attestations in the repository.
     fn list_all(&self, repo: &Repository) -> CliResult<()> {
         let mut attestations: Vec<(Hash, Attestation)> = Vec::new();
@@ -149,7 +313,11 @@ impl Attest {
         let total_tokens: u64 = attestations.iter().map(|(_, a)| a.total_tokens()).sum();
 
         println!("──────────────────────────────────────────");
-        let mut summary = format_count(total_changes, "change covered");
+        let mut summary = format!(
+            "{} {} covered",
+            total_changes,
+            if total_changes == 1 { "change" } else { "changes" },
+        );
         if total_cost > 0.0 {
             summary = format!("{}  ·  {}", format_cost(total_cost), summary);
         }
@@ -406,6 +574,49 @@ impl Attest {
 
 // Formatting Helpers
 
+/// Prettify a canonical vendor name (from `AIVendor::name()`, lowercase) into
+/// a product-facing label. Falls back to the raw string for unknown vendors.
+fn pretty_vendor(canonical: &str) -> String {
+    match canonical {
+        "anthropic" => "Anthropic",
+        "openai" => "OpenAI",
+        "google" => "Google",
+        "meta" => "Meta",
+        "mistral" => "Mistral",
+        "cohere" => "Cohere",
+        "amazon-bedrock" => "Amazon Bedrock",
+        "azure-openai" => "Azure OpenAI",
+        "local" => "Local",
+        other => other,
+    }
+    .to_string()
+}
+
+/// Prettify a tool label from `AITool::description()` (e.g. "CLI: claude-code")
+/// into a product-facing name. Drops the access-method prefix, then maps the
+/// known agent registry keys to display names (e.g. "claude-code" →
+/// "Claude Code"). Unknown names and prefix-less variants (e.g. "API") pass
+/// through unchanged.
+fn pretty_tool(description: &str) -> String {
+    let name = match description.split_once(": ") {
+        Some((_prefix, name)) => name,
+        None => description,
+    };
+    match name {
+        "claude-code" => "Claude Code",
+        "codex" => "Codex",
+        "gemini-cli" => "Gemini CLI",
+        "cursor" => "Cursor",
+        "cline" => "Cline",
+        "opencode" => "OpenCode",
+        "copilot" => "Copilot",
+        "sherpa" => "Sherpa",
+        "pi" => "Pi",
+        other => other,
+    }
+    .to_string()
+}
+
 fn format_tokens(tokens: u64) -> String {
     if tokens >= 1_000_000 {
         format!("{:.1}M", tokens as f64 / 1_000_000.0)
@@ -454,6 +665,8 @@ mod tests {
             hash: Some("XMJZ3IPF".to_string()),
             view: None,
             verbose: false,
+            summary: false,
+            pending: None,
         };
         assert_eq!(cmd.hash.as_deref(), Some("XMJZ3IPF"));
     }
@@ -464,6 +677,8 @@ mod tests {
             hash: None,
             view: Some("dev".to_string()),
             verbose: false,
+            summary: false,
+            pending: None,
         };
         assert_eq!(cmd.view.as_deref(), Some("dev"));
     }
@@ -474,8 +689,35 @@ mod tests {
             hash: None,
             view: None,
             verbose: true,
+            summary: false,
+            pending: None,
         };
         assert!(cmd.verbose);
+    }
+
+    #[test]
+    fn test_attest_summary_flag() {
+        let cmd = Attest {
+            hash: None,
+            view: None,
+            verbose: false,
+            summary: true,
+            pending: None,
+        };
+        assert!(cmd.summary);
+    }
+
+    #[test]
+    fn test_attest_pending_flag() {
+        let cmd = Attest {
+            hash: None,
+            view: Some("solitary-flower-0915".to_string()),
+            verbose: false,
+            summary: false,
+            pending: Some("dev".to_string()),
+        };
+        assert_eq!(cmd.pending.as_deref(), Some("dev"));
+        assert_eq!(cmd.view.as_deref(), Some("solitary-flower-0915"));
     }
 
     #[test]
@@ -526,5 +768,38 @@ mod tests {
     fn test_format_count_plural() {
         assert_eq!(format_count(0, "change"), "0 changes");
         assert_eq!(format_count(5, "change"), "5 changes");
+    }
+
+    #[test]
+    fn test_pretty_vendor_known() {
+        assert_eq!(pretty_vendor("anthropic"), "Anthropic");
+        assert_eq!(pretty_vendor("openai"), "OpenAI");
+        assert_eq!(pretty_vendor("google"), "Google");
+        assert_eq!(pretty_vendor("azure-openai"), "Azure OpenAI");
+    }
+
+    #[test]
+    fn test_pretty_vendor_unknown_passes_through() {
+        assert_eq!(pretty_vendor("some-future-vendor"), "some-future-vendor");
+    }
+
+    #[test]
+    fn test_pretty_tool_strips_prefix_and_maps_display_name() {
+        assert_eq!(pretty_tool("CLI: claude-code"), "Claude Code");
+        assert_eq!(pretty_tool("Editor: cursor"), "Cursor");
+        assert_eq!(pretty_tool("IDE Plugin: copilot"), "Copilot");
+        assert_eq!(pretty_tool("CLI: gemini-cli"), "Gemini CLI");
+    }
+
+    #[test]
+    fn test_pretty_tool_unknown_strips_prefix_only() {
+        // Unknown tool keys still drop the prefix but aren't remapped.
+        assert_eq!(pretty_tool("CLI: future-agent"), "future-agent");
+    }
+
+    #[test]
+    fn test_pretty_tool_no_prefix_passes_through() {
+        assert_eq!(pretty_tool("API"), "API");
+        assert_eq!(pretty_tool("Chat"), "Chat");
     }
 }

--- a/atomic-cli/src/commands/agent/attest.rs
+++ b/atomic-cli/src/commands/agent/attest.rs
@@ -3,8 +3,8 @@
 //! Lists attestations in the repository — graph-level audit nodes that
 //! capture AI cost, token usage, model breakdown, and session metadata.
 //!
-//! Attestations are not tied to any view. They live in the graph as
-//! standalone nodes with dependencies pointing to the changes they cover.
+//! Attestations cover concrete changes. Views provide the query and
+//! aggregation scope for listing receipts and provenance summaries.
 //!
 //! # Examples
 //!
@@ -38,8 +38,8 @@ use crate::output::print_warning;
 ///
 /// Attestations are graph-level audit nodes that capture metadata about
 /// AI agent sessions: cost, token usage per model, duration, and which
-/// changes are covered. They transcend views — one attestation can
-/// cover changes across multiple views.
+/// changes are covered. Views are the scope for asking which covered
+/// changes, receipts, or provenance summaries are relevant.
 #[derive(Debug, Args)]
 pub struct Attest {
     /// Show details for a specific attestation by hash (or prefix).

--- a/atomic-cli/src/commands/agent/attest.rs
+++ b/atomic-cli/src/commands/agent/attest.rs
@@ -208,7 +208,10 @@ impl Attest {
         // Verbose: internal accounting.
         if self.verbose {
             println!();
-            println!("System/bootstrap changes excluded: {}", summary.system_changes);
+            println!(
+                "System/bootstrap changes excluded: {}",
+                summary.system_changes
+            );
             println!("Needs attention: {}", summary.needs_attention_changes);
             println!("Unreadable: {}", summary.unreadable_changes);
             if !summary.by_model.is_empty() {
@@ -316,7 +319,11 @@ impl Attest {
         let mut summary = format!(
             "{} {} covered",
             total_changes,
-            if total_changes == 1 { "change" } else { "changes" },
+            if total_changes == 1 {
+                "change"
+            } else {
+                "changes"
+            },
         );
         if total_cost > 0.0 {
             summary = format!("{}  ·  {}", format_cost(total_cost), summary);

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -100,6 +100,7 @@ mod changes;
 mod content;
 mod history;
 mod insert;
+mod provenance_summary;
 mod record;
 mod remotes;
 mod status;
@@ -117,6 +118,7 @@ mod vault_triples;
 pub use insert::{
     ImportLineIndexSeed, ImportLineIndexSeedLine, ImportWriteOutcome, ImportWriteTimings,
 };
+pub use provenance_summary::ProvenanceSummary;
 pub use semantic_materialize::{CrdtMaterializeOptions, CrdtMaterializeOutcome};
 pub use vault_embeddings::{hash_embed, EmbedConfig, TextChunk};
 pub use vault_goal::{

--- a/atomic-repository/src/repository/provenance_summary.rs
+++ b/atomic-repository/src/repository/provenance_summary.rs
@@ -74,10 +74,7 @@ impl ProvenanceSummary {
     /// Total number of changes classified (excludes `unreadable_changes`,
     /// which never enter any bucket).
     pub fn total_changes(&self) -> usize {
-        self.ai_changes
-            + self.human_changes
-            + self.needs_attention_changes
-            + self.system_changes
+        self.ai_changes + self.human_changes + self.needs_attention_changes + self.system_changes
     }
 
     /// Denominator for the headline metric: changes authored by a person or an AI.

--- a/atomic-repository/src/repository/provenance_summary.rs
+++ b/atomic-repository/src/repository/provenance_summary.rs
@@ -42,8 +42,7 @@ use crate::history::HistoryOptions;
 
 /// Summary of AI-vs-human change attribution for a single view.
 ///
-/// Counts changes (not lines). For a line-level summary, see follow-up
-/// work on `file_ops` line counts (not yet implemented).
+/// Counts unique changes, not lines.
 #[derive(Debug, Clone, Default)]
 pub struct ProvenanceSummary {
     /// The view this summary covers.

--- a/atomic-repository/src/repository/provenance_summary.rs
+++ b/atomic-repository/src/repository/provenance_summary.rs
@@ -1,9 +1,10 @@
 //! Project-level AI provenance summary.
 //!
-//! Computes "what fraction of a view's changes are AI-authored" by reading
-//! each change's embedded [`Change::provenance()`](atomic_core::change::Change::provenance).
-//! This is decoupled from attestations: the summary is correct even when
-//! attestations are missing or have incorrect coverage.
+//! Computes "what fraction of a view's changes are AI-authored" by using
+//! the view as the aggregation scope and reading each reachable change's
+//! embedded [`Change::provenance()`](atomic_core::change::Change::provenance).
+//! This is decoupled from attestation receipts: the summary is correct even
+//! when receipts are missing or have incorrect coverage.
 //!
 //! # Classification (four buckets — see development/atomic-attest-fixes.md §3.2)
 //!

--- a/atomic-repository/src/repository/provenance_summary.rs
+++ b/atomic-repository/src/repository/provenance_summary.rs
@@ -1,0 +1,385 @@
+//! Project-level AI provenance summary.
+//!
+//! Computes "what fraction of a view's changes are AI-authored" by reading
+//! each change's embedded [`Change::provenance()`](atomic_core::change::Change::provenance).
+//! This is decoupled from attestations: the summary is correct even when
+//! attestations are missing or have incorrect coverage.
+//!
+//! # Classification (four buckets — see development/atomic-attest-fixes.md §3.2)
+//!
+//! - **AI** — `change.has_provenance()` is `true`. Bucketed by vendor / tool / model.
+//! - **Human** — no provenance AND author is not an agent identity.
+//! - **NeedsAttention** — no provenance BUT the author looks like an agent
+//!   identity (either `<normalized_agent>+<short>` from `build_agent_author` when
+//!   a user identity is configured, or one of the known agent display-name
+//!   fallbacks like `"Claude Code"`/`"Codex"` when no identity is configured).
+//!   Indicates a data-quality issue — must NOT be counted as Human.
+//! - **System** — no authors recorded (init / vault / bootstrap).
+//!
+//! # Headline metric
+//!
+//! `ai_authored_pct = AI / (AI + Human)`. System and NeedsAttention are excluded
+//! from the headline denominator but reported separately. A separate
+//! `ai_all_changes_pct` (AI / all) is also available for transparency.
+//!
+//! # Canonical vs pending (`provenance_summary_pending`)
+//!
+//! `provenance_summary(view)` scans the *full* history of `view`. That's the
+//! right thing for canonical views (`dev`) — the result describes the project
+//! state. For an **agent / draft view forked from a parent**, the full history
+//! includes everything inherited from the parent, which would inflate the
+//! denominator with the parent's human work. Use
+//! [`Repository::provenance_summary_pending`] to classify only the **delta**
+//! between the agent view and its parent.
+
+use std::collections::BTreeMap;
+
+use atomic_core::change::Author;
+
+use super::Repository;
+use crate::error::RepositoryError;
+use crate::history::HistoryOptions;
+
+/// Summary of AI-vs-human change attribution for a single view.
+///
+/// Counts changes (not lines). For a line-level summary, see follow-up
+/// work on `file_ops` line counts (not yet implemented).
+#[derive(Debug, Clone, Default)]
+pub struct ProvenanceSummary {
+    /// The view this summary covers.
+    pub view_name: String,
+    /// Changes with embedded AI provenance.
+    pub ai_changes: usize,
+    /// Changes authored by humans (no provenance, non-agent author).
+    pub human_changes: usize,
+    /// Changes whose author is an agent identity but lacks provenance —
+    /// indicates a recording / attestation pipeline bug.
+    pub needs_attention_changes: usize,
+    /// Bootstrap / init / vault changes (no authors recorded).
+    pub system_changes: usize,
+    /// Changes the storage layer could not load. These DO NOT enter the
+    /// denominator — they're reported separately so silent skips can't
+    /// quietly distort the percentage.
+    pub unreadable_changes: usize,
+    /// AI change counts bucketed by vendor (one increment per unique vendor
+    /// present in a change; multi-vendor changes are counted in each bucket).
+    pub by_vendor: BTreeMap<String, usize>,
+    /// AI change counts bucketed by tool description.
+    pub by_tool: BTreeMap<String, usize>,
+    /// AI change counts bucketed by model name.
+    pub by_model: BTreeMap<String, usize>,
+}
+
+impl ProvenanceSummary {
+    /// Total number of changes classified (excludes `unreadable_changes`,
+    /// which never enter any bucket).
+    pub fn total_changes(&self) -> usize {
+        self.ai_changes
+            + self.human_changes
+            + self.needs_attention_changes
+            + self.system_changes
+    }
+
+    /// Denominator for the headline metric: changes authored by a person or an AI.
+    /// Excludes System and NeedsAttention.
+    pub fn authored_denominator(&self) -> usize {
+        self.ai_changes + self.human_changes
+    }
+
+    /// Headline metric: percent of human-or-AI-authored changes that are AI.
+    /// Returns `None` when the denominator is zero (no authored changes).
+    pub fn ai_authored_pct(&self) -> Option<f64> {
+        let denom = self.authored_denominator();
+        if denom == 0 {
+            None
+        } else {
+            Some((self.ai_changes as f64) * 100.0 / denom as f64)
+        }
+    }
+
+    /// Transparency metric: percent of ALL changes that are AI (denominator
+    /// includes System and NeedsAttention). Named distinctly so it cannot be
+    /// confused with the headline `ai_authored_pct`.
+    pub fn ai_all_changes_pct(&self) -> Option<f64> {
+        let total = self.total_changes();
+        if total == 0 {
+            None
+        } else {
+            Some((self.ai_changes as f64) * 100.0 / total as f64)
+        }
+    }
+}
+
+impl Repository {
+    /// Compute the AI provenance summary for the **full history** of `view_name`.
+    ///
+    /// Right for canonical views (e.g., `dev`). For agent / draft views that
+    /// inherit from a parent, this includes inherited changes — use
+    /// [`Self::provenance_summary_pending`] instead.
+    pub fn provenance_summary(
+        &self,
+        view_name: &str,
+    ) -> Result<ProvenanceSummary, RepositoryError> {
+        let history = self.log(HistoryOptions::default().view(view_name))?;
+        let hashes: Vec<_> = history.iter().map(|e| e.hash).collect();
+        self.classify_hashes(view_name, &hashes)
+    }
+
+    /// Compute the AI provenance summary for the **delta** between an agent
+    /// view and its parent — only the changes present in `agent_view` and
+    /// *not* in `parent_view`.
+    ///
+    /// Use this for any forked / draft view to avoid inflating the
+    /// denominator with the parent's inherited (human / system / AI) changes.
+    pub fn provenance_summary_pending(
+        &self,
+        agent_view: &str,
+        parent_view: &str,
+    ) -> Result<ProvenanceSummary, RepositoryError> {
+        let delta = self.get_missing_changes_between(agent_view, Some(parent_view))?;
+        self.classify_hashes(agent_view, &delta)
+    }
+
+    fn classify_hashes(
+        &self,
+        view_name: &str,
+        hashes: &[atomic_core::types::Hash],
+    ) -> Result<ProvenanceSummary, RepositoryError> {
+        let mut summary = ProvenanceSummary {
+            view_name: view_name.to_string(),
+            ..Default::default()
+        };
+
+        for hash in hashes {
+            let change = match self.load_change(hash) {
+                Ok(c) => c,
+                Err(_) => {
+                    summary.unreadable_changes += 1;
+                    continue;
+                }
+            };
+
+            let provs = change.provenance();
+            if !provs.is_empty() {
+                summary.ai_changes += 1;
+
+                // Bucket once per unique vendor / tool / model present in this change.
+                let mut seen_vendors = std::collections::BTreeSet::new();
+                let mut seen_tools = std::collections::BTreeSet::new();
+                let mut seen_models = std::collections::BTreeSet::new();
+                for p in provs {
+                    let v = p.vendor.name().to_string();
+                    if seen_vendors.insert(v.clone()) {
+                        *summary.by_vendor.entry(v).or_insert(0) += 1;
+                    }
+                    let t = p.tool.description();
+                    if seen_tools.insert(t.clone()) {
+                        *summary.by_tool.entry(t).or_insert(0) += 1;
+                    }
+                    let m = p.model.clone();
+                    if seen_models.insert(m.clone()) {
+                        *summary.by_model.entry(m).or_insert(0) += 1;
+                    }
+                }
+                continue;
+            }
+
+            // No provenance — disambiguate by author.
+            if change.hashed.header.authors.is_empty() {
+                summary.system_changes += 1;
+            } else if change
+                .hashed
+                .header
+                .authors
+                .iter()
+                .any(author_is_agent_identity)
+            {
+                summary.needs_attention_changes += 1;
+            } else {
+                summary.human_changes += 1;
+            }
+        }
+
+        Ok(summary)
+    }
+}
+
+/// Normalized agent names produced by `atomic_agent::identity::normalize_agent_name`
+/// (first `-`-delimited segment, lowercased). These are the *prefixes* that
+/// appear in the `<agent>+<short>` author shape. Keep in sync with the agent
+/// registry (atomic-agent/src/hooks/).
+const KNOWN_AGENT_PREFIXES: &[&str] = &[
+    "claude", "codex", "gemini", "cursor", "cline", "opencode", "copilot", "sherpa", "pi",
+];
+
+/// Heuristically detect an agent-identity Author produced by
+/// `atomic_agent::identity::build_agent_author`.
+///
+/// `build_agent_author` has two output shapes:
+///
+/// 1. **User identity configured** — `claude+60f5` style:
+///    `<normalized_agent_name>+<3-8 char alphanumeric session short>`. We
+///    require the prefix to be a *known* normalized agent name — otherwise a
+///    real human author like `alice+2026` or `lee+laptop` would be
+///    misclassified as an agent and wrongly removed from the Human denominator.
+///
+/// 2. **No user identity (fallback)** — just the agent's display name with
+///    no email, e.g. `"Claude Code"` or `"Codex"`
+///    (see `atomic_agent::identity::fallback_agent_author`). We match a
+///    known set of agent display / registry names. Missing one here means
+///    a fallback-author change without provenance gets misclassified as
+///    Human — a false negative for the NeedsAttention data-quality signal.
+fn author_is_agent_identity(author: &Author) -> bool {
+    // Shape 1: <known-agent>+<short>
+    if let Some((prefix, suffix)) = author.name.split_once('+') {
+        if KNOWN_AGENT_PREFIXES.contains(&prefix) {
+            let suffix_len = suffix.len();
+            if (3..=8).contains(&suffix_len) && suffix.chars().all(|c| c.is_ascii_alphanumeric()) {
+                return true;
+            }
+        }
+    }
+
+    // Shape 2: fallback display / registry names when no user identity is set.
+    matches!(
+        author.name.as_str(),
+        "Claude Code"
+            | "claude-code"
+            | "Codex"
+            | "codex"
+            | "Gemini CLI"
+            | "gemini-cli"
+            | "Cursor"
+            | "cursor"
+            | "Cline"
+            | "cline"
+            | "OpenCode"
+            | "opencode"
+            | "Copilot"
+            | "copilot"
+            | "Sherpa"
+            | "sherpa"
+            | "Pi"
+            | "pi"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn author(name: &str) -> Author {
+        Author::new(name, None::<String>)
+    }
+
+    #[test]
+    fn detects_agent_identity_canonical() {
+        assert!(author_is_agent_identity(&author("claude+60f5")));
+        assert!(author_is_agent_identity(&author("codex+abc1")));
+        assert!(author_is_agent_identity(&author("gemini+a1b2c3d4")));
+    }
+
+    #[test]
+    fn detects_agent_identity_fallback_display_names() {
+        // When no user identity is configured, build_agent_author returns
+        // the agent's display_name with no email. These changes must still
+        // be classified as NeedsAttention if provenance is missing.
+        assert!(author_is_agent_identity(&author("Claude Code")));
+        assert!(author_is_agent_identity(&author("claude-code")));
+        assert!(author_is_agent_identity(&author("Codex")));
+        assert!(author_is_agent_identity(&author("Gemini CLI")));
+    }
+
+    #[test]
+    fn rejects_human_authors() {
+        assert!(!author_is_agent_identity(&author("Vincent Ruan")));
+        assert!(!author_is_agent_identity(&author("alice")));
+        assert!(!author_is_agent_identity(&author("Lee Faus")));
+        // Sanity: a human whose name *contains* "claude" but isn't an agent
+        // shape and isn't in the known display-name set.
+        assert!(!author_is_agent_identity(&author("Claude Monet")));
+    }
+
+    #[test]
+    fn rejects_human_authors_with_plus_suffix() {
+        // Real humans use `+` in git author names/emails. The `+<short>`
+        // shape must ONLY match known agent prefixes, otherwise these humans
+        // get wrongly pulled out of the Human denominator.
+        assert!(!author_is_agent_identity(&author("alice+2026")));
+        assert!(!author_is_agent_identity(&author("lee+laptop")));
+        assert!(!author_is_agent_identity(&author("bob+work1")));
+    }
+
+    #[test]
+    fn rejects_no_plus_separator() {
+        assert!(!author_is_agent_identity(&author("claude")));
+        assert!(!author_is_agent_identity(&author("")));
+    }
+
+    #[test]
+    fn rejects_implausible_suffix() {
+        assert!(!author_is_agent_identity(&author("foo+")));
+        assert!(!author_is_agent_identity(&author("foo+ab")));
+        assert!(!author_is_agent_identity(&author("foo+toolongsuffixhere")));
+        assert!(!author_is_agent_identity(&author("foo+has-dash")));
+        assert!(!author_is_agent_identity(&author("foo+has space")));
+    }
+
+    #[test]
+    fn rejects_empty_prefix() {
+        assert!(!author_is_agent_identity(&author("+60f5")));
+    }
+
+    #[test]
+    fn summary_default_is_empty() {
+        let s = ProvenanceSummary::default();
+        assert_eq!(s.total_changes(), 0);
+        assert_eq!(s.authored_denominator(), 0);
+        assert_eq!(s.ai_authored_pct(), None);
+        assert_eq!(s.ai_all_changes_pct(), None);
+    }
+
+    #[test]
+    fn ai_authored_pct_excludes_system() {
+        let mut s = ProvenanceSummary::default();
+        s.ai_changes = 4;
+        s.human_changes = 1;
+        s.system_changes = 2; // bootstrap excluded from headline denominator
+        assert_eq!(s.authored_denominator(), 5);
+        assert!((s.ai_authored_pct().unwrap() - 80.0).abs() < 1e-9);
+        // ai_all_changes_pct uses total: 4 / 7
+        assert!((s.ai_all_changes_pct().unwrap() - (4.0 * 100.0 / 7.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn ai_authored_pct_none_when_only_system() {
+        let mut s = ProvenanceSummary::default();
+        s.system_changes = 3;
+        assert_eq!(s.authored_denominator(), 0);
+        assert_eq!(s.ai_authored_pct(), None);
+    }
+
+    #[test]
+    fn needs_attention_does_not_count_as_human() {
+        let mut s = ProvenanceSummary::default();
+        s.ai_changes = 1;
+        s.human_changes = 0;
+        s.needs_attention_changes = 2; // must NOT be in denominator
+        assert_eq!(s.authored_denominator(), 1);
+        assert_eq!(s.ai_authored_pct(), Some(100.0));
+    }
+
+    #[test]
+    fn unreadable_changes_do_not_skew_percent() {
+        // Unreadable changes are reported separately, NOT counted in any
+        // bucket — they must not silently change the denominator.
+        let mut s = ProvenanceSummary::default();
+        s.ai_changes = 4;
+        s.human_changes = 1;
+        s.unreadable_changes = 3;
+        assert_eq!(s.authored_denominator(), 5);
+        assert_eq!(s.ai_authored_pct(), Some(80.0));
+        // total_changes excludes unreadable by design
+        assert_eq!(s.total_changes(), 5);
+    }
+}


### PR DESCRIPTION
## Problem

`atomic agent attest` could list individual attestation receipts but couldn't answer the project-level question from today standup: **"what share of this view's changes are AI-authored, and by which source?"**

(e.g. "of 10 changes, 5 from Codex, 2 from Claude, 3 human").

See below test result:
<img width="661" height="283" alt="Screenshot 2026-05-27 at 10 03 29 AM" src="https://github.com/user-attachments/assets/1d071175-dc65-4334-8181-bd892ca88b38" />

Fix a wording: `"change covereds"` -> `"changes covered"`.
Note: Codex attest will be fixed in a separate PR.

## Model

This keeps the two-layer model:

- Per-change / per-turn provenance or attestation receipt records what produced a concrete change.
- Views provide the query and aggregation scope for summaries and policy checks.

So #70 does not remove view-level aggregation. It adds the view-scoped aggregator: `--summary --view <view>` summarizes changes reachable from that view, and `--pending <parent> --view <draft>` summarizes only the draft delta before insert.

## What changed

- New repository query layer: `Repository::provenance_summary(view)` and `provenance_summary_pending(agent_view, parent)`. They classify each change by its **embedded provenance** (independent of attestation receipts, so the summary still works if receipts are missing or have bad coverage):
  - **AI** (bucketed by vendor / tool / model) · **Human** · **Needs-attention** (agent-author but no provenance — data-quality flag) · **System** (init/bootstrap)
- Headline metric: `AI / (AI + Human)`. System is excluded from the denominator and reported separately.
- CLI:
  - `atomic agent attest --summary [--view <v>]` — full-view summary (canonical views like `dev`)
  - `atomic agent attest --pending <parent> --view <v>` — fork **delta** only (avoids counting a parent's inherited changes)

## Tests

- Classification + denominator unit tests: agent-identity detection (incl. no-identity fallback display names like "Claude Code"); rejection of human authors with `+` suffixes (`alice+2026`); unreadable / needs-attention excluded from the denominator; `ai_authored_pct` math.
- CLI: flag tests + `pretty_vendor` / `pretty_tool` helper tests.

**Local test (end-to-end):** real repo with human + Claude + Codex changes, then project-level aggregation:

```console
$ atomic init                                    # repo starts with 2 bootstrap (System) changes
$ atomic agent enable --agent claude-code --force

# 1) a human change on dev
$ echo "by a human" > human.txt && atomic add human.txt && atomic record -m "human change"

# 2) a Claude session creates foo.txt (recorded into a forked agent view)
$ claude        # > create foo.txt with "hi"
$ atomic view list
* dev
  withered-hill-e526                             # <- Claude's agent view

# canonical dev: Claude's change not merged yet -> 0% AI, 1 human (2 System excluded)
$ atomic agent attest --summary --view dev
Project: dev
AI-authored: 0% (0 of 1 authored change)
Human-authored: 1 change

# the agent view (its full history inherits the human change) -> fork hint
$ atomic agent attest --summary --view withered-hill-e526
Project: withered-hill-e526
AI-authored: 50% (1 of 2 authored changes)
Human-authored: 1 change
AI sources: Anthropic 1
Tools: Claude Code 1
This looks like a draft view. To summarize only pending work:
  atomic agent attest --pending dev --view withered-hill-e526

# --pending isolates only what the agent authored (delta vs parent)
$ atomic agent attest --pending dev --view withered-hill-e526
Pending work: withered-hill-e526 -> dev
AI-authored: 100% (1 of 1 authored change)
AI sources: Anthropic 1
Tools: Claude Code 1

# --verbose surfaces internal accounting
$ atomic agent attest --summary --view withered-hill-e526 --verbose
...
System/bootstrap changes excluded: 2
Needs attention: 0
Unreadable: 0
Models: claude-opus-4-7[1m] 1

# 3) a Codex session creates codex_file.txt
$ atomic agent enable --agent codex --force      # "Installed 5 hooks for Codex" (no SessionEnd)
$ codex         # > create codex_file.txt with "from codex"

# merge both agent views into dev, then summarize the project
$ atomic insert from-view withered-hill-e526 --to-view dev   # Claude
$ atomic insert from-view purple-sand-897b   --to-view dev   # Codex
$ atomic agent attest --summary --view dev
Project: dev
AI-authored: 67% (2 of 3 authored changes)
Human-authored: 1 change
AI sources: Anthropic 1 · OpenAI 1
Tools: Claude Code 1 · Codex 1
```

The final output is the standup ask working end-to-end: **project-level AI share, bucketed by source/tool, count-based**.

Note: Codex was enabled with only **5 hooks (no SessionEnd)**, so Codex generates **no attestation receipt** — yet it is still classified correctly as `OpenAI 1 / Codex 1`. This confirms the summary reads **change provenance**, not attestation receipts (the decoupling that keeps the metric correct even when receipt generation is incomplete).

Error paths verified:

```console
$ atomic agent attest --pending dev             # error: --pending requires --view <agent_view>
$ atomic agent attest --hash ABC --summary      # error: --hash cannot be used with --summary
```

## Relation to other work

Independent of #69 (attestation coverage fix) — this summary reads change provenance directly, not attestation receipts. Both build cleanly off `dev` on their own.
