### PR TITLE
fix agent installs

### DIFF
--- a/atomic-agent/src/hooks/manifest.rs
+++ b/atomic-agent/src/hooks/manifest.rs
@@ -1,0 +1,587 @@
+//! Data-driven hook installation from an integration-supplied manifest.
+//!
+//! Instead of hardcoding each agent's hook definitions in this binary, an
+//! integration package (`atomic-codex`, `atomic-claude`, ...) ships a manifest
+//! file describing *where* its hooks live and *what* commands to register.
+//! `atomic agent enable --hooks <manifest>` merges that manifest into the
+//! agent's settings file idempotently, preserving any non-Atomic hooks.
+//!
+//! Because the definitions live in the integration repo, updating an agent's
+//! hook wiring (new event, renamed verb, schema tweak, bug fix) never requires
+//! rebuilding the `atomic` binary — only re-publishing the integration package.
+//! The merge engine ships with `atomic`, so installation needs no Node, `jq`,
+//! `sudo`, or other runtime.
+//!
+//! # Manifest format
+//!
+//! ```json
+//! {
+//!   "target": "~/.codex/hooks.json",
+//!   "hooks_key": "hooks",
+//!   "command_prefix": "atomic agent hooks codex",
+//!   "hooks": {
+//!     "SessionStart": [
+//!       { "hooks": [ { "type": "command", "command": "test -d .atomic && atomic agent hooks codex session-start || true", "statusMessage": "Atomic: tracking session" } ] }
+//!     ],
+//!     "Stop": [
+//!       { "hooks": [ { "type": "command", "command": "test -d .atomic && atomic agent hooks codex stop || true" } ] }
+//!     ]
+//!   }
+//! }
+//! ```
+//!
+//! - `target` — destination settings file (`~` is expanded to the home dir).
+//! - `hooks_key` — top-level key under which hooks live (default `"hooks"`).
+//! - `command_prefix` — substring identifying this integration's own hook
+//!   commands. Entries matching it are removed before re-adding, so re-running
+//!   syncs the target to the manifest (picks up command/event changes).
+//! - `hooks` — `event -> [group]`, in the target file's native shape. Groups
+//!   are merged verbatim, so agent-specific fields (e.g. `matcher`) are kept.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+use crate::error::{AgentError, AgentResult};
+
+fn default_hooks_key() -> String {
+    "hooks".to_string()
+}
+
+/// A hook manifest shipped by an integration package.
+#[derive(Debug, Deserialize)]
+pub struct HookManifest {
+    /// Destination settings file, e.g. `~/.codex/hooks.json`.
+    pub target: String,
+
+    /// JSON key under which hooks are stored in the target file.
+    #[serde(default = "default_hooks_key")]
+    pub hooks_key: String,
+
+    /// Substring identifying this integration's own hook commands.
+    pub command_prefix: String,
+
+    /// `event -> [entry]`, in the target file's native shape. Entries are
+    /// merged verbatim. Both nested (`{matcher?, hooks: [{command}]}`) and flat
+    /// (`{command}` / `{bash}`) entry shapes are supported.
+    #[serde(default)]
+    pub hooks: Map<String, Value>,
+
+    /// Extra non-hook settings to deep-merge into the target's root object
+    /// (e.g. Claude's `permissions.deny` rule). Objects are merged
+    /// recursively, arrays are unioned by value, scalars overwrite. Left in
+    /// place on uninstall.
+    #[serde(default)]
+    pub merge: Map<String, Value>,
+}
+
+/// Outcome of installing or uninstalling a manifest.
+#[derive(Debug, Clone)]
+pub struct ManifestOutcome {
+    /// Resolved destination file.
+    pub target: PathBuf,
+    /// Number of hook commands added.
+    pub added: usize,
+    /// Number of stale Atomic hook commands removed.
+    pub removed: usize,
+}
+
+/// Merge the manifest's hooks into its target settings file.
+///
+/// Existing entries whose command contains the manifest's `command_prefix` are
+/// removed first, so re-running syncs the target to the manifest (picking up
+/// command/event changes). Non-matching hooks are preserved untouched.
+pub fn install_from_manifest(manifest_path: &Path) -> AgentResult<ManifestOutcome> {
+    let manifest = read_manifest(manifest_path)?;
+    let target = expand_target(&manifest.target)?;
+
+    let mut root = read_json_object(&target)?;
+
+    let entry = root
+        .entry(manifest.hooks_key.clone())
+        .or_insert_with(|| Value::Object(Map::new()));
+    if !entry.is_object() {
+        *entry = Value::Object(Map::new());
+    }
+    let hooks = entry
+        .as_object_mut()
+        .expect("entry was just ensured to be an object");
+
+    // Remove our previous entries first so command/event changes take effect.
+    let removed = remove_prefixed(hooks, &manifest.command_prefix);
+
+    let mut added = 0;
+    for (event, entries) in &manifest.hooks {
+        let Some(src_entries) = entries.as_array() else {
+            continue;
+        };
+        let dst = hooks
+            .entry(event.clone())
+            .or_insert_with(|| Value::Array(Vec::new()));
+        let Some(dst_entries) = dst.as_array_mut() else {
+            continue;
+        };
+        for entry in src_entries {
+            dst_entries.push(entry.clone());
+            added += count_commands(entry);
+        }
+    }
+
+    // Deep-merge any extra non-hook settings (e.g. Claude's permissions.deny).
+    deep_merge(&mut root, &manifest.merge);
+
+    write_json_object(&target, &root)?;
+
+    Ok(ManifestOutcome {
+        target,
+        added,
+        removed,
+    })
+}
+
+/// Remove the manifest's hooks from its target settings file.
+///
+/// Only entries whose command contains the manifest's `command_prefix` are
+/// removed; the file and all other hooks are left intact.
+pub fn uninstall_from_manifest(manifest_path: &Path) -> AgentResult<ManifestOutcome> {
+    let manifest = read_manifest(manifest_path)?;
+    let target = expand_target(&manifest.target)?;
+
+    if !target.exists() {
+        return Ok(ManifestOutcome {
+            target,
+            added: 0,
+            removed: 0,
+        });
+    }
+
+    let mut root = read_json_object(&target)?;
+    let mut removed = 0;
+    if let Some(hooks) = root
+        .get_mut(&manifest.hooks_key)
+        .and_then(Value::as_object_mut)
+    {
+        removed = remove_prefixed(hooks, &manifest.command_prefix);
+    }
+
+    write_json_object(&target, &root)?;
+
+    Ok(ManifestOutcome {
+        target,
+        added: 0,
+        removed,
+    })
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+fn read_manifest(path: &Path) -> AgentResult<HookManifest> {
+    let content = std::fs::read_to_string(path).map_err(|e| AgentError::ConfigError {
+        operation: "read manifest".to_string(),
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })?;
+    serde_json::from_str(&content).map_err(|e| AgentError::ConfigError {
+        operation: "parse manifest".to_string(),
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })
+}
+
+fn expand_target(target: &str) -> AgentResult<PathBuf> {
+    if target == "~" {
+        return dirs::home_dir().ok_or_else(|| AgentError::ConfigError {
+            operation: "resolve home".to_string(),
+            path: PathBuf::from(target),
+            reason: "could not determine home directory".to_string(),
+        });
+    }
+    if let Some(rest) = target.strip_prefix("~/") {
+        let home = dirs::home_dir().ok_or_else(|| AgentError::ConfigError {
+            operation: "resolve home".to_string(),
+            path: PathBuf::from(target),
+            reason: "could not determine home directory".to_string(),
+        })?;
+        return Ok(home.join(rest));
+    }
+    Ok(PathBuf::from(target))
+}
+
+fn read_json_object(path: &Path) -> AgentResult<Map<String, Value>> {
+    if !path.exists() {
+        return Ok(Map::new());
+    }
+    let content = std::fs::read_to_string(path).map_err(|e| AgentError::ConfigError {
+        operation: "read".to_string(),
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })?;
+    if content.trim().is_empty() {
+        return Ok(Map::new());
+    }
+    let value: Value = serde_json::from_str(&content).map_err(|e| AgentError::ConfigError {
+        operation: "parse".to_string(),
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })?;
+    match value {
+        Value::Object(map) => Ok(map),
+        _ => Ok(Map::new()),
+    }
+}
+
+fn write_json_object(path: &Path, root: &Map<String, Value>) -> AgentResult<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| AgentError::ConfigError {
+            operation: "create directory".to_string(),
+            path: parent.to_path_buf(),
+            reason: e.to_string(),
+        })?;
+    }
+    let mut content = serde_json::to_string_pretty(root).map_err(|e| AgentError::ConfigError {
+        operation: "serialize".to_string(),
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })?;
+    content.push('\n');
+    std::fs::write(path, content).map_err(|e| AgentError::ConfigError {
+        operation: "write".to_string(),
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })
+}
+
+/// Command-carrying keys across agent schemas: Claude/Codex/Cursor use
+/// `command`; Copilot uses `bash`/`powershell`.
+const COMMAND_KEYS: [&str; 3] = ["command", "bash", "powershell"];
+
+/// Whether a single (flat) hook entry's command field contains `prefix`.
+fn entry_command_contains(entry: &Value, prefix: &str) -> bool {
+    COMMAND_KEYS.iter().any(|key| {
+        entry
+            .get(key)
+            .and_then(Value::as_str)
+            .is_some_and(|cmd| cmd.contains(prefix))
+    })
+}
+
+/// Whether a single (flat) hook entry carries any command field.
+fn entry_has_command(entry: &Value) -> bool {
+    COMMAND_KEYS
+        .iter()
+        .any(|key| entry.get(key).and_then(Value::as_str).is_some())
+}
+
+/// Remove hook entries whose command contains `prefix`. Handles both nested
+/// (`{matcher?, hooks: [{command}]}`) and flat (`{command}`/`{bash}`) shapes.
+/// Empty groups and empty event arrays are pruned. Returns commands removed.
+fn remove_prefixed(hooks: &mut Map<String, Value>, prefix: &str) -> usize {
+    let mut removed = 0;
+    for value in hooks.values_mut() {
+        let Some(entries) = value.as_array_mut() else {
+            continue;
+        };
+        entries.retain_mut(|entry| {
+            // Nested shape: a group with an inner `hooks` array.
+            if let Some(inner) = entry.get_mut("hooks").and_then(Value::as_array_mut) {
+                let before = inner.len();
+                inner.retain(|hook| !entry_command_contains(hook, prefix));
+                removed += before - inner.len();
+                return !inner.is_empty();
+            }
+            // Flat shape: the entry itself carries the command.
+            if entry_command_contains(entry, prefix) {
+                removed += 1;
+                return false;
+            }
+            true
+        });
+    }
+    // Drop event keys whose entry array is now empty.
+    hooks.retain(|_, v| v.as_array().map(|a| !a.is_empty()).unwrap_or(true));
+    removed
+}
+
+/// Count the hook commands carried by a single entry (nested or flat).
+fn count_commands(entry: &Value) -> usize {
+    if let Some(inner) = entry.get("hooks").and_then(Value::as_array) {
+        return inner.iter().filter(|h| entry_has_command(h)).count();
+    }
+    usize::from(entry_has_command(entry))
+}
+
+/// Deep-merge `extra` into `root`: objects merge recursively, arrays union by
+/// value (no duplicates), scalars overwrite. Used for non-hook settings such
+/// as Claude's `permissions.deny` rule.
+fn deep_merge(root: &mut Map<String, Value>, extra: &Map<String, Value>) {
+    for (key, value) in extra {
+        match root.get_mut(key) {
+            Some(existing) => merge_value(existing, value),
+            None => {
+                root.insert(key.clone(), value.clone());
+            }
+        }
+    }
+}
+
+fn merge_value(target: &mut Value, source: &Value) {
+    match (target, source) {
+        (Value::Object(t), Value::Object(s)) => deep_merge(t, s),
+        (Value::Array(t), Value::Array(s)) => {
+            for item in s {
+                if !t.contains(item) {
+                    t.push(item.clone());
+                }
+            }
+        }
+        (t, s) => *t = s.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn write(path: &Path, value: &Value) {
+        std::fs::write(path, serde_json::to_string_pretty(value).unwrap()).unwrap();
+    }
+
+    fn manifest_json(target: &Path, prefix: &str) -> Value {
+        json!({
+            "target": target.to_string_lossy(),
+            "command_prefix": prefix,
+            "hooks": {
+                "SessionStart": [
+                    { "hooks": [ { "type": "command", "command": format!("{} session-start", prefix), "statusMessage": "Atomic" } ] }
+                ],
+                "Stop": [
+                    { "hooks": [ { "type": "command", "command": format!("{} stop", prefix) } ] }
+                ]
+            }
+        })
+    }
+
+    #[test]
+    fn installs_into_empty_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("hooks.json");
+        let manifest = dir.path().join("manifest.json");
+        write(
+            &manifest,
+            &manifest_json(&target, "atomic agent hooks codex"),
+        );
+
+        let outcome = install_from_manifest(&manifest).unwrap();
+        assert_eq!(outcome.added, 2);
+        assert_eq!(outcome.removed, 0);
+
+        let written: Value =
+            serde_json::from_str(&std::fs::read_to_string(&target).unwrap()).unwrap();
+        assert!(written["hooks"]["SessionStart"].is_array());
+        assert!(written["hooks"]["Stop"].is_array());
+    }
+
+    #[test]
+    fn is_idempotent_and_syncs_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("hooks.json");
+        let manifest = dir.path().join("manifest.json");
+        write(
+            &manifest,
+            &manifest_json(&target, "atomic agent hooks codex"),
+        );
+
+        install_from_manifest(&manifest).unwrap();
+        // Second run removes the 2 stale entries and re-adds 2 — no duplicates.
+        let outcome = install_from_manifest(&manifest).unwrap();
+        assert_eq!(outcome.added, 2);
+        assert_eq!(outcome.removed, 2);
+
+        let written: Value =
+            serde_json::from_str(&std::fs::read_to_string(&target).unwrap()).unwrap();
+        assert_eq!(
+            written["hooks"]["SessionStart"].as_array().unwrap().len(),
+            1
+        );
+    }
+
+    #[test]
+    fn preserves_non_atomic_hooks() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("hooks.json");
+        // Pre-existing user hook plus unrelated top-level config.
+        write(
+            &target,
+            &json!({
+                "model": "gpt-5",
+                "hooks": {
+                    "Stop": [ { "hooks": [ { "type": "command", "command": "my-own-hook" } ] } ]
+                }
+            }),
+        );
+        let manifest = dir.path().join("manifest.json");
+        write(
+            &manifest,
+            &manifest_json(&target, "atomic agent hooks codex"),
+        );
+
+        install_from_manifest(&manifest).unwrap();
+
+        let written: Value =
+            serde_json::from_str(&std::fs::read_to_string(&target).unwrap()).unwrap();
+        // Unrelated config preserved.
+        assert_eq!(written["model"], "gpt-5");
+        // User's own Stop hook preserved alongside the Atomic one.
+        let stop = written["hooks"]["Stop"].as_array().unwrap();
+        let commands: Vec<&str> = stop
+            .iter()
+            .flat_map(|g| g["hooks"].as_array().unwrap())
+            .map(|h| h["command"].as_str().unwrap())
+            .collect();
+        assert!(commands.contains(&"my-own-hook"));
+        assert!(commands
+            .iter()
+            .any(|c| c.contains("atomic agent hooks codex stop")));
+    }
+
+    #[test]
+    fn uninstall_removes_only_atomic() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("hooks.json");
+        write(
+            &target,
+            &json!({
+                "hooks": {
+                    "Stop": [ { "hooks": [ { "type": "command", "command": "my-own-hook" } ] } ]
+                }
+            }),
+        );
+        let manifest = dir.path().join("manifest.json");
+        write(
+            &manifest,
+            &manifest_json(&target, "atomic agent hooks codex"),
+        );
+
+        install_from_manifest(&manifest).unwrap();
+        let outcome = uninstall_from_manifest(&manifest).unwrap();
+        assert_eq!(outcome.removed, 2);
+
+        let written: Value =
+            serde_json::from_str(&std::fs::read_to_string(&target).unwrap()).unwrap();
+        let commands: Vec<&str> = written["hooks"]["Stop"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .flat_map(|g| g["hooks"].as_array().unwrap())
+            .map(|h| h["command"].as_str().unwrap())
+            .collect();
+        assert_eq!(commands, vec!["my-own-hook"]);
+    }
+
+    #[test]
+    fn handles_flat_cursor_shape() {
+        // Cursor: event -> [ { command } ] (flat, no inner "hooks").
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("hooks.json");
+        write(
+            &target,
+            &json!({
+                "version": 1,
+                "hooks": {
+                    "sessionStart": [ { "command": "my-own-cursor-hook" } ]
+                }
+            }),
+        );
+        let manifest = dir.path().join("manifest.json");
+        write(
+            &manifest,
+            &json!({
+                "target": target.to_string_lossy(),
+                "command_prefix": "atomic agent hooks cursor",
+                "hooks": {
+                    "sessionStart": [ { "command": "atomic agent hooks cursor session-start" } ],
+                    "stop": [ { "command": "atomic agent hooks cursor stop" } ]
+                }
+            }),
+        );
+
+        let outcome = install_from_manifest(&manifest).unwrap();
+        assert_eq!(outcome.added, 2);
+
+        // Idempotent: re-run replaces our 2, keeps the user's hook.
+        let again = install_from_manifest(&manifest).unwrap();
+        assert_eq!(again.added, 2);
+        assert_eq!(again.removed, 2);
+
+        let written: Value =
+            serde_json::from_str(&std::fs::read_to_string(&target).unwrap()).unwrap();
+        assert_eq!(written["version"], 1);
+        let start: Vec<&str> = written["hooks"]["sessionStart"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| e["command"].as_str().unwrap())
+            .collect();
+        assert!(start.contains(&"my-own-cursor-hook"));
+        assert!(start
+            .iter()
+            .any(|c| c.contains("atomic agent hooks cursor session-start")));
+    }
+
+    #[test]
+    fn merges_extra_settings_idempotently() {
+        // Claude-style: deep-merge a permissions.deny rule alongside hooks.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("settings.json");
+        write(
+            &target,
+            &json!({ "permissions": { "deny": ["Read(./secret/**)"] } }),
+        );
+        let manifest = dir.path().join("manifest.json");
+        write(
+            &manifest,
+            &json!({
+                "target": target.to_string_lossy(),
+                "command_prefix": "atomic agent hooks claude-code",
+                "hooks": {
+                    "Stop": [ { "matcher": "", "hooks": [ { "type": "command", "command": "atomic agent hooks claude-code stop" } ] } ]
+                },
+                "merge": { "permissions": { "deny": ["Read(./.atomic/metadata/**)"] } }
+            }),
+        );
+
+        install_from_manifest(&manifest).unwrap();
+        install_from_manifest(&manifest).unwrap(); // idempotent
+
+        let written: Value =
+            serde_json::from_str(&std::fs::read_to_string(&target).unwrap()).unwrap();
+        let deny: Vec<&str> = written["permissions"]["deny"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        // User's rule preserved; Atomic's added exactly once.
+        assert_eq!(
+            deny,
+            vec!["Read(./secret/**)", "Read(./.atomic/metadata/**)"]
+        );
+        // The nested Stop hook is registered.
+        assert!(written["hooks"]["Stop"].is_array());
+    }
+
+    #[test]
+    fn expand_target_handles_tilde() {
+        let home = dirs::home_dir().unwrap();
+        assert_eq!(
+            expand_target("~/.codex/hooks.json").unwrap(),
+            home.join(".codex/hooks.json")
+        );
+        assert_eq!(
+            expand_target("/abs/path.json").unwrap(),
+            PathBuf::from("/abs/path.json")
+        );
+    }
+}

