### PR TITLE
Enhance Hermes agent with atomic settings and documentation updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-agent"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "atomic-core",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-cli"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "atomic-agent",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-config"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "dirs",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-core"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-identity"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "atomic-config",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-remote"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-repository"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "atomic-config",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-semantic"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-teams"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "atomic-remote",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 authors = ["Atomic Contributors"]
 license = "Apache-2.0"

--- a/atomic-agent/src/event.rs
+++ b/atomic-agent/src/event.rs
@@ -56,14 +56,14 @@ use serde::{Deserialize, Serialize};
 ///
 /// These map to agent-specific hook names:
 ///
-/// | HookType       | Claude Code            | Gemini CLI        |
-/// |----------------|------------------------|-------------------|
-/// | SessionStart   | session-start          | session-start     |
-/// | SessionEnd     | session-end            | session-end       |
-/// | TurnStart      | user-prompt-submit     | before-model      |
-/// | TurnEnd        | stop                   | after-model       |
-/// | PreToolUse     | pre-task               | before-tool       |
-/// | PostToolUse    | post-task / post-todo  | after-tool        |
+/// | HookType       | Claude Code            | Gemini CLI        | Hermes Agent     |
+/// |----------------|------------------------|-------------------|------------------|
+/// | SessionStart   | session-start          | session-start     | on_session_start |
+/// | SessionEnd     | session-end            | session-end       | on_session_end   |
+/// | TurnStart      | user-prompt-submit     | before-model      | pre_llm_call     |
+/// | TurnEnd        | stop                   | after-model       | post_llm_call    |
+/// | PreToolUse     | pre-task               | before-tool       | pre_tool_call    |
+/// | PostToolUse    | post-task / post-todo  | after-tool        | post_tool_call   |
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HookType {
@@ -148,6 +148,10 @@ impl HookType {
     /// // OpenCode verbs
     /// assert_eq!(HookType::from_verb("user-prompt"), Some(HookType::TurnStart));
     ///
+    /// // Hermes Agent verbs
+    /// assert_eq!(HookType::from_verb("pre_llm_call"), Some(HookType::TurnStart));
+    /// assert_eq!(HookType::from_verb("post_tool_call"), Some(HookType::PostToolUse));
+    ///
     /// // Unknown verb
     /// assert_eq!(HookType::from_verb("unknown"), None);
     /// ```
@@ -165,6 +169,12 @@ impl HookType {
             // Claude Code turn boundaries
             "user-prompt-submit" => Some(HookType::TurnStart),
             "stop" => Some(HookType::TurnEnd),
+
+            // Hermes Agent plugin/shell hook events
+            "on-session-start" | "on_session_start" => Some(HookType::SessionStart),
+            "on-session-end" | "on_session_end" => Some(HookType::SessionEnd),
+            "pre-llm-call" | "pre_llm_call" => Some(HookType::TurnStart),
+            "post-llm-call" | "post_llm_call" => Some(HookType::TurnEnd),
 
             // Gemini CLI turn boundaries
             "before-agent" => Some(HookType::TurnStart),
@@ -185,15 +195,15 @@ impl HookType {
             "pre-task" => Some(HookType::PreToolUse),
             "post-task" | "post-todo" | "post-tool" => Some(HookType::PostToolUse),
 
-            // Codex + Copilot pre-tool use
-            "pre-tool" => Some(HookType::PreToolUse),
+            // Codex + Copilot + Hermes pre-tool use
+            "pre-tool" | "pre_tool_call" => Some(HookType::PreToolUse),
 
             // Cursor thinking blocks
             "after-thought" => Some(HookType::PostToolUse),
 
             // Gemini CLI / OpenCode / Pi tool use (shared verbs)
             "before-tool" => Some(HookType::PreToolUse),
-            "after-tool" => Some(HookType::PostToolUse),
+            "after-tool" | "post_tool_call" => Some(HookType::PostToolUse),
 
             _ => None,
         }
@@ -664,6 +674,34 @@ mod tests {
         );
         assert_eq!(
             HookType::from_verb("after-tool"),
+            Some(HookType::PostToolUse)
+        );
+    }
+
+    #[test]
+    fn test_hook_type_from_verb_hermes() {
+        assert_eq!(
+            HookType::from_verb("on_session_start"),
+            Some(HookType::SessionStart)
+        );
+        assert_eq!(
+            HookType::from_verb("on_session_end"),
+            Some(HookType::SessionEnd)
+        );
+        assert_eq!(
+            HookType::from_verb("pre_llm_call"),
+            Some(HookType::TurnStart)
+        );
+        assert_eq!(
+            HookType::from_verb("post_llm_call"),
+            Some(HookType::TurnEnd)
+        );
+        assert_eq!(
+            HookType::from_verb("pre_tool_call"),
+            Some(HookType::PreToolUse)
+        );
+        assert_eq!(
+            HookType::from_verb("post_tool_call"),
             Some(HookType::PostToolUse)
         );
     }

--- a/atomic-agent/src/hooks/claude_code/settings.rs
+++ b/atomic-agent/src/hooks/claude_code/settings.rs
@@ -107,10 +107,48 @@ pub(crate) fn write_settings(
         output.push('\n');
     }
 
-    std::fs::write(settings_path, output.as_bytes()).map_err(|e| AgentError::ConfigError {
-        operation: "write".to_string(),
-        path: settings_path.to_path_buf(),
-        reason: e.to_string(),
+    // Atomic write (temp + rename) so a settings watcher never reads a
+    // half-written file (`std::fs::write` truncates the target first).
+    use std::io::Write as _;
+
+    let parent = settings_path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = settings_path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "settings.json".to_string());
+    // Same-dir, pid-suffixed temp: rename stays atomic, no clobber between writers.
+    let tmp_path = parent.join(format!(".{}.{}.tmp", file_name, std::process::id()));
+
+    // Preserve existing permissions.
+    let existing_perms = std::fs::metadata(settings_path)
+        .ok()
+        .map(|m| m.permissions());
+
+    if let Err(e) = (|| -> std::io::Result<()> {
+        let mut f = std::fs::File::create(&tmp_path)?;
+        f.write_all(output.as_bytes())?;
+        f.sync_all()?;
+        Ok(())
+    })() {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(AgentError::ConfigError {
+            operation: "write temp file".to_string(),
+            path: tmp_path,
+            reason: e.to_string(),
+        });
+    }
+
+    if let Some(perms) = existing_perms {
+        let _ = std::fs::set_permissions(&tmp_path, perms);
+    }
+
+    std::fs::rename(&tmp_path, settings_path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp_path);
+        AgentError::ConfigError {
+            operation: "rename temp file into place".to_string(),
+            path: settings_path.to_path_buf(),
+            reason: e.to_string(),
+        }
     })
 }
 

