### PR TITLE
Ignore semantic FileOps for Git

### DIFF
--- a/atomic-cli/src/commands/git/import.rs
+++ b/atomic-cli/src/commands/git/import.rs
@@ -23,6 +23,10 @@
 //! - Binary files are imported as-is
 //! - Default imports are mainline-only (first parent)
 //! - Use `--all` to import all local branches as views
+//! - Imports build only the graph layer by default. Git has no token-level
+//!   data, so the semantic (Trunk → Branch → Leaf) layer for imported history
+//!   is synthesized and derived on demand. Use `--with-crdt` to pre-materialize
+//!   it for token-level blame and word-diff.
 
 use std::collections::HashSet;
 use std::path::Path;
@@ -35,7 +39,7 @@ use atomic_repository::Repository;
 use super::parallel::{ParallelImportOptions, ParallelImporter};
 use crate::commands::{find_repository_root, Command};
 use crate::error::{CliError, CliResult};
-use crate::output::{print_info, print_success, print_warning};
+use crate::output::{print_hint, print_info, print_success, print_warning};
 
 /// Import a Git repository into Atomic.
 ///
@@ -87,6 +91,22 @@ pub struct Import {
     /// Use this flag to skip vault setup.
     #[arg(long)]
     pub no_vault: bool,
+
+    /// Eagerly build the semantic (Trunk → Branch → Leaf) layer during import.
+    ///
+    /// By default, `git import` imports only the graph shape of each commit.
+    /// Git stores no token-level (or even line-level) data — diffs and blame
+    /// are computed, not stored — so the semantic layer for imported history
+    /// is synthesized and fully derivable from the graph content plus commit
+    /// metadata already written. Skipping it keeps imports smaller and faster
+    /// while files and diffs still work.
+    ///
+    /// Use this flag to pre-materialize that synthesized layer up front (for
+    /// token-level blame and word-diff on imported history) instead of
+    /// deriving it on demand. Changes recorded after the import always build
+    /// the semantic layer regardless of this flag.
+    #[arg(long = "with-crdt")]
+    pub with_crdt: bool,
 }
 
 fn import_ignore_patterns(workdir: &Path, kind: Option<&str>) -> Vec<String> {
@@ -160,6 +180,7 @@ impl Import {
                 self.kind.as_deref(),
             ),
             mainline_only,
+            graph_only: !self.with_crdt,
         };
 
         let importer = ParallelImporter::new(git_repo, options);
@@ -368,6 +389,17 @@ impl Command for Import {
         } else {
             HashSet::new()
         };
+
+        if self.with_crdt {
+            print_info(
+                "Building the semantic (Trunk → Branch → Leaf) layer during import (--with-crdt).",
+            );
+        } else {
+            print_hint(
+                "Importing graph only; the semantic layer is derived on demand. \
+                 Pass --with-crdt to pre-materialize token-level blame/diff for imported history.",
+            );
+        }
 
         // Determine which branches to import
         let default_branch = self.get_default_branch(&git_repo)?;
@@ -658,6 +690,16 @@ mod tests {
 
         let import = Import::try_parse_from(["import", "--all-branches"]).unwrap();
         assert!(import.all_branches);
+    }
+
+    #[test]
+    fn test_with_crdt_flag_defaults_to_graph_only() {
+        // Default import is graph-only: the semantic layer is opt-in.
+        let import = Import::try_parse_from(["import"]).unwrap();
+        assert!(!import.with_crdt);
+
+        let import = Import::try_parse_from(["import", "--with-crdt"]).unwrap();
+        assert!(import.with_crdt);
     }
 
     #[test]

--- a/atomic-cli/src/commands/git/parallel.rs
+++ b/atomic-cli/src/commands/git/parallel.rs
@@ -195,6 +195,14 @@ pub struct ParallelImportOptions {
     /// long-running branch internals or repeated upstream merges into feature
     /// branches.
     pub mainline_only: bool,
+    /// Import only the graph shape of each commit, skipping the semantic
+    /// (Trunk → Branch → Leaf) FileOps layer.
+    ///
+    /// Graph operations and Git diff metadata are still written, so files
+    /// materialize and diffs render normally. The per-line CRDT FileOps that
+    /// duplicate file content are omitted, which significantly reduces change
+    /// size and import time for large repositories.
+    pub graph_only: bool,
 }
 
 impl Default for ParallelImportOptions {
@@ -205,6 +213,7 @@ impl Default for ParallelImportOptions {
             repo_name: "unknown".to_string(),
             ignored_path_patterns: Vec::new(),
             mainline_only: true,
+            graph_only: false,
         }
     }
 }