--- a/atomic-agent/src/hooks/mod.rs
+++ b/atomic-agent/src/hooks/mod.rs
@@ -63,6 +63,7 @@ pub mod copilot;
 pub mod cursor;
 pub mod gemini_cli;
 pub mod hermes;
+pub mod manifest;
 pub mod opencode;
 pub mod pi;
 pub mod sherpa;

--- a/atomic-cli/src/commands/agent/disable.rs
+++ b/atomic-cli/src/commands/agent/disable.rs
@@ -55,6 +55,14 @@ pub struct Disable {
     /// `atomic agent enable --global`.
     #[arg(short, long)]
     global: bool,
+
+    /// Remove hooks described by an integration-supplied manifest file.
+    ///
+    /// Reads the same manifest used by `atomic agent enable --hooks`, and
+    /// removes only the entries whose command matches the manifest's
+    /// `command_prefix` from its target file. Non-Atomic hooks are preserved.
+    #[arg(long, value_name = "FILE")]
+    hooks: Option<std::path::PathBuf>,
 }
 
 impl Disable {
@@ -65,12 +73,18 @@ impl Disable {
             agent: None,
             all: false,
             global: false,
+            hooks: None,
         }
     }
 }
 
 impl Command for Disable {
     fn run(&self) -> CliResult<()> {
+        // Data-driven uninstall — mirrors `enable --hooks`.
+        if let Some(ref manifest) = self.hooks {
+            return self.run_manifest(manifest);
+        }
+
         // Global uninstall — removes from ~/.claude/settings.json
         if self.global {
             return self.run_global();
@@ -158,6 +172,38 @@ impl Command for Disable {
 }
 
 impl Disable {
+    /// Remove hooks described by an integration-supplied manifest file.
+    ///
+    /// Mirrors `atomic agent enable --hooks`: removes only the entries whose
+    /// command matches the manifest's `command_prefix` from its target file.
+    fn run_manifest(&self, manifest: &std::path::Path) -> CliResult<()> {
+        use atomic_agent::hooks::manifest::uninstall_from_manifest;
+
+        match uninstall_from_manifest(manifest) {
+            Ok(outcome) => {
+                if outcome.removed > 0 {
+                    print_success(&format!(
+                        "Removed {} hook command(s) from {}",
+                        outcome.removed,
+                        outcome.target.display(),
+                    ));
+                    println!();
+                    println!("Agent turns will no longer be recorded automatically.");
+                } else {
+                    println!("No Atomic hooks found in {}.", outcome.target.display());
+                }
+            }
+            Err(e) => {
+                print_error(&format!(
+                    "Failed to remove hooks from manifest {}: {}",
+                    manifest.display(),
+                    e,
+                ));
+            }
+        }
+        Ok(())
+    }
+
     /// Remove hooks from global agent settings.
     ///
     /// Supports:
@@ -266,6 +312,7 @@ mod tests {
             agent: Some("claude-code".to_string()),
             all: false,
             global: false,
+            hooks: None,
         };
         assert_eq!(cmd.agent.as_deref(), Some("claude-code"));
     }
@@ -276,6 +323,7 @@ mod tests {
             agent: None,
             all: true,
             global: false,
+            hooks: None,
         };
         assert!(cmd.all);
     }
@@ -286,6 +334,7 @@ mod tests {
             agent: None,
             all: false,
             global: true,
+            hooks: None,
         };
         assert!(cmd.global);
     }

--- a/atomic-cli/src/commands/agent/enable.rs
+++ b/atomic-cli/src/commands/agent/enable.rs
@@ -68,6 +68,17 @@ pub struct Enable {
     /// install once, works everywhere that has a `.atomic/` directory.
     #[arg(short, long)]
     global: bool,
+
+    /// Install hooks from an integration-supplied manifest file.
+    ///
+    /// The manifest (shipped by an integration package such as atomic-codex)
+    /// names its own target settings file and the hook commands to register,
+    /// and is merged in idempotently — preserving non-Atomic hooks. Because the
+    /// definitions live in the integration repo, updating an agent's hook
+    /// wiring never requires rebuilding `atomic`. When set, `--agent`/`--global`
+    /// are not needed; the manifest is self-describing.
+    #[arg(long, value_name = "FILE")]
+    hooks: Option<std::path::PathBuf>,
 }
 
 impl Enable {
@@ -79,12 +90,18 @@ impl Enable {
             force: false,
             all: false,
             global: false,
+            hooks: None,
         }
     }
 }
 
 impl Command for Enable {
     fn run(&self) -> CliResult<()> {
+        // Data-driven install — definitions come from the integration's manifest.
+        if let Some(ref manifest) = self.hooks {
+            return self.run_manifest(manifest);
+        }
+
         // Global install — writes to ~/.claude/settings.json
         if self.global {
             return self.run_global();
@@ -241,6 +258,42 @@ impl Command for Enable {
 }
 
 impl Enable {
+    /// Install hooks from an integration-supplied manifest file.
+    ///
+    /// The manifest names its own target settings file and the hook commands to
+    /// register; this merges them in idempotently, preserving any non-Atomic
+    /// hooks. The hook definitions live in the integration repo, so this path
+    /// never needs the per-agent definitions baked into this binary.
+    fn run_manifest(&self, manifest: &std::path::Path) -> CliResult<()> {
+        use atomic_agent::hooks::manifest::install_from_manifest;
+
+        match install_from_manifest(manifest) {
+            Ok(outcome) => {
+                print_success(&format!(
+                    "Installed hooks from {} → {}",
+                    manifest.display(),
+                    outcome.target.display(),
+                ));
+                let mut summary = format!("{} hook command(s) registered", outcome.added);
+                if outcome.removed > 0 {
+                    summary.push_str(&format!(", {} stale entr(y/ies) replaced", outcome.removed));
+                }
+                println!("  {summary}");
+                println!();
+                println!("Each agent turn in a project with .atomic/ will be recorded");
+                println!("as an Atomic change with full AI provenance.");
+            }
+            Err(e) => {
+                print_error(&format!(
+                    "Failed to install hooks from manifest {}: {}",
+                    manifest.display(),
+                    e,
+                ));
+            }
+        }
+        Ok(())
+    }
+
     /// Install hooks globally to the agent's user-level settings.
     ///
     /// Supports:
@@ -390,6 +443,7 @@ mod tests {
             force: false,
             all: false,
             global: false,
+            hooks: None,
         };
     }
 
@@ -400,6 +454,7 @@ mod tests {
             force: true,
             all: false,
             global: false,
+            hooks: None,
         };
         assert!(cmd.force);
         assert_eq!(cmd.agent.as_deref(), Some("claude-code"));
@@ -412,6 +467,7 @@ mod tests {
             force: false,
             all: true,
             global: false,
+            hooks: None,
         };
         assert!(cmd.all);
         assert!(cmd.agent.is_none());
@@ -424,6 +480,7 @@ mod tests {
             force: false,
             all: false,
             global: true,
+            hooks: None,
         };
         assert!(cmd.global);
         assert_eq!(cmd.agent.as_deref(), Some("claude-code"));


### PR DESCRIPTION
This pull request adds full support for the Hermes Agent as an integration in the Atomic Agent system. It introduces a new `HermesHook` adapter, updates the hook event type system to recognize Hermes-specific hook verbs, and enables data-driven hook installation and removal via manifest files in the CLI. The changes are grouped into Hermes Agent integration, extensible hook management, and general improvements and tests.

**Hermes Agent integration:**

* Added a new `HermesHook` adapter in `atomic-agent/src/hooks/hermes.rs`, allowing Atomic Agent to parse and normalize Hermes shell hook payloads into `TurnEvent` records, with robust field extraction and provider tagging. Includes tests for Hermes payloads and hook verbs.
* Updated the hook event type mapping in `atomic-agent/src/event.rs` to support Hermes-specific hook verbs (e.g., `on_session_start`, `pre_llm_call`, `pre_tool_call`) and mapped them to the appropriate `HookType` variants. [[1]](diffhunk://#diff-157d98db3b12fdfd224cd1af3fe5a3e451e68cf75a31fb93ee3aac7ea80855d2L59-R66) [[2]](diffhunk://#diff-157d98db3b12fdfd224cd1af3fe5a3e451e68cf75a31fb93ee3aac7ea80855d2R151-R154) [[3]](diffhunk://#diff-157d98db3b12fdfd224cd1af3fe5a3e451e68cf75a31fb93ee3aac7ea80855d2R173-R178) [[4]](diffhunk://#diff-157d98db3b12fdfd224cd1af3fe5a3e451e68cf75a31fb93ee3aac7ea80855d2L188-R206) [[5]](diffhunk://#diff-157d98db3b12fdfd224cd1af3fe5a3e451e68cf75a31fb93ee3aac7ea80855d2R681-R708)
* Registered `HermesHook` in the default agent registry and added a test to ensure its presence. [[1]](diffhunk://#diff-60222d3408ef163416c11ca7c7f0e439ec888d20693d1fe8e40e78f99230506dR65-R66) [[2]](diffhunk://#diff-60222d3408ef163416c11ca7c7f0e439ec888d20693d1fe8e40e78f99230506dR252) [[3]](diffhunk://#diff-60222d3408ef163416c11ca7c7f0e439ec888d20693d1fe8e40e78f99230506dR264) [[4]](diffhunk://#diff-7d22ac194aeecd0a07fd234a60c828e53858f9afffd244eff93a334e71d1d55fR177-R184)

**Extensible hook management via manifest files:**

* Extended the `atomic agent enable` and `atomic agent disable` CLI commands to support a `--hooks <FILE>` option, enabling data-driven installation and removal of hooks from integration-supplied manifest files. This allows for idempotent, non-destructive updates to user hook configurations. [[1]](diffhunk://#diff-fdb630b83543a9af6e4070a0a89087cf30c01087390c8cadded3a343dc5f7f6aR71-R81) [[2]](diffhunk://#diff-fdb630b83543a9af6e4070a0a89087cf30c01087390c8cadded3a343dc5f7f6aR93-R104) [[3]](diffhunk://#diff-fdb630b83543a9af6e4070a0a89087cf30c01087390c8cadded3a343dc5f7f6aR261-R296) [[4]](diffhunk://#diff-7dba8b5b44ef3a7f41c3cb6444bb1d05d687235d01cdf06f7502d758af4a0983R58-R65) [[5]](diffhunk://#diff-7dba8b5b44ef3a7f41c3cb6444bb1d05d687235d01cdf06f7502d758af4a0983R76-R87) [[6]](diffhunk://#diff-7dba8b5b44ef3a7f41c3cb6444bb1d05d687235d01cdf06f7502d758af4a0983R175-R206)
* Updated CLI tests to cover the new manifest-driven hook management options. [[1]](diffhunk://#diff-7dba8b5b44ef3a7f41c3cb6444bb1d05d687235d01cdf06f7502d758af4a0983R315) [[2]](diffhunk://#diff-7dba8b5b44ef3a7f41c3cb6444bb1d05d687235d01cdf06f7502d758af4a0983R326) [[3]](diffhunk://#diff-7dba8b5b44ef3a7f41c3cb6444bb1d05d687235d01cdf06f7502d758af4a0983R337)

**General improvements and tests:**

* Improved documentation and mapping tables for hook event types, including Hermes-specific mappings.
* Added and updated tests for Hermes hook event parsing and registry presence. [[1]](diffhunk://#diff-f5c085fbb70dd484be84deb21f45f6b3989e0ab2db7f172b237d32ca53f1e256R1-R246) [[2]](diffhunk://#diff-7d22ac194aeecd0a07fd234a60c828e53858f9afffd244eff93a334e71d1d55fR177-R184) [[3]](diffhunk://#diff-157d98db3b12fdfd224cd1af3fe5a3e451e68cf75a31fb93ee3aac7ea80855d2R681-R708)

These changes make it easier to integrate new agents like Hermes, ensure robust parsing and normalization of their events, and provide a flexible, manifest-driven approach for managing hook installation and removal.