--- a/atomic-agent/src/hooks/hermes.rs
+++ b/atomic-agent/src/hooks/hermes.rs
@@ -1,0 +1,246 @@
+//! Hermes Agent hook adapter for Atomic Agent.
+//!
+//! Hermes can run shell hooks for CLI and gateway sessions. Hook commands
+//! receive a JSON payload on stdin with fields such as `hook_event_name`,
+//! `session_id`, `cwd`, `tool_name`, `tool_input`, and `extra`.
+//!
+//! This adapter normalizes those shell-hook payloads into Atomic [`TurnEvent`]
+//! records. Installation is intentionally left to Hermes-specific packages or
+//! documentation so Atomic does not clobber an existing `~/.hermes/config.yaml`.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use crate::error::{AgentError, AgentResult};
+use crate::event::{HookType, TurnEvent};
+
+use super::AgentHook;
+
+const HERMES_DIR: &str = ".hermes";
+
+#[derive(Debug)]
+pub struct HermesHook {
+    _private: (),
+}
+
+impl HermesHook {
+    pub fn new() -> Self {
+        Self { _private: () }
+    }
+
+    fn parse_json(&self, hook_type: HookType, input: &[u8]) -> AgentResult<Value> {
+        if input.is_empty() {
+            return Err(AgentError::HookInputEmpty {
+                agent: self.name().to_string(),
+                hook_type: hook_type.as_str().to_string(),
+            });
+        }
+
+        serde_json::from_slice(input).map_err(|e| AgentError::HookParseFailed {
+            agent: self.name().to_string(),
+            hook_type: hook_type.as_str().to_string(),
+            reason: e.to_string(),
+        })
+    }
+
+    fn extract_session_id(raw: &Value) -> String {
+        value_string(raw, "session_id")
+            .or_else(|| value_string(raw, "conversation_id"))
+            .or_else(|| value_string(raw, "thread_id"))
+            .or_else(|| value_at(raw, &["extra", "session_id"]))
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "hermes-session".to_string())
+    }
+
+    fn extract_prompt(raw: &Value) -> Option<String> {
+        value_string(raw, "prompt")
+            .or_else(|| value_string(raw, "user_message"))
+            .or_else(|| value_string(raw, "message"))
+            .or_else(|| value_at(raw, &["extra", "prompt"]))
+            .or_else(|| value_at(raw, &["extra", "user_message"]))
+            .filter(|s| !s.is_empty())
+    }
+
+    fn extract_transcript_path(raw: &Value) -> Option<String> {
+        value_string(raw, "transcript_path")
+            .or_else(|| value_at(raw, &["extra", "transcript_path"]))
+            .or_else(|| value_at(raw, &["extra", "log_path"]))
+            .filter(|s| !s.is_empty())
+    }
+
+    fn extract_tool_name(raw: &Value) -> Option<String> {
+        value_string(raw, "tool_name")
+            .or_else(|| value_at(raw, &["extra", "tool_name"]))
+            .filter(|s| !s.is_empty())
+    }
+
+    fn extract_tool_use_id(raw: &Value) -> Option<String> {
+        value_string(raw, "tool_use_id")
+            .or_else(|| value_string(raw, "tool_call_id"))
+            .or_else(|| value_string(raw, "call_id"))
+            .or_else(|| value_string(raw, "id"))
+            .or_else(|| value_at(raw, &["extra", "tool_use_id"]))
+            .or_else(|| value_at(raw, &["extra", "tool_call_id"]))
+            .or_else(|| value_at(raw, &["extra", "call_id"]))
+            .filter(|s| !s.is_empty())
+    }
+
+    fn config_path() -> Option<PathBuf> {
+        dirs::home_dir().map(|home| home.join(HERMES_DIR).join("config.yaml"))
+    }
+}
+
+impl Default for HermesHook {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AgentHook for HermesHook {
+    fn name(&self) -> &str {
+        "hermes"
+    }
+
+    fn display_name(&self) -> &str {
+        "Hermes Agent"
+    }
+
+    fn parse_event(&self, hook_type: HookType, input: &[u8]) -> AgentResult<TurnEvent> {
+        let raw_json = self.parse_json(hook_type, input)?;
+        let mut event = TurnEvent::new(Self::extract_session_id(&raw_json), hook_type)
+            .with_raw_json(with_hermes_provider(raw_json.clone()));
+
+        if let Some(path) = Self::extract_transcript_path(&raw_json) {
+            event = event.with_transcript_path(path);
+        }
+
+        if hook_type == HookType::TurnStart {
+            if let Some(prompt) = Self::extract_prompt(&raw_json) {
+                event = event.with_prompt(prompt);
+            }
+        }
+
+        if matches!(hook_type, HookType::PreToolUse | HookType::PostToolUse) {
+            if let Some(name) = Self::extract_tool_name(&raw_json) {
+                event = event.with_tool_name(name);
+            }
+            if let Some(id) = Self::extract_tool_use_id(&raw_json) {
+                event = event.with_tool_use_id(id);
+            }
+        }
+
+        Ok(event)
+    }
+
+    fn install(&self, _repo_root: &Path) -> AgentResult<usize> {
+        // Hermes stores hooks in YAML config and often prompts for shell-hook
+        // consent. Avoid mutating user config from Atomic core; the dedicated
+        // Hermes integration package can merge config safely.
+        Ok(0)
+    }
+
+    fn uninstall(&self, _repo_root: &Path) -> AgentResult<()> {
+        Ok(())
+    }
+
+    fn is_installed(&self, repo_root: &Path) -> bool {
+        repo_root.join(HERMES_DIR).is_dir() || Self::config_path().is_some_and(|path| path.exists())
+    }
+
+    fn supported_hooks(&self) -> Vec<HookType> {
+        vec![
+            HookType::SessionStart,
+            HookType::SessionEnd,
+            HookType::TurnStart,
+            HookType::TurnEnd,
+            HookType::PreToolUse,
+            HookType::PostToolUse,
+        ]
+    }
+
+    fn detect_presence(&self, repo_root: &Path) -> bool {
+        self.is_installed(repo_root)
+    }
+
+    fn hook_verbs(&self) -> Vec<&str> {
+        vec![
+            "on_session_start",
+            "on_session_end",
+            "pre_llm_call",
+            "post_llm_call",
+            "pre_tool_call",
+            "post_tool_call",
+        ]
+    }
+}
+
+fn value_string(raw: &Value, key: &str) -> Option<String> {
+    raw.get(key).and_then(Value::as_str).map(ToOwned::to_owned)
+}
+
+fn value_at(raw: &Value, path: &[&str]) -> Option<String> {
+    let mut current = raw;
+    for key in path {
+        current = current.get(*key)?;
+    }
+    current.as_str().map(ToOwned::to_owned)
+}
+
+fn with_hermes_provider(mut raw: Value) -> Value {
+    if let Value::Object(ref mut map) = raw {
+        map.entry("provider".to_string())
+            .or_insert_with(|| Value::String("hermes".to_string()));
+    }
+    raw
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_turn_start_prompt_from_hermes_payload() {
+        let hook = HermesHook::new();
+        let input = br#"{
+            "hook_event_name": "pre_llm_call",
+            "session_id": "sess-123",
+            "cwd": "/repo",
+            "extra": {"prompt": "ship this"}
+        }"#;
+
+        let event = hook.parse_event(HookType::TurnStart, input).unwrap();
+        assert_eq!(event.session_id, "sess-123");
+        assert_eq!(event.event_type, HookType::TurnStart);
+        assert_eq!(event.prompt.as_deref(), Some("ship this"));
+        assert_eq!(
+            event.raw_json.as_ref().unwrap()["provider"].as_str(),
+            Some("hermes")
+        );
+    }
+
+    #[test]
+    fn parses_tool_payload_fields() {
+        let hook = HermesHook::new();
+        let input = br#"{
+            "hook_event_name": "pre_tool_call",
+            "session_id": "sess-456",
+            "tool_name": "terminal",
+            "tool_call_id": "call-1",
+            "tool_input": {"command": "cargo test"}
+        }"#;
+
+        let event = hook.parse_event(HookType::PreToolUse, input).unwrap();
+        assert_eq!(event.session_id, "sess-456");
+        assert_eq!(event.tool_name.as_deref(), Some("terminal"));
+        assert_eq!(event.tool_use_id.as_deref(), Some("call-1"));
+    }
+
+    #[test]
+    fn supports_hermes_hook_verbs() {
+        let hook = HermesHook::new();
+        assert_eq!(hook.name(), "hermes");
+        assert!(hook.hook_verbs().contains(&"post_tool_call"));
+        assert!(hook.supported_hooks().contains(&HookType::SessionEnd));
+    }
+}

