### PR TITLE
Add sandbox support for concurrent agent OCI commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,16 +280,20 @@ dependencies = [
  "atomic-semantic",
  "chrono",
  "dirs",
+ "flate2",
  "ignore",
  "log",
  "postcard",
  "rand 0.8.5",
  "rayon",
  "redb",
+ "reflink-copy",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "syntext",
+ "tar",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -845,6 +849,16 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -2132,6 +2146,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "reflink-copy"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13362233b147e57674c37b802d216b7c5e3dcccbed8967c84f0d8d223868ae27"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rustix",
+ "windows",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2680,6 +2706,17 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -3375,6 +3412,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3385,6 +3443,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3414,6 +3483,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -3535,6 +3614,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3777,6 +3865,16 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "xxhash-rust"

--- a/README.md
+++ b/README.md
@@ -406,6 +406,57 @@ atomic/
 | **atomic-remote-client** | `atomic-enterprise/atomic-remote` | HTTP client library for push/pull/clone |
 | **atomic-docs** | `atomic-docs/` | Documentation site ([docs.atomic.dev](https://docs.atomic.dev/)) |
 
+## Atomic + smolvm: Concurrent Agent Sandboxes
+
+When several agents work a repository at once, each needs an isolated build
+surface (no `node_modules` / `target` collisions) while still sharing one
+history. Atomic does this with **copy-on-write working trees over a single
+canonical graph** — no per-agent forks, no virtualized I/O.
+
+- **The working tree is cloned; the graph is not.** A sandbox is a reflink
+  (copy-on-write) clone of the working tree — APFS `clonefile`, Btrfs/XFS
+  `FICLONE`, ReFS block-clone — done in-process via the `reflink-copy` crate.
+  Five agents off a 200 MB base cost a few MB and run at bare-metal filesystem
+  speed. There is exactly **one** pristine; a sandbox carries a small
+  `.atomic-sandbox` pointer, so `status`, `record`, `diff`, and `vault query`
+  all work inside it and land in the canonical graph.
+- **No FUSE, no virtio, no VM in the hot path.** Filesystem-protocol
+  virtualization (virtio-fs) is fatal for the metadata-heavy workloads agents
+  run (git, cargo, npm). Copy-on-write on the real filesystem needs none of it.
+
+```bash
+# Give each agent a private, copy-on-write working tree
+atomic sandbox create agent-1 --from dev      # forks a per-agent draft view
+atomic sandbox create agent-2 --from dev      # isolated artifacts, shared graph
+```
+
+### Shipping a sandbox: `stage` and `seal`
+
+A sandbox can be packaged as a **standard OCI image** (consumable by smolvm,
+podman, containerd — built in-process, no shelling out) for two purposes:
+
+| Command | Shape | Purpose |
+|---------|-------|---------|
+| `atomic sandbox stage` | layered: shared base + thin delta | inner-loop CI / circuit-breaker runs — base is pulled once and cached, only the delta ships each iteration |
+| `atomic sandbox seal` | flattened, single self-contained layer | a deployable runtime — "run this exact version" anywhere |
+
+```bash
+# Inner-loop CI artifact: base layer (dev) + delta layer (only what changed)
+atomic sandbox stage agent-1 --base dev -o ./ci-image
+
+# Deployable runtime image of the full merged state
+atomic sandbox seal dev -o ./runtime --entrypoint /app/run --env PORT=8080
+```
+
+Both embed provenance (the view names and Merkle states) in the image
+annotations, so a shipped image traces back to exact graph state. The runtime
+is [smolvm](https://github.com/binsquare/smolvm) — lightweight microVMs that
+boot OCI images in under 200 ms — making these images the unit of work for
+shared-infrastructure CI and circuit-breaker workflows.
+
+See [docs/CONCURRENT-AGENT-SANDBOXES.md](docs/CONCURRENT-AGENT-SANDBOXES.md) for
+the full design.
+
 ## Design Principles
 
 1. **Mathematical Soundness** — Operations are well-defined transformations with provable properties

--- a/atomic-cli/src/commands/mod.rs
+++ b/atomic-cli/src/commands/mod.rs
@@ -59,7 +59,7 @@
 use std::path::{Path, PathBuf};
 
 use atomic_core::types::{Base32, Hash};
-use atomic_repository::Repository;
+use atomic_repository::{Repository, SANDBOX_POINTER};
 use chrono::{DateTime, Local, Utc};
 
 use crate::error::{CliError, CliResult};
@@ -79,6 +79,7 @@ pub mod record;
 pub mod remove;
 pub mod restore;
 pub mod revise;
+pub mod sandbox;
 pub mod split;
 pub mod stash;
 pub mod status;
@@ -140,6 +141,7 @@ pub use remote::Remote;
 pub use remove::Remove;
 pub use restore::Restore;
 pub use revise::Revise;
+pub use sandbox::Sandbox;
 pub use split::Split;
 pub use stash::Stash;
 pub use status::Status;
@@ -272,6 +274,13 @@ pub fn find_repository_root_from(start_path: &Path) -> CliResult<PathBuf> {
     loop {
         let dot_dir = current.join(DOT_DIR);
         if dot_dir.is_dir() {
+            return Ok(current);
+        }
+
+        // A sandbox working tree has no `.atomic/` of its own — it carries a
+        // pointer to the canonical graph. Treat the sandbox root as a valid
+        // repository root; `Repository::open*` resolves the pointer.
+        if current.join(SANDBOX_POINTER).is_file() {
             return Ok(current);
         }
 

--- a/atomic-cli/src/commands/sandbox.rs
+++ b/atomic-cli/src/commands/sandbox.rs
@@ -1,0 +1,245 @@
+//! The `sandbox` command for provisioning concurrent agent workspaces.
+//!
+//! A sandbox is a private, copy-on-write clone of the repository's working
+//! tree. Several agents can each work in their own sandbox at once — isolated
+//! build artifacts (`node_modules`, `target`), no collisions — while sharing
+//! the single canonical graph. On filesystems that support reflinks (APFS,
+//! Btrfs, XFS, ReFS) the clone shares blocks until written, so the disk cost is
+//! the delta, not a full copy.
+//!
+//! The copy-on-write clone is performed in-process by the `atomic` binary
+//! itself (via the `reflink-copy` crate) — no external `cp` is invoked.
+//!
+//! # Usage
+//!
+//! ```text
+//! atomic sandbox create <NAME> [--dest <PATH>] [--view <VIEW>]
+//! ```
+
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+use atomic_repository::{Repository, SealOptions, StageOptions};
+
+use crate::commands::{find_repository_root, Command};
+use crate::error::{CliError, CliResult};
+
+/// Provision and manage concurrent agent sandboxes.
+#[derive(Debug, clap::Args)]
+#[command(name = "sandbox")]
+pub struct Sandbox {
+    #[command(subcommand)]
+    pub command: SandboxCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SandboxCommands {
+    /// Create a sandbox: a copy-on-write clone of the working tree.
+    Create(Create),
+
+    /// Stage a sandbox as a layered OCI image (shared base + thin delta).
+    ///
+    /// Built for the inner loop: the base layer is the shared view, the delta
+    /// layer is only what changed. Ship the delta to CI / circuit-breaker
+    /// workflows while the base is pulled once and cached.
+    Stage(Stage),
+
+    /// Seal a view as a flattened, self-contained OCI runtime image.
+    ///
+    /// Produces a single-layer deployable image of the full merged state —
+    /// "run this exact version" anywhere an OCI runtime is available.
+    Seal(Seal),
+}
+
+impl Command for Sandbox {
+    fn run(&self) -> CliResult<()> {
+        match &self.command {
+            SandboxCommands::Create(cmd) => cmd.run(),
+            SandboxCommands::Stage(cmd) => cmd.run(),
+            SandboxCommands::Seal(cmd) => cmd.run(),
+        }
+    }
+}
+
+/// Create a sandbox working tree for an agent.
+///
+/// Clones the current working tree (copy-on-write where supported) into a
+/// private directory. The sandbox shares the canonical graph — it is not a
+/// separate repository.
+#[derive(Parser, Debug)]
+pub struct Create {
+    /// Name of the sandbox (used in the default destination path).
+    #[arg(value_name = "NAME")]
+    pub name: String,
+
+    /// Destination directory for the sandbox working tree.
+    ///
+    /// Defaults to `<repo-parent>/<repo-name>-sandboxes/<name>`.
+    #[arg(long, value_name = "PATH")]
+    pub dest: Option<PathBuf>,
+
+    /// View the sandbox operates on. Defaults to the current view.
+    ///
+    /// Mutually exclusive with `--from`.
+    #[arg(long, value_name = "VIEW", conflicts_with = "from")]
+    pub view: Option<String>,
+
+    /// Create a new draft view (named after the sandbox) from this view, and
+    /// point the sandbox at it.
+    ///
+    /// With `--from dev`, the sandbox gets its own draft view forked from
+    /// `dev`, so the agent's records land in that draft rather than a shared
+    /// view — isolating each agent's history as well as its files.
+    #[arg(long, value_name = "VIEW")]
+    pub from: Option<String>,
+}
+
+impl Create {
+    fn default_dest(repo_root: &std::path::Path, name: &str) -> PathBuf {
+        let repo_name = repo_root
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "repo".to_string());
+        let parent = repo_root.parent().unwrap_or(repo_root);
+        parent.join(format!("{repo_name}-sandboxes")).join(name)
+    }
+}
+
+impl Command for Create {
+    fn run(&self) -> CliResult<()> {
+        let root = find_repository_root()?;
+        let mut repo = Repository::open(&root).map_err(CliError::Repository)?;
+
+        let dest = self
+            .dest
+            .clone()
+            .unwrap_or_else(|| Self::default_dest(&root, &self.name));
+
+        if dest.exists() {
+            return Err(CliError::InvalidArgument {
+                message: format!("destination already exists: {}", dest.display()),
+            });
+        }
+
+        // Resolve the view this sandbox records into:
+        //   --from <v>  → create a new draft named after the sandbox, forked from <v>
+        //   --view <v>  → use the existing view <v>
+        //   (neither)   → the current view
+        let (view, created_draft) = if let Some(from) = &self.from {
+            repo.create_view_from(&self.name, from)
+                .map_err(CliError::Repository)?;
+            (self.name.clone(), true)
+        } else {
+            let v = self
+                .view
+                .clone()
+                .unwrap_or_else(|| repo.current_view().to_string());
+            (v, false)
+        };
+
+        let count = repo
+            .provision_sandbox(&dest, &view)
+            .map_err(CliError::Repository)?;
+
+        println!("Sandbox '{}' created", self.name);
+        println!("  Working tree: {}", dest.display());
+        if created_draft {
+            println!(
+                "  View:         {view} (new draft from '{}')",
+                self.from.as_deref().unwrap_or("")
+            );
+        } else {
+            println!("  View:         {view}");
+        }
+        println!("  Files cloned: {count} (copy-on-write where supported)");
+        println!(
+            "  Graph:        shared (canonical {}/.atomic)",
+            root.display()
+        );
+
+        Ok(())
+    }
+}
+
+/// Stage a view as a layered OCI image (base + delta).
+#[derive(Parser, Debug)]
+pub struct Stage {
+    /// The view to stage (the sandbox's draft view).
+    #[arg(value_name = "VIEW")]
+    pub view: String,
+
+    /// The shared base view the delta is computed against.
+    #[arg(long, value_name = "VIEW", default_value = "dev")]
+    pub base: String,
+
+    /// Output directory for the OCI image layout.
+    #[arg(long, short = 'o', value_name = "DIR")]
+    pub out: PathBuf,
+}
+
+impl Command for Stage {
+    fn run(&self) -> CliResult<()> {
+        let root = find_repository_root()?;
+        let repo = Repository::open(&root).map_err(CliError::Repository)?;
+
+        let result = repo
+            .stage(StageOptions {
+                view: self.view.clone(),
+                base_view: self.base.clone(),
+                out: self.out.clone(),
+            })
+            .map_err(CliError::Repository)?;
+
+        println!("Staged '{}' (delta over '{}')", self.view, self.base);
+        println!("  Image:        {}", result.out.display());
+        println!("  Manifest:     {}", result.manifest_digest);
+        println!("  Base layer:   {}", result.base_diff_id);
+        println!("  Delta files:  {}", result.delta_files);
+
+        Ok(())
+    }
+}
+
+/// Seal a view as a flattened, self-contained OCI runtime image.
+#[derive(Parser, Debug)]
+pub struct Seal {
+    /// The view to seal.
+    #[arg(value_name = "VIEW")]
+    pub view: String,
+
+    /// Output directory for the OCI image layout.
+    #[arg(long, short = 'o', value_name = "DIR")]
+    pub out: PathBuf,
+
+    /// Image entrypoint argv (repeatable), e.g. `--entrypoint /app/run`.
+    #[arg(long, value_name = "ARG")]
+    pub entrypoint: Vec<String>,
+
+    /// Image environment variable (repeatable), e.g. `--env PORT=8080`.
+    #[arg(long, value_name = "KEY=VAL")]
+    pub env: Vec<String>,
+}
+
+impl Command for Seal {
+    fn run(&self) -> CliResult<()> {
+        let root = find_repository_root()?;
+        let repo = Repository::open(&root).map_err(CliError::Repository)?;
+
+        let result = repo
+            .seal(SealOptions {
+                view: self.view.clone(),
+                out: self.out.clone(),
+                entrypoint: self.entrypoint.clone(),
+                env: self.env.clone(),
+            })
+            .map_err(CliError::Repository)?;
+
+        println!("Sealed '{}'", self.view);
+        println!("  Image:        {}", result.out.display());
+        println!("  Manifest:     {}", result.manifest_digest);
+        println!("  Files:        {}", result.files);
+
+        Ok(())
+    }
+}

--- a/atomic-cli/src/main.rs
+++ b/atomic-cli/src/main.rs
@@ -77,6 +77,7 @@ use commands::{
     Remove,
     Restore,
     Revise,
+    Sandbox,
     Split,
     Stash,
     Status,
@@ -237,6 +238,20 @@ enum Commands {
     /// ```
     #[command(alias = "reset")]
     Restore(Restore),
+
+    /// Provision concurrent agent sandboxes (copy-on-write working trees).
+    ///
+    /// Each sandbox is a private, copy-on-write clone of the working tree so
+    /// multiple agents can work at once with isolated build artifacts while
+    /// sharing the single canonical graph.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// atomic sandbox create agent-1
+    /// atomic sandbox create agent-2 --dest /tmp/agent-2
+    /// ```
+    Sandbox(Sandbox),
 
     /// Split a view (create a new view from an existing one).
     ///
@@ -717,6 +732,8 @@ fn main() {
         Commands::Move(mv) => mv.run(),
 
         Commands::Restore(restore) => restore.run(),
+
+        Commands::Sandbox(sandbox) => sandbox.run(),
 
         Commands::Split(split) => split.run(),
 

--- a/atomic-repository/Cargo.toml
+++ b/atomic-repository/Cargo.toml
@@ -25,6 +25,7 @@ redb = { workspace = true }
 zstd = { workspace = true }
 dirs = "5.0"
 walkdir = { workspace = true }
+reflink-copy = "0.1"
 ignore = { workspace = true }
 syntext = { workspace = true }
 tempfile = { workspace = true }
@@ -33,6 +34,9 @@ chrono = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true, features = ["rustls-tls"] }
 tokio = { workspace = true }
+tar = "0.4"
+flate2 = "1.0"
+sha2 = "0.10"
 
 [features]
 default = ["ast"]

--- a/atomic-repository/src/lib.rs
+++ b/atomic-repository/src/lib.rs
@@ -119,6 +119,9 @@ pub mod ai;
 // Content search powered by syntext
 pub mod content_search;
 
+// OCI image layout production (sandbox stage/seal)
+pub mod oci;
+
 // Query plan schema and executor
 pub mod query_plan;
 

--- a/atomic-repository/src/oci.rs
+++ b/atomic-repository/src/oci.rs
@@ -1,0 +1,450 @@
+//! In-process production of standard [OCI image layouts].
+//!
+//! This module turns directory contents (or in-memory file sets) into gzipped
+//! tar layers and assembles them into a standard OCI image layout on disk —
+//! the format consumed by any OCI runtime (podman, containerd, smolvm). Nothing
+//! shells out: tar and gzip are built in memory with the `tar` and `flate2`
+//! crates and digests are computed with `sha2`.
+//!
+//! The two entry points for building layers are [`layer_from_dir`] (recursively
+//! tar a directory) and [`layer_from_entries`] (build a layer from an in-memory
+//! set of files plus optional whiteouts, used for delta layers). The assembled
+//! layout is written by [`write_image_layout`].
+//!
+//! [OCI image layouts]: https://github.com/opencontainers/image-spec/blob/main/image-layout.md
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use sha2::{Digest, Sha256};
+use tar::{Builder, EntryType, Header};
+use walkdir::WalkDir;
+
+/// Media type for a gzipped tar image layer.
+const MEDIA_TYPE_LAYER: &str = "application/vnd.oci.image.layer.v1.tar+gzip";
+/// Media type for an image config blob.
+const MEDIA_TYPE_CONFIG: &str = "application/vnd.oci.image.config.v1+json";
+/// Media type for an image manifest.
+const MEDIA_TYPE_MANIFEST: &str = "application/vnd.oci.image.manifest.v1+json";
+/// Media type for an image index.
+const MEDIA_TYPE_INDEX: &str = "application/vnd.oci.image.index.v1+json";
+
+/// A built, gzipped image layer plus its digests.
+pub struct OciLayer {
+    /// The gzipped tar bytes (the blob stored in the layout).
+    pub tar_gz: Vec<u8>,
+    /// `"sha256:<hex>"` of the **uncompressed** tar stream (the layer's
+    /// `diff_id` in the image config's `rootfs`).
+    pub diff_id: String,
+    /// `"sha256:<hex>"` of the gzipped bytes (the layer descriptor digest).
+    pub digest: String,
+    /// Size, in bytes, of the gzipped layer.
+    pub size: u64,
+}
+
+/// Configuration used to assemble an OCI image config and manifest.
+pub struct OciImageConfig {
+    /// Target architecture in OCI form, e.g. `"arm64"` or `"amd64"`.
+    pub architecture: String,
+    /// Operating system, e.g. `"linux"`.
+    pub os: String,
+    /// Environment variables, each as `"KEY=VAL"`.
+    pub env: Vec<String>,
+    /// Entrypoint argv. Empty if the image has no entrypoint.
+    pub entrypoint: Vec<String>,
+    /// Image-level annotations (used here to carry Atomic provenance).
+    pub annotations: BTreeMap<String, String>,
+}
+
+/// Map the host architecture (`std::env::consts::ARCH`) to its OCI name.
+///
+/// `"aarch64"` becomes `"arm64"`, `"x86_64"` becomes `"amd64"`; any other value
+/// is passed through unchanged.
+pub fn host_arch() -> String {
+    match std::env::consts::ARCH {
+        "aarch64" => "arm64",
+        "x86_64" => "amd64",
+        other => other,
+    }
+    .to_string()
+}
+
+/// Build a gzipped tar layer from a directory's contents (recursive).
+///
+/// Paths inside the tar are relative to `dir`. Regular files and symlinks are
+/// included; directory entries themselves are omitted (their paths are implied
+/// by the files within). Entries are emitted in a deterministic (sorted) order.
+/// Computes `diff_id` (sha256 of the uncompressed tar stream) and `digest`
+/// (sha256 of the gzipped bytes).
+pub fn layer_from_dir(dir: &Path) -> std::io::Result<OciLayer> {
+    let mut entries: Vec<(String, PathBuf, bool)> = Vec::new();
+    for entry in WalkDir::new(dir) {
+        let entry = entry.map_err(std::io::Error::from)?;
+        let file_type = entry.file_type();
+        if file_type.is_dir() {
+            continue;
+        }
+        let rel = match entry.path().strip_prefix(dir) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        if rel.as_os_str().is_empty() {
+            continue;
+        }
+        entries.push((
+            rel.to_string_lossy().into_owned(),
+            entry.path().to_path_buf(),
+            file_type.is_symlink(),
+        ));
+    }
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut tar_buf = Vec::new();
+    {
+        let mut builder = Builder::new(&mut tar_buf);
+        for (rel, full, is_symlink) in &entries {
+            if *is_symlink {
+                let target = std::fs::read_link(full)?;
+                let mut header = Header::new_gnu();
+                header.set_entry_type(EntryType::Symlink);
+                header.set_size(0);
+                header.set_mode(0o777);
+                header.set_mtime(0);
+                builder.append_link(&mut header, rel, &target)?;
+            } else {
+                let data = std::fs::read(full)?;
+                let mut header = Header::new_gnu();
+                header.set_entry_type(EntryType::Regular);
+                header.set_size(data.len() as u64);
+                header.set_mode(0o644);
+                header.set_mtime(0);
+                builder.append_data(&mut header, rel, data.as_slice())?;
+            }
+        }
+        builder.finish()?;
+    }
+
+    finish_layer(tar_buf)
+}
+
+/// Build a single layer from an in-memory set of `(relative_path, bytes)` files
+/// plus optional whiteouts.
+///
+/// Whiteouts mark deletions relative to a lower layer: a deleted path `foo/bar`
+/// is encoded as a zero-byte tar entry `foo/.wh.bar`, per the OCI spec. Entries
+/// are emitted in a deterministic (sorted) order. Useful for delta layers where
+/// staging files on disk is undesirable.
+pub fn layer_from_entries(
+    files: &[(String, Vec<u8>)],
+    whiteouts: &[String],
+) -> std::io::Result<OciLayer> {
+    let mut items: Vec<(String, Vec<u8>)> = Vec::with_capacity(files.len() + whiteouts.len());
+    for (path, bytes) in files {
+        items.push((path.clone(), bytes.clone()));
+    }
+    for path in whiteouts {
+        items.push((whiteout_path(path), Vec::new()));
+    }
+    items.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut tar_buf = Vec::new();
+    {
+        let mut builder = Builder::new(&mut tar_buf);
+        for (path, data) in &items {
+            let mut header = Header::new_gnu();
+            header.set_entry_type(EntryType::Regular);
+            header.set_size(data.len() as u64);
+            header.set_mode(0o644);
+            header.set_mtime(0);
+            builder.append_data(&mut header, path, data.as_slice())?;
+        }
+        builder.finish()?;
+    }
+
+    finish_layer(tar_buf)
+}
+
+/// Write a complete OCI image layout under `out` (created if needed):
+/// `out/oci-layout`, `out/index.json`, and `out/blobs/sha256/<...>` blobs.
+///
+/// `layers` are ordered base→top. Returns the manifest digest (`"sha256:..."`).
+/// The image config records the layers' uncompressed `diff_id`s; the manifest
+/// records the gzipped layer digests; `config.annotations` are passed through to
+/// the manifest.
+pub fn write_image_layout(
+    out: &Path,
+    layers: &[OciLayer],
+    config: &OciImageConfig,
+) -> std::io::Result<String> {
+    let blobs = out.join("blobs").join("sha256");
+    std::fs::create_dir_all(&blobs)?;
+
+    // Image config blob. diff_ids are the UNCOMPRESSED layer digests.
+    let diff_ids: Vec<String> = layers.iter().map(|l| l.diff_id.clone()).collect();
+    let history: Vec<serde_json::Value> = layers
+        .iter()
+        .map(|_| serde_json::json!({ "created_by": "atomic sandbox" }))
+        .collect();
+    let config_json = serde_json::json!({
+        "architecture": config.architecture,
+        "os": config.os,
+        "config": {
+            "Env": config.env,
+            "Entrypoint": config.entrypoint,
+        },
+        "rootfs": {
+            "type": "layers",
+            "diff_ids": diff_ids,
+        },
+        "history": history,
+    });
+    let config_bytes = json_to_vec(&config_json)?;
+    let config_hex = sha256_hex(&config_bytes);
+    std::fs::write(blobs.join(&config_hex), &config_bytes)?;
+    let config_digest = format!("sha256:{config_hex}");
+
+    // Layer blobs (the gzipped bytes), keyed by their gzipped digest.
+    for layer in layers {
+        std::fs::write(blobs.join(digest_hex(&layer.digest)), &layer.tar_gz)?;
+    }
+
+    // Manifest blob. Layer digests here are the GZIPPED digests.
+    let manifest_layers: Vec<serde_json::Value> = layers
+        .iter()
+        .map(|l| {
+            serde_json::json!({
+                "mediaType": MEDIA_TYPE_LAYER,
+                "digest": l.digest,
+                "size": l.size,
+            })
+        })
+        .collect();
+    let manifest_json = serde_json::json!({
+        "schemaVersion": 2,
+        "mediaType": MEDIA_TYPE_MANIFEST,
+        "config": {
+            "mediaType": MEDIA_TYPE_CONFIG,
+            "digest": config_digest,
+            "size": config_bytes.len(),
+        },
+        "layers": manifest_layers,
+        "annotations": config.annotations,
+    });
+    let manifest_bytes = json_to_vec(&manifest_json)?;
+    let manifest_hex = sha256_hex(&manifest_bytes);
+    std::fs::write(blobs.join(&manifest_hex), &manifest_bytes)?;
+    let manifest_digest = format!("sha256:{manifest_hex}");
+
+    // index.json references the manifest by digest + size.
+    let index_json = serde_json::json!({
+        "schemaVersion": 2,
+        "mediaType": MEDIA_TYPE_INDEX,
+        "manifests": [{
+            "mediaType": MEDIA_TYPE_MANIFEST,
+            "digest": manifest_digest,
+            "size": manifest_bytes.len(),
+            "platform": {
+                "architecture": config.architecture,
+                "os": config.os,
+            },
+        }],
+    });
+    let index_bytes = json_to_vec(&index_json)?;
+    std::fs::write(out.join("index.json"), &index_bytes)?;
+
+    // The layout marker file.
+    std::fs::write(out.join("oci-layout"), br#"{"imageLayoutVersion":"1.0.0"}"#)?;
+
+    Ok(manifest_digest)
+}
+
+/// Finalize an uncompressed tar buffer into an [`OciLayer`]: compute the
+/// uncompressed digest (`diff_id`), gzip the bytes, and compute the gzipped
+/// digest and size.
+fn finish_layer(tar_buf: Vec<u8>) -> std::io::Result<OciLayer> {
+    let diff_id = format!("sha256:{}", sha256_hex(&tar_buf));
+
+    let mut tar_gz = Vec::new();
+    {
+        let mut encoder = GzEncoder::new(&mut tar_gz, Compression::default());
+        encoder.write_all(&tar_buf)?;
+        encoder.finish()?;
+    }
+
+    let digest = format!("sha256:{}", sha256_hex(&tar_gz));
+    let size = tar_gz.len() as u64;
+    Ok(OciLayer {
+        tar_gz,
+        diff_id,
+        digest,
+        size,
+    })
+}
+
+/// Encode the OCI whiteout entry name for a deleted path.
+fn whiteout_path(path: &str) -> String {
+    match path.rfind('/') {
+        Some(idx) => format!("{}/.wh.{}", &path[..idx], &path[idx + 1..]),
+        None => format!(".wh.{path}"),
+    }
+}
+
+/// Strip the `sha256:` prefix from a digest, yielding the bare hex used as a
+/// blob filename.
+fn digest_hex(digest: &str) -> &str {
+    digest.strip_prefix("sha256:").unwrap_or(digest)
+}
+
+/// Lowercase-hex encode bytes.
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Compute the lowercase-hex sha256 of `bytes`.
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex_encode(&hasher.finalize())
+}
+
+/// Serialize a JSON value to bytes, mapping serialization failure to an IO error
+/// so callers can use `?` against `std::io::Result`.
+fn json_to_vec(value: &serde_json::Value) -> std::io::Result<Vec<u8>> {
+    serde_json::to_vec(value).map_err(std::io::Error::other)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+    use tempfile::tempdir;
+
+    /// Read all entries (path, bytes) from a gzipped tar layer.
+    fn read_layer_entries(tar_gz: &[u8]) -> Vec<(String, Vec<u8>)> {
+        let decoder = flate2::read::GzDecoder::new(tar_gz);
+        let mut archive = tar::Archive::new(decoder);
+        let mut out = Vec::new();
+        for entry in archive.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            let path = entry.path().unwrap().to_string_lossy().into_owned();
+            let mut bytes = Vec::new();
+            entry.read_to_end(&mut bytes).unwrap();
+            out.push((path, bytes));
+        }
+        out
+    }
+
+    #[test]
+    fn layer_from_dir_produces_valid_gzipped_tar() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/main.rs"), b"fn main() {}").unwrap();
+        std::fs::write(dir.path().join("README.md"), b"# hello").unwrap();
+
+        let layer = layer_from_dir(dir.path()).unwrap();
+
+        assert!(layer.diff_id.starts_with("sha256:"));
+        assert!(layer.digest.starts_with("sha256:"));
+        // The uncompressed digest must differ from the compressed digest.
+        assert_ne!(layer.diff_id, layer.digest);
+        assert_eq!(layer.size, layer.tar_gz.len() as u64);
+
+        let entries = read_layer_entries(&layer.tar_gz);
+        let paths: Vec<&str> = entries.iter().map(|(p, _)| p.as_str()).collect();
+        assert!(paths.contains(&"src/main.rs"));
+        assert!(paths.contains(&"README.md"));
+
+        let main = entries.iter().find(|(p, _)| p == "src/main.rs").unwrap();
+        assert_eq!(main.1, b"fn main() {}");
+    }
+
+    #[test]
+    fn layer_from_entries_encodes_whiteouts() {
+        let files = vec![("a/b.txt".to_string(), b"content".to_vec())];
+        let whiteouts = vec!["a/gone.txt".to_string()];
+
+        let layer = layer_from_entries(&files, &whiteouts).unwrap();
+        let entries = read_layer_entries(&layer.tar_gz);
+        let paths: Vec<&str> = entries.iter().map(|(p, _)| p.as_str()).collect();
+
+        assert!(paths.contains(&"a/b.txt"));
+        assert!(paths.contains(&"a/.wh.gone.txt"));
+        let wh = entries.iter().find(|(p, _)| p == "a/.wh.gone.txt").unwrap();
+        assert!(wh.1.is_empty());
+    }
+
+    #[test]
+    fn whiteout_path_handles_root_and_nested() {
+        assert_eq!(whiteout_path("foo"), ".wh.foo");
+        assert_eq!(whiteout_path("a/b/c"), "a/b/.wh.c");
+    }
+
+    #[test]
+    fn write_image_layout_creates_addressable_blobs() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("file.txt"), b"data").unwrap();
+
+        let layer = layer_from_dir(&src).unwrap();
+        let layer_digest = layer.digest.clone();
+
+        let mut annotations = BTreeMap::new();
+        annotations.insert("org.atomic.view".to_string(), "dev".to_string());
+        let config = OciImageConfig {
+            architecture: host_arch(),
+            os: "linux".to_string(),
+            env: vec!["FOO=bar".to_string()],
+            entrypoint: vec!["/bin/sh".to_string()],
+            annotations,
+        };
+
+        let out = dir.path().join("image");
+        let manifest_digest = write_image_layout(&out, &[layer], &config).unwrap();
+
+        // oci-layout
+        let layout = std::fs::read_to_string(out.join("oci-layout")).unwrap();
+        assert_eq!(layout, r#"{"imageLayoutVersion":"1.0.0"}"#);
+
+        // index.json references the manifest by digest + size.
+        let index_bytes = std::fs::read(out.join("index.json")).unwrap();
+        let index: serde_json::Value = serde_json::from_slice(&index_bytes).unwrap();
+        let manifest_ref = &index["manifests"][0];
+        assert_eq!(manifest_ref["digest"], manifest_digest);
+
+        // Every blob filename equals the sha256 of its contents.
+        let blobs = out.join("blobs").join("sha256");
+        for entry in std::fs::read_dir(&blobs).unwrap() {
+            let entry = entry.unwrap();
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let bytes = std::fs::read(entry.path()).unwrap();
+            assert_eq!(name, sha256_hex(&bytes), "blob filename must match content");
+        }
+
+        // The manifest blob exists and resolves config + layer to real blobs.
+        let manifest_hex = manifest_digest.strip_prefix("sha256:").unwrap();
+        let manifest_bytes = std::fs::read(blobs.join(manifest_hex)).unwrap();
+        let manifest: serde_json::Value = serde_json::from_slice(&manifest_bytes).unwrap();
+
+        let config_digest = manifest["config"]["digest"].as_str().unwrap();
+        assert!(blobs
+            .join(config_digest.strip_prefix("sha256:").unwrap())
+            .is_file());
+
+        let manifest_layer_digest = manifest["layers"][0]["digest"].as_str().unwrap();
+        assert_eq!(manifest_layer_digest, layer_digest);
+        assert!(blobs
+            .join(manifest_layer_digest.strip_prefix("sha256:").unwrap())
+            .is_file());
+
+        // Annotations are passed through.
+        assert_eq!(manifest["annotations"]["org.atomic.view"], "dev");
+    }
+}

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -77,6 +77,7 @@ use crate::RepositoryError;
 
 mod filter;
 mod materialize;
+mod sandbox;
 mod semantic_materialize;
 mod switch;
 mod views;
@@ -87,6 +88,7 @@ pub use filter::{
     collect_view_change_ids, collect_visible_change_ids, collect_visible_change_ids_with_deps,
     expand_indexed_dependency_closure,
 };
+pub use sandbox::{SealOptions, SealResult, StageOptions, StageResult, SANDBOX_POINTER};
 pub use views::ViewInfo;
 
 // Re-import workspace helpers from `switch` so they are available to
@@ -297,6 +299,9 @@ default = "{}"
     ///
     /// Returns an error if no repository is found.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, RepositoryError> {
+        if let Some((working_root, canonical, view)) = sandbox::detect_sandbox(path.as_ref()) {
+            return Self::open_sandbox(working_root, canonical, &view);
+        }
         let root = Self::find_root(path.as_ref())?;
         let dot_dir = root.join(DOT_DIR);
 
@@ -333,6 +338,9 @@ default = "{}"
     /// Use this for short-lived processes (agent hooks, background jobs)
     /// where blocking on the init write lock would hang the process.
     pub fn open_existing<P: AsRef<Path>>(path: P) -> Result<Self, RepositoryError> {
+        if let Some((working_root, canonical, view)) = sandbox::detect_sandbox(path.as_ref()) {
+            return Self::open_sandbox(working_root, canonical, &view);
+        }
         let root = Self::find_root(path.as_ref())?;
         let dot_dir = root.join(DOT_DIR);
 
@@ -387,6 +395,9 @@ default = "{}"
     /// let status = repo.status(StatusOptions::default())?;
     /// ```
     pub fn open_readonly<P: AsRef<Path>>(path: P) -> Result<Self, RepositoryError> {
+        if let Some((working_root, canonical, view)) = sandbox::detect_sandbox(path.as_ref()) {
+            return Self::open_sandbox(working_root, canonical, &view);
+        }
         let root = Self::find_root(path.as_ref())?;
         let dot_dir = root.join(DOT_DIR);
 

--- a/atomic-repository/src/repository/sandbox.rs
+++ b/atomic-repository/src/repository/sandbox.rs
@@ -1,0 +1,493 @@
+//! Concurrent agent sandboxes.
+//!
+//! A sandbox lets several agents work at once, each in its own working tree,
+//! while sharing a single canonical graph. Two pieces make that work:
+//!
+//! 1. [`Repository::provision_sandbox`] — give an agent a private working tree
+//!    that is a **copy-on-write clone** of the canonical one. On filesystems
+//!    that support it (APFS, Btrfs, XFS, ReFS) the clone shares blocks until
+//!    written, so five agents off a 200 MB base cost a few MB, not a gigabyte.
+//!    Build artifacts (`node_modules`, `target`) land in the agent's own tree
+//!    and never collide.
+//!
+//! 2. [`Repository::open_sandbox`] — open the repository with the agent's
+//!    working tree as the root, but the **canonical** `.atomic/` as the graph.
+//!    The graph (`pristine` + `changes`) is never cloned: there is one graph,
+//!    and views are filters over it. Every `atomic` command the agent runs —
+//!    `record`, `status`, `diff`, `vault query` — works unchanged, because it
+//!    is a normal repository whose working tree just happens to live elsewhere.
+//!
+//! The only OS-specific concern (how to clone a file copy-on-write) is owned by
+//! the `reflink-copy` crate, which falls back to a plain copy when the
+//! filesystem cannot reflink. Our code has a single path.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use atomic_core::pristine::Pristine;
+use serde::{Deserialize, Serialize};
+
+use crate::changestore::{ChangeStore, DEFAULT_CACHE_CAPACITY};
+use crate::oci::{self, OciImageConfig};
+
+use super::{Repository, DOT_DIR};
+use crate::RepositoryError;
+
+/// Options for [`Repository::stage`].
+pub struct StageOptions {
+    /// The sandbox's draft view (the working view to package).
+    pub view: String,
+    /// The shared base view this sandbox forked from.
+    pub base_view: String,
+    /// Output directory for the OCI image layout (created if needed).
+    pub out: PathBuf,
+}
+
+/// Result of [`Repository::stage`].
+pub struct StageResult {
+    /// Digest (`"sha256:..."`) of the written image manifest.
+    pub manifest_digest: String,
+    /// `diff_id` of the base layer — its content-address, by which a cached
+    /// base can be matched and reused across staged iterations.
+    pub base_diff_id: String,
+    /// Number of files in the delta layer (new or changed vs. the base).
+    pub delta_files: usize,
+    /// The output directory the layout was written to.
+    pub out: PathBuf,
+}
+
+/// Options for [`Repository::seal`].
+pub struct SealOptions {
+    /// The view to package as a flattened, self-contained image.
+    pub view: String,
+    /// Output directory for the OCI image layout (created if needed).
+    pub out: PathBuf,
+    /// Image entrypoint argv. Empty for none.
+    pub entrypoint: Vec<String>,
+    /// Image environment variables, each as `"KEY=VAL"`.
+    pub env: Vec<String>,
+}
+
+/// Result of [`Repository::seal`].
+pub struct SealResult {
+    /// Digest (`"sha256:..."`) of the written image manifest.
+    pub manifest_digest: String,
+    /// Number of files written into the (single) layer.
+    pub files: usize,
+    /// The output directory the layout was written to.
+    pub out: PathBuf,
+}
+
+/// Marker file written at the root of a sandbox working tree. Its presence
+/// tells `Repository::open*` to resolve the graph from the canonical repo
+/// instead of looking for a local `.atomic/`.
+pub const SANDBOX_POINTER: &str = ".atomic-sandbox";
+
+/// Persisted contents of a sandbox pointer: where the canonical graph lives
+/// and which view this sandbox operates on.
+#[derive(Debug, Serialize, Deserialize)]
+struct SandboxPointer {
+    /// Absolute path to the canonical repository root (the one with `.atomic/`).
+    canonical: PathBuf,
+    /// View this sandbox operates on.
+    view: String,
+}
+
+/// Walk up from `start` looking for a [`SANDBOX_POINTER`] file. If found,
+/// return `(working_root, canonical_root, view)`.
+pub(super) fn detect_sandbox(start: &Path) -> Option<(PathBuf, PathBuf, String)> {
+    let mut dir = if start.is_absolute() {
+        start.to_path_buf()
+    } else {
+        std::env::current_dir().ok()?.join(start)
+    };
+
+    loop {
+        let pointer = dir.join(SANDBOX_POINTER);
+        if pointer.is_file() {
+            let bytes = std::fs::read(&pointer).ok()?;
+            let parsed: SandboxPointer = serde_json::from_slice(&bytes).ok()?;
+            return Some((dir.clone(), parsed.canonical, parsed.view));
+        }
+        // Stop if we reach a real repository root — that's not a sandbox.
+        if dir.join(DOT_DIR).join("pristine.redb").is_file() {
+            return None;
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
+impl Repository {
+    /// Open a repository for an agent sandbox.
+    ///
+    /// The agent's private working tree is at `working_root`, but the graph
+    /// lives in the **canonical** repository found from `canonical`. All
+    /// sandboxes opened this way read and write the same `pristine` and
+    /// `changes` store, so there is exactly one graph. `view` selects which
+    /// view this sandbox operates on (typically the agent's own draft view).
+    ///
+    /// The canonical `current_view` file on disk is left untouched — the view
+    /// is held in memory for this handle only, so concurrent agents on
+    /// different views never clobber one another.
+    ///
+    /// redb serialises writers, so concurrent `record`s from several agents
+    /// take turns; reads run concurrently via MVCC.
+    pub fn open_sandbox<P, Q>(
+        working_root: P,
+        canonical: Q,
+        view: &str,
+    ) -> Result<Self, RepositoryError>
+    where
+        P: AsRef<Path>,
+        Q: AsRef<Path>,
+    {
+        let working_root = working_root.as_ref().to_path_buf();
+        let canonical_root = Self::find_root(canonical.as_ref())?;
+        let dot_dir = canonical_root.join(DOT_DIR);
+
+        let pristine = Arc::new(
+            Pristine::open_existing(dot_dir.join("pristine.redb"))
+                .map_err(|e| RepositoryError::Database(e.to_string()))?,
+        );
+        let change_store = ChangeStore::new(dot_dir.join("changes"), DEFAULT_CACHE_CAPACITY)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        Ok(Self {
+            root: working_root,
+            dot_dir,
+            current_view: view.to_string(),
+            pristine,
+            change_store,
+        })
+    }
+
+    /// Provision an agent's private working tree as a copy-on-write clone of
+    /// this repository's working tree.
+    ///
+    /// Copies every tracked-or-untracked working file into `dest`, reflinking
+    /// where the filesystem supports it (so unchanged blocks are shared on
+    /// disk) and falling back to a plain copy otherwise. The `.atomic/`
+    /// directory is **never** cloned — the sandbox shares the canonical graph
+    /// via [`Repository::open_sandbox`].
+    ///
+    /// Returns the number of files provisioned.
+    ///
+    /// Also writes a [`SANDBOX_POINTER`] file into `dest` so that `atomic`
+    /// commands run inside the sandbox resolve to this repository's canonical
+    /// graph and the given `view`.
+    pub fn provision_sandbox<P: AsRef<Path>>(
+        &self,
+        dest: P,
+        view: &str,
+    ) -> Result<usize, RepositoryError> {
+        let dest = dest.as_ref();
+        let count = provision_working_tree(&self.root, dest)?;
+
+        let pointer = SandboxPointer {
+            canonical: self.root.clone(),
+            view: view.to_string(),
+        };
+        let bytes = serde_json::to_vec_pretty(&pointer)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        std::fs::write(dest.join(SANDBOX_POINTER), bytes)?;
+
+        Ok(count)
+    }
+
+    /// Materialize a view's visible file content into `dir` (created if needed).
+    ///
+    /// Writes each visible file's bytes exactly as they appear on `view` (the
+    /// view's own changes plus its parent chain). Returns the number of files
+    /// written.
+    pub fn materialize_view_to(&self, view: &str, dir: &Path) -> Result<usize, RepositoryError> {
+        std::fs::create_dir_all(dir)?;
+
+        let mut count = 0usize;
+        for path in self.visible_file_paths(view)? {
+            let bytes = match self.get_file_content_on_view(&path, view)? {
+                Some(bytes) => bytes,
+                None => continue,
+            };
+            let target = dir.join(&path);
+            if let Some(parent) = target.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(&target, &bytes)?;
+            count += 1;
+        }
+
+        Ok(count)
+    }
+
+    /// Produce a two-layer OCI image: a base layer (the `base_view`
+    /// materialized) plus a thin delta layer (files that differ on `view`
+    /// versus `base_view`, with whiteouts for files removed on `view`).
+    ///
+    /// Built for the inner loop: the base is content-addressed by its `diff_id`
+    /// and can be pulled once and cached, so each iteration ships only the small
+    /// delta. Provenance (view names and Merkle states) is recorded in the
+    /// manifest annotations. Returns the manifest digest and base `diff_id`.
+    pub fn stage(&self, opts: StageOptions) -> Result<StageResult, RepositoryError> {
+        // 1. Base layer: materialize the shared base view to a temp dir.
+        let base_dir = tempfile::tempdir()?;
+        self.materialize_view_to(&opts.base_view, base_dir.path())?;
+        let base_layer = oci::layer_from_dir(base_dir.path())?;
+        let base_diff_id = base_layer.diff_id.clone();
+
+        // 2. Delta: files new or changed on `view` vs. `base_view`, plus
+        //    whiteouts for files present on the base but gone on `view`.
+        let view_paths = self.visible_file_paths(&opts.view)?;
+        let base_paths = self.visible_file_paths(&opts.base_view)?;
+
+        let mut changed: Vec<(String, Vec<u8>)> = Vec::new();
+        for path in &view_paths {
+            let view_bytes = match self.get_file_content_on_view(path, &opts.view)? {
+                Some(bytes) => bytes,
+                None => continue,
+            };
+            let base_bytes = self.get_file_content_on_view(path, &opts.base_view)?;
+            if base_bytes.as_deref() != Some(view_bytes.as_slice()) {
+                changed.push((path.clone(), view_bytes));
+            }
+        }
+
+        let mut whiteouts: Vec<String> = Vec::new();
+        for path in &base_paths {
+            if !view_paths.contains(path) {
+                whiteouts.push(path.clone());
+            }
+        }
+
+        let delta_files = changed.len();
+        let delta_layer = oci::layer_from_entries(&changed, &whiteouts)?;
+
+        // 3. Assemble the layout with provenance annotations.
+        let view_info = self.get_view_info(&opts.view)?;
+        let base_info = self.get_view_info(&opts.base_view)?;
+        let mut annotations = BTreeMap::new();
+        annotations.insert("org.atomic.view".to_string(), opts.view.clone());
+        annotations.insert("org.atomic.base-view".to_string(), opts.base_view.clone());
+        annotations.insert(
+            "org.atomic.view-merkle".to_string(),
+            view_info.state_base32(),
+        );
+        annotations.insert(
+            "org.atomic.base-merkle".to_string(),
+            base_info.state_base32(),
+        );
+
+        let config = OciImageConfig {
+            architecture: oci::host_arch(),
+            os: "linux".to_string(),
+            env: Vec::new(),
+            entrypoint: Vec::new(),
+            annotations,
+        };
+
+        let manifest_digest =
+            oci::write_image_layout(&opts.out, &[base_layer, delta_layer], &config)?;
+
+        Ok(StageResult {
+            manifest_digest,
+            base_diff_id,
+            delta_files,
+            out: opts.out,
+        })
+    }
+
+    /// Produce a single-layer (flattened) OCI image of the full merged state of
+    /// `view`.
+    ///
+    /// Because a draft view sees its entire parent chain, the materialized
+    /// content is the complete, self-contained rootfs — a deployable runtime.
+    /// Provenance (view name and Merkle state) is recorded in the manifest
+    /// annotations. Returns the manifest digest and file count.
+    pub fn seal(&self, opts: SealOptions) -> Result<SealResult, RepositoryError> {
+        let work_dir = tempfile::tempdir()?;
+        let files = self.materialize_view_to(&opts.view, work_dir.path())?;
+        let layer = oci::layer_from_dir(work_dir.path())?;
+
+        let view_info = self.get_view_info(&opts.view)?;
+        let mut annotations = BTreeMap::new();
+        annotations.insert("org.atomic.view".to_string(), opts.view.clone());
+        annotations.insert(
+            "org.atomic.view-merkle".to_string(),
+            view_info.state_base32(),
+        );
+
+        let config = OciImageConfig {
+            architecture: oci::host_arch(),
+            os: "linux".to_string(),
+            env: opts.env.clone(),
+            entrypoint: opts.entrypoint.clone(),
+            annotations,
+        };
+
+        let manifest_digest = oci::write_image_layout(&opts.out, &[layer], &config)?;
+
+        Ok(SealResult {
+            manifest_digest,
+            files,
+            out: opts.out,
+        })
+    }
+}
+
+/// Clone a working tree from `src` to `dest`, one file at a time, reflinking
+/// where possible. Skips the `.atomic/` graph directory.
+fn provision_working_tree(src: &Path, dest: &Path) -> Result<usize, RepositoryError> {
+    use walkdir::WalkDir;
+
+    let mut count = 0usize;
+    std::fs::create_dir_all(dest)?;
+
+    for entry in WalkDir::new(src).into_iter().filter_entry(|e| {
+        // Never descend into the canonical graph — it is shared, not cloned.
+        if e.file_name() == DOT_DIR {
+            return false;
+        }
+        // Never descend into a nested sandbox (a dir holding its own pointer).
+        if e.file_type().is_dir() && e.path().join(SANDBOX_POINTER).is_file() {
+            return false;
+        }
+        true
+    }) {
+        let entry = entry.map_err(std::io::Error::from)?;
+        let rel = match entry.path().strip_prefix(src) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        if rel.as_os_str().is_empty() {
+            continue;
+        }
+        let target = dest.join(rel);
+
+        let ft = entry.file_type();
+        if ft.is_dir() {
+            std::fs::create_dir_all(&target)?;
+        } else if ft.is_file() {
+            if let Some(parent) = target.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            // Single cross-platform path: reflink (CoW) where the filesystem
+            // supports it, plain copy where it does not.
+            reflink_copy::reflink_or_copy(entry.path(), &target)?;
+            count += 1;
+        } else if ft.is_symlink() {
+            // Recreate symlinks rather than following them.
+            if let Ok(link_target) = std::fs::read_link(entry.path()) {
+                if let Some(parent) = target.parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
+                let _ = std::os::unix::fs::symlink(link_target, &target);
+            }
+        }
+    }
+
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::record::RecordOptions;
+    use crate::tracking::TrackingOptions;
+    use crate::InsertOptions;
+    use atomic_core::change::ChangeHeader;
+    use tempfile::tempdir;
+
+    /// Initialize a repository at `root` and record+apply a single file on the
+    /// default `dev` view, returning the opened repository.
+    fn repo_with_recorded_file(root: &Path, rel: &str, contents: &[u8]) -> Repository {
+        std::fs::create_dir_all(root).unwrap();
+        let repo = Repository::init(root).unwrap();
+
+        let path = root.join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&path, contents).unwrap();
+
+        repo.add(rel, TrackingOptions::default()).unwrap();
+        let header = ChangeHeader::new("add file");
+        let options = RecordOptions::new()
+            .with_all(true)
+            .save_to_store(true)
+            .apply_after_record(false);
+        let outcome = repo.record(header, options).unwrap();
+        repo.write_recorded(&outcome, InsertOptions::default())
+            .unwrap();
+
+        repo
+    }
+
+    #[test]
+    fn materialize_view_to_writes_visible_files() {
+        let dir = tempdir().unwrap();
+        let repo = repo_with_recorded_file(&dir.path().join("repo"), "src/hello.txt", b"hi\n");
+
+        let out = dir.path().join("mat");
+        let count = repo.materialize_view_to("dev", &out).unwrap();
+
+        assert_eq!(count, 1);
+        assert_eq!(std::fs::read(out.join("src/hello.txt")).unwrap(), b"hi\n");
+    }
+
+    #[test]
+    fn seal_produces_single_layer_oci_layout() {
+        let dir = tempdir().unwrap();
+        let repo = repo_with_recorded_file(&dir.path().join("repo"), "hello.txt", b"hello world\n");
+
+        let out = dir.path().join("image");
+        let result = repo
+            .seal(SealOptions {
+                view: "dev".to_string(),
+                out: out.clone(),
+                entrypoint: vec!["/bin/sh".to_string()],
+                env: vec!["FOO=bar".to_string()],
+            })
+            .unwrap();
+
+        assert_eq!(result.files, 1);
+        assert!(result.manifest_digest.starts_with("sha256:"));
+        assert!(out.join("oci-layout").is_file());
+        assert!(out.join("index.json").is_file());
+
+        // The manifest blob exists and references exactly one layer.
+        let manifest_hex = result.manifest_digest.strip_prefix("sha256:").unwrap();
+        let manifest_path = out.join("blobs").join("sha256").join(manifest_hex);
+        assert!(manifest_path.is_file());
+        let manifest: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+        assert_eq!(manifest["layers"].as_array().unwrap().len(), 1);
+        assert_eq!(manifest["annotations"]["org.atomic.view"], "dev");
+    }
+
+    #[test]
+    fn provision_clones_working_tree_and_skips_dot_dir() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("repo");
+        std::fs::create_dir_all(src.join("src")).unwrap();
+        std::fs::create_dir_all(src.join(DOT_DIR)).unwrap();
+        std::fs::write(src.join("src/main.rs"), b"fn main() {}").unwrap();
+        std::fs::write(src.join("Cargo.toml"), b"[package]").unwrap();
+        std::fs::write(src.join(DOT_DIR).join("pristine.redb"), b"GRAPH").unwrap();
+
+        let dest = dir.path().join("agent-1");
+        let count = provision_working_tree(&src, &dest).unwrap();
+
+        assert_eq!(count, 2, "two working files cloned");
+        assert_eq!(
+            std::fs::read(dest.join("src/main.rs")).unwrap(),
+            b"fn main() {}"
+        );
+        assert!(dest.join("Cargo.toml").exists());
+        assert!(
+            !dest.join(DOT_DIR).exists(),
+            "the canonical graph must not be cloned into the sandbox"
+        );
+    }
+}

--- a/atomic-repository/src/repository/sandbox.rs
+++ b/atomic-repository/src/repository/sandbox.rs
@@ -377,17 +377,30 @@ fn provision_working_tree(src: &Path, dest: &Path) -> Result<usize, RepositoryEr
             reflink_copy::reflink_or_copy(entry.path(), &target)?;
             count += 1;
         } else if ft.is_symlink() {
-            // Recreate symlinks rather than following them.
-            if let Ok(link_target) = std::fs::read_link(entry.path()) {
-                if let Some(parent) = target.parent() {
-                    std::fs::create_dir_all(parent)?;
-                }
-                let _ = std::os::unix::fs::symlink(link_target, &target);
+            if let Some(parent) = target.parent() {
+                std::fs::create_dir_all(parent)?;
             }
+            let _ = recreate_symlink(entry.path(), &target);
         }
     }
 
     Ok(count)
+}
+
+/// Recreate a symlink found at `src` into `dest`, preserving its target.
+///
+/// Unix has a dedicated definition; everything else falls back below.
+#[cfg(unix)]
+fn recreate_symlink(src: &Path, dest: &Path) -> std::io::Result<()> {
+    let link_target = std::fs::read_link(src)?;
+    std::os::unix::fs::symlink(link_target, dest)
+}
+
+/// Non-Unix fallback: symlink creation needs special privileges, so copy the
+/// file the link resolves to (correct content-wise).
+#[cfg(not(unix))]
+fn recreate_symlink(src: &Path, dest: &Path) -> std::io::Result<()> {
+    std::fs::copy(src, dest).map(|_| ())
 }
 
 #[cfg(test)]

--- a/docs/CONCURRENT-AGENT-SANDBOXES.md
+++ b/docs/CONCURRENT-AGENT-SANDBOXES.md
@@ -1,0 +1,148 @@
+# Concurrent Agent Sandboxes
+
+**Status:** `create` / `--from` implemented and tested. `stage` / `seal` are
+design investigations (this doc).
+
+## The model
+
+Several agents work at once, each in a private working tree, sharing **one**
+canonical graph. Two facts make it simple:
+
+1. **The working tree is cloned copy-on-write; the graph is not.** A sandbox is
+   a reflink clone of the working tree (APFS `clonefile`, Btrfs/XFS `FICLONE`,
+   ReFS block-clone — one path via the `reflink-copy` crate, falling back to a
+   plain copy). Five agents off a 200 MB base cost a few MB, not a gigabyte, and
+   run at bare-metal filesystem speed — no FUSE, no virtio, no VM.
+2. **There is exactly one pristine.** The sandbox carries a small pointer file
+   (`.atomic-sandbox`) naming the canonical repo and the sandbox's view. Every
+   `atomic` command run inside the sandbox resolves the graph from there, so
+   `status`, `record`, `diff`, `vault query` all work as in a normal repo.
+
+This is "views, not forks" taken to the filesystem: one graph, many cheap
+working-tree projections.
+
+### Why not the things we tried first
+
+Recorded here so nobody re-walks them: a host-side FUSE overlay (macFUSE) is
+impractical to deploy on Apple Silicon + macOS 26 (Recovery-Mode security
+downgrade, kext staging, and a fuser/libfuse2 ABI break) and showed no speed
+win; virtio-fs virtualizes the filesystem protocol and is death for the
+metadata-heavy workloads (git, cargo, npm) we care about. Copy-on-write on the
+real filesystem needs none of it.
+
+## Implemented
+
+### `Repository` (atomic-repository/src/repository/sandbox.rs)
+
+- `provision_sandbox(dest, view)` — reflink-clone the working tree into `dest`,
+  skipping `.atomic/` (shared) and nested sandboxes; write the `.atomic-sandbox`
+  pointer. In-process in the binary — no shell.
+- `open_sandbox(working_root, canonical, view)` — working tree in one place, the
+  one canonical graph in another.
+- `detect_sandbox()` — wired into `open` / `open_existing` / `open_readonly`, and
+  the CLI's `find_repository_root`, so any command inside a sandbox routes to the
+  canonical graph.
+
+### CLI
+
+```text
+atomic sandbox create <NAME> [--dest <PATH>] [--view <VIEW>] [--from <VIEW>]
+```
+
+- `--from <view>` forks a per-agent **draft** view (named after the sandbox)
+  from `<view>`, so the agent's records land in its own draft — isolating each
+  agent's history as well as its files.
+- `--view <view>` records into an existing view; default is the current view.
+
+Covered by `tests/harness/20_sandbox.sh` (18 assertions): clone happens, graph
+is not cloned, artifacts are per-agent, commands work inside the sandbox, records
+land in the canonical graph / the per-agent draft, the canonical working tree is
+untouched.
+
+### Concurrency caveat
+
+The harness is sequential. Multiple agent **processes** opening the canonical
+pristine concurrently rely on redb's cross-process locking — records serialize
+(the intended model), but simultaneous writers haven't been load-tested. Verify
+before relying on true parallelism.
+
+---
+
+## Investigation: `atomic sandbox stage` and `atomic sandbox seal`
+
+Both turn a sandbox into a shippable OCI artifact. They differ in *what* they
+package and *why*.
+
+| | `stage` | `seal` |
+|--|--|--|
+| Purpose | inner-loop CI / circuit-breaker runs | deployable runtime |
+| Shape | **layered**: shared base + thin delta | **flattened**: one self-contained rootfs |
+| Base sharing | yes — base keyed by the shared view's Merkle, pulled once and cached | no — fully self-contained |
+| Ships each iteration | only the delta (small, fast) | the whole image (release artifact) |
+| Lifecycle | ephemeral, per turn | versioned release |
+
+### What each side already provides
+
+**atomic** (graph → rootfs + dependency metadata):
+- Materialize a view's visible state to a directory (the core `materialize_view`
+  over a `FileSystem` working copy rooted at an arbitrary dir — the same path
+  `Repository::materialize` uses, pointed elsewhere).
+- The dependency closure of a view: `collect_visible_change_ids_with_deps`
+  (already public) — the "dependency xxxx" the artifact must carry.
+- Per-view change sets: `collect_visible_change_ids` — the symmetric difference
+  between the draft and its base is the "delta yyyy".
+- Merkle state per view — a stable content-address for the shared base.
+
+**smolvm** (rootfs → OCI artifact, registry):
+- `pack create` already accepts `--image`, `--from-vm`, and a hidden
+  `--rootfs-dir` — i.e. packing a directory into a `.smolmachine` is mostly
+  plumbed.
+- `pack push` / `pull` move `.smolmachine` artifacts to/from an OCI registry.
+- `BlobCache` + the registry are content-addressed (sha256) — the substrate for
+  "base pulled once, cached, delta ships each time."
+- `ContainerizationEXT4` (Apple) can build ext4 images natively on macOS (drops
+  the e2fsprogs dependency) if we want block images instead of layer dirs.
+
+### `atomic sandbox stage` — flow
+
+1. Resolve base = the shared view (`--from`) at its current Merkle `M`.
+2. If the base layer for `M` isn't in the registry, materialize the shared view
+   to a dir, pack it (`pack --rootfs-dir`), push it tagged by `M`. Otherwise
+   reuse it (this is the win — built once, shared across all stagings).
+3. Materialize **only the delta** (changes in the sandbox's draft not in the
+   base) to a dir → pack as a thin layer on top of base `M`.
+4. Emit an OCI image = `[base@M] + [delta]` plus a reinflate manifest (which base
+   to pull, how to stack). Push.
+5. CI pulls base (cached) + delta (small) → smolvm reinflates → runs build/test
+   and circuit-breaker checks against the agent's WIP. Cheap inner loop.
+
+### `atomic sandbox seal` — flow
+
+1. Compute the full dependency closure of the view (base deps + draft changes).
+2. Materialize the **merged** state (base + delta flattened) to a single rootfs.
+3. Add a runtime layer (toolchain/entrypoint needed to *run* the app).
+4. Pack as a self-contained `.smolmachine` / OCI image, push as a versioned
+   release. Runs "this exact version" as a runtime anywhere smolvm runs.
+
+### Gaps to close (the actual work)
+
+- **atomic:** a `materialize_view_to(view, dir)` helper (re-introduces the
+  directory-targeted materialize), and a `delta-vs-base` change-set computation
+  surfaced as a stable list for packing.
+- **smolvm:** a supported (un-hidden) `pack --rootfs-dir` entry or a library API
+  to pack a directory + a parent-layer reference into a layered `.smolmachine`;
+  base-by-digest reuse on push.
+- **shared:** the reinflate manifest schema (base digest + delta + how smolvm
+  stacks them — in-guest overlayfs over two block layers, or a flattened rootfs).
+
+### Open questions
+
+- Layer boundary: ship base/delta as two ext4 block images (overlayfs in-guest)
+  or as OCI tar layers (merged at unpack)? Block images keep native FS speed in
+  CI; tar layers are more registry-standard.
+- Does `stage` include build artifacts (`target`, `node_modules`) to skip a cold
+  build in CI, or only source? Artifacts bloat the delta but cut CI time —
+  probably a flag.
+- Provenance: seal/stage artifacts should embed the view Merkle + change hashes
+  so a shipped image is traceable back to exact graph state (ties into the
+  existing attestation/provenance model).

--- a/tests/harness/20_sandbox.sh
+++ b/tests/harness/20_sandbox.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# 20_sandbox.sh — Concurrent agent sandbox tests.
+#
+# A sandbox is a private, copy-on-write clone of the working tree. Several
+# agents can each work in their own sandbox at once — isolated build
+# artifacts, no collisions — while sharing the ONE canonical graph.
+#
+# Key principles ("views, not forks", taken further):
+#   - The working tree is cloned (copy-on-write); the graph is NOT.
+#   - There is exactly one pristine. A sandbox shares it via a pointer file.
+#   - `atomic` commands run inside a sandbox resolve to the canonical graph,
+#     so `status` / `record` work as if it were a normal repo.
+#   - Recording in a sandbox lands the change in the canonical graph.
+#   - Each sandbox's untracked artifacts are independent.
+#
+# What this verifies:
+#   1. `sandbox create` clones the working tree into a private directory
+#   2. The canonical `.atomic/` graph is NOT cloned into the sandbox
+#   3. Untracked artifacts (node_modules) ARE cloned (per-agent isolation)
+#   4. A sandbox pointer file is written
+#   5. `atomic status` works INSIDE the sandbox (resolves to canonical graph)
+#   6. Editing + recording inside the sandbox lands in the canonical graph
+#   7. The canonical working tree is untouched by sandbox edits
+#   8. Two sandboxes have independent artifacts
+
+HARNESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$HARNESS_DIR/helpers.sh"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Sandbox: create clones the working tree, not the graph"
+# ═══════════════════════════════════════════════════════════════════════════
+
+make_temp_repo "sandbox-create"
+CANON="$REPO_DIR"
+init_repo
+
+create_file "src/main.rs" "fn main() {}"
+create_file "Cargo.toml" "[package]"
+assert_success "add tracked files" atomic add src/main.rs Cargo.toml
+record_change "init" >/dev/null 2>&1 || true
+
+# Untracked build artifact (simulates npm install output)
+mkdir -p node_modules/lodash
+create_file "node_modules/lodash/index.js" "module.exports = {}"
+
+# Sandboxes live OUTSIDE the canonical repo (as the default dest does), so
+# provisioning never recurses into them.
+SBROOT="$(mktemp -d "${TMPDIR:-/tmp}/atomic-sandboxes-XXXXXX")"
+_HARNESS_TMPDIRS+=("$SBROOT")
+SB="$SBROOT/agent-1"
+assert_success "sandbox create" atomic sandbox create agent-1 --dest "$SB"
+
+assert_file_exists "tracked file cloned into sandbox" "$SB/src/main.rs"
+assert_file_exists "Cargo.toml cloned into sandbox" "$SB/Cargo.toml"
+assert_file_exists "untracked artifact cloned into sandbox" "$SB/node_modules/lodash/index.js"
+assert_dir_not_exists "graph .atomic NOT cloned into sandbox" "$SB/.atomic"
+assert_file_exists "sandbox pointer written" "$SB/.atomic-sandbox"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Sandbox: atomic commands inside resolve to the canonical graph"
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Running status from inside the sandbox must succeed even though there is no
+# local .atomic/ — it resolves the graph from the canonical repo via the pointer.
+assert_success "status works inside sandbox" bash -c "cd '$SB' && '$ATOMIC_BIN' status"
+
+# The tracked file should be clean (it was recorded in the canonical graph).
+assert_output_not_contains \
+    "tracked file is clean inside sandbox" \
+    "src/main.rs" \
+    bash -c "cd '$SB' && '$ATOMIC_BIN' status --short"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Sandbox: record inside lands in the canonical graph"
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Edit a file inside the sandbox and record from there.
+overwrite_file "$SB/src/main.rs" "fn main() { println!(\"from sandbox\"); }"
+
+RECORD_OUT="$(cd "$SB" && "$ATOMIC_BIN" record -m "edit from sandbox" 2>&1)" || true
+
+# The change must be visible in the canonical repo's log.
+assert_output_contains \
+    "sandbox change appears in canonical log" \
+    "edit from sandbox" \
+    bash -c "cd '$CANON' && '$ATOMIC_BIN' log"
+
+# The canonical working-tree file on disk is untouched (the edit was isolated
+# to the sandbox clone; the change lives in the graph until materialized).
+assert_file_content \
+    "canonical working file unchanged by sandbox edit" \
+    "$CANON/src/main.rs" \
+    "fn main() {}"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Sandbox: two sandboxes have independent artifacts"
+# ═══════════════════════════════════════════════════════════════════════════
+
+SB2="$SBROOT/agent-2"
+assert_success "second sandbox create" atomic sandbox create agent-2 --dest "$SB2"
+
+# Agent 1 installs a dep that agent 2 does not.
+mkdir -p "$SB/node_modules/only-in-1"
+create_file "$SB/node_modules/only-in-1/x.js" "1"
+
+assert_file_exists "agent-1 has its own dep" "$SB/node_modules/only-in-1/x.js"
+assert_file_not_exists "agent-2 does NOT see agent-1's dep" "$SB2/node_modules/only-in-1/x.js"
+
+# Both sandboxes still share the same canonical graph (one pristine).
+assert_file_exists "canonical pristine is single source" "$CANON/.atomic/pristine.redb"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Sandbox: --from creates a per-agent draft view"
+# ═══════════════════════════════════════════════════════════════════════════
+
+SB3="$SBROOT/agent-3"
+assert_success "sandbox create --from dev" \
+    bash -c "cd '$CANON' && '$ATOMIC_BIN' sandbox create agent-3 --dest '$SB3' --from dev"
+
+# The new draft view exists in the canonical repo.
+assert_output_contains \
+    "draft view 'agent-3' created" \
+    "agent-3" \
+    bash -c "cd '$CANON' && '$ATOMIC_BIN' view list"
+
+# Recording in the sandbox lands in the agent-3 draft, not in dev.
+overwrite_file "$SB3/src/main.rs" "fn main() { println!(\"draft work\"); }"
+(cd "$SB3" && "$ATOMIC_BIN" record -m "work in draft" >/dev/null 2>&1) || true
+
+assert_output_contains \
+    "draft change visible on agent-3 view" \
+    "work in draft" \
+    bash -c "cd '$CANON' && '$ATOMIC_BIN' log --view agent-3"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Sandbox: seal produces a valid OCI image layout"
+# ═══════════════════════════════════════════════════════════════════════════
+
+SEAL_OUT="$SBROOT/seal-dev"
+assert_success "seal dev view" \
+    bash -c "cd '$CANON' && '$ATOMIC_BIN' sandbox seal dev -o '$SEAL_OUT' --entrypoint /app/run --env PORT=8080"
+
+assert_file_exists "oci-layout written" "$SEAL_OUT/oci-layout"
+assert_file_exists "index.json written" "$SEAL_OUT/index.json"
+assert_dir_exists "blobs/sha256 written" "$SEAL_OUT/blobs/sha256"
+assert_output_contains "oci-layout has version" "imageLayoutVersion" cat "$SEAL_OUT/oci-layout"
+
+# Every blob filename must equal the sha256 of its contents (content-addressed).
+BLOB_OK=1
+for blob in "$SEAL_OUT"/blobs/sha256/*; do
+    name="$(basename "$blob")"
+    actual="$(shasum -a 256 "$blob" | awk '{print $1}')"
+    [ "$name" = "$actual" ] || BLOB_OK=0
+done
+if [ "$BLOB_OK" = "1" ]; then
+    _pass "every blob is content-addressed (filename == sha256)"
+else
+    _fail "every blob is content-addressed (filename == sha256)" "a blob filename did not match its sha256"
+fi
+
+# The manifest the index points to must reference exactly one layer (flattened).
+INDEX_MANIFEST="$(grep -o 'sha256:[0-9a-f]\{64\}' "$SEAL_OUT/index.json" | head -1 | cut -d: -f2)"
+assert_file_exists "index references a manifest blob" "$SEAL_OUT/blobs/sha256/$INDEX_MANIFEST"
+assert_output_contains \
+    "sealed image carries provenance annotation" \
+    "org.atomic.view" \
+    cat "$SEAL_OUT/blobs/sha256/$INDEX_MANIFEST"
+
+# Seal of the SHARED dev view must contain dev's recorded GRAPH content (not
+# the working tree on disk). Extract the single layer and inspect it.
+SEAL_LAYER="$(python3 -c "import json,sys; m=json.load(open('$SEAL_OUT/blobs/sha256/$INDEX_MANIFEST')); print(m['layers'][0]['digest'].split(':')[1])")"
+SEAL_EXTRACT="$SBROOT/seal-dev-extract"
+mkdir -p "$SEAL_EXTRACT"
+tar -xzf "$SEAL_OUT/blobs/sha256/$SEAL_LAYER" -C "$SEAL_EXTRACT" 2>/dev/null || true
+
+assert_file_exists "sealed dev layer contains src/main.rs" "$SEAL_EXTRACT/src/main.rs"
+assert_file_exists "sealed dev layer contains Cargo.toml" "$SEAL_EXTRACT/Cargo.toml"
+
+# dev's graph state for src/main.rs is the change recorded from the agent-1
+# sandbox earlier ("from sandbox"), proving seal reads recorded view state
+# rather than the canonical working copy (which still has the original).
+assert_file_content \
+    "sealed dev content is the recorded graph state" \
+    "$SEAL_EXTRACT/src/main.rs" \
+    'fn main() { println!("from sandbox"); }'
+
+assert_file_content \
+    "canonical working copy still has original (graph != disk)" \
+    "$CANON/src/main.rs" \
+    "fn main() {}"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Sandbox: stage produces a two-layer (base + delta) image"
+# ═══════════════════════════════════════════════════════════════════════════
+
+# agent-3 has the "work in draft" change on top of dev — stage it as base+delta.
+STAGE_OUT="$SBROOT/stage-agent-3"
+assert_success "stage agent-3 over dev" \
+    bash -c "cd '$CANON' && '$ATOMIC_BIN' sandbox stage agent-3 --base dev -o '$STAGE_OUT'"
+
+assert_file_exists "staged oci-layout written" "$STAGE_OUT/oci-layout"
+
+# The staged manifest must reference TWO layers (base + delta).
+STAGE_MANIFEST="$(grep -o 'sha256:[0-9a-f]\{64\}' "$STAGE_OUT/index.json" | head -1 | cut -d: -f2)"
+LAYER_COUNT="$(grep -o 'tar+gzip' "$STAGE_OUT/blobs/sha256/$STAGE_MANIFEST" | wc -l | tr -d ' ')"
+if [ "$LAYER_COUNT" = "2" ]; then
+    _pass "staged image has two layers (base + delta)"
+else
+    _fail "staged image has two layers (base + delta)" "expected 2 tar+gzip layers, got $LAYER_COUNT"
+fi
+
+assert_output_contains \
+    "staged image records base-view provenance" \
+    "org.atomic.base-view" \
+    cat "$STAGE_OUT/blobs/sha256/$STAGE_MANIFEST"
+
+# ═══════════════════════════════════════════════════════════════════════════
+
+print_summary


### PR DESCRIPTION
This pull request introduces a new "sandbox" feature to Atomic, enabling concurrent agents to work on isolated, copy-on-write clones of the repository's working tree while sharing a single canonical graph. It adds a new CLI command (`atomic sandbox`) with subcommands for creating, staging, and sealing sandboxes, and updates repository logic to recognize and operate within sandboxed environments. Supporting infrastructure for OCI image creation and copy-on-write cloning is also included.

**Sandbox CLI and Workflow:**

- Added a new `atomic sandbox` CLI command with `create`, `stage`, and `seal` subcommands to provision, package, and deploy concurrent agent sandboxes. This allows multiple agents to work in parallel with isolated build artifacts and shared history. [[1]](diffhunk://#diff-0a224d62b428b93dec1c67b610644a035e6a0d6b98b667a2075b2e2994df80b8R1-R245) [[2]](diffhunk://#diff-e3bbe5f981d5470482b4afeab1a32e5cc82f1c5e88be190376d55b97f2f81f49R242-R255) [[3]](diffhunk://#diff-e3bbe5f981d5470482b4afeab1a32e5cc82f1c5e88be190376d55b97f2f81f49R736-R737)
- Updated CLI module exports and command dispatch to support the new `sandbox` command. [[1]](diffhunk://#diff-20c162e1185710242f9838bee1a8985cd4ac31c015572d29f6c1013b08065d77R82) [[2]](diffhunk://#diff-20c162e1185710242f9838bee1a8985cd4ac31c015572d29f6c1013b08065d77R144) [[3]](diffhunk://#diff-e3bbe5f981d5470482b4afeab1a32e5cc82f1c5e88be190376d55b97f2f81f49R80)

**Repository and Sandbox Detection:**

- Enhanced repository root detection and opening logic to recognize sandbox working trees (which contain a `.atomic-sandbox` pointer instead of a `.atomic/` directory), enabling all repository operations to work transparently inside sandboxes. [[1]](diffhunk://#diff-20c162e1185710242f9838bee1a8985cd4ac31c015572d29f6c1013b08065d77R280-R286) [[2]](diffhunk://#diff-e6fb908e7852ab01ffc10ccdb8b3030ec546e76a3fcc56d8316e0114b20faf67R302-R304) [[3]](diffhunk://#diff-e6fb908e7852ab01ffc10ccdb8b3030ec546e76a3fcc56d8316e0114b20faf67R341-R343) [[4]](diffhunk://#diff-e6fb908e7852ab01ffc10ccdb8b3030ec546e76a3fcc56d8316e0114b20faf67R398-R400)
- Exposed new sandbox-related types and constants (`SealOptions`, `StageOptions`, etc.) from the repository crate for CLI integration.

**Copy-on-Write and OCI Image Support:**

- Added dependencies on `reflink-copy`, `tar`, `flate2`, and `sha2` crates to enable efficient copy-on-write cloning and OCI image packaging for sandboxes. [[1]](diffhunk://#diff-e03f07920e5743c1912cc07aa7ba2618301161c5bbf03ee2c20001ba85189bcdR28) [[2]](diffhunk://#diff-e03f07920e5743c1912cc07aa7ba2618301161c5bbf03ee2c20001ba85189bcdR37-R39)
- Introduced a new `oci` module in the repository crate to support OCI image layout production for sandbox staging and sealing.

**Documentation:**

- Updated `README.md` with a detailed explanation of the sandbox model, its benefits, usage examples, and integration with smolvm for fast, reproducible agent environments.

**Summary of most important changes:**

**1. Sandbox CLI and Workflow**
- Added `atomic sandbox` CLI command with `create`, `stage`, and `seal` subcommands for concurrent agent sandboxes. [[1]](diffhunk://#diff-0a224d62b428b93dec1c67b610644a035e6a0d6b98b667a2075b2e2994df80b8R1-R245) [[2]](diffhunk://#diff-e3bbe5f981d5470482b4afeab1a32e5cc82f1c5e88be190376d55b97f2f81f49R242-R255) [[3]](diffhunk://#diff-e3bbe5f981d5470482b4afeab1a32e5cc82f1c5e88be190376d55b97f2f81f49R736-R737)
- Updated CLI exports and command dispatch to include sandbox support. [[1]](diffhunk://#diff-20c162e1185710242f9838bee1a8985cd4ac31c015572d29f6c1013b08065d77R82) [[2]](diffhunk://#diff-20c162e1185710242f9838bee1a8985cd4ac31c015572d29f6c1013b08065d77R144) [[3]](diffhunk://#diff-e3bbe5f981d5470482b4afeab1a32e5cc82f1c5e88be190376d55b97f2f81f49R80)

**2. Repository and Sandbox Detection**
- Improved repository root-finding and opening to recognize sandbox working trees via `.atomic-sandbox` pointer, enabling transparent use inside sandboxes. [[1]](diffhunk://#diff-20c162e1185710242f9838bee1a8985cd4ac31c015572d29f6c1013b08065d77R280-R286) [[2]](diffhunk://#diff-e6fb908e7852ab01ffc10ccdb8b3030ec546e76a3fcc56d8316e0114b20faf67R302-R304) [[3]](diffhunk://#diff-e6fb908e7852ab01ffc10ccdb8b3030ec546e76a3fcc56d8316e0114b20faf67R341-R343) [[4]](diffhunk://#diff-e6fb908e7852ab01ffc10ccdb8b3030ec546e76a3fcc56d8316e0114b20faf67R398-R400)
- Exposed new sandbox-related types and constants for CLI integration.

**3. Copy-on-Write and OCI Image Support**
- Added dependencies and modules for copy-on-write cloning (`reflink-copy`) and OCI image packaging (`tar`, `flate2`, `sha2`). [[1]](diffhunk://#diff-e03f07920e5743c1912cc07aa7ba2618301161c5bbf03ee2c20001ba85189bcdR28) [[2]](diffhunk://#diff-e03f07920e5743c1912cc07aa7ba2618301161c5bbf03ee2c20001ba85189bcdR37-R39) [[3]](diffhunk://#diff-042732155406b6be60bd25790242aa498f6880d348cdbc5764868361dfc5d25fR122-R124)

**4. Documentation**
- Expanded `README.md` with a new section on concurrent agent sandboxes, usage, and design rationale.concurrent agent sandbox OCI docs and commands.