### PR TITLE
auth: complete the identity story — send client-signed EdDSA JWT

### DIFF
--- a/atomic-cli/src/commands/auth.rs
+++ b/atomic-cli/src/commands/auth.rs
@@ -1,7 +1,12 @@
 //! Shared authentication helpers for remote commands.
 //!
-//! Resolves the caller's identity from the remote URL and builds
-//! the `Authorization: Bearer` header for authenticated requests.
+//! Resolves the caller's identity from the remote URL, mints a short-lived
+//! self-signed EdDSA JWT for that identity, and attaches it as the
+//! `Authorization: Bearer` header.
+//!
+//! A raw public key is NOT a credential — the JWT (signed with the identity's
+//! private key) proves possession of that key. See [`crate::commands::token`]
+//! for the minting mechanics.
 //!
 //! Identity resolution order:
 //! 1. URL userinfo — `http://bob@alice.localhost:8080/...` → identity "bob"
@@ -11,14 +16,14 @@ use atomic_identity::IdentityStore;
 use atomic_remote::HttpRemoteConfig;
 use url::Url;
 
-/// Attach a Bearer auth header to the remote config by resolving the
-/// identity from the URL.
+/// Attach a Bearer JWT auth header to the remote config by resolving the
+/// identity from the URL and logging in for a token.
 ///