--- a/atomic-agent/src/hooks/manifest.rs
+++ b/atomic-agent/src/hooks/manifest.rs
@@ -1,0 +1,587 @@
+//! Data-driven hook installation from an integration-supplied manifest.
+//!
+//! Instead of hardcoding each agent's hook definitions in this binary, an
+//! integration package (`atomic-codex`, `atomic-claude`, ...) ships a manifest
+//! file describing *where* its hooks live and *what* commands to register.
+//! `atomic agent enable --hooks <manifest>` merges that manifest into the
+//! agent's settings file idempotently, preserving any non-Atomic hooks.
+//!
+//! Because the definitions live in the integration repo, updating an agent's
+//! hook wiring (new event, renamed verb, schema tweak, bug fix) never requires
+//! rebuilding the `atomic` binary — only re-publishing the integration package.
+//! The merge engine ships with `atomic`, so installation needs no Node, `jq`,
+//! `sudo`, or other runtime.
+//!
+//! # Manifest format
+//!
+//! ```json
+//! {
+//!   "target": "~/.codex/hooks.json",
+//!   "hooks_key": "hooks",
+//!   "command_prefix": "atomic agent hooks codex",
+//!   "hooks": {
+//!     "SessionStart": [
+//!       { "hooks": [ { "type": "command", "command": "test -d .atomic && atomic agent hooks codex session-start || true", "statusMessage": "Atomic: tracking session" } ] }
+//!     ],
+//!     "Stop": [
+//!       { "hooks": [ { "type": "command", "command": "test -d .atomic && atomic agent hooks codex stop || true" } ] }
+//!     ]
+//!   }
+//! }
+//! ```
+//!
+//! - `target` — destination settings file (`~` is expanded to the home dir).
+//! - `hooks_key` — top-level key under which hooks live (default `"hooks"`).
+//! - `command_prefix` — substring identifying this integration's own hook
+//!   commands. Entries matching it are removed before re-adding, so re-running
+//!   syncs the target to the manifest (picks up command/event changes).
+//! - `hooks` — `event -> [group]`, in the target file's native shape. Groups
+//!   are merged verbatim, so agent-specific fields (e.g. `matcher`) are kept.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+use crate::error::{AgentError, AgentResult};
+
+fn default_hooks_key() -> String {
+    "hooks".to_string()
+}
+
+/// A hook manifest shipped by an integration package.
+#[derive(Debug, Deserialize)]
+pub struct HookManifest {
+    /// Destination settings file, e.g. `~/.codex/hooks.json`.
+    pub target: String,
+
+    /// JSON key under which hooks are stored in the target file.
+    #[serde(default = "default_hooks_key")]
+    pub hooks_key: String,
+
+    /// Substring identifying this integration's own hook commands.
+    pub command_prefix: String,
+
+    /// `event -> [entry]`, in the target file's native shape. Entries are
+    /// merged verbatim. Both nested (`{matcher?, hooks: [{command}]}`) and flat
+    /// (`{command}` / `{bash}`) entry shapes are supported.
+    #[serde(default)]
+    pub hooks: Map<String, Value>,
+
+    /// Extra non-hook settings to deep-merge into the target's root object
+    /// (e.g. Claude's `permissions.deny` rule). Objects are merged
+    /// recursively, arrays are unioned by value, scalars overwrite. Left in
+    /// place on uninstall.
+    #[serde(default)]
+    pub merge: Map<String, Value>,
+}
+
+/// Outcome of installing or uninstalling a manifest.
+#[derive(Debug, Clone)]
+pub struct ManifestOutcome {
+    /// Resolved destination file.
+    pub target: PathBuf,
+    /// Number of hook commands added.
+    pub added: usize,
+    /// Number of stale Atomic hook commands removed.
+    pub removed: usize,
+}
+
+/// Merge the manifest's hooks into its target settings file.
+///
+/// Existing entries whose command contains the manifest's `command_prefix` are
+/// removed first, so re-running syncs the target to the manifest (picking up
+/// command/event changes). Non-matching hooks are preserved untouched.
+pub fn install_from_manifest(manifest_path: &Path) -> AgentResult<ManifestOutcome> {
+    let manifest = read_manifest(manifest_path)?;
+    let target = expand_target(&manifest.target)?;
+
+    let mut root = read_json_object(&target)?;
+
+    let entry = root
+        .entry(manifest.hooks_key.clone())
+        .or_insert_with(|| Value::Object(Map::new()));
+    if !entry.is_object() {
+        *entry = Value::Object(Map::new());
+    }
+    let hooks = entry
+        .as_object_mut()
+        .expect("entry was just ensured to be an object");
+
+    // Remove our previous entries first so command/event changes take effect.
+    let removed = remove_prefixed(hooks, &manifest.command_prefix);
+
+    let mut added = 0;
+    for (event, entries) in &manifest.hooks {
+        let Some(src_entries) = entries.as_array() else {
+            continue;
+        };
+        let dst = hooks
+            .entry(event.clone())
+            .or_insert_with(|| Value::Array(Vec::new()));
+        let Some(dst_entries) = dst.as_array_mut() else {
+            continue;
+        };
+        for entry in src_entries {
+            dst_entries.push(entry.clone());
+            added += count_commands(entry);
+        }
+    }
+
+    // Deep-merge any extra non-hook settings (e.g. Claude's permissions.deny).
+    deep_merge(&mut root, &manifest.merge);
+
+    write_json_object(&target, &root)?;
+
+    Ok(ManifestOutcome {
+        target,
+        added,
+        removed,
+    })
+}
+
+/// Remove the manifest's hooks from its target settings file.
+///
+/// Only entries whose command contains the manifest's `command_prefix` are
+/// removed; the file and all other hooks are left intact.
+pub fn uninstall_from_manifest(manifest_path: &Path) -> AgentResult<ManifestOutcome> {
+    let manifest = read_manifest(manifest_path)?;
+    let target = expand_target(&manifest.target)?;
+
+    if !target.exists() {
+        return Ok(ManifestOutcome {
+            target,
+            added: 0,
+            removed: 0,
+        });
+    }
+
+    let mut root = read_json_object(&target)?;
+    let mut removed = 0;
+    if let Some(hooks) = root
+        .get_mut(&manifest.hooks_key)
+        .and_then(Value::as_object_mut)
+    {
+        removed = remove_prefixed(hooks, &manifest.command_prefix);
+    }
+
+    write_json_object(&target, &root)?;
+
+    Ok(ManifestOutcome {
+        target,
+        added: 0,
+        removed,
+    })
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+fn read_manifest(path: &Path) -> AgentResult<HookManifest> {
+    let content = std::fs::read_to_string(path).map_err(|e| AgentError::ConfigError {
+        operation: "read manifest".to_string(),
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })?;
+    serde_json::from_str(&content).map_err(|e| AgentError::ConfigError {
+        operation: "parse manifest".to_string(),
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })
+}
+
+fn expand_target(target: &str) -> AgentResult<PathBuf> {
+    if target == "~" {
+        return dirs::home_dir().ok_or_else(|| AgentError::ConfigError {
+            operation: "resolve home".to_string(),
+            path: PathBuf::from(target),
+            reason: "could not determine home directory".to_string(),
+        });
+    }
+    if let Some(rest) = target.strip_prefix("~/") {
+        let home = dirs::home_dir().ok_or_else(|| AgentError::ConfigError {
+            operation: "resolve home".to_string(),
+            path: PathBuf::from(target),
+            reason: "could not determine home directory".to_string(),
+        })?;
+        return Ok(home.join(rest));
+    }
+    Ok(PathBuf::from(target))
+}
+
+fn read_json_object(path: &Path) -> AgentResult<Map<String, Value>> {
+    if !path.exists() {
+        return Ok(Map::new());
+    }
+    let content = std::fs::read_to_string(path).map_err(|e| AgentError::ConfigError {
+        operation: "read".to_string(),
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })?;
+    if content.trim().is_empty() {
+        return Ok(Map::new());
+    }
+    let value: Value = serde_json::from_str(&content).map_err(|e| AgentError::ConfigError {
+        operation: "parse".to_string(),
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })?;
+    match value {
+        Value::Object(map) => Ok(map),
+        _ => Ok(Map::new()),
+    }
+}
+
+fn write_json_object(path: &Path, root: &Map<String, Value>) -> AgentResult<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| AgentError::ConfigError {
+            operation: "create directory".to_string(),
+            path: parent.to_path_buf(),
+            reason: e.to_string(),
+        })?;
+    }
+    let mut content = serde_json::to_string_pretty(root).map_err(|e| AgentError::ConfigError {
+        operation: "serialize".to_string(),
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })?;
+    content.push('\n');
+    std::fs::write(path, content).map_err(|e| AgentError::ConfigError {
+        operation: "write".to_string(),
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })
+}
+
+/// Command-carrying keys across agent schemas: Claude/Codex/Cursor use
+/// `command`; Copilot uses `bash`/`powershell`.
+const COMMAND_KEYS: [&str; 3] = ["command", "bash", "powershell"];
+
+/// Whether a single (flat) hook entry's command field contains `prefix`.
+fn entry_command_contains(entry: &Value, prefix: &str) -> bool {
+    COMMAND_KEYS.iter().any(|key| {
+        entry
+            .get(key)
+            .and_then(Value::as_str)
+            .is_some_and(|cmd| cmd.contains(prefix))
+    })
+}
+
+/// Whether a single (flat) hook entry carries any command field.
+fn entry_has_command(entry: &Value) -> bool {
+    COMMAND_KEYS
+        .iter()
+        .any(|key| entry.get(key).and_then(Value::as_str).is_some())
+}
+
+/// Remove hook entries whose command contains `prefix`. Handles both nested
+/// (`{matcher?, hooks: [{command}]}`) and flat (`{command}`/`{bash}`) shapes.
+/// Empty groups and empty event arrays are pruned. Returns commands removed.
+fn remove_prefixed(hooks: &mut Map<String, Value>, prefix: &str) -> usize {
+    let mut removed = 0;
+    for value in hooks.values_mut() {
+        let Some(entries) = value.as_array_mut() else {
+            continue;
+        };
+        entries.retain_mut(|entry| {
+            // Nested shape: a group with an inner `hooks` array.
+            if let Some(inner) = entry.get_mut("hooks").and_then(Value::as_array_mut) {
+                let before = inner.len();
+                inner.retain(|hook| !entry_command_contains(hook, prefix));
+                removed += before - inner.len();
+                return !inner.is_empty();
+            }
+            // Flat shape: the entry itself carries the command.
+            if entry_command_contains(entry, prefix) {
+                removed += 1;
+                return false;
+            }
+            true
+        });
+    }
+    // Drop event keys whose entry array is now empty.
+    hooks.retain(|_, v| v.as_array().map(|a| !a.is_empty()).unwrap_or(true));
+    removed
+}
+
+/// Count the hook commands carried by a single entry (nested or flat).
+fn count_commands(entry: &Value) -> usize {
+    if let Some(inner) = entry.get("hooks").and_then(Value::as_array) {
+        return inner.iter().filter(|h| entry_has_command(h)).count();
+    }
+    usize::from(entry_has_command(entry))
+}
+
+/// Deep-merge `extra` into `root`: objects merge recursively, arrays union by
+/// value (no duplicates), scalars overwrite. Used for non-hook settings such
+/// as Claude's `permissions.deny` rule.
+fn deep_merge(root: &mut Map<String, Value>, extra: &Map<String, Value>) {
+    for (key, value) in extra {
+        match root.get_mut(key) {
+            Some(existing) => merge_value(existing, value),
+            None => {
+                root.insert(key.clone(), value.clone());
+            }
+        }
+    }
+}
+
+fn merge_value(target: &mut Value, source: &Value) {
+    match (target, source) {
+        (Value::Object(t), Value::Object(s)) => deep_merge(t, s),
+        (Value::Array(t), Value::Array(s)) => {
+            for item in s {
+                if !t.contains(item) {
+                    t.push(item.clone());
+                }
+            }
+        }
+        (t, s) => *t = s.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn write(path: &Path, value: &Value) {
+        std::fs::write(path, serde_json::to_string_pretty(value).unwrap()).unwrap();
+    }
+
+    fn manifest_json(target: &Path, prefix: &str) -> Value {
+        json!({
+            "target": target.to_string_lossy(),
+            "command_prefix": prefix,
+            "hooks": {
+                "SessionStart": [
+                    { "hooks": [ { "type": "command", "command": format!("{} session-start", prefix), "statusMessage": "Atomic" } ] }
+                ],
+                "Stop": [
+                    { "hooks": [ { "type": "command", "command": format!("{} stop", prefix) } ] }
+                ]
+            }
+        })
+    }
+
+    #[test]
+    fn installs_into_empty_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("hooks.json");
+        let manifest = dir.path().join("manifest.json");
+        write(
+            &manifest,
+            &manifest_json(&target, "atomic agent hooks codex"),
+        );
+
+        let outcome = install_from_manifest(&manifest).unwrap();
+        assert_eq!(outcome.added, 2);
+        assert_eq!(outcome.removed, 0);
+
+        let written: Value =
+            serde_json::from_str(&std::fs::read_to_string(&target).unwrap()).unwrap();
+        assert!(written["hooks"]["SessionStart"].is_array());
+        assert!(written["hooks"]["Stop"].is_array());
+    }
+
+    #[test]
+    fn is_idempotent_and_syncs_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("hooks.json");
+        let manifest = dir.path().join("manifest.json");
+        write(
+            &manifest,
+            &manifest_json(&target, "atomic agent hooks codex"),
+        );
+
+        install_from_manifest(&manifest).unwrap();
+        // Second run removes the 2 stale entries and re-adds 2 — no duplicates.
+        let outcome = install_from_manifest(&manifest).unwrap();
+        assert_eq!(outcome.added, 2);
+        assert_eq!(outcome.removed, 2);
+
+        let written: Value =
+            serde_json::from_str(&std::fs::read_to_string(&target).unwrap()).unwrap();
+        assert_eq!(
+            written["hooks"]["SessionStart"].as_array().unwrap().len(),
+            1
+        );
+    }
+
+    #[test]
+    fn preserves_non_atomic_hooks() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("hooks.json");
+        // Pre-existing user hook plus unrelated top-level config.
+        write(
+            &target,
+            &json!({
+                "model": "gpt-5",
+                "hooks": {
+                    "Stop": [ { "hooks": [ { "type": "command", "command": "my-own-hook" } ] } ]
+                }
+            }),
+        );
+        let manifest = dir.path().join("manifest.json");
+        write(
+            &manifest,
+            &manifest_json(&target, "atomic agent hooks codex"),
+        );
+
+        install_from_manifest(&manifest).unwrap();
+
+        let written: Value =
+            serde_json::from_str(&std::fs::read_to_string(&target).unwrap()).unwrap();
+        // Unrelated config preserved.
+        assert_eq!(written["model"], "gpt-5");
+        // User's own Stop hook preserved alongside the Atomic one.
+        let stop = written["hooks"]["Stop"].as_array().unwrap();
+        let commands: Vec<&str> = stop
+            .iter()
+            .flat_map(|g| g["hooks"].as_array().unwrap())
+            .map(|h| h["command"].as_str().unwrap())
+            .collect();
+        assert!(commands.contains(&"my-own-hook"));
+        assert!(commands
+            .iter()
+            .any(|c| c.contains("atomic agent hooks codex stop")));
+    }
+
+    #[test]
+    fn uninstall_removes_only_atomic() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("hooks.json");
+        write(
+            &target,
+            &json!({
+                "hooks": {
+                    "Stop": [ { "hooks": [ { "type": "command", "command": "my-own-hook" } ] } ]
+                }
+            }),
+        );
+        let manifest = dir.path().join("manifest.json");
+        write(
+            &manifest,
+            &manifest_json(&target, "atomic agent hooks codex"),
+        );
+
+        install_from_manifest(&manifest).unwrap();
+        let outcome = uninstall_from_manifest(&manifest).unwrap();
+        assert_eq!(outcome.removed, 2);
+
+        let written: Value =
+            serde_json::from_str(&std::fs::read_to_string(&target).unwrap()).unwrap();
+        let commands: Vec<&str> = written["hooks"]["Stop"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .flat_map(|g| g["hooks"].as_array().unwrap())
+            .map(|h| h["command"].as_str().unwrap())
+            .collect();
+        assert_eq!(commands, vec!["my-own-hook"]);
+    }
+
+    #[test]
+    fn handles_flat_cursor_shape() {
+        // Cursor: event -> [ { command } ] (flat, no inner "hooks").
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("hooks.json");
+        write(
+            &target,
+            &json!({
+                "version": 1,
+                "hooks": {
+                    "sessionStart": [ { "command": "my-own-cursor-hook" } ]
+                }
+            }),
+        );
+        let manifest = dir.path().join("manifest.json");
+        write(
+            &manifest,
+            &json!({
+                "target": target.to_string_lossy(),
+                "command_prefix": "atomic agent hooks cursor",
+                "hooks": {
+                    "sessionStart": [ { "command": "atomic agent hooks cursor session-start" } ],
+                    "stop": [ { "command": "atomic agent hooks cursor stop" } ]
+                }
+            }),
+        );
+
+        let outcome = install_from_manifest(&manifest).unwrap();
+        assert_eq!(outcome.added, 2);
+
+        // Idempotent: re-run replaces our 2, keeps the user's hook.
+        let again = install_from_manifest(&manifest).unwrap();
+        assert_eq!(again.added, 2);
+        assert_eq!(again.removed, 2);
+
+        let written: Value =
+            serde_json::from_str(&std::fs::read_to_string(&target).unwrap()).unwrap();
+        assert_eq!(written["version"], 1);
+        let start: Vec<&str> = written["hooks"]["sessionStart"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| e["command"].as_str().unwrap())
+            .collect();
+        assert!(start.contains(&"my-own-cursor-hook"));
+        assert!(start
+            .iter()
+            .any(|c| c.contains("atomic agent hooks cursor session-start")));
+    }
+
+    #[test]
+    fn merges_extra_settings_idempotently() {
+        // Claude-style: deep-merge a permissions.deny rule alongside hooks.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("settings.json");
+        write(
+            &target,
+            &json!({ "permissions": { "deny": ["Read(./secret/**)"] } }),
+        );
+        let manifest = dir.path().join("manifest.json");
+        write(
+            &manifest,
+            &json!({
+                "target": target.to_string_lossy(),
+                "command_prefix": "atomic agent hooks claude-code",
+                "hooks": {
+                    "Stop": [ { "matcher": "", "hooks": [ { "type": "command", "command": "atomic agent hooks claude-code stop" } ] } ]
+                },
+                "merge": { "permissions": { "deny": ["Read(./.atomic/metadata/**)"] } }
+            }),
+        );
+
+        install_from_manifest(&manifest).unwrap();
+        install_from_manifest(&manifest).unwrap(); // idempotent
+
+        let written: Value =
+            serde_json::from_str(&std::fs::read_to_string(&target).unwrap()).unwrap();
+        let deny: Vec<&str> = written["permissions"]["deny"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        // User's rule preserved; Atomic's added exactly once.
+        assert_eq!(
+            deny,
+            vec!["Read(./secret/**)", "Read(./.atomic/metadata/**)"]
+        );
+        // The nested Stop hook is registered.
+        assert!(written["hooks"]["Stop"].is_array());
+    }
+
+    #[test]
+    fn expand_target_handles_tilde() {
+        let home = dirs::home_dir().unwrap();
+        assert_eq!(
+            expand_target("~/.codex/hooks.json").unwrap(),
+            home.join(".codex/hooks.json")
+        );
+        assert_eq!(
+            expand_target("/abs/path.json").unwrap(),
+            PathBuf::from("/abs/path.json")
+        );
+    }
+}

