### PR TITLE
fix(git): ignore Atomic state during import

### DIFF
--- a/atomic-cli/src/commands/git/import.rs
+++ b/atomic-cli/src/commands/git/import.rs
@@ -29,6 +29,7 @@
 //!   it for token-level blame and word-diff.
 
 use std::collections::HashSet;
+use std::io::ErrorKind;
 use std::path::Path;
 
 use clap::Parser;
@@ -155,6 +156,45 @@ fn current_git_branch(git_repo: &GitRepository) -> Option<String> {
         return None;
     }
     head.shorthand().map(ToOwned::to_owned)
+}
+
+const GIT_SHADOW_EXCLUDE_PATTERNS: &[&str] = &["/.atomic/", "/.vault/", "/.atomicignore"];
+
+fn ensure_git_shadow_excludes(git_dir: &Path) -> CliResult<bool> {
+    let info_dir = git_dir.join("info");
+    std::fs::create_dir_all(&info_dir)?;
+
+    let exclude_path = info_dir.join("exclude");
+    let mut content = match std::fs::read_to_string(&exclude_path) {
+        Ok(content) => content,
+        Err(e) if e.kind() == ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(e.into()),
+    };
+
+    let missing: Vec<&str> = GIT_SHADOW_EXCLUDE_PATTERNS
+        .iter()
+        .copied()
+        .filter(|pattern| !content.lines().any(|line| line.trim() == *pattern))
+        .collect();
+
+    if missing.is_empty() {
+        return Ok(false);
+    }
+
+    if !content.is_empty() && !content.ends_with('\n') {
+        content.push('\n');
+    }
+    if !content.is_empty() {
+        content.push('\n');
+    }
+    content.push_str("# Atomic local state (managed by atomic git import)\n");
+    for pattern in missing {
+        content.push_str(pattern);
+        content.push('\n');
+    }
+
+    std::fs::write(exclude_path, content)?;
+    Ok(true)
 }
 
 impl Import {
@@ -375,6 +415,10 @@ impl Command for Import {
             }
 
             return Ok(());
+        }
+
+        if ensure_git_shadow_excludes(git_repo.path())? {
+            print_info("Configured Git to ignore Atomic local state.");
         }
 
         // Check if Atomic repository exists in THIS directory (not parent dirs).
@@ -714,5 +758,20 @@ mod tests {
         assert!(patterns.iter().any(|p| p == "node_modules/"));
         assert!(patterns.iter().any(|p| p == ".yarn/cache/"));
         assert!(patterns.iter().any(|p| p == "vendor/"));
+    }
+
+    #[test]
+    fn test_git_shadow_excludes_are_added_to_git_info_exclude() {
+        let temp = tempfile::tempdir().unwrap();
+        let git_dir = temp.path().join(".git");
+
+        assert!(ensure_git_shadow_excludes(&git_dir).unwrap());
+
+        let exclude = std::fs::read_to_string(git_dir.join("info").join("exclude")).unwrap();
+        assert!(exclude.contains("/.atomic/"));
+        assert!(exclude.contains("/.vault/"));
+        assert!(exclude.contains("/.atomicignore"));
+
+        assert!(!ensure_git_shadow_excludes(&git_dir).unwrap());
     }
 }

--- a/tests/harness/10_git_import.sh
+++ b/tests/harness/10_git_import.sh
@@ -88,6 +88,13 @@ echo "  Found $expected_commits first-parent commits on branch '$default_branch'
 # Initialize atomic and import
 assert_success "atomic git import succeeds" atomic git import
 
+git_status_after_import="$(git status --short)"
+if [[ -z "$git_status_after_import" ]]; then
+    _pass "git status stays clean after import"
+else
+    _fail "git status dirty after import" "$git_status_after_import"
+fi
+
 # Verify view created (should use default branch name)
 assert_view_exists "view '$default_branch' created" "$default_branch"
 
@@ -564,6 +571,13 @@ if [[ "$_status_lines" -eq 0 ]]; then
 else
     _dirty=$(cd "$GIT_REPO" && atomic status --short 2>/dev/null | head -10)
     _fail "status not clean after import" "$_status_lines dirty entries: $_dirty"
+fi
+
+_git_status_lines=$(cd "$GIT_REPO" && git status --short)
+if [[ -z "$_git_status_lines" ]]; then
+    _pass "git status is clean after import"
+else
+    _fail "git status dirty after import" "$_git_status_lines"
 fi
 
 # 7. Change count matches git commit count


### PR DESCRIPTION
## Problem

`atomic git import` creates local Atomic files like `.atomic/`, `.vault/`, and `.atomicignore`.

In Git shadow mode, these files showed up in `git status` as untracked files. This made the Git working tree dirty even though the user did not change their project files.

before the fix: 
<img width="817" height="504" alt="Screenshot 2026-06-17 at 2 15 26 PM" src="https://github.com/user-attachments/assets/5fb1ef04-93fb-4736-853a-339d53161d99" />


after the fix: 
<img width="764" height="501" alt="Screenshot 2026-06-17 at 2 16 09 PM" src="https://github.com/user-attachments/assets/7fc27498-5671-4b44-8623-144dfe85421b" />


## Fix

`atomic git import` now adds these paths to `.git/info/exclude`:

- `/.atomic/`
- `/.vault/`
- `/.atomicignore`

This keeps the ignore rules local to the current Git clone. It does not modify `.gitignore` and does not affect other users.

## Testing

Tested with a fresh Git repo:

- Ran `atomic git import`
- Confirmed `git status` stayed clean
- Confirmed `.git/info/exclude` contains the Atomic local state paths
- Confirmed `atomic status --short` stayed clean

Also ran:

- `cargo fmt --check`
- `cargo test -p atomic-cli commands::git::import::tests`
- `tests/harness/19_git_shadow.sh`