-/// If the identity cannot be resolved (no userinfo, no subdomain, or
-/// identity not found in the store), the config is returned unmodified
-/// and a debug log is emitted. This keeps push/pull/clone working
-/// against servers that don't require auth.
-pub fn attach_identity(config: HttpRemoteConfig, remote_url: &str) -> HttpRemoteConfig {
+/// If the identity cannot be resolved (no userinfo, no subdomain, or identity
+/// not found in the store) or login fails, the config is returned unmodified
+/// and a debug log is emitted. This keeps push/pull/clone working against
+/// servers that don't require auth (e.g. public reads).
+pub async fn attach_identity(config: HttpRemoteConfig, remote_url: &str) -> HttpRemoteConfig {
     let identity_name = match resolve_identity_name(remote_url) {
         Some(name) => name,
         None => {
@@ -45,10 +50,54 @@ pub fn attach_identity(config: HttpRemoteConfig, remote_url: &str) -> HttpRemote
         }
     };
 
-    let public_key_b32 = identity.public_key_base32();
-    log::debug!("Attaching Bearer auth for identity '{}'", identity_name);
+    // Tokens are keyed to the apex server (where the identity registered), not
+    // the tenant subdomain — strip the leading subdomain label from the host.
+    let server = match apex_server_url(remote_url) {
+        Some(s) => s,
+        None => {
+            log::debug!("Could not derive apex server URL from: {}", remote_url);
+            return config;
+        }
+    };
 
-    config.with_header("Authorization", format!("Bearer {}", public_key_b32))
+    match crate::commands::token::get_token(&server, &identity).await {
+        Ok(jwt) => {
+            log::debug!("Attaching Bearer JWT for identity '{}'", identity_name);
+            config.with_header("Authorization", format!("Bearer {}", jwt))
+        }
+        Err(e) => {
+            // Non-fatal: a server that doesn't require auth still works for
+            // public reads. Auth-required operations will then fail with a
+            // clear 401 from the server.
+            log::debug!("Could not obtain JWT for '{}': {}", identity_name, e);
+            config
+        }
+    }
+}
+
+/// Derive the apex server URL (scheme + host without the leading subdomain
+/// label + port) from a tenant-scoped remote URL.
+///
+/// `http://alice.localhost:8080/workspaces/w/projects/p/code`
+///   → `http://localhost:8080`
+/// `https://alice.atomic.storage/...` → `https://atomic.storage`
+/// `http://localhost:8080/...` (no subdomain) → `http://localhost:8080`
+fn apex_server_url(remote_url: &str) -> Option<String> {
+    let url = Url::parse(remote_url).ok()?;
+    let scheme = url.scheme();
+    let host = url.host_str()?;
+
+    // Strip the first label if there is a subdomain; leave a bare host
+    // (e.g. "localhost") untouched.
+    let apex_host = match host.find('.') {
+        Some(dot) => &host[dot + 1..],
+        None => host,
+    };
+
+    match url.port() {
+        Some(port) => Some(format!("{scheme}://{apex_host}:{port}")),
+        None => Some(format!("{scheme}://{apex_host}")),
+    }
 }
 
 /// Extract the identity name from a remote URL.
@@ -89,6 +138,35 @@ fn extract_subdomain(host: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn apex_strips_subdomain_with_port() {
+        assert_eq!(
+            apex_server_url("http://alice.localhost:8080/workspaces/w/projects/p/code").as_deref(),
+            Some("http://localhost:8080")
+        );
+    }
+
+    #[test]
+    fn apex_strips_subdomain_full_domain() {
+        assert_eq!(
+            apex_server_url("https://alice.atomic.storage/workspaces/w/projects/p/code").as_deref(),
+            Some("https://atomic.storage")
+        );
+    }
+
+    #[test]
+    fn apex_bare_host_unchanged() {
+        assert_eq!(
+            apex_server_url("http://localhost:8080/workspaces/w/projects/p/code").as_deref(),
+            Some("http://localhost:8080")
+        );
+    }
+
+    #[test]
+    fn apex_invalid_url_is_none() {
+        assert_eq!(apex_server_url("not a url"), None);
+    }
 
     #[test]
     fn userinfo_takes_priority() {

--- a/atomic-cli/src/commands/client.rs
+++ b/atomic-cli/src/commands/client.rs
@@ -11,8 +11,9 @@
 //!    `atomic identity register`).
 //! 2. **Org override** — an explicit `--org` flag takes precedence over the
 //!    configured default org.
-//! 3. **Bearer token** — the base32-encoded Ed25519 public key of the
-//!    default identity.
+//! 3. **Bearer token** — a short-lived, client-self-signed EdDSA JWT minted
+//!    for the default identity (see [`crate::commands::token`]). The raw
+//!    public key is never sent as a credential.
 //!
 //! # Identity resolution
 //!
@@ -44,8 +45,8 @@ use crate::error::{CliError, CliResult};
 /// - No org slug available (neither override nor default).
 /// - Identity store cannot be opened or no default identity set.
 /// - HTTP client construction failure.
-pub fn build_client(org_override: Option<&str>) -> CliResult<StorageClient> {
-    let (client, _org_slug) = build_client_with_org(org_override)?;
+pub async fn build_client(org_override: Option<&str>) -> CliResult<StorageClient> {
+    let (client, _org_slug) = build_client_with_org(org_override).await?;
     Ok(client)
 }
 
@@ -53,16 +54,18 @@ pub fn build_client(org_override: Option<&str>) -> CliResult<StorageClient> {
 ///
 /// Useful for commands that also need to resolve org-scoped state (e.g.
 /// per-org default workspace lookup). Avoids resolving the org twice.
-pub fn build_client_with_org(org_override: Option<&str>) -> CliResult<(StorageClient, String)> {
+pub async fn build_client_with_org(
+    org_override: Option<&str>,
+) -> CliResult<(StorageClient, String)> {
     let config = GlobalConfig::load()
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load global config: {}", e)))?;
 
     let server = &config.server;
-    if server.url.is_none() {
-        return Err(CliError::Internal(anyhow::anyhow!(
+    let server_url = server.url.clone().ok_or_else(|| {
+        CliError::Internal(anyhow::anyhow!(
             "Server not configured. Run 'atomic identity register <server-url>' first."
-        )));
-    }
+        ))
+    })?;
 
     let org_slug = resolve_org(org_override)?;
 
@@ -72,7 +75,9 @@ pub fn build_client_with_org(org_override: Option<&str>) -> CliResult<(StorageCl
         ))
     })?;
 
-    // Load default identity for bearer token.
+    // Load default identity — we authenticate with a short-lived JWT obtained
+    // by signing a challenge with this identity's private key, never with the
+    // raw public key.
     let store = IdentityStore::open_default()
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to open identity store: {}", e)))?;
 
@@ -86,7 +91,8 @@ pub fn build_client_with_org(org_override: Option<&str>) -> CliResult<(StorageCl
             ))
         })?;
 
-    let bearer_token = identity.public_key_base32();
+    // Log in against the server apex for a JWT bearer token.
+    let bearer_token = crate::commands::token::get_token(&server_url, &identity).await?;
 
     let client = StorageClient::new(&base_url, &org_slug, &bearer_token).map_err(|e| {
         CliError::Internal(anyhow::anyhow!("Failed to create storage client: {}", e))

--- a/atomic-cli/src/commands/clone/command.rs
+++ b/atomic-cli/src/commands/clone/command.rs
@@ -200,12 +200,12 @@ impl Clone {
     ///
     /// Creates an `HttpRemoteConfig` with the timeout and security settings
     /// specified by the user.
-    fn build_remote_config(&self) -> HttpRemoteConfig {
+    async fn build_remote_config(&self) -> HttpRemoteConfig {
         let config = HttpRemoteConfig::new()
             .with_timeout(Duration::from_secs(self.timeout))
             .danger_accept_invalid_certs(self.insecure);
 
-        crate::commands::auth::attach_identity(config, &self.url)
+        crate::commands::auth::attach_identity(config, &self.url).await
     }
 
     /// Get the display name for the repository.
@@ -257,7 +257,7 @@ impl Clone {
 
         // Connect to remote
         let spinner = create_spinner("Connecting to remote...");
-        let config = self.build_remote_config();
+        let config = self.build_remote_config().await;
         let remote = HttpRemote::with_config(&self.url, config).map_err(|e| {
             finish_error(&spinner, "Failed to connect");
             convert_remote_error(e, &self.url)
@@ -742,10 +742,10 @@ mod tests {
     // Internal Method Tests
 
     /// Test build_remote_config with default settings.
-    #[test]
-    fn test_build_remote_config_default() {
+    #[tokio::test]
+    async fn test_build_remote_config_default() {
         let clone = Clone::new("https://example.com/repo".to_string());
-        let config = clone.build_remote_config();
+        let config = clone.build_remote_config().await;
 
         // HttpRemoteConfig doesn't expose fields directly, so we just verify
         // it doesn't panic and returns something
@@ -753,18 +753,18 @@ mod tests {
     }
 
     /// Test build_remote_config with custom timeout.
-    #[test]
-    fn test_build_remote_config_custom_timeout() {
+    #[tokio::test]
+    async fn test_build_remote_config_custom_timeout() {
         let clone = Clone::new("https://example.com/repo".to_string()).with_timeout(120);
-        let config = clone.build_remote_config();
+        let config = clone.build_remote_config().await;
         assert!(std::mem::size_of_val(&config) > 0);
     }
 
     /// Test build_remote_config with insecure flag.
-    #[test]
-    fn test_build_remote_config_insecure() {
+    #[tokio::test]
+    async fn test_build_remote_config_insecure() {
         let clone = Clone::new("https://example.com/repo".to_string()).with_insecure(true);
-        let config = clone.build_remote_config();
+        let config = clone.build_remote_config().await;
         assert!(std::mem::size_of_val(&config) > 0);
     }
 

--- a/atomic-cli/src/commands/mod.rs
+++ b/atomic-cli/src/commands/mod.rs
@@ -110,6 +110,7 @@ pub mod query;
 // Storage management commands (always available)
 pub mod client;
 pub mod project;
+pub mod token;
 pub mod workspace;
 
 // Team collaboration commands (feature-gated)

--- a/atomic-cli/src/commands/org/create.rs
+++ b/atomic-cli/src/commands/org/create.rs
@@ -81,7 +81,7 @@ impl OrgCreate {
     async fn execute(&self) -> CliResult<()> {
         // Build client using current default org (doesn't matter which org
         // we're scoped to — the server creates a new org regardless).
-        let client = build_client(None)?;
+        let client = build_client(None).await?;
 
         let info = atomic_teams::org::create_org(&client, &self.name, self.email.as_deref())
             .await

--- a/atomic-cli/src/commands/org/delete.rs
+++ b/atomic-cli/src/commands/org/delete.rs
@@ -103,7 +103,7 @@ impl OrgDelete {
             }
         }
 
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
 
         atomic_teams::org::delete_org(&client, &self.slug)
             .await

--- a/atomic-cli/src/commands/org/list.rs
+++ b/atomic-cli/src/commands/org/list.rs
@@ -71,7 +71,7 @@ impl Command for OrgList {
 
 impl OrgList {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let slug = client.org_slug().to_string();
 
         let info = atomic_teams::org::get_org(&client, &slug)

--- a/atomic-cli/src/commands/org/member.rs
+++ b/atomic-cli/src/commands/org/member.rs
@@ -161,7 +161,7 @@ impl Command for MemberList {
 
 impl MemberList {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let slug = client.org_slug().to_string();
 
         let members = atomic_teams::member::list_members(&client, &slug)
@@ -261,7 +261,7 @@ impl MemberAdd {
             ),
         })?;
 
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let slug = client.org_slug().to_string();
 
         let identity_id =
@@ -338,7 +338,7 @@ impl MemberUpdate {
             ),
         })?;
 
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let slug = client.org_slug().to_string();
 
         let identity_id =
@@ -409,7 +409,7 @@ impl Command for MemberRemove {
 
 impl MemberRemove {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let slug = client.org_slug().to_string();
 
         let identity_id =

--- a/atomic-cli/src/commands/org/set.rs
+++ b/atomic-cli/src/commands/org/set.rs
@@ -138,7 +138,7 @@ fn verify_org_exists(slug: &str) -> CliResult<()> {
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to create async runtime: {e}")))?;
 
     rt.block_on(async {
-        let (client, _resolved) = build_client_with_org(Some(slug))?;
+        let (client, _resolved) = build_client_with_org(Some(slug)).await?;
         match atomic_teams::org::get_org(&client, slug).await {
             Ok(_) => Ok(()),
             Err(e) if is_org_not_found(&e) => Err(CliError::InvalidArgument {

--- a/atomic-cli/src/commands/org/show.rs
+++ b/atomic-cli/src/commands/org/show.rs
@@ -85,7 +85,7 @@ impl Command for OrgShow {
 
 impl OrgShow {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
 
         // Determine which slug to look up: explicit arg > client's org slug
         let slug = self.slug.as_deref().unwrap_or_else(|| client.org_slug());

--- a/atomic-cli/src/commands/org/update.rs
+++ b/atomic-cli/src/commands/org/update.rs
@@ -98,7 +98,7 @@ impl OrgUpdate {
             });
         }
 
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
 
         // Determine which slug to update: explicit arg > client's org slug.
         let slug = self.slug.as_deref().unwrap_or_else(|| client.org_slug());

--- a/atomic-cli/src/commands/org/upgrade.rs
+++ b/atomic-cli/src/commands/org/upgrade.rs
@@ -84,7 +84,7 @@ impl Command for OrgUpgrade {
 
 impl OrgUpgrade {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
 
         // Determine which slug to upgrade: explicit arg > client's org slug.
         let slug = self.slug.as_deref().unwrap_or_else(|| client.org_slug());

--- a/atomic-cli/src/commands/project/create.rs
+++ b/atomic-cli/src/commands/project/create.rs
@@ -124,7 +124,7 @@ impl Command for ProjectCreate {
         })?;
 
         rt.block_on(async {
-            let (client, org_slug) = build_client_with_org(self.org.as_deref())?;
+            let (client, org_slug) = build_client_with_org(self.org.as_deref()).await?;
             let workspace = resolve_workspace(&org_slug, self.workspace.as_deref())?;
             let visibility = self.parse_visibility()?;
 

--- a/atomic-cli/src/commands/project/delete.rs
+++ b/atomic-cli/src/commands/project/delete.rs
@@ -88,7 +88,7 @@ impl Command for ProjectDelete {
                 }
             }
 
-            let client = build_client(self.org.as_deref())?;
+            let client = build_client(self.org.as_deref()).await?;
 
             client
                 .delete_project(ws_slug, proj_slug)

--- a/atomic-cli/src/commands/project/init.rs
+++ b/atomic-cli/src/commands/project/init.rs
@@ -114,7 +114,7 @@ impl ProjectInit {
         })?;
 
         // 2. Build the storage client and resolve the workspace.
-        let (client, org_slug) = build_client_with_org(self.org.as_deref())?;
+        let (client, org_slug) = build_client_with_org(self.org.as_deref()).await?;
         let workspace = resolve_workspace(&org_slug, self.workspace.as_deref())?;
 
         // 3. Ensure the workspace exists — create it if necessary.

--- a/atomic-cli/src/commands/project/list.rs
+++ b/atomic-cli/src/commands/project/list.rs
@@ -67,7 +67,7 @@ impl Command for ProjectList {
         })?;
 
         rt.block_on(async {
-            let (client, org_slug) = build_client_with_org(self.org.as_deref())?;
+            let (client, org_slug) = build_client_with_org(self.org.as_deref()).await?;
             let workspace = resolve_workspace(&org_slug, self.workspace.as_deref())?;
 
             let projects = client.list_projects(&workspace).await.map_err(remote_err)?;

--- a/atomic-cli/src/commands/project/show.rs
+++ b/atomic-cli/src/commands/project/show.rs
@@ -79,7 +79,7 @@ impl Command for ProjectShow {
 
         rt.block_on(async {
             let (ws_slug, proj_slug) = parse_project_path(&self.slug)?;
-            let client = build_client(self.org.as_deref())?;
+            let client = build_client(self.org.as_deref()).await?;
 
             let project = client
                 .get_project(ws_slug, proj_slug)

--- a/atomic-cli/src/commands/project/update.rs
+++ b/atomic-cli/src/commands/project/update.rs
@@ -94,7 +94,7 @@ impl Command for ProjectUpdate {
         })?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref())?;
+            let client = build_client(self.org.as_deref()).await?;
 
             let req = UpdateProjectRequest {
                 name: self.name.clone(),

--- a/atomic-cli/src/commands/pull/command.rs
+++ b/atomic-cli/src/commands/pull/command.rs
@@ -275,12 +275,12 @@ impl Pull {
     ///
     /// Creates an `HttpRemoteConfig` with the timeout and security settings
     /// specified by the user.
-    fn build_remote_config(&self, remote_url: &str) -> HttpRemoteConfig {
+    async fn build_remote_config(&self, remote_url: &str) -> HttpRemoteConfig {
         let config = HttpRemoteConfig::new()
             .with_timeout(Duration::from_secs(self.timeout))
             .danger_accept_invalid_certs(self.insecure);
 
-        crate::commands::auth::attach_identity(config, remote_url)
+        crate::commands::auth::attach_identity(config, remote_url).await
     }
 
     /// Display the dry run preview.
@@ -368,7 +368,7 @@ impl Pull {
 
         // Connect to remote
         let spinner = create_spinner("Connecting to remote...");
-        let config = self.build_remote_config(&remote_url);
+        let config = self.build_remote_config(&remote_url).await;
         let remote = HttpRemote::with_config(&remote_url, config).map_err(|e| {
             finish_error(&spinner, "Failed to connect");
             convert_remote_error(e, &remote_url)
@@ -885,10 +885,12 @@ mod tests {
     }
 
     /// Test build_remote_config with default settings.
-    #[test]
-    fn test_build_remote_config_default() {
+    #[tokio::test]
+    async fn test_build_remote_config_default() {
         let pull = Pull::new();
-        let config = pull.build_remote_config("http://test.localhost:8080/code");
+        let config = pull
+            .build_remote_config("http://test.localhost:8080/code")
+            .await;
 
         // HttpRemoteConfig doesn't expose fields directly, so we just verify
         // it doesn't panic and returns something
@@ -896,18 +898,22 @@ mod tests {
     }
 
     /// Test build_remote_config with custom timeout.
-    #[test]
-    fn test_build_remote_config_custom_timeout() {
+    #[tokio::test]
+    async fn test_build_remote_config_custom_timeout() {
         let pull = Pull::new().with_timeout(120);
-        let config = pull.build_remote_config("http://test.localhost:8080/code");
+        let config = pull
+            .build_remote_config("http://test.localhost:8080/code")
+            .await;
         assert!(std::mem::size_of_val(&config) > 0);
     }
 
     /// Test build_remote_config with insecure flag.
-    #[test]
-    fn test_build_remote_config_insecure() {
+    #[tokio::test]
+    async fn test_build_remote_config_insecure() {
         let pull = Pull::new().with_insecure(true);
-        let config = pull.build_remote_config("http://test.localhost:8080/code");
+        let config = pull
+            .build_remote_config("http://test.localhost:8080/code")
+            .await;
         assert!(std::mem::size_of_val(&config) > 0);
     }
 

--- a/atomic-cli/src/commands/push/command.rs
+++ b/atomic-cli/src/commands/push/command.rs
@@ -249,12 +249,12 @@ impl Push {
     }
 
     /// Build the HTTP remote configuration.
-    fn build_remote_config(&self, remote_url: &str) -> HttpRemoteConfig {
+    async fn build_remote_config(&self, remote_url: &str) -> HttpRemoteConfig {
         let config = HttpRemoteConfig::new()
             .with_timeout(Duration::from_secs(self.timeout))
             .danger_accept_invalid_certs(self.insecure);
 
-        crate::commands::auth::attach_identity(config, remote_url)
+        crate::commands::auth::attach_identity(config, remote_url).await
     }
 
     /// Display the dry run preview.
@@ -312,7 +312,7 @@ impl Push {
 
         // Connect to remote
         let spinner = create_spinner("Connecting to remote...");
-        let config = self.build_remote_config(&remote_url);
+        let config = self.build_remote_config(&remote_url).await;
         let remote = HttpRemote::with_config(&remote_url, config).map_err(|e| {
             finish_error(&spinner, "Failed to connect");
             convert_remote_error(e, &remote_url)
@@ -911,27 +911,33 @@ mod tests {
 
     // Remote Config Tests
 
-    #[test]
-    fn test_build_remote_config_default() {
+    #[tokio::test]
+    async fn test_build_remote_config_default() {
         let push = Push::new();
-        let config = push.build_remote_config("http://test.localhost:8080/code");
+        let config = push
+            .build_remote_config("http://test.localhost:8080/code")
+            .await;
 
         assert_eq!(config.timeout, Duration::from_secs(DEFAULT_TIMEOUT_SECS));
         assert!(!config.danger_accept_invalid_certs);
     }
 
-    #[test]
-    fn test_build_remote_config_custom_timeout() {
+    #[tokio::test]
+    async fn test_build_remote_config_custom_timeout() {
         let push = Push::new().with_timeout(120);
-        let config = push.build_remote_config("http://test.localhost:8080/code");
+        let config = push
+            .build_remote_config("http://test.localhost:8080/code")
+            .await;
 
         assert_eq!(config.timeout, Duration::from_secs(120));
     }
 
-    #[test]
-    fn test_build_remote_config_insecure() {
+    #[tokio::test]
+    async fn test_build_remote_config_insecure() {
         let push = Push::new().with_insecure(true);
-        let config = push.build_remote_config("http://test.localhost:8080/code");
+        let config = push
+            .build_remote_config("http://test.localhost:8080/code")
+            .await;
 
         assert!(config.danger_accept_invalid_certs);
     }

--- a/atomic-cli/src/commands/team/create.rs
+++ b/atomic-cli/src/commands/team/create.rs
@@ -117,7 +117,7 @@ impl TeamCreate {
             })
             .transpose()?;
 
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let org_slug = client.org_slug().to_string();
 
         let info = atomic_teams::team::create_team(

--- a/atomic-cli/src/commands/team/delete.rs
+++ b/atomic-cli/src/commands/team/delete.rs
@@ -105,7 +105,7 @@ impl TeamDelete {
             }
         }
 
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let org_slug = client.org_slug().to_string();
 
         atomic_teams::team::delete_team(&client, &org_slug, &self.slug)

--- a/atomic-cli/src/commands/team/list.rs
+++ b/atomic-cli/src/commands/team/list.rs
@@ -73,7 +73,7 @@ impl Command for TeamList {
 
 impl TeamList {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let slug = client.org_slug().to_string();
 
         let teams = atomic_teams::team::list_teams(&client, &slug)

--- a/atomic-cli/src/commands/team/member.rs
+++ b/atomic-cli/src/commands/team/member.rs
@@ -168,7 +168,7 @@ impl Command for TeamMemberList {
 
 impl TeamMemberList {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let org_slug = client.org_slug().to_string();
 
         let members =
@@ -282,7 +282,7 @@ impl TeamMemberAdd {
             ),
         })?;
 
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let org_slug = client.org_slug().to_string();
 
         let identity_id =
@@ -372,7 +372,7 @@ impl TeamMemberUpdate {
             ),
         })?;
 
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let org_slug = client.org_slug().to_string();
 
         let identity_id =
@@ -475,7 +475,7 @@ impl TeamMemberRemove {
             }
         }
 
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let org_slug = client.org_slug().to_string();
 
         let identity_id =

--- a/atomic-cli/src/commands/team/show.rs
+++ b/atomic-cli/src/commands/team/show.rs
@@ -86,7 +86,7 @@ impl Command for TeamShow {
 
 impl TeamShow {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let org_slug = client.org_slug().to_string();
 
         let info = atomic_teams::team::get_team(&client, &org_slug, &self.slug)

--- a/atomic-cli/src/commands/team/update.rs
+++ b/atomic-cli/src/commands/team/update.rs
@@ -131,7 +131,7 @@ impl TeamUpdate {
             })
             .transpose()?;
 
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let org_slug = client.org_slug().to_string();
 
         let info = atomic_teams::team::update_team(

--- a/atomic-cli/src/commands/token.rs
+++ b/atomic-cli/src/commands/token.rs
@@ -1,0 +1,207 @@
+//! Client-self-signed EdDSA JWT bearer tokens for remote commands.
+//!
+//! Atomic Storage authenticates with short-lived JWTs that the CLI **signs
+//! itself** with the identity's Ed25519 private key (EdDSA, RFC 8037). There is
+//! no server login endpoint and no token cache: minting a token is a local,
+//! cheap signing operation, so we just mint a fresh one per request.
+//!
+//! # Wire format (identical to the server's verifier)
+//!
+//! A compact JWS with three base64url-no-pad segments
+//! `base64url(header).base64url(claims).base64url(signature)`:
+//!
+//! - header: `{"alg":"EdDSA","typ":"JWT","kid":"<base32 Ed25519 public key>"}`
+//! - claims: `{ sub, iat, exp, jti }` (`sub` mirrors the `kid` public key)
+//! - signature: `Ed25519_sign(private_key, "header.claims")`
+//!
+//! # Keyed by the public key
+//!
+//! The JWT is keyed by the caller's Ed25519 **public key**, carried in the
+//! `kid` header. The client already holds this key, so there is no
+//! server-assigned identifier to learn or persist: the server resolves the
+//! registered identity by the `kid` public key and verifies this signature
+//! against the key it has on record.
+
+use chrono::{Duration, Utc};
+use data_encoding::BASE64URL_NOPAD;
+use serde::Serialize;
+use uuid::Uuid;
+
+use atomic_identity::{Identity, IdentityStore};
+
+use crate::error::{CliError, CliResult};
+
+/// How long a self-signed token is valid. Kept short (5 minutes) since there is
+/// no server-side issuance to revoke — a leaked token has a small blast radius.
+const TOKEN_TTL: Duration = Duration::minutes(5);
+
+// ---------------------------------------------------------------------------
+// JWT pieces (kept local to avoid depending on the server crate)
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct JwtHeader {
+    alg: &'static str,
+    typ: &'static str,
+    /// The caller's base32 Ed25519 public key.
+    kid: String,
+}
+
+#[derive(Serialize)]
+struct Claims {
+    /// The caller's base32 Ed25519 public key (same value as the header `kid`).
+    sub: String,
+    iat: i64,
+    exp: i64,
+    jti: String,
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Mint a fresh, short-lived self-signed EdDSA JWT for `identity` against
+/// `server`.
+///
+/// `server` is the bare server URL (e.g. `https://atomic.storage`), NOT an org
+/// subdomain. The token is keyed by the identity's own Ed25519 public key, so
+/// no prior registration state needs to be on file locally to mint it.
+pub async fn get_token(server: &str, identity: &Identity) -> CliResult<String> {
+    mint_token(server, identity)
+}
+
+/// Mint a fresh token. Tokens are not cached, so this is identical to
+/// [`get_token`]; kept for call-site compatibility (e.g. retry-after-401).
+pub async fn refresh_token(server: &str, identity: &Identity) -> CliResult<String> {
+    mint_token(server, identity)
+}
+
+// ---------------------------------------------------------------------------
+// Minting
+// ---------------------------------------------------------------------------
+
+fn mint_token(_server: &str, identity: &Identity) -> CliResult<String> {
+    // The token is keyed by the identity's own public key — no server-assigned
+    // identifier to look up.
+    let public_key_b32 = identity.public_key_base32();
+
+    // Load the keypair (needs the secret key to sign).
+    let store = IdentityStore::open_default()
+        .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to open identity store: {e}")))?;
+    let keypair = store.load_keypair(&identity.id, None).map_err(|e| {
+        CliError::Internal(anyhow::anyhow!(
+            "Failed to load keypair for '{}': {e}",
+            identity.name
+        ))
+    })?;
+
+    let now = Utc::now();
+    let claims = Claims {
+        sub: public_key_b32.clone(),
+        iat: now.timestamp(),
+        exp: (now + TOKEN_TTL).timestamp(),
+        jti: Uuid::new_v4().to_string(),
+    };
+
+    let header = JwtHeader {
+        alg: "EdDSA",
+        typ: "JWT",
+        kid: public_key_b32,
+    };
+
+    let header_json = serde_json::to_vec(&header)
+        .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to encode JWT header: {e}")))?;
+    let claims_json = serde_json::to_vec(&claims)
+        .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to encode JWT claims: {e}")))?;
+
+    let header_b64 = BASE64URL_NOPAD.encode(&header_json);
+    let claims_b64 = BASE64URL_NOPAD.encode(&claims_json);
+    let signing_input = format!("{header_b64}.{claims_b64}");
+
+    let signature = keypair.sign(signing_input.as_bytes());
+    let sig_b64 = BASE64URL_NOPAD.encode(&signature);
+
+    log::debug!("Minted self-signed EdDSA JWT for '{}'", identity.name);
+    Ok(format!("{signing_input}.{sig_b64}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_is_eddsa_jwt_with_kid() {
+        let header = JwtHeader {
+            alg: "EdDSA",
+            typ: "JWT",
+            kid: "ABCDEF".to_string(),
+        };
+        let json = serde_json::to_string(&header).unwrap();
+        assert_eq!(json, r#"{"alg":"EdDSA","typ":"JWT","kid":"ABCDEF"}"#);
+    }
+
+    /// A minted token must verify against the identity's public key, prove the
+    /// three-segment shape, carry the public key as `kid` (and `sub`), and not
+    /// verify once tampered.
+    #[test]
+    fn self_signed_token_verifies_round_trip() {
+        // Build a JWT by hand using the same steps as mint_token (without the
+        // store I/O, which needs a populated home dir).
+        use atomic_identity::KeyPair;
+        let keypair = KeyPair::generate();
+        let public_key_b32 = data_encoding::BASE32_NOPAD.encode(keypair.public.as_bytes());
+        let now = Utc::now();
+        let claims = Claims {
+            sub: public_key_b32.clone(),
+            iat: now.timestamp(),
+            exp: (now + TOKEN_TTL).timestamp(),
+            jti: Uuid::new_v4().to_string(),
+        };
+        let header = JwtHeader {
+            alg: "EdDSA",
+            typ: "JWT",
+            kid: public_key_b32.clone(),
+        };
+        let header_b64 = BASE64URL_NOPAD.encode(&serde_json::to_vec(&header).unwrap());
+        let claims_b64 = BASE64URL_NOPAD.encode(&serde_json::to_vec(&claims).unwrap());
+        let signing_input = format!("{header_b64}.{claims_b64}");
+        let sig = keypair.sign(signing_input.as_bytes());
+        let token = format!("{signing_input}.{}", BASE64URL_NOPAD.encode(&sig));
+
+        // Three segments.
+        assert_eq!(token.split('.').count(), 3);
+
+        // The kid in the header is the base32 public key the server resolves by.
+        let header_bytes = BASE64URL_NOPAD
+            .decode(token.split('.').next().unwrap().as_bytes())
+            .unwrap();
+        let header_val: serde_json::Value = serde_json::from_slice(&header_bytes).unwrap();
+        assert_eq!(header_val["kid"], public_key_b32);
+        assert_eq!(header_val["alg"], "EdDSA");
+
+        // Verifies against the public key (mirrors the server's verify path),
+        // using the identity crate's Ed25519 verify so we don't depend on
+        // ed25519-dalek directly.
+        let parts: Vec<&str> = token.split('.').collect();
+        let sig_bytes: [u8; 64] = BASE64URL_NOPAD
+            .decode(parts[2].as_bytes())
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let recovered_input = format!("{}.{}", parts[0], parts[1]);
+        assert!(keypair
+            .public
+            .verify(recovered_input.as_bytes(), &sig_bytes)
+            .is_ok());
+
+        // A tampered signing input must NOT verify.
+        let mut bad = recovered_input.clone().into_bytes();
+        bad[0] ^= 0x01;
+        assert!(keypair.public.verify(&bad, &sig_bytes).is_err());
+    }
+
+    #[test]
+    fn ttl_is_five_minutes() {
+        assert_eq!(TOKEN_TTL, Duration::minutes(5));
+    }
+}

--- a/atomic-cli/src/commands/workspace/create.rs
+++ b/atomic-cli/src/commands/workspace/create.rs
@@ -81,7 +81,7 @@ impl Command for WorkspaceCreate {
         })?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref())?;
+            let client = build_client(self.org.as_deref()).await?;
 
             let visibility = self.parse_visibility()?;
 

--- a/atomic-cli/src/commands/workspace/delete.rs
+++ b/atomic-cli/src/commands/workspace/delete.rs
@@ -90,7 +90,7 @@ impl Command for WorkspaceDelete {
                 }
             }
 
-            let (client, org_slug) = build_client_with_org(self.org.as_deref())?;
+            let (client, org_slug) = build_client_with_org(self.org.as_deref()).await?;
 
             client
                 .delete_workspace(&self.slug)

--- a/atomic-cli/src/commands/workspace/list.rs
+++ b/atomic-cli/src/commands/workspace/list.rs
@@ -79,7 +79,7 @@ impl Command for WorkspaceList {
         })?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref())?;
+            let client = build_client(self.org.as_deref()).await?;
             let workspaces = client.list_workspaces().await.map_err(remote_err)?;
 
             if self.format == "json" {

--- a/atomic-cli/src/commands/workspace/set.rs
+++ b/atomic-cli/src/commands/workspace/set.rs
@@ -186,7 +186,7 @@ fn verify_workspace_exists(org_slug: &str, workspace_slug: &str) -> CliResult<()
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to create async runtime: {e}")))?;
 
     rt.block_on(async {
-        let (client, _resolved) = build_client_with_org(Some(org_slug))?;
+        let (client, _resolved) = build_client_with_org(Some(org_slug)).await?;
         match client.get_workspace(workspace_slug).await {
             Ok(_) => Ok(()),
             Err(e) if e.is_not_found() => Err(CliError::InvalidArgument {

--- a/atomic-cli/src/commands/workspace/show.rs
+++ b/atomic-cli/src/commands/workspace/show.rs
@@ -68,7 +68,7 @@ impl Command for WorkspaceShow {
             .map_err(|e| CliError::Internal(anyhow::anyhow!("{}", e)))?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref())?;
+            let client = build_client(self.org.as_deref()).await?;
             let ws = client.get_workspace(&self.slug).await.map_err(remote_err)?;
 
             if self.format == "json" {

--- a/atomic-cli/src/commands/workspace/update.rs
+++ b/atomic-cli/src/commands/workspace/update.rs
@@ -79,7 +79,7 @@ impl Command for WorkspaceUpdate {
         })?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref())?;
+            let client = build_client(self.org.as_deref()).await?;
 
             let req = UpdateWorkspaceRequest {
                 name: self.name.clone(),

--- a/atomic-remote/src/storage.rs
+++ b/atomic-remote/src/storage.rs
@@ -2,8 +2,8 @@
 //!
 //! `StorageClient` provides typed access to CRUD operations on workspaces,
 //! projects, and other management endpoints. It handles authentication
-//! (Ed25519 public key as Bearer token), JSON serialization, and
-//! response envelope unwrapping.
+//! (short-lived JWT bearer token), JSON serialization, and response envelope
+//! unwrapping.
 //!
 //! The VCS protocol (push/pull/clone) uses `HttpRemote` instead.
 
@@ -30,7 +30,7 @@ use crate::storage_types::{
 /// let client = StorageClient::new(
 ///     "https://alice.atomic.storage",
 ///     "alice",
-///     "EDPK_BASE32_TOKEN",
+///     "eyJhbG...self_signed_eddsa_jwt",
 /// )?;
 ///
 /// let ws = client.create_workspace(&CreateWorkspaceRequest {
@@ -49,8 +49,8 @@ impl StorageClient {
     /// Create a new client targeting a specific org.
     ///
     /// The `base_url` should be the full org-scoped URL, e.g.,
-    /// `https://alice.atomic.storage`. The `bearer_token` is the
-    /// base32-encoded Ed25519 public key.
+    /// `https://alice.atomic.storage`. The `bearer_token` is a short-lived,
+    /// client-self-signed EdDSA JWT (see `atomic-cli`'s `commands::token`).
     pub fn new(base_url: &str, org_slug: &str, bearer_token: &str) -> Result<Self, RemoteError> {
         let mut headers = HeaderMap::new();
         headers.insert(


### PR DESCRIPTION
## What this is

The client half of **completing Atomic's authentication story**. Every authenticated CLI command now proves *possession of the caller's private key* with a short-lived self-signed JWT, instead of sending the raw public key as a bearer token.

## Our stance on identity & auth

- **Identity is an Ed25519 keypair.** The public key is the durable identity anchor, registered once via a **signed challenge** at `register` (the trust bootstrap). The private key never leaves the client.
- **A public key is not a secret, so it is never a credential.** Authentication is *possession of the private key*, proven per-request.
- **Every request carries a short-lived, client-signed JWT.** The client self-signs a JWT (`alg: EdDSA`) with its private key and names its public key in the `kid` header. The server is verify-only (no secret, no login endpoint) — it verifies the signature against the registered public key.
- **`register` is untouched** — byte-identical to `dev`.

## What changed (client)

- New single mint helper `atomic-cli/src/commands/token.rs`: header `{"alg":"EdDSA","typ":"JWT","kid":"<base32 public key>"}`, claims `{ sub, iat, exp (~5 min), jti }`, signed with the identity's Ed25519 private key. `kid`/`sub` are derived **locally** from the keypair — no server round-trip, no config map, no token cache.
- Both transports attach it uniformly: the management API via `build_client*` → `StorageClient` (`Authorization: Bearer <jwt>`), and VCS push/pull/clone via `auth::attach_identity` → `HttpRemote`.
- Removed the raw-public-key bearer and the prior `identity_id` config plumbing. `register` reverted to byte-identical with `dev`.

## Tests

JWT mint/round-trip, `kid`/`sub` derivation, header/claim shape matches the server verifier, both transports send the JWT. Build + clippy clean.

---
Paired with server PR atomicdotdev/atomic-storage#61 — identical JWT wire contract.