--- a/atomic-agent/src/hooks/mod.rs
+++ b/atomic-agent/src/hooks/mod.rs
@@ -63,6 +63,7 @@ pub mod copilot;
 pub mod cursor;
 pub mod gemini_cli;
 pub mod hermes;
+pub mod manifest;
 pub mod opencode;
 pub mod pi;
 pub mod sherpa;

--- a/atomic-agent/src/hooks/mod.rs
+++ b/atomic-agent/src/hooks/mod.rs
@@ -62,6 +62,7 @@ pub mod codex;
 pub mod copilot;
 pub mod cursor;
 pub mod gemini_cli;
+pub mod hermes;
 pub mod opencode;
 pub mod pi;
 pub mod sherpa;
@@ -247,6 +248,7 @@ impl AgentRegistry {
     /// - Copilot (`copilot`)
     /// - Cursor (`cursor`)
     /// - Gemini CLI (`gemini-cli`)
+    /// - Hermes Agent (`hermes`)
     /// - OpenCode (`opencode`)
     /// - Pi (`pi`)
     /// - Sherpa (`sherpa`)
@@ -258,6 +260,7 @@ impl AgentRegistry {
         registry.register(Box::new(copilot::CopilotHook::new()));
         registry.register(Box::new(cursor::CursorHook::new()));
         registry.register(Box::new(gemini_cli::GeminiCliHook::new()));
+        registry.register(Box::new(hermes::HermesHook::new()));
         registry.register(Box::new(opencode::OpenCodeHook::new()));
         registry.register(Box::new(pi::PiHook::new()));
         registry.register(Box::new(sherpa::SherpaHook::new()));

--- a/atomic-agent/src/lib.rs
+++ b/atomic-agent/src/lib.rs
@@ -175,6 +175,14 @@ mod tests {
     }
 
     #[test]
+    fn test_default_registry_has_hermes() {
+        let registry = AgentRegistry::with_defaults();
+        let agent = registry.get("hermes");
+        assert!(agent.is_some(), "Default registry should include hermes");
+        assert_eq!(agent.unwrap().display_name(), "Hermes Agent");
+    }
+
+    #[test]
     fn test_default_registry_has_pi() {
         let registry = AgentRegistry::with_defaults();
         let agent = registry.get("pi");

--- a/atomic-cli/src/commands/agent/disable.rs
+++ b/atomic-cli/src/commands/agent/disable.rs
@@ -55,6 +55,14 @@ pub struct Disable {
     /// `atomic agent enable --global`.
     #[arg(short, long)]
     global: bool,
+
+    /// Remove hooks described by an integration-supplied manifest file.
+    ///
+    /// Reads the same manifest used by `atomic agent enable --hooks`, and
+    /// removes only the entries whose command matches the manifest's
+    /// `command_prefix` from its target file. Non-Atomic hooks are preserved.
+    #[arg(long, value_name = "FILE")]
+    hooks: Option<std::path::PathBuf>,
 }
 
 impl Disable {
@@ -65,12 +73,18 @@ impl Disable {
             agent: None,
             all: false,
             global: false,
+            hooks: None,
         }
     }
 }
 
 impl Command for Disable {
     fn run(&self) -> CliResult<()> {
+        // Data-driven uninstall — mirrors `enable --hooks`.
+        if let Some(ref manifest) = self.hooks {
+            return self.run_manifest(manifest);
+        }
+
         // Global uninstall — removes from ~/.claude/settings.json
         if self.global {
             return self.run_global();
@@ -158,6 +172,38 @@ impl Command for Disable {
 }
 
 impl Disable {
+    /// Remove hooks described by an integration-supplied manifest file.
+    ///
+    /// Mirrors `atomic agent enable --hooks`: removes only the entries whose
+    /// command matches the manifest's `command_prefix` from its target file.
+    fn run_manifest(&self, manifest: &std::path::Path) -> CliResult<()> {
+        use atomic_agent::hooks::manifest::uninstall_from_manifest;
+
+        match uninstall_from_manifest(manifest) {
+            Ok(outcome) => {
+                if outcome.removed > 0 {
+                    print_success(&format!(
+                        "Removed {} hook command(s) from {}",
+                        outcome.removed,
+                        outcome.target.display(),
+                    ));
+                    println!();
+                    println!("Agent turns will no longer be recorded automatically.");
+                } else {
+                    println!("No Atomic hooks found in {}.", outcome.target.display());
+                }
+            }
+            Err(e) => {
+                print_error(&format!(
+                    "Failed to remove hooks from manifest {}: {}",
+                    manifest.display(),
+                    e,
+                ));
+            }
+        }
+        Ok(())
+    }
+
     /// Remove hooks from global agent settings.
     ///
     /// Supports:
@@ -266,6 +312,7 @@ mod tests {
             agent: Some("claude-code".to_string()),
             all: false,
             global: false,
+            hooks: None,
         };
         assert_eq!(cmd.agent.as_deref(), Some("claude-code"));
     }
@@ -276,6 +323,7 @@ mod tests {
             agent: None,
             all: true,
             global: false,
+            hooks: None,
         };
         assert!(cmd.all);
     }
@@ -286,6 +334,7 @@ mod tests {
             agent: None,
             all: false,
             global: true,
+            hooks: None,
         };
         assert!(cmd.global);
     }

--- a/atomic-cli/src/commands/agent/enable.rs
+++ b/atomic-cli/src/commands/agent/enable.rs
@@ -68,6 +68,17 @@ pub struct Enable {
     /// install once, works everywhere that has a `.atomic/` directory.
     #[arg(short, long)]
     global: bool,
+
+    /// Install hooks from an integration-supplied manifest file.
+    ///
+    /// The manifest (shipped by an integration package such as atomic-codex)
+    /// names its own target settings file and the hook commands to register,
+    /// and is merged in idempotently — preserving non-Atomic hooks. Because the
+    /// definitions live in the integration repo, updating an agent's hook
+    /// wiring never requires rebuilding `atomic`. When set, `--agent`/`--global`
+    /// are not needed; the manifest is self-describing.
+    #[arg(long, value_name = "FILE")]
+    hooks: Option<std::path::PathBuf>,
 }
 
 impl Enable {
@@ -79,12 +90,18 @@ impl Enable {
             force: false,
             all: false,
             global: false,
+            hooks: None,
         }
     }
 }
 
 impl Command for Enable {
     fn run(&self) -> CliResult<()> {
+        // Data-driven install — definitions come from the integration's manifest.
+        if let Some(ref manifest) = self.hooks {
+            return self.run_manifest(manifest);
+        }
+
         // Global install — writes to ~/.claude/settings.json
         if self.global {
             return self.run_global();
@@ -241,6 +258,42 @@ impl Command for Enable {
 }
 
 impl Enable {
+    /// Install hooks from an integration-supplied manifest file.
+    ///
+    /// The manifest names its own target settings file and the hook commands to
+    /// register; this merges them in idempotently, preserving any non-Atomic
+    /// hooks. The hook definitions live in the integration repo, so this path
+    /// never needs the per-agent definitions baked into this binary.
+    fn run_manifest(&self, manifest: &std::path::Path) -> CliResult<()> {
+        use atomic_agent::hooks::manifest::install_from_manifest;
+
+        match install_from_manifest(manifest) {
+            Ok(outcome) => {
+                print_success(&format!(
+                    "Installed hooks from {} → {}",
+                    manifest.display(),
+                    outcome.target.display(),
+                ));
+                let mut summary = format!("{} hook command(s) registered", outcome.added);
+                if outcome.removed > 0 {
+                    summary.push_str(&format!(", {} stale entr(y/ies) replaced", outcome.removed));
+                }
+                println!("  {summary}");
+                println!();
+                println!("Each agent turn in a project with .atomic/ will be recorded");
+                println!("as an Atomic change with full AI provenance.");
+            }
+            Err(e) => {
+                print_error(&format!(
+                    "Failed to install hooks from manifest {}: {}",
+                    manifest.display(),
+                    e,
+                ));
+            }
+        }
+        Ok(())
+    }
+
     /// Install hooks globally to the agent's user-level settings.
     ///
     /// Supports:
@@ -390,6 +443,7 @@ mod tests {
             force: false,
             all: false,
             global: false,
+            hooks: None,
         };
     }
 
@@ -400,6 +454,7 @@ mod tests {
             force: true,
             all: false,
             global: false,
+            hooks: None,
         };
         assert!(cmd.force);
         assert_eq!(cmd.agent.as_deref(), Some("claude-code"));
@@ -412,6 +467,7 @@ mod tests {
             force: false,
             all: true,
             global: false,
+            hooks: None,
         };
         assert!(cmd.all);
         assert!(cmd.agent.is_none());
@@ -424,6 +480,7 @@ mod tests {
             force: false,
             all: false,
             global: true,
+            hooks: None,
         };
         assert!(cmd.global);
         assert_eq!(cmd.agent.as_deref(), Some("claude-code"));

--- a/atomic-cli/src/commands/agent/hooks.rs
+++ b/atomic-cli/src/commands/agent/hooks.rs
@@ -160,9 +160,13 @@ impl Command for Hooks {
         let agent_name = agent.name().to_string();
         let agent_display = agent.display_name().to_string();
 
-        eprintln!(
-            "[atomic-debug] hooks: agent={} display={} verb={}",
-            agent_name, agent_display, self.verb
+        // Keep hooks quiet on stdout/stderr — Claude Code surfaces both, so
+        // route diagnostics through `log` instead.
+        log::debug!(
+            "hooks: agent={} display={} verb={}",
+            agent_name,
+            agent_display,
+            self.verb
         );
 
         let result = rt.block_on(async {

--- a/atomic-cli/src/commands/git/import.rs
+++ b/atomic-cli/src/commands/git/import.rs
@@ -23,6 +23,10 @@
 //! - Binary files are imported as-is
 //! - Default imports are mainline-only (first parent)
 //! - Use `--all` to import all local branches as views
+//! - Imports build only the graph layer by default. Git has no token-level
+//!   data, so the semantic (Trunk → Branch → Leaf) layer for imported history
+//!   is synthesized and derived on demand. Use `--with-crdt` to pre-materialize
+//!   it for token-level blame and word-diff.
 
 use std::collections::HashSet;
 use std::path::Path;
@@ -35,7 +39,7 @@ use atomic_repository::Repository;
 use super::parallel::{ParallelImportOptions, ParallelImporter};
 use crate::commands::{find_repository_root, Command};
 use crate::error::{CliError, CliResult};
-use crate::output::{print_info, print_success, print_warning};
+use crate::output::{print_hint, print_info, print_success, print_warning};
 
 /// Import a Git repository into Atomic.
 ///
@@ -87,6 +91,22 @@ pub struct Import {
     /// Use this flag to skip vault setup.
     #[arg(long)]
     pub no_vault: bool,
+
+    /// Eagerly build the semantic (Trunk → Branch → Leaf) layer during import.
+    ///
+    /// By default, `git import` imports only the graph shape of each commit.
+    /// Git stores no token-level (or even line-level) data — diffs and blame
+    /// are computed, not stored — so the semantic layer for imported history
+    /// is synthesized and fully derivable from the graph content plus commit
+    /// metadata already written. Skipping it keeps imports smaller and faster
+    /// while files and diffs still work.
+    ///
+    /// Use this flag to pre-materialize that synthesized layer up front (for
+    /// token-level blame and word-diff on imported history) instead of
+    /// deriving it on demand. Changes recorded after the import always build
+    /// the semantic layer regardless of this flag.
+    #[arg(long = "with-crdt")]
+    pub with_crdt: bool,
 }
 
 fn import_ignore_patterns(workdir: &Path, kind: Option<&str>) -> Vec<String> {
@@ -160,6 +180,7 @@ impl Import {
                 self.kind.as_deref(),
             ),
             mainline_only,
+            graph_only: !self.with_crdt,
         };
 
         let importer = ParallelImporter::new(git_repo, options);
@@ -368,6 +389,17 @@ impl Command for Import {
         } else {
             HashSet::new()
         };
+
+        if self.with_crdt {
+            print_info(
+                "Building the semantic (Trunk → Branch → Leaf) layer during import (--with-crdt).",
+            );
+        } else {
+            print_hint(
+                "Importing graph only; the semantic layer is derived on demand. \
+                 Pass --with-crdt to pre-materialize token-level blame/diff for imported history.",
+            );
+        }
 
         // Determine which branches to import
         let default_branch = self.get_default_branch(&git_repo)?;
@@ -658,6 +690,16 @@ mod tests {
 
         let import = Import::try_parse_from(["import", "--all-branches"]).unwrap();
         assert!(import.all_branches);
+    }
+
+    #[test]
+    fn test_with_crdt_flag_defaults_to_graph_only() {
+        // Default import is graph-only: the semantic layer is opt-in.
+        let import = Import::try_parse_from(["import"]).unwrap();
+        assert!(!import.with_crdt);
+
+        let import = Import::try_parse_from(["import", "--with-crdt"]).unwrap();
+        assert!(import.with_crdt);
     }
 
     #[test]

--- a/atomic-cli/src/commands/git/parallel.rs
+++ b/atomic-cli/src/commands/git/parallel.rs
@@ -195,6 +195,14 @@ pub struct ParallelImportOptions {
     /// long-running branch internals or repeated upstream merges into feature
     /// branches.
     pub mainline_only: bool,
+    /// Import only the graph shape of each commit, skipping the semantic
+    /// (Trunk → Branch → Leaf) FileOps layer.
+    ///
+    /// Graph operations and Git diff metadata are still written, so files
+    /// materialize and diffs render normally. The per-line CRDT FileOps that
+    /// duplicate file content are omitted, which significantly reduces change
+    /// size and import time for large repositories.
+    pub graph_only: bool,
 }
 
 impl Default for ParallelImportOptions {
@@ -205,6 +213,7 @@ impl Default for ParallelImportOptions {
             repo_name: "unknown".to_string(),
             ignored_path_patterns: Vec::new(),
             mainline_only: true,
+            graph_only: false,
         }
     }
 }
@@ -1080,6 +1089,7 @@ fn build_graph_first_change(
     header: ChangeHeader,
     parsed: &ParsedCommit,
     line_index: &ImportLineIndex,
+    graph_only: bool,
 ) -> Result<(Change, Vec<PendingLineIndexUpdate>, Vec<String>), Vec<GraphFirstSkip>> {
     if parsed.files.is_empty() {
         return Err(vec![GraphFirstSkip {
@@ -1192,15 +1202,17 @@ fn build_graph_first_change(
                     });
                 }
 
-                file_ops.push(build_graph_first_file_ops_for_added_file(
-                    &file.path,
-                    &new_line_contents,
-                    &new_ranges,
-                    encoding,
-                    next_file_idx,
-                    &mut next_branch_idx,
-                ));
-                next_file_idx += 1;
+                if !graph_only {
+                    file_ops.push(build_graph_first_file_ops_for_added_file(
+                        &file.path,
+                        &new_line_contents,
+                        &new_ranges,
+                        encoding,
+                        next_file_idx,
+                        &mut next_branch_idx,
+                    ));
+                    next_file_idx += 1;
+                }
                 pending.push(PendingLineIndexUpdate::Add {
                     path: file.path.clone(),
                     inode_pos,
@@ -1270,7 +1282,10 @@ fn build_graph_first_change(
                     new_path: file.path.clone(),
                 });
 
-                if encoding != Encoding::Binary && !is_generated_diff_skip_path(&file.path) {
+                if !graph_only
+                    && encoding != Encoding::Binary
+                    && !is_generated_diff_skip_path(&file.path)
+                {
                     if let Some(diff_lines) = file.diff_lines.as_ref() {
                         let (ops, _) = atomic_core::record::workflow::build_crdt_ops_from_git_diff(
                             &file.path, diff_lines,
@@ -1502,11 +1517,13 @@ fn build_graph_first_change(
                     path: file.path.clone(),
                 });
                 deleted_paths.push(file.path.clone());
-                if let Some(diff_lines) = file.diff_lines.as_ref() {
-                    let (ops, _) = atomic_core::record::workflow::build_crdt_ops_from_git_diff(
-                        &file.path, diff_lines,
-                    );
-                    file_ops.push(ops);
+                if !graph_only {
+                    if let Some(diff_lines) = file.diff_lines.as_ref() {
+                        let (ops, _) = atomic_core::record::workflow::build_crdt_ops_from_git_diff(
+                            &file.path, diff_lines,
+                        );
+                        file_ops.push(ops);
+                    }
                 }
                 continue;
             }
@@ -1522,35 +1539,37 @@ fn build_graph_first_change(
             continue;
         };
         let encoding = Encoding::detect(new_content);
-        let replacements = if encoding == Encoding::Binary
-            || is_generated_diff_skip_path(&file.path)
-        {
-            vec![GitReplacementBlock {
-                old_start: if indexed.lines.is_empty() { 0 } else { 1 },
-                old_len: indexed.lines.len(),
-                new_start: 1,
-                new_lines: if new_content.is_empty() {
-                    Vec::new()
-                } else {
-                    vec![new_content.to_vec()]
-                },
-            }]
-        } else if parsed.is_merge {
-            current_state_replacements(indexed, new_content)
-        } else {
-            let Some(diff_lines) = file.diff_lines.as_ref() else {
-                skips.push(GraphFirstSkip::new(file, "modified_missing_diff_lines"));
-                continue;
+        let replacements =
+            if encoding == Encoding::Binary || is_generated_diff_skip_path(&file.path) {
+                vec![GitReplacementBlock {
+                    old_start: if indexed.lines.is_empty() { 0 } else { 1 },
+                    old_len: indexed.lines.len(),
+                    new_start: 1,
+                    new_lines: if new_content.is_empty() {
+                        Vec::new()
+                    } else {
+                        vec![new_content.to_vec()]
+                    },
+                }]
+            } else if parsed.is_merge {
+                current_state_replacements(indexed, new_content)
+            } else {
+                let Some(diff_lines) = file.diff_lines.as_ref() else {
+                    skips.push(GraphFirstSkip::new(file, "modified_missing_diff_lines"));
+                    continue;
+                };
+                if !graph_only {
+                    let (ops, _) = atomic_core::record::workflow::build_crdt_ops_from_git_diff(
+                        &file.path, diff_lines,
+                    );
+                    file_ops.push(ops);
+                }
+                let Some(replacements) = parse_git_diff_replacements(diff_lines) else {
+                    skips.push(GraphFirstSkip::new(file, "modified_unparseable_diff_lines"));
+                    continue;
+                };
+                replacements
             };
-            let (ops, _) =
-                atomic_core::record::workflow::build_crdt_ops_from_git_diff(&file.path, diff_lines);
-            file_ops.push(ops);
-            let Some(replacements) = parse_git_diff_replacements(diff_lines) else {
-                skips.push(GraphFirstSkip::new(file, "modified_unparseable_diff_lines"));
-                continue;
-            };
-            replacements
-        };
         if replacements.is_empty() {
             continue;
         }
@@ -2579,7 +2598,8 @@ impl ParallelImporter {
 
         line_index.seed_missing_modified_files(repo, parsed);
         let graph_first_skips = build_graph_first_skip_reasons(parsed, line_index);
-        let graph_first_result = build_graph_first_change(header.clone(), parsed, line_index);
+        let graph_first_result =
+            build_graph_first_change(header.clone(), parsed, line_index, self.options.graph_only);
 
         if let Ok((mut graph_change, pending_updates, graph_deleted_paths)) = graph_first_result {
             graph_change.unhashed = Some(self.build_git_metadata(parsed, false, false));

--- a/atomic-remote/README.md
+++ b/atomic-remote/README.md
@@ -1,0 +1,35 @@
+# atomic-remote
+
+`atomic-remote` is the HTTP client library for Atomic remote repository operations.
+It provides protocol types, storage APIs, and sync helpers used by Atomic tooling to
+communicate with `atomic-api` servers.
+
+## What it provides
+
+- `HttpRemote` for push, pull, clone, and view-state operations over HTTP.
+- Protocol types for changelists, state responses, pull deltas, and push deltas.
+- Storage management APIs for workspaces and projects.
+- Error types with retry/auth/not-found classification and user-facing suggestions.
+- Streaming push/pull support for chunked remote transfers.
+
+## Usage
+
+```rust,ignore
+use atomic_remote::HttpRemote;
+
+async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    let remote = HttpRemote::new(
+        "https://api.example.com/tenant/t/portfolio/p/project/myrepo/code",
+    )?;
+
+    let state = remote.get_state("main").await?;
+    println!("Remote state: {state:?}");
+
+    Ok(())
+}
+```
+
+## Feature flags
+
+- `integration-tests`: enables integration tests that require a running
+  `atomic-api` server.


### PR DESCRIPTION
This pull request introduces support for the Hermes Agent as a new integration within the Atomic Agent project, alongside improvements to agent hook handling and CLI usability. The main changes include adding a Hermes-specific hook adapter, updating hook type mappings to support Hermes events, and enhancing the CLI to allow enabling and disabling hooks via integration-supplied manifest files. Additionally, the update ensures safer settings file writes and includes new tests for these features.

**Hermes Agent Integration:**
- Added a new `HermesHook` adapter in `atomic-agent/src/hooks/hermes.rs` to support Hermes Agent shell hooks. This adapter parses Hermes-specific JSON payloads, extracts relevant fields, and normalizes them into Atomic `TurnEvent` records. Tests are included to verify parsing and compatibility.
- Registered the Hermes agent in the default agent registry and added corresponding tests to ensure it's available by default. [[1]](diffhunk://#diff-60222d3408ef163416c11ca7c7f0e439ec888d20693d1fe8e40e78f99230506dR65-R66) [[2]](diffhunk://#diff-60222d3408ef163416c11ca7c7f0e439ec888d20693d1fe8e40e78f99230506dR252) [[3]](diffhunk://#diff-60222d3408ef163416c11ca7c7f0e439ec888d20693d1fe8e40e78f99230506dR264) [[4]](diffhunk://#diff-7d22ac194aeecd0a07fd234a60c828e53858f9afffd244eff93a334e71d1d55fR177-R184)

**Hook Type and Event Handling Improvements:**
- Expanded `HookType` enum and mapping logic to recognize Hermes-specific hook verbs (e.g., `on_session_start`, `pre_llm_call`, `pre_tool_call`, etc.), ensuring consistent event handling across agents. Updated documentation and added tests for these new mappings. [[1]](diffhunk://#diff-157d98db3b12fdfd224cd1af3fe5a3e451e68cf75a31fb93ee3aac7ea80855d2L59-R66) [[2]](diffhunk://#diff-157d98db3b12fdfd224cd1af3fe5a3e451e68cf75a31fb93ee3aac7ea80855d2R151-R154) [[3]](diffhunk://#diff-157d98db3b12fdfd224cd1af3fe5a3e451e68cf75a31fb93ee3aac7ea80855d2R173-R178) [[4]](diffhunk://#diff-157d98db3b12fdfd224cd1af3fe5a3e451e68cf75a31fb93ee3aac7ea80855d2L188-R206) [[5]](diffhunk://#diff-157d98db3b12fdfd224cd1af3fe5a3e451e68cf75a31fb93ee3aac7ea80855d2R681-R708)

**CLI Enhancements for Manifest-based Hook Management:**
- Updated the `atomic agent enable` and `disable` commands to accept a `--hooks <FILE>` option, allowing users to install or remove hooks based on integration-supplied manifest files. This approach is idempotent and preserves non-Atomic hooks. [[1]](diffhunk://#diff-fdb630b83543a9af6e4070a0a89087cf30c01087390c8cadded3a343dc5f7f6aR71-R81) [[2]](diffhunk://#diff-7dba8b5b44ef3a7f41c3cb6444bb1d05d687235d01cdf06f7502d758af4a0983R58-R65) [[3]](diffhunk://#diff-7dba8b5b44ef3a7f41c3cb6444bb1d05d687235d01cdf06f7502d758af4a0983R76-R87) [[4]](diffhunk://#diff-7dba8b5b44ef3a7f41c3cb6444bb1d05d687235d01cdf06f7502d758af4a0983R175-R206)
- Added and updated tests to ensure correct CLI behavior when using the new `--hooks` option. [[1]](diffhunk://#diff-7dba8b5b44ef3a7f41c3cb6444bb1d05d687235d01cdf06f7502d758af4a0983R315) [[2]](diffhunk://#diff-7dba8b5b44ef3a7f41c3cb6444bb1d05d687235d01cdf06f7502d758af4a0983R326) [[3]](diffhunk://#diff-7dba8b5b44ef3a7f41c3cb6444bb1d05d687235d01cdf06f7502d758af4a0983R337)

**Settings File Write Safety:**
- Improved the settings file write logic to use atomic file operations (write to temp file and rename), preventing partial writes and preserving file permissions. This makes settings updates more robust and reliable.

**Other:**
- Bumped the workspace version from `0.6.2` to `0.6.3` in `Cargo.toml`.