### PR TITLE
fix(claude-code): silence hook output & atomic settings write

### DIFF
--- a/atomic-agent/src/hooks/claude_code/settings.rs
+++ b/atomic-agent/src/hooks/claude_code/settings.rs
@@ -107,10 +107,48 @@ pub(crate) fn write_settings(
         output.push('\n');
     }
 
-    std::fs::write(settings_path, output.as_bytes()).map_err(|e| AgentError::ConfigError {
-        operation: "write".to_string(),
-        path: settings_path.to_path_buf(),
-        reason: e.to_string(),
+    // Atomic write (temp + rename) so a settings watcher never reads a
+    // half-written file (`std::fs::write` truncates the target first).
+    use std::io::Write as _;
+
+    let parent = settings_path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = settings_path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "settings.json".to_string());
+    // Same-dir, pid-suffixed temp: rename stays atomic, no clobber between writers.
+    let tmp_path = parent.join(format!(".{}.{}.tmp", file_name, std::process::id()));
+
+    // Preserve existing permissions.
+    let existing_perms = std::fs::metadata(settings_path)
+        .ok()
+        .map(|m| m.permissions());
+
+    if let Err(e) = (|| -> std::io::Result<()> {
+        let mut f = std::fs::File::create(&tmp_path)?;
+        f.write_all(output.as_bytes())?;
+        f.sync_all()?;
+        Ok(())
+    })() {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(AgentError::ConfigError {
+            operation: "write temp file".to_string(),
+            path: tmp_path,
+            reason: e.to_string(),
+        });
+    }
+
+    if let Some(perms) = existing_perms {
+        let _ = std::fs::set_permissions(&tmp_path, perms);
+    }
+
+    std::fs::rename(&tmp_path, settings_path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp_path);
+        AgentError::ConfigError {
+            operation: "rename temp file into place".to_string(),
+            path: settings_path.to_path_buf(),
+            reason: e.to_string(),
+        }
     })
 }
 

--- a/atomic-cli/src/commands/agent/hooks.rs
+++ b/atomic-cli/src/commands/agent/hooks.rs
@@ -160,9 +160,13 @@ impl Command for Hooks {
         let agent_name = agent.name().to_string();
         let agent_display = agent.display_name().to_string();
 
-        eprintln!(
-            "[atomic-debug] hooks: agent={} display={} verb={}",
-            agent_name, agent_display, self.verb
+        // Keep hooks quiet on stdout/stderr — Claude Code surfaces both, so
+        // route diagnostics through `log` instead.
+        log::debug!(
+            "hooks: agent={} display={} verb={}",
+            agent_name,
+            agent_display,
+            self.verb
         );
 
         let result = rt.block_on(async {


### PR DESCRIPTION
## What

- Write Claude Code `settings.json` atomically via same-directory temp file + rename.
- Remove the `[atomic-debug]` stderr print from hook execution and route it through `log::debug!`.

## Why

Claude Code records hook stdout/stderr into session artifacts, so debug output from Atomic hooks can leak into the Claude transcript/UI. Also, `settings.json` is watched by Claude Code, so writing it atomically avoids exposing a truncated or partial config during updates.

This is a small cleanup for the Claude Code integration. It does not change installed hook commands or agent recording behavior.

## Tests

- `cargo fmt --check`
- `cargo test -p atomic-agent claude_code --quiet`
- `cargo test -p atomic-cli agent --quiet`