### PR TITLE
Support callers for blast radius and fix provenance truncation

### DIFF
--- a/atomic-agent/src/provenance/classify.rs
+++ b/atomic-agent/src/provenance/classify.rs
@@ -481,7 +481,7 @@ fn summarize_exploration(tool_name: &str, tool_input: Option<&serde_json::Value>
         (None, Some(target), _) => {
             format!("Examine {}", target)
         }
-        (None, None, Some(desc)) => truncate_for_summary(desc, 80),
+        (None, None, Some(desc)) => truncate_for_summary(desc, 500),
         (None, None, None) => {
             let verb = match tool_name.to_lowercase().as_str() {
                 "grep" | "rg" | "ripgrep" | "search" => "Search codebase",
@@ -544,7 +544,7 @@ fn summarize_commitment(tool_name: &str, tool_input: Option<&serde_json::Value>)
     };
 
     match path {
-        Some(p) => format!("{} {}", verb, truncate_for_summary(p, 80)),
+        Some(p) => format!("{} {}", verb, p),
         None => format!("{} file", verb),
     }
 }
@@ -584,7 +584,7 @@ fn summarize_verification(
     if cmd.is_empty() {
         format!("Run verification{}", result_suffix)
     } else {
-        format!("{}{}", truncate_for_summary(cmd, 80), result_suffix)
+        format!("{}{}", truncate_for_summary(cmd, 300), result_suffix)
     }
 }
 
@@ -598,7 +598,7 @@ fn summarize_execution(tool_name: &str, tool_input: Option<&serde_json::Value>) 
         let cmd = extract_command(tool_input);
         let cmd = cmd.trim();
         if !cmd.is_empty() {
-            return truncate_for_summary(cmd, 100);
+            return truncate_for_summary(cmd, 300);
         }
     }
 

--- a/atomic-cli/Cargo.toml
+++ b/atomic-cli/Cargo.toml
@@ -1,7 +1,6 @@
 [features]
-default = ["ast", "teams"]
+default = ["teams"]
 remote = []
-ast = ["atomic-semantic", "atomic-repository/ast"]
 teams = ["atomic-teams"]
 
 [package]
@@ -29,7 +28,7 @@ atomic-config = { workspace = true }
 atomic-identity = { workspace = true }
 atomic-remote = { workspace = true }
 atomic-repository = { workspace = true }
-atomic-semantic = { workspace = true, optional = true }
+atomic-semantic = { workspace = true }
 atomic-teams = { workspace = true, optional = true }
 
 # CLI

--- a/atomic-cli/src/commands/diff/helpers.rs
+++ b/atomic-cli/src/commands/diff/helpers.rs
@@ -492,10 +492,21 @@ impl Diff {
             if matched_rm.contains(ri) || matched_add.contains(ai) {
                 continue;
             }
-            matched_rm.insert(*ri);
-            matched_add.insert(*ai);
             let rm_orig_idx = rm_entries[*ri].0;
             let add_orig_idx = add_entries[*ai].0;
+
+            // Only pull an add forward if there are no other Added lines
+            // between the remove and the matched add in the original order.
+            // Intervening Added lines represent genuinely new content that
+            // belongs before the matched line in the new file — moving the
+            // matched add past them would put it in the wrong position.
+            let has_intervening_adds = (rm_orig_idx + 1..add_orig_idx).any(|i| lines[i].is_added());
+            if has_intervening_adds {
+                continue;
+            }
+
+            matched_rm.insert(*ri);
+            matched_add.insert(*ai);
             rm_to_add.insert(rm_orig_idx, add_orig_idx);
             paired_add_indices.insert(add_orig_idx);
         }

