### PR TITLE
feat: warn when CLI version is below server minimum

### DIFF
--- a/atomic-remote/src/http/download.rs
+++ b/atomic-remote/src/http/download.rs
@@ -40,6 +40,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -121,6 +122,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -177,6 +179,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {

--- a/atomic-remote/src/http/queries.rs
+++ b/atomic-remote/src/http/queries.rs
@@ -37,6 +37,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
         trace!("GET state response status: {}", status);
 
@@ -90,6 +91,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
         trace!("GET changelist response status: {}", status);
 
@@ -136,6 +138,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -179,6 +182,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -223,6 +227,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -283,6 +288,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -342,6 +348,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -388,6 +395,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {

--- a/atomic-remote/src/http/upload.rs
+++ b/atomic-remote/src/http/upload.rs
@@ -35,6 +35,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -84,6 +85,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -141,6 +143,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -202,6 +205,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -251,6 +255,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -331,6 +336,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {

--- a/atomic-remote/src/lib.rs
+++ b/atomic-remote/src/lib.rs
@@ -128,8 +128,12 @@ pub mod storage_types;
 pub mod streaming;
 pub mod sync;
 pub mod types;
+pub mod version;
 
 // Re-exports
+
+// Version checking
+pub use version::{check_min_version_header, needs_upgrade};
 
 // Error types
 pub use error::{RemoteError, RemoteResult};

--- a/atomic-remote/src/storage.rs
+++ b/atomic-remote/src/storage.rs
@@ -171,6 +171,7 @@ impl StorageClient {
             .await
             .map_err(|e| RemoteError::other(format!("request failed: {}", e)))?;
 
+        crate::check_min_version_header(resp.headers());
         let status = resp.status();
         if status.is_success() {
             Ok(())
@@ -185,6 +186,7 @@ impl StorageClient {
         &self,
         resp: reqwest::Response,
     ) -> Result<T, RemoteError> {
+        crate::check_min_version_header(resp.headers());
         let status = resp.status();
         let body = resp
             .text()

--- a/atomic-remote/src/version.rs
+++ b/atomic-remote/src/version.rs
@@ -1,0 +1,133 @@
+//! Version comparison utilities for CLI upgrade warnings.
+//!
+//! When the server sends an `X-Atomic-Min-Version` header, the CLI
+//! checks whether the running version satisfies the minimum requirement
+//! and warns the user if it does not.
+
+use reqwest::header::HeaderMap;
+
+/// Check if `current` version is less than `required` version.
+///
+/// Performs a simple major.minor.patch numeric comparison. Missing parts
+/// default to 0 (e.g. `"1.2"` is treated as `"1.2.0"`).
+///
+/// Returns `true` if `current < required` (upgrade needed).
+/// Returns `false` if `current >= required` or if either version string
+/// cannot be parsed — this avoids spurious warnings on dev or pre-release
+/// version strings.
+pub fn needs_upgrade(current: &str, required: &str) -> bool {
+    fn parse_version(v: &str) -> Option<(u32, u32, u32)> {
+        let mut parts = v.trim().splitn(4, '.');
+        let major = parts.next()?.parse::<u32>().ok()?;
+        let minor = parts.next().unwrap_or("0").parse::<u32>().ok()?;
+        let patch = parts.next().unwrap_or("0").parse::<u32>().ok()?;
+        Some((major, minor, patch))
+    }
+
+    match (parse_version(current), parse_version(required)) {
+        (Some(cur), Some(req)) => cur < req,
+        _ => false,
+    }
+}
+
+/// Check the `X-Atomic-Min-Version` response header and warn if the
+/// current CLI version is older than the server's minimum requirement.
+///
+/// Prints a warning to stderr when an upgrade is needed. Silently does
+/// nothing if the header is absent, unparseable, or already satisfied.
+pub fn check_min_version_header(headers: &HeaderMap) {
+    let header_name =
+        reqwest::header::HeaderName::from_static("x-atomic-min-version");
+
+    if let Some(val) = headers.get(&header_name) {
+        if let Ok(min_ver) = val.to_str() {
+            let current = crate::VERSION;
+            if needs_upgrade(current, min_ver) {
+                eprintln!(
+                    "warning: this server requires Atomic CLI >= {} (you have {}). \
+                     Please upgrade: https://atomic.dev/install",
+                    min_ver, current
+                );
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- needs_upgrade ---
+
+    #[test]
+    fn older_major_needs_upgrade() {
+        assert!(needs_upgrade("0.9.0", "1.0.0"));
+    }
+
+    #[test]
+    fn same_version_no_upgrade() {
+        assert!(!needs_upgrade("1.2.3", "1.2.3"));
+    }
+
+    #[test]
+    fn newer_version_no_upgrade() {
+        assert!(!needs_upgrade("2.0.0", "1.9.9"));
+    }
+
+    #[test]
+    fn older_minor_needs_upgrade() {
+        assert!(needs_upgrade("1.1.0", "1.2.0"));
+    }
+
+    #[test]
+    fn older_patch_needs_upgrade() {
+        assert!(needs_upgrade("1.2.2", "1.2.3"));
+    }
+
+    #[test]
+    fn newer_patch_no_upgrade() {
+        assert!(!needs_upgrade("1.2.4", "1.2.3"));
+    }
+
+    #[test]
+    fn missing_patch_treated_as_zero() {
+        // "1.2" == "1.2.0", so "1.2" vs "1.2.0" → equal → no upgrade
+        assert!(!needs_upgrade("1.2", "1.2.0"));
+    }
+
+    #[test]
+    fn unparseable_current_no_upgrade() {
+        // Don't warn on dev builds or dirty version strings
+        assert!(!needs_upgrade("dev", "1.0.0"));
+    }
+
+    #[test]
+    fn unparseable_required_no_upgrade() {
+        assert!(!needs_upgrade("1.0.0", "not-a-version"));
+    }
+
+    // --- check_min_version_header ---
+
+    #[test]
+    fn no_header_no_panic() {
+        let headers = HeaderMap::new();
+        // Should not panic or print anything
+        check_min_version_header(&headers);
+    }
+
+    #[test]
+    fn header_already_satisfied_no_warn() {
+        // When required <= current, no warning (the function just returns)
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            reqwest::header::HeaderName::from_static("x-atomic-min-version"),
+            reqwest::header::HeaderValue::from_static("0.0.1"),
+        );
+        // crate::VERSION is the actual crate version, which will be >= 0.0.1
+        check_min_version_header(&headers);
+    }
+}

--- a/atomic-remote/src/version.rs
+++ b/atomic-remote/src/version.rs
@@ -45,7 +45,7 @@ pub fn check_min_version_header(headers: &HeaderMap) {
             if needs_upgrade(current, min_ver) {
                 eprintln!(
                     "warning: this server requires Atomic CLI >= {} (you have {}). \
-                     Please upgrade: https://atomic.dev/install",
+                     Run 'atomic update' to upgrade.",
                     min_ver, current
                 );
             }

--- a/atomic-remote/src/version.rs
+++ b/atomic-remote/src/version.rs
@@ -36,8 +36,7 @@ pub fn needs_upgrade(current: &str, required: &str) -> bool {
 /// Prints a warning to stderr when an upgrade is needed. Silently does
 /// nothing if the header is absent, unparseable, or already satisfied.
 pub fn check_min_version_header(headers: &HeaderMap) {
-    let header_name =
-        reqwest::header::HeaderName::from_static("x-atomic-min-version");
+    let header_name = reqwest::header::HeaderName::from_static("x-atomic-min-version");
 
     if let Some(val) = headers.get(&header_name) {
         if let Ok(min_ver) = val.to_str() {


### PR DESCRIPTION
When any response from atomic-storage includes `X-Atomic-Min-Version`, the CLI compares it against the running version and prints a warning to stderr if an upgrade is needed:

```
warning: this server requires Atomic CLI >= 0.8.0 (you have 0.7.0). Run 'atomic update' to upgrade.
```

## Changes

- **`atomic-remote/src/version.rs`** (new): `needs_upgrade(current, required)` for simple semver comparison, `check_min_version_header(headers)` to read the header and warn
- **`atomic-remote/src/storage.rs`**: check fires in `handle_response` and `delete` (covers all management API commands: projects, workspaces, orgs, teams, etc.)
- **`atomic-remote/src/http/queries.rs`**, **`upload.rs`**, **`download.rs`**: check fires in every VCS protocol method (push, pull, clone, tags, provenance)

## Behaviour

- Fires on every command that talks to the server — not just `project list`
- Silently ignored if the header is absent, unparseable, or already satisfied
- Unparseable version strings (dev builds, pre-releases) never warn

Pairs with atomicdotdev/atomic-storage#feat/version-header.