### PR TITLE
feat(vault): allow editing intent body via `intent update`

### DIFF
--- a/atomic-cli/src/commands/vault/intent.rs
+++ b/atomic-cli/src/commands/vault/intent.rs
@@ -38,6 +38,12 @@
 //! # Update intent status
 //! atomic vault intent update PIMO-1 --status in-progress
 //!
+//! # Replace the intent body inline
+//! atomic vault intent update PIMO-1 --body "# Title\n\n## Problem\n..."
+//!
+//! # Replace the intent body from a file
+//! cat plan.md | atomic vault intent update PIMO-1 --body-stdin
+//!
 //! # Delete an accidental draft intent
 //! atomic vault intent delete PIMO-1
 //! atomic vault intent delete PIMO-1 --force
@@ -114,13 +120,17 @@ pub enum IntentCommands {
 
     /// Update an intent's fields.
     ///
-    /// Modifies the status, assignee, priority, or title of an existing intent.
+    /// Modifies the status, assignee, priority, title, or Markdown body
+    /// of an existing intent. The body can be set inline with `--body`
+    /// or piped via `--body-stdin`.
     ///
     /// # Examples
     ///
     /// ```text
     /// atomic vault intent update PIMO-1 --status in-progress
     /// atomic vault intent update PIMO-1 --assignee bob --priority critical
+    /// atomic vault intent update PIMO-1 --body "# Fix auth\n\n## Problem\n..."
+    /// cat plan.md | atomic vault intent update PIMO-1 --body-stdin
     /// ```
     Update(IntentUpdate),
 
@@ -370,6 +380,31 @@ pub struct IntentUpdate {
     /// New title.
     #[arg(long)]
     pub title: Option<String>,
+
+    /// New Markdown body content, provided inline.
+    #[arg(long, conflicts_with = "body_stdin")]
+    pub body: Option<String>,
+
+    /// Read the new Markdown body content from standard input.
+    #[arg(long)]
+    pub body_stdin: bool,
+}
+
+impl IntentUpdate {
+    fn resolve_body(&self) -> CliResult<Option<String>> {
+        if let Some(ref body) = self.body {
+            return Ok(Some(body.clone()));
+        }
+        if self.body_stdin {
+            use std::io::Read;
+            let mut content = String::new();
+            std::io::stdin()
+                .read_to_string(&mut content)
+                .map_err(CliError::Io)?;
+            return Ok(Some(content));
+        }
+        Ok(None)
+    }
 }
 
 impl Command for IntentUpdate {
@@ -377,6 +412,22 @@ impl Command for IntentUpdate {
         let root = find_repository_root()?;
         let repo = Repository::open(&root).map_err(CliError::Repository)?;
 
+        let content = self.resolve_body()?;
+        if self.status.is_none()
+            && self.assignee.is_none()
+            && self.priority.is_none()
+            && self.title.is_none()
+            && content.is_none()
+        {
+            return Err(CliError::InvalidArgument {
+                message: "Nothing to update. Provide at least one of \
+                    --status, --assignee, --priority, --title, --body, \
+                    or --body-stdin."
+                    .to_string(),
+            });
+        }
+
+        let body_updated = content.is_some();
         let info = repo
             .vault_intent_update(
                 &self.id,
@@ -385,6 +436,7 @@ impl Command for IntentUpdate {
                     assignee: self.assignee.clone(),
                     priority: self.priority.clone(),
                     title: self.title.clone(),
+                    content,
                 },
             )
             .map_err(CliError::Repository)?;
@@ -394,6 +446,9 @@ impl Command for IntentUpdate {
         println!("  priority: {}", info.priority);
         if let Some(ref assignee) = info.assignee {
             println!("  assignee: {}", assignee);
+        }
+        if body_updated {
+            println!("  body: updated");
         }
 
         Ok(())

--- a/atomic-cli/src/commands/vault/intent.rs
+++ b/atomic-cli/src/commands/vault/intent.rs
@@ -388,6 +388,10 @@ pub struct IntentUpdate {
     /// Read the new Markdown body content from standard input.
     #[arg(long)]
     pub body_stdin: bool,
+
+    /// Rewrite the body even if the intent has started or is linked to a goal.
+    #[arg(long, short = 'f')]
+    pub force: bool,
 }
 
 impl IntentUpdate {
@@ -437,6 +441,7 @@ impl Command for IntentUpdate {
                     priority: self.priority.clone(),
                     title: self.title.clone(),
                     content,
+                    force: self.force,
                 },
             )
             .map_err(CliError::Repository)?;

--- a/atomic-repository/src/repository/vault_intent.rs
+++ b/atomic-repository/src/repository/vault_intent.rs
@@ -75,6 +75,8 @@ pub struct IntentUpdateOptions {
     pub title: Option<String>,
     /// New Markdown body content. When `None`, the existing body is kept.
     pub content: Option<String>,
+    /// Allow rewriting the body after the intent has started or been linked.
+    pub force: bool,
 }
 
 /// Info for listing intents.
@@ -432,6 +434,31 @@ impl Repository {
         // Update frontmatter
         let mut fm: serde_json::Map<String, serde_json::Value> =
             serde_json::from_str(&entry.frontmatter_json).unwrap_or_default();
+
+        if options.content.is_some() && !options.force {
+            let manifest = self.vault_manifest()?;
+            let summary = manifest.intents.get(&full_id);
+            let current_status = summary
+                .map(|intent| intent.status.as_str())
+                .or_else(|| fm.get("status").and_then(|value| value.as_str()))
+                .unwrap_or("unknown");
+            let has_linked_goal = summary.is_some_and(|intent| intent.goals > 0)
+                || manifest.goals.values().any(|goal| {
+                    goal.intent
+                        .as_deref()
+                        .is_some_and(|id| id.eq_ignore_ascii_case(&full_id))
+                });
+
+            if current_status != "backlog" || has_linked_goal {
+                return Err(RepositoryError::InvalidOperation {
+                    message: format!(
+                        "Intent '{}' has started or is linked to a goal; rewriting its body would \
+                         change the execution context. Retry with force enabled.",
+                        full_id
+                    ),
+                });
+            }
+        }
 
         if let Some(ref status) = options.status {
             fm.insert(
@@ -1069,6 +1096,97 @@ mod tests {
         let err = repo.vault_intent_delete(&intent.id).unwrap_err();
         assert!(err.to_string().contains("linked to 1 goal"));
         assert!(repo.vault_retrieve(&intent.intent_file).unwrap().is_some());
+    }
+
+    #[test]
+    fn test_intent_update_body_rejects_started_intent_without_force() {
+        let dir = tempdir().unwrap();
+        let repo = init_repo_with_vault(dir.path());
+
+        let result = repo.vault_intent_create(create_opts("Started")).unwrap();
+        repo.vault_intent_update(
+            &result.id,
+            IntentUpdateOptions {
+                status: Some("in-progress".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let before = repo.vault_intent_show(&result.id).unwrap().content_bytes;
+        let err = repo
+            .vault_intent_update(
+                &result.id,
+                IntentUpdateOptions {
+                    content: Some("# Rewritten".to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+
+        assert!(err.to_string().contains("Retry with force enabled"));
+        assert_eq!(
+            repo.vault_intent_show(&result.id).unwrap().content_bytes,
+            before
+        );
+    }
+
+    #[test]
+    fn test_intent_update_body_rejects_goal_reference_without_force() {
+        let dir = tempdir().unwrap();
+        let repo = init_repo_with_vault(dir.path());
+
+        let intent = repo.vault_intent_create(create_opts("Linked")).unwrap();
+        repo.vault_goal_start(GoalStartOptions {
+            name: Some("test-goal".to_string()),
+            intent: Some(intent.id.clone()),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let err = repo
+            .vault_intent_update(
+                &intent.id,
+                IntentUpdateOptions {
+                    content: Some("# Rewritten".to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+
+        assert!(err.to_string().contains("Retry with force enabled"));
+    }
+
+    #[test]
+    fn test_intent_update_body_force_allows_started_intent() {
+        let dir = tempdir().unwrap();
+        let repo = init_repo_with_vault(dir.path());
+
+        let result = repo.vault_intent_create(create_opts("Started")).unwrap();
+        repo.vault_intent_update(
+            &result.id,
+            IntentUpdateOptions {
+                status: Some("in-progress".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let new_body = "# Rewritten with explicit force\n";
+        repo.vault_intent_update(
+            &result.id,
+            IntentUpdateOptions {
+                content: Some(new_body.to_string()),
+                force: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            String::from_utf8_lossy(&repo.vault_intent_show(&result.id).unwrap().content_bytes),
+            new_body
+        );
     }
 
     #[test]

--- a/atomic-repository/src/repository/vault_intent.rs
+++ b/atomic-repository/src/repository/vault_intent.rs
@@ -60,6 +60,9 @@ pub struct IntentDeleteResult {
 }
 
 /// Options for updating an intent.
+///
+/// `content` replaces the intent's Markdown body. When it is `None`, the
+/// existing body is preserved unchanged.
 #[derive(Debug, Clone, Default)]
 pub struct IntentUpdateOptions {
     /// New status (backlog, planned, in-progress, review, done).
@@ -70,6 +73,8 @@ pub struct IntentUpdateOptions {
     pub priority: Option<String>,
     /// New title.
     pub title: Option<String>,
+    /// New Markdown body content. When `None`, the existing body is kept.
+    pub content: Option<String>,
 }
 
 /// Info for listing intents.
@@ -454,13 +459,12 @@ impl Repository {
         }
         let new_fm = serde_json::to_string(&fm).unwrap_or_else(|_| "{}".to_string());
 
-        // Re-store with updated frontmatter
-        self.vault_store(
-            &intent_file,
-            VaultEntryType::Intent,
-            entry.content_bytes.clone(),
-            new_fm,
-        )?;
+        let new_content = match options.content {
+            Some(ref body) => body.clone().into_bytes(),
+            None => entry.content_bytes.clone(),
+        };
+
+        self.vault_store(&intent_file, VaultEntryType::Intent, new_content, new_fm)?;
 
         // Update manifest
         {
@@ -902,6 +906,79 @@ mod tests {
         // Manifest should reflect update
         let manifest = repo.vault_manifest().unwrap();
         assert_eq!(manifest.intents[&result.id].status, "in-progress");
+    }
+
+    #[test]
+    fn test_intent_update_body_content() {
+        let dir = tempdir().unwrap();
+        let repo = init_repo_with_vault(dir.path());
+
+        let result = repo.vault_intent_create(create_opts("Body edit")).unwrap();
+        let new_body = "# Body edit\n\n## Problem\n\nThe widget leaks memory.\n";
+
+        repo.vault_intent_update(
+            &result.id,
+            IntentUpdateOptions {
+                content: Some(new_body.to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let after = repo.vault_intent_show(&result.id).unwrap();
+        assert_eq!(String::from_utf8_lossy(&after.content_bytes), new_body);
+    }
+
+    #[test]
+    fn test_intent_update_without_content_preserves_body() {
+        let dir = tempdir().unwrap();
+        let repo = init_repo_with_vault(dir.path());
+
+        let result = repo.vault_intent_create(create_opts("Keep body")).unwrap();
+        let original_body = repo.vault_intent_show(&result.id).unwrap().content_bytes;
+
+        repo.vault_intent_update(
+            &result.id,
+            IntentUpdateOptions {
+                priority: Some("high".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            repo.vault_intent_show(&result.id).unwrap().content_bytes,
+            original_body
+        );
+    }
+
+    #[test]
+    fn test_intent_update_body_and_frontmatter_together() {
+        let dir = tempdir().unwrap();
+        let repo = init_repo_with_vault(dir.path());
+
+        let result = repo.vault_intent_create(create_opts("Combined")).unwrap();
+        let new_body = "# Combined\n\nFully rewritten.\n";
+        let updated = repo
+            .vault_intent_update(
+                &result.id,
+                IntentUpdateOptions {
+                    status: Some("review".to_string()),
+                    priority: Some("high".to_string()),
+                    content: Some(new_body.to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        assert_eq!(updated.status, "review");
+        assert_eq!(updated.priority, "high");
+        assert_eq!(
+            String::from_utf8_lossy(
+                &repo.vault_intent_show(&result.id).unwrap().content_bytes
+            ),
+            new_body
+        );
     }
 
     #[test]

--- a/atomic-repository/src/repository/vault_intent.rs
+++ b/atomic-repository/src/repository/vault_intent.rs
@@ -1001,9 +1001,7 @@ mod tests {
         assert_eq!(updated.status, "review");
         assert_eq!(updated.priority, "high");
         assert_eq!(
-            String::from_utf8_lossy(
-                &repo.vault_intent_show(&result.id).unwrap().content_bytes
-            ),
+            String::from_utf8_lossy(&repo.vault_intent_show(&result.id).unwrap().content_bytes),
             new_body
         );
     }


### PR DESCRIPTION
## What
Adds `--body` and `--body-stdin` to `atomic vault intent update`.

## Why
Intent bodies previously required editing the materialized Markdown file and running vault sync.

## Safety
Body edits are allowed directly while an intent is backlog and unlinked. Once it has started or is linked to a goal, rewriting the body requires `--force`. Metadata updates remain unaffected.

## Test
- `cargo test -p atomic-repository intent_update --lib`
- `cargo check -p atomic-cli`
- `cargo clippy -p atomic-repository -p atomic-cli -- -D warnings`