--- a/atomic-cli/src/commands/query/mod.rs
+++ b/atomic-cli/src/commands/query/mod.rs
@@ -42,6 +42,23 @@ pub enum QueryCommands {
     /// ```
     Neighbors(QueryNeighbors),
 
+    /// Find all functions that call a given entity.
+    ///
+    /// Queries the knowledge graph for CALLS edges whose destination is the
+    /// specified entity node. Useful for blast-radius analysis: see every
+    /// function that breaks if this function's signature changes.
+    ///
+    /// Run `atomic vault query enrich` first to populate CALLS edges.
+    /// Run `atomic vault query entities <file>` to discover entity IDs.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// atomic vault query callers entity:src/auth.rs:verify:42
+    /// atomic vault query callers entity:src/auth.rs:verify:42 --json
+    /// ```
+    Callers(QueryCallers),
+
     /// List tree-sitter entities (functions, classes, types) in a file.
     ///
     /// Parses the file with tree-sitter and prints all extracted entities.
@@ -187,6 +204,7 @@ impl Command for Query {
         match &self.command {
             QueryCommands::Search(cmd) => cmd.run(),
             QueryCommands::Neighbors(cmd) => cmd.run(),
+            QueryCommands::Callers(cmd) => cmd.run(),
             QueryCommands::Entities(cmd) => cmd.run(),
             QueryCommands::Index(cmd) => cmd.run(),
             QueryCommands::Code(cmd) => cmd.run(),
@@ -1152,6 +1170,95 @@ impl Command for QueryNeighbors {
 }
 
 // ---------------------------------------------------------------------------
+// QueryCallers — find all functions that call a given entity
+// ---------------------------------------------------------------------------
+
+/// Find all functions that call a given entity node.
+#[derive(Parser, Debug)]
+pub struct QueryCallers {
+    /// Full entity node ID, e.g. `entity:src/auth.rs:verify:42`.
+    ///
+    /// Use `atomic vault query entities <file>` to list entity IDs for a file,
+    /// then pass one here.
+    pub entity_id: String,
+
+    /// Output as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Command for QueryCallers {
+    fn run(&self) -> CliResult<()> {
+        let root = find_repository_root()?;
+        let repo = Repository::open(&root).map_err(CliError::Repository)?;
+
+        let subgraph = repo
+            .vault_kg_neighbors(&self.entity_id, 1)
+            .map_err(CliError::Repository)?;
+
+        // Incoming CALLS edges: from_id is the caller, to_id is our entity.
+        let caller_edges: Vec<&KgEdge> = subgraph
+            .edges
+            .iter()
+            .filter(|e| e.kind.to_uppercase() == "CALLS" && e.to_id == self.entity_id)
+            .collect();
+
+        if self.json {
+            let out: Vec<serde_json::Value> = caller_edges
+                .iter()
+                .map(|e| {
+                    let node = subgraph.nodes.iter().find(|n| n.id == e.from_id);
+                    serde_json::json!({
+                        "caller_id": e.from_id,
+                        "summary": node.and_then(|n| n.summary.as_deref()),
+                    })
+                })
+                .collect();
+            println!("{}", serde_json::to_string_pretty(&out).unwrap());
+            return Ok(());
+        }
+
+        if caller_edges.is_empty() {
+            println!("No callers found for '{}'.", self.entity_id);
+            // Distinguish "no callers" from "CALLS edges not yet enriched"
+            let has_any_calls = subgraph
+                .edges
+                .iter()
+                .any(|e| e.kind.to_uppercase() == "CALLS");
+            if !has_any_calls {
+                println!(
+                    "Hint: run `atomic vault query enrich` to populate CALLS edges, \
+                    then retry."
+                );
+            } else {
+                println!("This function is an entry point — nothing in the repo calls it.");
+            }
+        } else {
+            println!("{} caller(s) of {}:\n", caller_edges.len(), self.entity_id);
+            for edge in &caller_edges {
+                // Parse entity:{file}:{name}:{line} for a readable display
+                let display = if let Some(rest) = edge.from_id.strip_prefix("entity:") {
+                    let last = rest.rfind(':').unwrap_or(rest.len());
+                    let inner = &rest[..last]; // {file}:{name}
+                    let sig = subgraph
+                        .nodes
+                        .iter()
+                        .find(|n| n.id == edge.from_id)
+                        .and_then(|n| n.summary.as_deref())
+                        .map(|s| format!("  [{}]", s.lines().next().unwrap_or(s)));
+                    format!("  {}{}", inner, sig.unwrap_or_default())
+                } else {
+                    format!("  {}", edge.from_id)
+                };
+                println!("{display}");
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
 // QueryEntities — list tree-sitter entities in a file
 // ---------------------------------------------------------------------------
 
@@ -1166,7 +1273,6 @@ pub struct QueryEntities {
     pub json: bool,
 }
 
-#[cfg(feature = "ast")]
 impl Command for QueryEntities {
     fn run(&self) -> CliResult<()> {
         let root = find_repository_root()?;
@@ -1208,14 +1314,6 @@ impl Command for QueryEntities {
             println!("\n{} entity(ies) in {}", entities.len(), self.path);
         }
 
-        Ok(())
-    }
-}
-
-#[cfg(not(feature = "ast"))]
-impl Command for QueryEntities {
-    fn run(&self) -> CliResult<()> {
-        println!("Tree-sitter support not enabled. Rebuild with --features ast.");
         Ok(())
     }
 }
@@ -1420,32 +1518,36 @@ impl Command for QueryEnrich {
         }
 
         // Phase 5: AST entities
-        #[cfg(feature = "ast")]
-        {
-            let spinner = create_spinner("Extracting entities (tree-sitter)...");
-            match repo.kg_enrich_entities() {
-                Ok(n) => {
-                    total.entities = n;
-                    finish_success(&spinner, &format!("{} entit(ies)", n));
-                }
-                Err(e) => finish_error(&spinner, &format!("entities failed: {}", e)),
+        let spinner = create_spinner("Extracting entities (tree-sitter)...");
+        match repo.kg_enrich_entities() {
+            Ok(n) => {
+                total.entities = n;
+                finish_success(&spinner, &format!("{} entit(ies)", n));
             }
+            Err(e) => finish_error(&spinner, &format!("entities failed: {}", e)),
         }
 
         // Phase 6: INCLUDES edges
-        #[cfg(feature = "ast")]
-        {
-            let spinner = create_spinner("Resolving includes...");
-            match repo.kg_enrich_includes() {
-                Ok(n) => {
-                    total.includes = n;
-                    finish_success(&spinner, &format!("{} include(s)", n));
-                }
-                Err(e) => finish_error(&spinner, &format!("includes failed: {}", e)),
+        let spinner = create_spinner("Resolving includes...");
+        match repo.kg_enrich_includes() {
+            Ok(n) => {
+                total.includes = n;
+                finish_success(&spinner, &format!("{} include(s)", n));
             }
+            Err(e) => finish_error(&spinner, &format!("includes failed: {}", e)),
         }
 
-        // Phase 7: Content search index (syntext)
+        // Phase 7: CALLS edges (caller entity → callee entity)
+        let spinner = create_spinner("Resolving call sites...");
+        match repo.kg_enrich_calls() {
+            Ok(n) => {
+                total.calls = n;
+                finish_success(&spinner, &format!("{} call(s)", n));
+            }
+            Err(e) => finish_error(&spinner, &format!("calls failed: {}", e)),
+        }
+
+        // Phase 8: Content search index (syntext)
         let spinner = create_spinner("Building content index...");
         match atomic_repository::build_content_index(&root) {
             Ok(()) => {

--- a/atomic-repository/Cargo.toml
+++ b/atomic-repository/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 atomic-core = { workspace = true }
 atomic-config = { workspace = true }
 atomic-identity = { workspace = true }
-atomic-semantic = { workspace = true, optional = true }
+atomic-semantic = { workspace = true }
 
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -33,10 +33,6 @@ chrono = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true, features = ["rustls-tls"] }
 tokio = { workspace = true }
-
-[features]
-default = ["ast"]
-ast = ["atomic-semantic"]
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/atomic-repository/src/ai/tools.rs
+++ b/atomic-repository/src/ai/tools.rs
@@ -816,7 +816,6 @@ impl<'a> ToolExecutor for RepoToolExecutor<'a> {
             },
         ];
 
-        #[cfg(feature = "ast")]
         defs.push(ToolDefinition {
             name: "list_entities".into(),
             description: "List code entities (functions, classes, types, etc.) in a file \
@@ -844,7 +843,6 @@ impl<'a> ToolExecutor for RepoToolExecutor<'a> {
             "read_file" => self.exec_read_file(&call.arguments),
             "code_search" => self.exec_code_search(&call.arguments),
             "vault_read" => self.exec_vault_read(&call.arguments),
-            #[cfg(feature = "ast")]
             "list_entities" => self.exec_list_entities(&call.arguments),
             other => Err(format!("unknown tool: {other}")),
         }
@@ -998,7 +996,6 @@ impl<'a> RepoToolExecutor<'a> {
         }
     }
 
-    #[cfg(feature = "ast")]
     fn exec_list_entities(&self, args: &serde_json::Value) -> Result<String, String> {
         let path_str = args["path"]
             .as_str()

--- a/atomic-repository/src/repository/vault_kg_enrich.rs
+++ b/atomic-repository/src/repository/vault_kg_enrich.rs
@@ -45,16 +45,13 @@ impl Repository {
         };
 
         // Phase 4: AST entities → nodes + DEFINES edges
-        #[cfg(feature = "ast")]
-        {
-            stats.entities = self.kg_enrich_entities()?;
-        }
+        stats.entities = self.kg_enrich_entities()?;
 
         // Phase 4b: INCLUDES edges (from import entities)
-        #[cfg(feature = "ast")]
-        {
-            stats.includes = self.kg_enrich_includes()?;
-        }
+        stats.includes = self.kg_enrich_includes()?;
+
+        // Phase 4c: CALLS edges (caller entity → callee entity)
+        stats.calls = self.kg_enrich_calls()?;
 
         Ok(stats)
     }
@@ -463,7 +460,6 @@ impl Repository {
         }
 
         // AST entity extraction for changed files
-        #[cfg(feature = "ast")]
         {
             let mut parser_registry = atomic_semantic::ParserRegistry::new();
 
@@ -514,6 +510,16 @@ impl Repository {
                     ))
                     .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
+                    // EXPORTS edge: only for publicly visible entities
+                    if entity.exported {
+                        txn.upsert_kg_edge(&KgEdge::new(
+                            format!("file:{}", entity.file),
+                            &entity_id,
+                            edge_kind::EXPORTS,
+                        ))
+                        .map_err(|e| RepositoryError::Database(e.to_string()))?;
+                    }
+
                     // Change MODIFIES entity (more precise than file-level)
                     txn.upsert_kg_edge(&KgEdge::new(
                         format!("change:{}", short_hash),
@@ -538,7 +544,6 @@ impl Repository {
     /// resolve each import path to an existing `file:{path}` node in the KG.
     /// If a match is found, creates an `INCLUDES` edge from the source file
     /// to the included file. Best-effort — unresolvable imports are skipped.
-    #[cfg(feature = "ast")]
     pub fn kg_enrich_includes(&self) -> Result<usize, RepositoryError> {
         let files = self
             .list_tracked_files()
@@ -657,11 +662,153 @@ impl Repository {
         Ok(count)
     }
 
+    /// Parses all tracked source files and writes `CALLS` edges between entity nodes.
+    ///
+    /// For every tracked file, this function:
+    /// 1. Extracts function/method entities (to build a name → entity-ID index).
+    /// 2. Extracts call sites via tree-sitter reference extraction.
+    /// 3. For each call site, finds the innermost enclosing function (the caller entity)
+    ///    and resolves the callee name to known entity nodes in the graph.
+    /// 4. Writes `KgEdge { from: caller_entity, to: callee_entity, kind: CALLS }`.
+    ///
+    /// Callee resolution is name-based: a call to `foo()` matches any entity named `foo`
+    /// across all tracked files. Calls to external crates / stdlib are silently skipped.
+    pub fn kg_enrich_calls(&self) -> Result<usize, RepositoryError> {
+        let files = self
+            .list_tracked_files()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        let mut parser_registry = atomic_semantic::ParserRegistry::new();
+
+        // ── Pass 1: Parse every file to build the name → entity-ID index.
+        struct FileData {
+            path: String,
+            source: String,
+            entities: Vec<atomic_semantic::Entity>,
+        }
+
+        let mut all_file_data: Vec<FileData> = Vec::new();
+        // function/method name → list of entity IDs (names can appear in multiple files)
+        let mut name_to_entity_ids: HashMap<String, Vec<String>> = HashMap::new();
+
+        for file in &files {
+            if file.is_directory {
+                continue;
+            }
+            let path_str = file.path.to_string_lossy().to_string();
+            if !atomic_semantic::is_supported(&path_str) {
+                continue;
+            }
+            let abs_path = self.root().join(&file.path);
+            let source = match std::fs::read_to_string(&abs_path) {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+
+            let entities = parser_registry.extract(&path_str, &source);
+
+            for entity in &entities {
+                match entity.kind {
+                    atomic_semantic::EntityKind::Function | atomic_semantic::EntityKind::Method => {
+                        let entity_id =
+                            format!("entity:{}:{}:{}", entity.file, entity.name, entity.line);
+                        name_to_entity_ids
+                            .entry(entity.name.clone())
+                            .or_default()
+                            .push(entity_id);
+                    }
+                    _ => {}
+                }
+            }
+
+            all_file_data.push(FileData {
+                path: path_str,
+                source,
+                entities,
+            });
+        }
+
+        // ── Pass 2: Extract call sites and write CALLS edges.
+        let mut txn = self
+            .pristine
+            .write_txn()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        let mut count = 0;
+
+        for file_data in &all_file_data {
+            let refs = parser_registry.extract_references(&file_data.path, &file_data.source);
+            if refs.is_empty() {
+                continue;
+            }
+
+            // Build a (start_line, end_line, entity_id) list for this file's callable
+            // entities so we can find which function encloses each call site by line.
+            let mut callable_entities: Vec<(u32, u32, String)> = file_data
+                .entities
+                .iter()
+                .filter(|e| {
+                    matches!(
+                        e.kind,
+                        atomic_semantic::EntityKind::Function | atomic_semantic::EntityKind::Method
+                    )
+                })
+                .map(|e| {
+                    (
+                        e.line,
+                        e.end_line,
+                        format!("entity:{}:{}:{}", e.file, e.name, e.line),
+                    )
+                })
+                .collect();
+            callable_entities.sort_by_key(|(start, _, _)| *start);
+
+            for r in &refs {
+                // Find the innermost (smallest range) enclosing function.
+                let caller_id = callable_entities
+                    .iter()
+                    .filter(|(start, end, _)| r.line >= *start && r.line <= *end)
+                    .min_by_key(|(start, end, _)| end - start)
+                    .map(|(_, _, id)| id.as_str());
+
+                let caller_id = match caller_id {
+                    Some(id) => id,
+                    None => continue, // call outside any function (top-level, macro, etc.)
+                };
+
+                // Skip names that resolve to too many definitions — they are almost
+                // certainly common trait-method names (new, clone, fmt, from, into,
+                // push, len, …) where name-only matching produces pure noise.
+                // A call to `Vec::new()` should not write edges to every `fn new()`
+                // across all 600+ files.
+                const MAX_CALLEE_FANOUT: usize = 10;
+
+                let callee_ids = match name_to_entity_ids.get(&r.symbol) {
+                    Some(ids) if ids.len() <= MAX_CALLEE_FANOUT => ids,
+                    Some(_) => continue, // too ambiguous — common trait method, skip
+                    None => continue,    // callee not in repo (stdlib / external dep)
+                };
+
+                for callee_id in callee_ids {
+                    if callee_id == caller_id {
+                        continue; // skip direct recursion
+                    }
+                    txn.upsert_kg_edge(&KgEdge::new(caller_id, callee_id, edge_kind::CALLS))
+                        .map_err(|e| RepositoryError::Database(e.to_string()))?;
+                    count += 1;
+                }
+            }
+        }
+
+        txn.commit()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        Ok(count)
+    }
+
     /// Parses all supported source files in the working copy and creates
     /// `entity:{file}:{name}:{line}` nodes with `DEFINES` edges from
     /// the corresponding file nodes. Runs during bulk enrichment
     /// (`atomic vault query enrich`, `atomic git import`).
-    #[cfg(feature = "ast")]
     pub fn kg_enrich_entities(&self) -> Result<usize, RepositoryError> {
         let files = self
             .list_tracked_files()
@@ -720,6 +867,16 @@ impl Repository {
                 ))
                 .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
+                // EXPORTS edge: only for publicly visible entities
+                if entity.exported {
+                    txn.upsert_kg_edge(&KgEdge::new(
+                        format!("file:{}", entity.file),
+                        &entity_id,
+                        edge_kind::EXPORTS,
+                    ))
+                    .map_err(|e| RepositoryError::Database(e.to_string()))?;
+                }
+
                 count += 1;
             }
         }
@@ -745,12 +902,20 @@ pub struct KgEnrichStats {
     pub entities: usize,
     /// Number of INCLUDES edges created.
     pub includes: usize,
+    /// Number of CALLS edges created.
+    pub calls: usize,
 }
 
 impl KgEnrichStats {
     /// Total number of nodes created across all phases.
     pub fn total(&self) -> usize {
-        self.views + self.files + self.modules + self.changes + self.entities + self.includes
+        self.views
+            + self.files
+            + self.modules
+            + self.changes
+            + self.entities
+            + self.includes
+            + self.calls
     }
 }
 
@@ -758,8 +923,14 @@ impl std::fmt::Display for KgEnrichStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{} views, {} files, {} modules, {} changes, {} entities, {} includes",
-            self.views, self.files, self.modules, self.changes, self.entities, self.includes
+            "{} views, {} files, {} modules, {} changes, {} entities, {} includes, {} calls",
+            self.views,
+            self.files,
+            self.modules,
+            self.changes,
+            self.entities,
+            self.includes,
+            self.calls
         )
     }
 }
@@ -786,10 +957,11 @@ mod tests {
             changes: 5,
             entities: 8,
             includes: 4,
+            calls: 0,
         };
         assert_eq!(
             stats.to_string(),
-            "3 views, 10 files, 2 modules, 5 changes, 8 entities, 4 includes"
+            "3 views, 10 files, 2 modules, 5 changes, 8 entities, 4 includes, 0 calls"
         );
     }
 
@@ -802,8 +974,9 @@ mod tests {
             changes: 3,
             entities: 4,
             includes: 1,
+            calls: 5,
         };
-        assert_eq!(stats.total(), 20);
+        assert_eq!(stats.total(), 25);
     }
 
     #[test]
@@ -815,10 +988,11 @@ mod tests {
         assert_eq!(stats.changes, 0);
         assert_eq!(stats.entities, 0);
         assert_eq!(stats.includes, 0);
+        assert_eq!(stats.calls, 0);
         assert_eq!(stats.total(), 0);
         assert_eq!(
             stats.to_string(),
-            "0 views, 0 files, 0 modules, 0 changes, 0 entities, 0 includes"
+            "0 views, 0 files, 0 modules, 0 changes, 0 entities, 0 includes, 0 calls"
         );
     }
 

--- a/atomic-repository/src/repository/vault_triples.rs
+++ b/atomic-repository/src/repository/vault_triples.rs
@@ -5,7 +5,7 @@
 
 use super::*;
 use crate::content_search::{has_content_index, search_content, ContentSearchOptions};
-use atomic_core::pristine::ontology::edge_kind;
+use atomic_core::pristine::ontology::{edge_kind, predicate};
 use atomic_core::pristine::vault::{KgEdge, KgNode, KgSubgraph, VaultEntry, VaultEntryType};
 use atomic_core::pristine::{KgMutTxnT, KgTxnT};
 
@@ -56,12 +56,19 @@ impl Repository {
         if let Ok(fm) = serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(
             &entry.frontmatter_json,
         ) {
-            extract_frontmatter_kg(&subject, entry.entry_type, &fm, &mut node, &mut edges);
+            extract_frontmatter_kg(
+                &subject,
+                entry.entry_type,
+                &fm,
+                &mut node,
+                &mut nodes,
+                &mut edges,
+            );
         }
 
         // Extract from content
         let content = String::from_utf8_lossy(&entry.content_bytes);
-        extract_content_edges(&subject, &content, &mut edges);
+        extract_content_edges(&subject, entry.entry_type, &content, &mut edges);
 
         nodes.push(node);
         Ok((nodes, edges))
@@ -574,6 +581,7 @@ fn extract_frontmatter_kg(
     entry_type: VaultEntryType,
     fm: &serde_json::Map<String, serde_json::Value>,
     node: &mut KgNode,
+    nodes: &mut Vec<KgNode>,
     edges: &mut Vec<KgEdge>,
 ) {
     // Common fields → edges
@@ -636,7 +644,7 @@ fn extract_frontmatter_kg(
                     obj.insert("priority".to_string(), serde_json::json!(s));
                 }
             }
-            // blocked_by array
+            // blocked_by array — write both directions for symmetric traversal
             if let Some(arr) = fm.get("blocked_by").and_then(|v| v.as_array()) {
                 for item in arr {
                     if let Some(s) = item.as_str() {
@@ -645,10 +653,16 @@ fn extract_frontmatter_kg(
                             format!("intent:{}", s),
                             edge_kind::BLOCKED_BY,
                         ));
+                        // Symmetric: the blocker also BLOCKS this intent
+                        edges.push(KgEdge::new(
+                            format!("intent:{}", s),
+                            subject,
+                            edge_kind::BLOCKS,
+                        ));
                     }
                 }
             }
-            // labels array -> HAS_LABEL edges
+            // labels array -> HAS_LABEL edges + concept nodes
             if let Some(arr) = fm.get("labels").and_then(|v| v.as_array()) {
                 for item in arr {
                     if let Some(s) = item.as_str() {
@@ -657,6 +671,8 @@ fn extract_frontmatter_kg(
                             format!("concept:{}", s),
                             edge_kind::HAS_LABEL,
                         ));
+                        // Ensure the concept node exists so it is searchable
+                        nodes.push(KgNode::new(format!("concept:{}", s), "concept", s, "vault"));
                     }
                 }
             }
@@ -687,13 +703,31 @@ fn extract_frontmatter_kg(
                 }
             }
         }
+        VaultEntryType::ToolResult => {
+            // ToolResult files always live at goals/{goal-name}/toolu_*.md.
+            // Derive the parent goal from the subject: "tool:goals:{goal}:{file}"
+            if let Some(rest) = subject.strip_prefix("tool:goals:") {
+                if let Some((goal_name, _)) = rest.split_once(':') {
+                    edges.push(KgEdge::new(
+                        subject,
+                        format!("goal:{}", goal_name),
+                        predicate::WAS_ASSOCIATED_WITH,
+                    ));
+                }
+            }
+        }
         _ => {}
     }
 }
 
 /// Extract edges from content text (wiki-links, file paths).
-fn extract_content_edges(subject: &str, content: &str, edges: &mut Vec<KgEdge>) {
-    // Extract [[wiki-links]]
+fn extract_content_edges(
+    subject: &str,
+    entry_type: VaultEntryType,
+    content: &str,
+    edges: &mut Vec<KgEdge>,
+) {
+    // Extract [[wiki-links]] — always REFERENCES regardless of entry type
     let mut pos = 0;
     while let Some(start) = content[pos..].find("[[") {
         let abs_start = pos + start + 2;
@@ -712,7 +746,14 @@ fn extract_content_edges(subject: &str, content: &str, edges: &mut Vec<KgEdge>) 
         }
     }
 
-    // Extract file paths (simple heuristic: paths with extensions)
+    // File paths: ToolResult content represents files the agent actually read/used,
+    // so emit USED edges.  All other entry types emit REFERENCES edges.
+    let file_edge_kind = if entry_type == VaultEntryType::ToolResult {
+        predicate::USED
+    } else {
+        edge_kind::REFERENCES
+    };
+
     for word in content.split_whitespace() {
         let clean = word.trim_matches(|c: char| {
             c == '`' || c == '"' || c == '\'' || c == '(' || c == ')' || c == ','
@@ -721,7 +762,7 @@ fn extract_content_edges(subject: &str, content: &str, edges: &mut Vec<KgEdge>) 
             edges.push(KgEdge::new(
                 subject,
                 format!("file:{}", clean),
-                edge_kind::REFERENCES,
+                file_edge_kind,
             ));
         }
     }
@@ -810,10 +851,17 @@ mod tests {
             .vault_extract_kg("intents/pimo-1/intent.md", &entry)
             .unwrap();
 
-        assert_eq!(nodes.len(), 1);
-        assert_eq!(nodes[0].kind, "intent");
-        assert_eq!(nodes[0].id, "intent:PIMO-1");
-        assert_eq!(nodes[0].summary.as_deref(), Some("Fix auth"));
+        // 1 intent node + 1 concept node per label ("auth", "security")
+        assert_eq!(nodes.len(), 3);
+        let intent_node = nodes.iter().find(|n| n.kind == "intent").unwrap();
+        assert_eq!(intent_node.id, "intent:PIMO-1");
+        assert_eq!(intent_node.summary.as_deref(), Some("Fix auth"));
+        assert!(nodes
+            .iter()
+            .any(|n| n.kind == "concept" && n.id == "concept:auth"));
+        assert!(nodes
+            .iter()
+            .any(|n| n.kind == "concept" && n.id == "concept:security"));
 
         assert!(
             edges
@@ -985,6 +1033,7 @@ mod tests {
         let mut edges = Vec::new();
         extract_content_edges(
             "goal:test",
+            VaultEntryType::Session,
             "Check [[architecture]] and [[auth-design]] for details.",
             &mut edges,
         );
@@ -1007,6 +1056,7 @@ mod tests {
         let mut edges = Vec::new();
         extract_content_edges(
             "goal:test",
+            VaultEntryType::Session,
             "Modified `src/main.rs` and crates/core/src/lib.rs today.",
             &mut edges,
         );
@@ -1051,11 +1101,13 @@ mod tests {
             "blocked_by".to_string(),
             serde_json::json!(["PIMO-2", "PIMO-3"]),
         );
+        let mut nodes = Vec::new();
         extract_frontmatter_kg(
             "intent:PIMO-1",
             VaultEntryType::Intent,
             &fm,
             &mut node,
+            &mut nodes,
             &mut edges,
         );
         assert!(
@@ -1070,6 +1122,13 @@ mod tests {
                 .any(|e| e.kind == edge_kind::BLOCKED_BY && e.to_id == "intent:PIMO-3"),
             "Missing BLOCKED_BY edge for PIMO-3"
         );
+        // Reverse BLOCKS edges should also be present
+        assert!(
+            edges.iter().any(|e| e.kind == edge_kind::BLOCKS
+                && e.from_id == "intent:PIMO-2"
+                && e.to_id == "intent:PIMO-1"),
+            "Missing reverse BLOCKS edge from PIMO-2"
+        );
     }
 
     #[test]
@@ -1081,11 +1140,13 @@ mod tests {
             "goals".to_string(),
             serde_json::json!(["swift-meadow-a3f2"]),
         );
+        let mut nodes = Vec::new();
         extract_frontmatter_kg(
             "intent:PIMO-1",
             VaultEntryType::Intent,
             &fm,
             &mut node,
+            &mut nodes,
             &mut edges,
         );
         assert!(
@@ -1099,7 +1160,12 @@ mod tests {
     #[test]
     fn test_wiki_link_with_newline_ignored() {
         let mut edges = Vec::new();
-        extract_content_edges("goal:test", "See [[bad\nlink]] here.", &mut edges);
+        extract_content_edges(
+            "goal:test",
+            VaultEntryType::Session,
+            "See [[bad\nlink]] here.",
+            &mut edges,
+        );
         assert!(
             edges.iter().all(|e| e.kind != edge_kind::REFERENCES),
             "Should not extract wiki-link with newline"
@@ -1109,7 +1175,12 @@ mod tests {
     #[test]
     fn test_unclosed_wiki_link_ignored() {
         let mut edges = Vec::new();
-        extract_content_edges("goal:test", "See [[unclosed link here.", &mut edges);
+        extract_content_edges(
+            "goal:test",
+            VaultEntryType::Session,
+            "See [[unclosed link here.",
+            &mut edges,
+        );
         assert!(
             edges.iter().all(|e| e.kind != edge_kind::REFERENCES),
             "Should not extract unclosed wiki-link"

--- a/atomic-semantic/src/parsers/cpp.rs
+++ b/atomic-semantic/src/parsers/cpp.rs
@@ -20,7 +20,7 @@
 //! | `#define FOO` | `preproc_def` | Const |
 
 use super::{Language, LanguageParser};
-use crate::entity::{Entity, EntityKind};
+use crate::entity::{Confidence, Entity, EntityKind, Reference};
 use tree_sitter::{Node, Parser};
 
 /// C/C++ AST entity extractor using tree-sitter.
@@ -694,6 +694,64 @@ impl CppParser {
             String::new()
         }
     }
+
+    fn walk_tree_for_calls(
+        &self,
+        node: &Node,
+        source: &str,
+        file_path: &str,
+        refs: &mut Vec<Reference>,
+    ) {
+        if node.kind() == "call_expression" {
+            if let Some(func_node) = node.child_by_field_name("function") {
+                if let Some(name) = self.extract_call_name(&func_node, source) {
+                    if !name.is_empty() {
+                        refs.push(Reference {
+                            symbol: name,
+                            file: file_path.to_string(),
+                            line: (node.start_position().row as u32) + 1,
+                            column: Some(node.start_position().column as u32),
+                            context: None,
+                            confidence: Confidence::High,
+                        });
+                    }
+                }
+            }
+        }
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.walk_tree_for_calls(&child, source, file_path, refs);
+        }
+    }
+
+    fn extract_call_name(&self, func_node: &Node, source: &str) -> Option<String> {
+        match func_node.kind() {
+            "identifier" => {
+                let name = self.node_text(func_node, source);
+                if name.is_empty() {
+                    None
+                } else {
+                    Some(name)
+                }
+            }
+            "field_expression" => {
+                // obj.method() or ptr->method() — extract just the member name
+                func_node
+                    .child_by_field_name("field")
+                    .map(|f| self.node_text(&f, source))
+                    .filter(|s| !s.is_empty())
+            }
+            "scoped_identifier" => {
+                // Namespace::func() — extract just "func"
+                func_node
+                    .child_by_field_name("name")
+                    .map(|n| self.node_text(&n, source))
+                    .filter(|s| !s.is_empty())
+            }
+            _ => None,
+        }
+    }
 }
 
 impl Default for CppParser {
@@ -727,6 +785,16 @@ impl LanguageParser for CppParser {
             false,
         );
         entities
+    }
+
+    fn extract_references(&mut self, source: &str, file_path: &str) -> Vec<Reference> {
+        let tree = match self.parser.parse(source, None) {
+            Some(t) => t,
+            None => return vec![],
+        };
+        let mut refs = Vec::new();
+        self.walk_tree_for_calls(&tree.root_node(), source, file_path, &mut refs);
+        refs
     }
 }
 

--- a/atomic-semantic/src/parsers/go.rs
+++ b/atomic-semantic/src/parsers/go.rs
@@ -17,7 +17,7 @@
 //! | `import "fmt"` | Import | Import declaration |
 
 use super::{Language, LanguageParser};
-use crate::entity::{Entity, EntityKind};
+use crate::entity::{Confidence, Entity, EntityKind, Reference};
 use tree_sitter::{Node, Parser};
 
 /// Go AST entity extractor using tree-sitter.
@@ -327,6 +327,57 @@ impl GoParser {
             String::new()
         }
     }
+
+    fn walk_tree_for_calls(
+        &self,
+        node: &Node,
+        source: &str,
+        file_path: &str,
+        refs: &mut Vec<Reference>,
+    ) {
+        if node.kind() == "call_expression" {
+            if let Some(func_node) = node.child_by_field_name("function") {
+                if let Some(name) = self.extract_call_name(&func_node, source) {
+                    if !name.is_empty() {
+                        refs.push(Reference {
+                            symbol: name,
+                            file: file_path.to_string(),
+                            line: (node.start_position().row as u32) + 1,
+                            column: Some(node.start_position().column as u32),
+                            context: None,
+                            confidence: Confidence::High,
+                        });
+                    }
+                }
+            }
+        }
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.walk_tree_for_calls(&child, source, file_path, refs);
+        }
+    }
+
+    fn extract_call_name(&self, func_node: &Node, source: &str) -> Option<String> {
+        match func_node.kind() {
+            "identifier" => {
+                let name = self.node_text(func_node, source);
+                if name.is_empty() {
+                    None
+                } else {
+                    Some(name)
+                }
+            }
+            "selector_expression" => {
+                // pkg.Func() or receiver.Method() — extract just the function/method name
+                func_node
+                    .child_by_field_name("field")
+                    .map(|f| self.node_text(&f, source))
+                    .filter(|s| !s.is_empty())
+            }
+            _ => None,
+        }
+    }
 }
 
 impl Default for GoParser {
@@ -349,6 +400,16 @@ impl LanguageParser for GoParser {
         let mut entities = Vec::new();
         self.walk_tree(&tree.root_node(), source, file_path, &mut entities);
         entities
+    }
+
+    fn extract_references(&mut self, source: &str, file_path: &str) -> Vec<Reference> {
+        let tree = match self.parser.parse(source, None) {
+            Some(t) => t,
+            None => return vec![],
+        };
+        let mut refs = Vec::new();
+        self.walk_tree_for_calls(&tree.root_node(), source, file_path, &mut refs);
+        refs
     }
 }
 

--- a/atomic-semantic/src/parsers/java.rs
+++ b/atomic-semantic/src/parsers/java.rs
@@ -18,7 +18,7 @@
 //! | `import java.util.List;` | Import | Import statement |
 
 use super::{Language, LanguageParser};
-use crate::entity::{Entity, EntityKind};
+use crate::entity::{Confidence, Entity, EntityKind, Reference};
 use tree_sitter::{Node, Parser};
 
 /// Java AST entity extractor using tree-sitter.
@@ -599,6 +599,35 @@ impl JavaParser {
             String::new()
         }
     }
+
+    fn walk_tree_for_calls(
+        &self,
+        node: &Node,
+        source: &str,
+        file_path: &str,
+        refs: &mut Vec<Reference>,
+    ) {
+        if node.kind() == "method_invocation" {
+            if let Some(name_node) = node.child_by_field_name("name") {
+                let name = self.node_text(&name_node, source);
+                if !name.is_empty() {
+                    refs.push(Reference {
+                        symbol: name,
+                        file: file_path.to_string(),
+                        line: (node.start_position().row as u32) + 1,
+                        column: Some(node.start_position().column as u32),
+                        context: None,
+                        confidence: Confidence::High,
+                    });
+                }
+            }
+        }
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.walk_tree_for_calls(&child, source, file_path, refs);
+        }
+    }
 }
 
 impl Default for JavaParser {
@@ -621,6 +650,16 @@ impl LanguageParser for JavaParser {
         let mut entities = Vec::new();
         self.walk_tree(&tree.root_node(), source, file_path, &mut entities, None);
         entities
+    }
+
+    fn extract_references(&mut self, source: &str, file_path: &str) -> Vec<Reference> {
+        let tree = match self.parser.parse(source, None) {
+            Some(t) => t,
+            None => return vec![],
+        };
+        let mut refs = Vec::new();
+        self.walk_tree_for_calls(&tree.root_node(), source, file_path, &mut refs);
+        refs
     }
 }
 

--- a/atomic-semantic/src/parsers/python.rs
+++ b/atomic-semantic/src/parsers/python.rs
@@ -17,7 +17,7 @@
 //! | `from x import y` | Import | From-import statement |
 
 use super::{Language, LanguageParser};
-use crate::entity::{Entity, EntityKind};
+use crate::entity::{Confidence, Entity, EntityKind, Reference};
 use tree_sitter::{Node, Parser};
 
 /// Python AST entity extractor using tree-sitter.
@@ -352,6 +352,57 @@ impl PythonParser {
             String::new()
         }
     }
+
+    fn walk_tree_for_calls(
+        &self,
+        node: &Node,
+        source: &str,
+        file_path: &str,
+        refs: &mut Vec<Reference>,
+    ) {
+        if node.kind() == "call" {
+            if let Some(func_node) = node.child_by_field_name("function") {
+                if let Some(name) = self.extract_call_name(&func_node, source) {
+                    if !name.is_empty() {
+                        refs.push(Reference {
+                            symbol: name,
+                            file: file_path.to_string(),
+                            line: (node.start_position().row as u32) + 1,
+                            column: Some(node.start_position().column as u32),
+                            context: None,
+                            confidence: Confidence::High,
+                        });
+                    }
+                }
+            }
+        }
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.walk_tree_for_calls(&child, source, file_path, refs);
+        }
+    }
+
+    fn extract_call_name(&self, func_node: &Node, source: &str) -> Option<String> {
+        match func_node.kind() {
+            "identifier" => {
+                let name = self.node_text(func_node, source);
+                if name.is_empty() {
+                    None
+                } else {
+                    Some(name)
+                }
+            }
+            "attribute" => {
+                // obj.method() — extract just "method"
+                func_node
+                    .child_by_field_name("attribute")
+                    .map(|f| self.node_text(&f, source))
+                    .filter(|s| !s.is_empty())
+            }
+            _ => None,
+        }
+    }
 }
 
 impl Default for PythonParser {
@@ -374,6 +425,16 @@ impl LanguageParser for PythonParser {
         let mut entities = Vec::new();
         self.walk_tree(&tree.root_node(), source, file_path, &mut entities, None);
         entities
+    }
+
+    fn extract_references(&mut self, source: &str, file_path: &str) -> Vec<Reference> {
+        let tree = match self.parser.parse(source, None) {
+            Some(t) => t,
+            None => return vec![],
+        };
+        let mut refs = Vec::new();
+        self.walk_tree_for_calls(&tree.root_node(), source, file_path, &mut refs);
+        refs
     }
 }
 

--- a/atomic-semantic/src/parsers/rust.rs
+++ b/atomic-semantic/src/parsers/rust.rs
@@ -23,7 +23,7 @@
 //! | `use std::io` | Import | Use statement |
 
 use super::{Language, LanguageParser};
-use crate::entity::{Entity, EntityKind};
+use crate::entity::{Confidence, Entity, EntityKind, Reference};
 use tree_sitter::{Node, Parser};
 
 /// Rust AST entity extractor using tree-sitter.
@@ -502,6 +502,78 @@ impl RustParser {
         let first = text.lines().next()?;
         Some(first.trim_end_matches('{').trim().to_string())
     }
+
+    /// Walk the AST collecting function call sites.
+    ///
+    /// Visits every `call_expression` node and extracts the simple callee name.
+    /// Recurses into all children including function bodies.
+    fn walk_tree_for_calls(
+        &self,
+        node: &Node,
+        source: &str,
+        file_path: &str,
+        refs: &mut Vec<Reference>,
+    ) {
+        if node.kind() == "call_expression" {
+            if let Some(func_node) = node.child_by_field_name("function") {
+                if let Some(name) = self.extract_call_name(&func_node, source) {
+                    if !name.is_empty() {
+                        refs.push(Reference {
+                            symbol: name,
+                            file: file_path.to_string(),
+                            line: (node.start_position().row as u32) + 1,
+                            column: Some(node.start_position().column as u32),
+                            context: None,
+                            confidence: Confidence::High,
+                        });
+                    }
+                }
+            }
+        }
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.walk_tree_for_calls(&child, source, file_path, refs);
+        }
+    }
+
+    /// Extract the simple function name from the callee sub-node of a `call_expression`.
+    ///
+    /// Returns `None` for call targets we cannot name simply (closures, raw pointers, etc.).
+    fn extract_call_name(&self, func_node: &Node, source: &str) -> Option<String> {
+        match func_node.kind() {
+            "identifier" => {
+                let name = self.node_text(func_node, source);
+                if name.is_empty() {
+                    None
+                } else {
+                    Some(name)
+                }
+            }
+            "field_expression" => {
+                // self.method() or obj.method() — extract just "method"
+                func_node
+                    .child_by_field_name("field")
+                    .map(|f| self.node_text(&f, source))
+                    .filter(|s| !s.is_empty())
+            }
+            "scoped_identifier" => {
+                // Module::func() — extract just "func"
+                func_node
+                    .child_by_field_name("name")
+                    .map(|n| self.node_text(&n, source))
+                    .filter(|s| !s.is_empty())
+            }
+            "generic_function" => {
+                // func::<T>() — recurse into the inner function node
+                func_node
+                    .child_by_field_name("function")
+                    .as_ref()
+                    .and_then(|f| self.extract_call_name(f, source))
+            }
+            _ => None,
+        }
+    }
 }
 
 impl Default for RustParser {
@@ -524,6 +596,23 @@ impl LanguageParser for RustParser {
         let mut entities = Vec::new();
         self.walk_tree(&tree.root_node(), source, file_path, &mut entities, None);
         entities
+    }
+
+    /// Extract all function call sites from a Rust source file.
+    ///
+    /// Each `Reference` has:
+    /// - `symbol`  — the simple callee name (e.g., `"authenticate"`, not `"auth::authenticate"`)
+    /// - `file`    — the caller file path
+    /// - `line`    — 1-based line of the call expression
+    /// - `confidence` — always `High` (tree-sitter parse is exact)
+    fn extract_references(&mut self, source: &str, file_path: &str) -> Vec<Reference> {
+        let tree = match self.parser.parse(source, None) {
+            Some(t) => t,
+            None => return vec![],
+        };
+        let mut refs = Vec::new();
+        self.walk_tree_for_calls(&tree.root_node(), source, file_path, &mut refs);
+        refs
     }
 }
 

--- a/atomic-semantic/src/parsers/swift.rs
+++ b/atomic-semantic/src/parsers/swift.rs
@@ -32,7 +32,7 @@
 //! | `private` / `fileprivate` | `false` |
 
 use super::{Language, LanguageParser};
-use crate::entity::{Entity, EntityKind};
+use crate::entity::{Confidence, Entity, EntityKind, Reference};
 use tree_sitter::{Node, Parser};
 
 /// Swift AST entity extractor using tree-sitter.
@@ -563,6 +563,71 @@ impl SwiftParser {
             String::new()
         }
     }
+
+    fn walk_tree_for_calls(
+        &self,
+        node: &Node,
+        source: &str,
+        file_path: &str,
+        refs: &mut Vec<Reference>,
+    ) {
+        if node.kind() == "call_expression" {
+            // In tree-sitter-swift the callee is the first child (no named field)
+            if let Some(func_node) = node.child(0) {
+                if let Some(name) = self.extract_call_name(&func_node, source) {
+                    if !name.is_empty() {
+                        refs.push(Reference {
+                            symbol: name,
+                            file: file_path.to_string(),
+                            line: (node.start_position().row as u32) + 1,
+                            column: Some(node.start_position().column as u32),
+                            context: None,
+                            confidence: Confidence::High,
+                        });
+                    }
+                }
+            }
+        }
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.walk_tree_for_calls(&child, source, file_path, refs);
+        }
+    }
+
+    fn extract_call_name(&self, func_node: &Node, source: &str) -> Option<String> {
+        match func_node.kind() {
+            "simple_identifier" => {
+                let name = self.node_text(func_node, source);
+                if name.is_empty() {
+                    None
+                } else {
+                    Some(name)
+                }
+            }
+            "navigation_expression" => {
+                // obj.method() — find the last navigation_suffix to get the method name
+                for i in (0..func_node.child_count()).rev() {
+                    if let Some(suffix) = func_node.child(i) {
+                        if suffix.kind() == "navigation_suffix" {
+                            for j in 0..suffix.child_count() {
+                                if let Some(name_node) = suffix.child(j) {
+                                    if name_node.kind() == "simple_identifier" {
+                                        let name = self.node_text(&name_node, source);
+                                        if !name.is_empty() {
+                                            return Some(name);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
 }
 
 impl Default for SwiftParser {
@@ -585,6 +650,16 @@ impl LanguageParser for SwiftParser {
         let mut entities = Vec::new();
         self.walk_tree(&tree.root_node(), source, file_path, &mut entities, None);
         entities
+    }
+
+    fn extract_references(&mut self, source: &str, file_path: &str) -> Vec<Reference> {
+        let tree = match self.parser.parse(source, None) {
+            Some(t) => t,
+            None => return vec![],
+        };
+        let mut refs = Vec::new();
+        self.walk_tree_for_calls(&tree.root_node(), source, file_path, &mut refs);
+        refs
     }
 }
 


### PR DESCRIPTION
This pull request introduces significant improvements to the `atomic-cli` and `atomic-repository` codebases, mainly by removing the `ast` feature flag and making AST-based features (such as entity extraction and call graph analysis) always enabled. It also adds a new `callers` query command to the CLI for analyzing function call relationships, and improves the accuracy of diff matching and summary truncation limits for various provenance summaries.

Key changes include:

### AST Feature Always Enabled & Dependency Updates

- The `ast` feature flag is removed from both `atomic-cli` and `atomic-repository`, and dependencies on `atomic-semantic` are now unconditional. This means AST-based features (entity extraction, call graph, etc.) are always available, simplifying builds and usage. (`[[1]](diffhunk://#diff-114013fe183ffb9c325447ac26230adfa7fa4df8ff6295470180c48174712052L2-L4)`, `[[2]](diffhunk://#diff-114013fe183ffb9c325447ac26230adfa7fa4df8ff6295470180c48174712052L32-R31)`, `[[3]](diffhunk://#diff-e03f07920e5743c1912cc07aa7ba2618301161c5bbf03ee2c20001ba85189bcdL15-R15)`, `[[4]](diffhunk://#diff-e03f07920e5743c1912cc07aa7ba2618301161c5bbf03ee2c20001ba85189bcdL37-L40)`)
- All AST-related code and commands are now always compiled and executed, with conditional compilation blocks removed throughout the codebase. (`[[1]](diffhunk://#diff-7133be5d5495f1f08df85aa61a978ab9b975e1f95790c4d28c2e8e7aa9dba6adL1169)`, `[[2]](diffhunk://#diff-7133be5d5495f1f08df85aa61a978ab9b975e1f95790c4d28c2e8e7aa9dba6adL1215-L1222)`, `[[3]](diffhunk://#diff-7133be5d5495f1f08df85aa61a978ab9b975e1f95790c4d28c2e8e7aa9dba6adL1423-L1424)`, `[[4]](diffhunk://#diff-7133be5d5495f1f08df85aa61a978ab9b975e1f95790c4d28c2e8e7aa9dba6adL1433-L1437)`, `[[5]](diffhunk://#diff-abf95bf8a34662c7cacfaa64072231434208a92815165be07b94106a755e4750L819)`, `[[6]](diffhunk://#diff-abf95bf8a34662c7cacfaa64072231434208a92815165be07b94106a755e4750L847)`, `[[7]](diffhunk://#diff-abf95bf8a34662c7cacfaa64072231434208a92815165be07b94106a755e4750L1001)`, `[[8]](diffhunk://#diff-56a1c62f273e47a102069630426c7bf92261f4ed63a769d3e4c1a2962ba066d2L48-R54)`, `[[9]](diffhunk://#diff-56a1c62f273e47a102069630426c7bf92261f4ed63a769d3e4c1a2962ba066d2L466)`, `[[10]](diffhunk://#diff-56a1c62f273e47a102069630426c7bf92261f4ed63a769d3e4c1a2962ba066d2L541)`)

### Knowledge Graph & Call Graph Enhancements

- Adds a new `callers` subcommand to `atomic vault query`, allowing users to list all functions that call a given entity (function), which is useful for blast-radius and impact analysis. (`[[1]](diffhunk://#diff-7133be5d5495f1f08df85aa61a978ab9b975e1f95790c4d28c2e8e7aa9dba6adR45-R61)`, `[[2]](diffhunk://#diff-7133be5d5495f1f08df85aa61a978ab9b975e1f95790c4d28c2e8e7aa9dba6adR207)`, `[[3]](diffhunk://#diff-7133be5d5495f1f08df85aa61a978ab9b975e1f95790c4d28c2e8e7aa9dba6adR1172-R1260)`)
- During enrichment, the knowledge graph now always extracts CALLS edges (caller → callee relationships) and EXPORTS edges for public entities, making call graph queries and public API analysis more robust. (`[[1]](diffhunk://#diff-7133be5d5495f1f08df85aa61a978ab9b975e1f95790c4d28c2e8e7aa9dba6adR1539-R1550)`, `[[2]](diffhunk://#diff-56a1c62f273e47a102069630426c7bf92261f4ed63a769d3e4c1a2962ba066d2R513-R522)`)

### Diff Algorithm Improvement

- Improves the diff matching algorithm to prevent incorrectly reordering added lines when matching removes to adds, ensuring genuinely new content is not misplaced. (`[atomic-cli/src/commands/diff/helpers.rsL495-R509](diffhunk://#diff-560988d8c9e95d6190e49722a35c97879362f2f3f17445e0b8ed0c8a0f2ce523L495-R509)`)

### Provenance Summary Improvements

- Increases truncation limits for various provenance summary fields, allowing more context to be included in summaries for exploration, execution, and verification steps. (`[[1]](diffhunk://#diff-9f46c8abc7508cb7ef2b543aa5dcdb87b1e83a4caa9eb47af29d74e4ef6a03e8L484-R484)`, `[[2]](diffhunk://#diff-9f46c8abc7508cb7ef2b543aa5dcdb87b1e83a4caa9eb47af29d74e4ef6a03e8L587-R587)`, `[[3]](diffhunk://#diff-9f46c8abc7508cb7ef2b543aa5dcdb87b1e83a4caa9eb47af29d74e4ef6a03e8L601-R601)`)
- Removes truncation from commitment path summaries, displaying full paths for better clarity. (`[atomic-agent/src/provenance/classify.rsL547-R547](diffhunk://#diff-9f46c8abc7508cb7ef2b543aa5dcdb87b1e83a4caa9eb47af29d74e4ef6a03e8L547-R547)`)

These changes collectively make the CLI more powerful and user-friendly, improve the accuracy of code analysis, and simplify the build and deployment process by removing unnecessary feature gating.