@@ -1080,6 +1089,7 @@ fn build_graph_first_change(
     header: ChangeHeader,
     parsed: &ParsedCommit,
     line_index: &ImportLineIndex,
+    graph_only: bool,
 ) -> Result<(Change, Vec<PendingLineIndexUpdate>, Vec<String>), Vec<GraphFirstSkip>> {
     if parsed.files.is_empty() {
         return Err(vec![GraphFirstSkip {
@@ -1192,15 +1202,17 @@ fn build_graph_first_change(
                     });
                 }
 
-                file_ops.push(build_graph_first_file_ops_for_added_file(
-                    &file.path,
-                    &new_line_contents,
-                    &new_ranges,
-                    encoding,
-                    next_file_idx,
-                    &mut next_branch_idx,
-                ));
-                next_file_idx += 1;
+                if !graph_only {
+                    file_ops.push(build_graph_first_file_ops_for_added_file(
+                        &file.path,
+                        &new_line_contents,
+                        &new_ranges,
+                        encoding,
+                        next_file_idx,
+                        &mut next_branch_idx,
+                    ));
+                    next_file_idx += 1;
+                }
                 pending.push(PendingLineIndexUpdate::Add {
                     path: file.path.clone(),
                     inode_pos,
@@ -1270,7 +1282,10 @@ fn build_graph_first_change(
                     new_path: file.path.clone(),
                 });
 
-                if encoding != Encoding::Binary && !is_generated_diff_skip_path(&file.path) {
+                if !graph_only
+                    && encoding != Encoding::Binary
+                    && !is_generated_diff_skip_path(&file.path)
+                {
                     if let Some(diff_lines) = file.diff_lines.as_ref() {
                         let (ops, _) = atomic_core::record::workflow::build_crdt_ops_from_git_diff(
                             &file.path, diff_lines,
@@ -1502,11 +1517,13 @@ fn build_graph_first_change(
                     path: file.path.clone(),
                 });
                 deleted_paths.push(file.path.clone());
-                if let Some(diff_lines) = file.diff_lines.as_ref() {
-                    let (ops, _) = atomic_core::record::workflow::build_crdt_ops_from_git_diff(
-                        &file.path, diff_lines,
-                    );
-                    file_ops.push(ops);
+                if !graph_only {
+                    if let Some(diff_lines) = file.diff_lines.as_ref() {
+                        let (ops, _) = atomic_core::record::workflow::build_crdt_ops_from_git_diff(
+                            &file.path, diff_lines,
+                        );
+                        file_ops.push(ops);
+                    }
                 }
                 continue;
             }
@@ -1522,35 +1539,37 @@ fn build_graph_first_change(
             continue;
         };
         let encoding = Encoding::detect(new_content);
-        let replacements = if encoding == Encoding::Binary
-            || is_generated_diff_skip_path(&file.path)
-        {
-            vec![GitReplacementBlock {
-                old_start: if indexed.lines.is_empty() { 0 } else { 1 },
-                old_len: indexed.lines.len(),
-                new_start: 1,
-                new_lines: if new_content.is_empty() {
-                    Vec::new()
-                } else {
-                    vec![new_content.to_vec()]
-                },
-            }]
-        } else if parsed.is_merge {
-            current_state_replacements(indexed, new_content)
-        } else {
-            let Some(diff_lines) = file.diff_lines.as_ref() else {
-                skips.push(GraphFirstSkip::new(file, "modified_missing_diff_lines"));
-                continue;
+        let replacements =
+            if encoding == Encoding::Binary || is_generated_diff_skip_path(&file.path) {
+                vec![GitReplacementBlock {
+                    old_start: if indexed.lines.is_empty() { 0 } else { 1 },
+                    old_len: indexed.lines.len(),
+                    new_start: 1,
+                    new_lines: if new_content.is_empty() {
+                        Vec::new()
+                    } else {
+                        vec![new_content.to_vec()]
+                    },
+                }]
+            } else if parsed.is_merge {
+                current_state_replacements(indexed, new_content)
+            } else {
+                let Some(diff_lines) = file.diff_lines.as_ref() else {
+                    skips.push(GraphFirstSkip::new(file, "modified_missing_diff_lines"));
+                    continue;
+                };
+                if !graph_only {
+                    let (ops, _) = atomic_core::record::workflow::build_crdt_ops_from_git_diff(
+                        &file.path, diff_lines,
+                    );
+                    file_ops.push(ops);
+                }
+                let Some(replacements) = parse_git_diff_replacements(diff_lines) else {
+                    skips.push(GraphFirstSkip::new(file, "modified_unparseable_diff_lines"));
+                    continue;
+                };
+                replacements
             };
-            let (ops, _) =
-                atomic_core::record::workflow::build_crdt_ops_from_git_diff(&file.path, diff_lines);
-            file_ops.push(ops);
-            let Some(replacements) = parse_git_diff_replacements(diff_lines) else {
-                skips.push(GraphFirstSkip::new(file, "modified_unparseable_diff_lines"));
-                continue;
-            };
-            replacements
-        };
         if replacements.is_empty() {
             continue;
         }
@@ -2579,7 +2598,8 @@ impl ParallelImporter {
 
         line_index.seed_missing_modified_files(repo, parsed);
         let graph_first_skips = build_graph_first_skip_reasons(parsed, line_index);
-        let graph_first_result = build_graph_first_change(header.clone(), parsed, line_index);
+        let graph_first_result =
+            build_graph_first_change(header.clone(), parsed, line_index, self.options.graph_only);
 
         if let Ok((mut graph_change, pending_updates, graph_deleted_paths)) = graph_first_result {
             graph_change.unhashed = Some(self.build_git_metadata(parsed, false, false));


### PR DESCRIPTION
This pull request adds an opt-in flag to the `git import` command that allows users to pre-materialize the semantic (Trunk → Branch → Leaf) layer during import, instead of building only the commit graph by default. This change improves import speed and storage efficiency for large repositories, while still allowing users to generate token-level blame and word-diff information on demand or up front if needed. The implementation includes updates to the CLI, internal import logic, and relevant tests.

**CLI and User Experience Improvements:**

* Added a `--with-crdt` flag to the `Import` struct and CLI, enabling users to choose whether to build the semantic layer during import or derive it on demand. The default is now graph-only import for improved speed and size. User-facing messages were updated to reflect this behavior. [[1]](diffhunk://#diff-94ef74913277bb663c884963c6345c55b80353a8ed2e284f3c883d9310de31f5R26-R29) [[2]](diffhunk://#diff-94ef74913277bb663c884963c6345c55b80353a8ed2e284f3c883d9310de31f5R94-R109) [[3]](diffhunk://#diff-94ef74913277bb663c884963c6345c55b80353a8ed2e284f3c883d9310de31f5R393-R403)
* Added tests to ensure the default and flag-driven behaviors for the semantic layer import.

**Import Logic and Internal API Changes:**

* Updated `ParallelImportOptions` and `ParallelImporter` to support a `graph_only` option, controlling whether the semantic (CRDT FileOps) layer is built during import. [[1]](diffhunk://#diff-e0517d8c8f8eb0ddfaa2b2030f85571504967a3b637e3228505b51ab3599f34eR198-R205) [[2]](diffhunk://#diff-e0517d8c8f8eb0ddfaa2b2030f85571504967a3b637e3228505b51ab3599f34eR216) [[3]](diffhunk://#diff-94ef74913277bb663c884963c6345c55b80353a8ed2e284f3c883d9310de31f5R183)
* Modified the import pipeline (`build_graph_first_change` and related logic) to conditionally skip building the semantic layer when `graph_only` is true, reducing import time and storage requirements. [[1]](diffhunk://#diff-e0517d8c8f8eb0ddfaa2b2030f85571504967a3b637e3228505b51ab3599f34eR1092) [[2]](diffhunk://#diff-e0517d8c8f8eb0ddfaa2b2030f85571504967a3b637e3228505b51ab3599f34eR1205) [[3]](diffhunk://#diff-e0517d8c8f8eb0ddfaa2b2030f85571504967a3b637e3228505b51ab3599f34eR1215) [[4]](diffhunk://#diff-e0517d8c8f8eb0ddfaa2b2030f85571504967a3b637e3228505b51ab3599f34eL1273-R1288) [[5]](diffhunk://#diff-e0517d8c8f8eb0ddfaa2b2030f85571504967a3b637e3228505b51ab3599f34eR1520-R1527) [[6]](diffhunk://#diff-e0517d8c8f8eb0ddfaa2b2030f85571504967a3b637e3228505b51ab3599f34eL1545-R1566) [[7]](diffhunk://#diff-e0517d8c8f8eb0ddfaa2b2030f85571504967a3b637e3228505b51ab3599f34eL2582-R2602)

These changes make the import process more efficient by default, while still allowing advanced users to opt in to full semantic history when needed.