### PR TITLE
feat: multi-server profiles and per-identity remote binding

### DIFF
--- a/atomic-cli/src/commands/auth.rs
+++ b/atomic-cli/src/commands/auth.rs
@@ -1,16 +1,18 @@
 //! Shared authentication helpers for remote commands.
 //!
-//! Resolves the caller's identity from the remote URL, mints a short-lived
-//! self-signed EdDSA JWT for that identity, and attaches it as the
-//! `Authorization: Bearer` header.
+//! Resolves the caller's identity from the remote URL (or an explicit
+//! override), mints a short-lived self-signed EdDSA JWT for that identity,
+//! and attaches it as the `Authorization: Bearer` header.
 //!
 //! A raw public key is NOT a credential — the JWT (signed with the identity's
 //! private key) proves possession of that key. See [`crate::commands::token`]
 //! for the minting mechanics.
 //!
 //! Identity resolution order:
-//! 1. URL userinfo — `http://bob@alice.localhost:8080/...` → identity "bob"
-//! 2. Subdomain — `http://alice.localhost:8080/...` → identity "alice"
+//! 1. Explicit override — `identity_override` from `--identity` flag or
+//!    `RemoteEntry.identity` config field.
+//! 2. URL userinfo — `http://bob@alice.localhost:8080/...` → identity "bob"
+//! 3. Subdomain — `http://alice.localhost:8080/...` → identity "alice"
 
 use atomic_identity::IdentityStore;
 use atomic_remote::HttpRemoteConfig;
@@ -18,19 +20,33 @@ use url::Url;
 
 use crate::error::{CliError, CliResult};
 
-/// Attach a Bearer JWT auth header to the remote config by resolving the
-/// identity from the URL and logging in for a token.
+/// Attach a Bearer JWT auth header to the remote config.
 ///
-/// If the identity cannot be resolved (no userinfo, no subdomain, or identity
-/// not found in the store) or login fails, the config is returned unmodified
-/// and a debug log is emitted. This keeps push/pull/clone working against
-/// servers that don't require auth (e.g. public reads).
-pub async fn attach_identity(config: HttpRemoteConfig, remote_url: &str) -> HttpRemoteConfig {
-    let identity_name = match resolve_identity_name(remote_url) {
-        Some(name) => name,
-        None => {
-            log::debug!("No identity resolvable from URL: {}", remote_url);
-            return config;
+/// `identity_override` — if provided, this identity name is used directly,
+/// bypassing URL-based inference. Set from `RemoteEntry.identity` or the
+/// `--identity` CLI flag.
+///
+/// If the identity cannot be resolved (no override, no userinfo, no subdomain,
+/// or identity not found in the store) or login fails, the config is returned
+/// unmodified and a debug log is emitted. This keeps push/pull/clone working
+/// against servers that don't require auth (e.g. public reads).
+pub async fn attach_identity(
+    config: HttpRemoteConfig,
+    remote_url: &str,
+    identity_override: Option<&str>,
+) -> HttpRemoteConfig {
+    // Priority 1: explicit override (from --identity or RemoteEntry.identity)
+    let identity_name = if let Some(name) = identity_override {
+        log::debug!("Using explicit identity override: {}", name);
+        name.to_string()
+    } else {
+        // Priority 2/3: infer from URL userinfo or subdomain
+        match resolve_identity_name(remote_url) {
+            Some(name) => name,
+            None => {
+                log::debug!("No identity resolvable from URL: {}", remote_url);
+                return config;
+            }
         }
     };
 

--- a/atomic-cli/src/commands/client.rs
+++ b/atomic-cli/src/commands/client.rs
@@ -7,12 +7,15 @@
 //!
 //! # Resolution order
 //!
-//! 1. **Server URL + org slug** — from `GlobalConfig::server` (set during
-//!    `atomic identity register`).
+//! 1. **Server profile** — `--server <name>` selects a named profile from
+//!    `~/.atomic/config.toml` `[servers.*]`. Falls back to `default_server`,
+//!    then to the legacy `[server]` block.
 //! 2. **Org override** — an explicit `--org` flag takes precedence over the
-//!    configured default org.
-//! 3. **Bearer token** — a short-lived, client-self-signed EdDSA JWT minted
-//!    for the default identity (see [`crate::commands::token`]). The raw
+//!    configured default org for the resolved server.
+//! 3. **Identity** — the server profile's `identity` field, if set, overrides
+//!    the global default identity.
+//! 4. **Bearer token** — a short-lived, client-self-signed EdDSA JWT minted
+//!    for the resolved identity (see [`crate::commands::token`]). The raw
 //!    public key is never sent as a credential.
 //!
 //! # Identity resolution
@@ -34,19 +37,24 @@ use atomic_remote::StorageClient;
 
 use crate::error::{CliError, CliResult};
 
-/// Build a [`StorageClient`] from global config and the default identity.
+/// Build a [`StorageClient`] from global config and the resolved identity.
 ///
-/// The optional `org_override` takes precedence over the default org stored
-/// in `GlobalConfig::server`.
+/// - `org_override` — explicit `--org` flag value.
+/// - `server_override` — explicit `--server <name>` flag value; selects a
+///   named profile from `[servers.*]` in `~/.atomic/config.toml`.
 ///
 /// # Errors
 ///
 /// - Config not loaded or server not configured.
+/// - Named server profile not found.
 /// - No org slug available (neither override nor default).
 /// - Identity store cannot be opened or no default identity set.
 /// - HTTP client construction failure.
-pub async fn build_client(org_override: Option<&str>) -> CliResult<StorageClient> {
-    let (client, _org_slug) = build_client_with_org(org_override).await?;
+pub async fn build_client(
+    org_override: Option<&str>,
+    server_override: Option<&str>,
+) -> CliResult<StorageClient> {
+    let (client, _org_slug) = build_client_with_org(org_override, server_override).await?;
     Ok(client)
 }
 
@@ -56,18 +64,27 @@ pub async fn build_client(org_override: Option<&str>) -> CliResult<StorageClient
 /// per-org default workspace lookup). Avoids resolving the org twice.
 pub async fn build_client_with_org(
     org_override: Option<&str>,
+    server_override: Option<&str>,
 ) -> CliResult<(StorageClient, String)> {
     let config = GlobalConfig::load()
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load global config: {}", e)))?;
 
-    let server = &config.server;
+    // Resolve the server profile (named or legacy).
+    let server = config
+        .resolve_server(server_override)
+        .map_err(|e| CliError::Internal(anyhow::anyhow!("{}", e)))?
+        .0;
+
     let server_url = server.url.clone().ok_or_else(|| {
-        CliError::Internal(anyhow::anyhow!(
-            "Server not configured. Run 'atomic identity register <server-url>' first."
-        ))
+        let hint = if let Some(name) = server_override {
+            format!("Server profile '{}' has no URL configured.", name)
+        } else {
+            "Server not configured. Run 'atomic identity register <server-url>' first.".to_string()
+        };
+        CliError::Internal(anyhow::anyhow!("{}", hint))
     })?;
 
-    let org_slug = resolve_org(org_override)?;
+    let org_slug = resolve_org_with_server(org_override, server)?;
 
     let base_url = server.org_base_url(&org_slug).ok_or_else(|| {
         CliError::Internal(anyhow::anyhow!(
@@ -75,21 +92,33 @@ pub async fn build_client_with_org(
         ))
     })?;
 
-    // Load default identity — we authenticate with a short-lived JWT obtained
-    // by signing a challenge with this identity's private key, never with the
-    // raw public key.
+    // Resolve identity: per-server override → global default.
     let store = IdentityStore::open_default()
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to open identity store: {}", e)))?;
 
-    let identity = store
-        .get_default()
-        .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load default identity: {}", e)))?
-        .ok_or_else(|| {
+    let identity = if let Some(ref identity_name) = server.identity {
+        // Server profile specifies an identity — use it.
+        store.load_by_name(identity_name).map_err(|e| {
             CliError::Internal(anyhow::anyhow!(
-                "No default identity set. Create one first:\n  \
-                 atomic identity new <name> --email <email> --set-default"
+                "Identity '{}' specified by server profile not found: {}",
+                identity_name,
+                e
             ))
-        })?;
+        })?
+    } else {
+        // Fall back to global default identity.
+        store
+            .get_default()
+            .map_err(|e| {
+                CliError::Internal(anyhow::anyhow!("Failed to load default identity: {}", e))
+            })?
+            .ok_or_else(|| {
+                CliError::Internal(anyhow::anyhow!(
+                    "No default identity set. Create one first:\n  \
+                     atomic identity new <name> --email <email> --set-default"
+                ))
+            })?
+    };
 
     // Log in against the server apex for a JWT bearer token.
     let bearer_token = crate::commands::token::get_token(&server_url, &identity).await?;
@@ -111,13 +140,42 @@ pub fn remote_err(e: atomic_remote::RemoteError) -> CliError {
 
 /// Resolve the org slug for a command, with fallback to the configured default.
 ///
+/// This variant uses the *active* server's `default_org` so that per-server
+/// org defaults are respected.
+///
 /// Resolution order:
 /// 1. `--org` override (if `Some(non-empty)`)
-/// 2. `server.default_org` from global config
+/// 2. `server.default_org` from the resolved server profile
 /// 3. Error with a hint to run `atomic org set`
 ///
 /// An explicit empty string (`--org ""`) is an error: the user asked for "no
 /// org" which never makes sense.
+pub fn resolve_org_with_server(
+    org_override: Option<&str>,
+    server: &atomic_config::ServerConfig,
+) -> CliResult<String> {
+    if let Some(s) = org_override {
+        if s.is_empty() {
+            return Err(CliError::InvalidArgument {
+                message: "Organization slug cannot be empty.".to_string(),
+            });
+        }
+        return Ok(s.to_string());
+    }
+
+    server
+        .default_org
+        .clone()
+        .ok_or_else(|| CliError::InvalidArgument {
+            message: "No organization specified.\n  \
+                      Use --org or set a default with: atomic org set <slug>"
+                .to_string(),
+        })
+}
+
+/// Resolve the org slug using the legacy (single-server) config path.
+///
+/// Kept for callers that don't yet pass a server override.
 pub fn resolve_org(org_override: Option<&str>) -> CliResult<String> {
     if let Some(s) = org_override {
         if s.is_empty() {
@@ -142,11 +200,48 @@ pub fn resolve_org(org_override: Option<&str>) -> CliResult<String> {
 }
 
 /// Resolve the workspace slug for a command, with fallback to the
-/// org-scoped default workspace from global config.
+/// org-scoped default workspace from a server config.
 ///
 /// Workspaces are org-scoped, so the lookup is keyed by `org_slug`. The
 /// caller is responsible for resolving the org first (typically with
-/// [`resolve_org`]).
+/// [`resolve_org_with_server`]).
+///
+/// Resolution order:
+/// 1. `--workspace` override (if `Some(non-empty)`)
+/// 2. `server.default_workspaces[org_slug]` from the resolved server profile
+/// 3. Error with a hint to run `atomic workspace set`
+pub fn resolve_workspace_with_server(
+    org_slug: &str,
+    workspace_override: Option<&str>,
+    server: &atomic_config::ServerConfig,
+) -> CliResult<String> {
+    if let Some(s) = workspace_override {
+        if s.is_empty() {
+            return Err(CliError::InvalidArgument {
+                message: "Workspace slug cannot be empty.".to_string(),
+            });
+        }
+        return Ok(s.to_string());
+    }
+
+    server
+        .default_workspaces
+        .get(org_slug)
+        .cloned()
+        .ok_or_else(|| CliError::InvalidArgument {
+            message: format!(
+                "No workspace specified for org '{org_slug}'.\n  \
+                 Use --workspace or set a default with: atomic workspace set <slug>"
+            ),
+        })
+}
+
+/// Resolve the workspace slug for a command, with fallback to the
+/// org-scoped default workspace from global config.
+///
+/// Uses the legacy (single-server) config path. Prefer
+/// [`resolve_workspace_with_server`] when you have already resolved the
+/// active server.
 ///
 /// Resolution order:
 /// 1. `--workspace` override (if `Some(non-empty)`)

--- a/atomic-cli/src/commands/clone/command.rs
+++ b/atomic-cli/src/commands/clone/command.rs
@@ -205,7 +205,8 @@ impl Clone {
             .with_timeout(Duration::from_secs(self.timeout))
             .danger_accept_invalid_certs(self.insecure);
 
-        crate::commands::auth::attach_identity(config, &self.url).await
+        // Clone uses the URL directly — identity inferred from subdomain only.
+        crate::commands::auth::attach_identity(config, &self.url, None).await
     }
 
     /// Get the display name for the repository.

--- a/atomic-cli/src/commands/identity/mod.rs
+++ b/atomic-cli/src/commands/identity/mod.rs
@@ -59,6 +59,8 @@ pub use whoami::WhoAmI;
 
 use clap::Subcommand;
 
+use atomic_config::GlobalConfig;
+
 use crate::commands::Command;
 use crate::error::CliResult;
 
@@ -325,6 +327,7 @@ impl Command for Default {
                     "Set '{}' as default identity for {} usage",
                     name, usage
                 ));
+                activate_server_for_identity(name);
             } else {
                 store.set_default(&identity.id).map_err(|e| {
                     crate::error::CliError::Internal(anyhow::anyhow!(
@@ -333,6 +336,7 @@ impl Command for Default {
                     ))
                 })?;
                 print_success(&format!("Set '{}' as default identity", name));
+                activate_server_for_identity(name);
             }
         }
 
@@ -341,6 +345,49 @@ impl Command for Default {
 }
 
 // Helper Functions
+
+/// When an identity becomes the active default, automatically activate the
+/// server profile bound to it (if any).
+///
+/// Looks for a named profile in `~/.atomic/config.toml` whose `identity`
+/// field matches `identity_name`. If found, sets `default_server` to that
+/// profile name and saves the config. Emits a hint so the user knows the
+/// server switched alongside the identity.
+///
+/// This is intentionally non-fatal: if the config can't be loaded/saved,
+/// a debug log is emitted and the command still succeeds — the identity
+/// switch itself is the important operation.
+pub fn activate_server_for_identity(identity_name: &str) {
+    let mut config = match GlobalConfig::load() {
+        Ok(c) => c,
+        Err(e) => {
+            log::debug!("Could not load config for server auto-activation: {}", e);
+            return;
+        }
+    };
+
+    // Find a named server profile whose identity binding matches.
+    let matching_profile = config
+        .servers
+        .iter()
+        .find(|(_, srv)| srv.identity.as_deref() == Some(identity_name))
+        .map(|(name, _)| name.clone());
+
+    if let Some(profile_name) = matching_profile {
+        // Only update + print if it's actually changing.
+        if config.default_server.as_deref() != Some(&profile_name) {
+            config.default_server = Some(profile_name.clone());
+            if let Err(e) = config.save() {
+                log::debug!("Could not save config for server auto-activation: {}", e);
+                return;
+            }
+            crate::output::print_hint(&format!(
+                "Server profile '{}' activated (bound to identity '{}')",
+                profile_name, identity_name
+            ));
+        }
+    }
+}
 
 /// Format an identity type for display.
 pub fn format_identity_type(identity_type: &atomic_identity::IdentityType) -> &'static str {

--- a/atomic-cli/src/commands/identity/new.rs
+++ b/atomic-cli/src/commands/identity/new.rs
@@ -158,6 +158,7 @@ impl Command for New {
             store.set_default(&identity.id).map_err(|e| {
                 CliError::Internal(anyhow::anyhow!("Failed to set as default: {}", e))
             })?;
+            super::activate_server_for_identity(&identity.name);
         }
 
         if self.set_default_for_usage {
@@ -166,6 +167,7 @@ impl Command for New {
                 .map_err(|e| {
                     CliError::Internal(anyhow::anyhow!("Failed to set as default for usage: {}", e))
                 })?;
+            super::activate_server_for_identity(&identity.name);
         }
 
         // Print success message

--- a/atomic-cli/src/commands/identity/register.rs
+++ b/atomic-cli/src/commands/identity/register.rs
@@ -61,6 +61,12 @@ const SIGNING_DOMAIN: &str = "atomic-storage:register";
 /// Pushes the local identity to the server, which creates a tenant
 /// whose slug is derived from the identity's username. Authentication
 /// is Ed25519 signature-based — no passwords required.
+///
+/// When `--identity` is specified, a named server profile is automatically
+/// created in `~/.atomic/config.toml` so that commands targeting this
+/// server use that identity automatically. The profile name is derived
+/// from the server hostname (e.g. `staging.atomic.storage` → `staging`).
+/// Use `--server-name <name>` to choose a custom profile name.
 #[derive(Debug, Parser)]
 pub struct Register {
     /// URL of the atomic-storage server.
@@ -76,9 +82,19 @@ pub struct Register {
 
     /// Name of the identity to register.
     ///
-    /// If not specified, the current default identity is used.
+    /// If not specified, the current default identity is used. When
+    /// specified, the server URL and identity are automatically saved as
+    /// a named server profile (see `--server-name`).
     #[arg(short, long)]
     pub identity: Option<String>,
+
+    /// Custom name for the auto-created server profile.
+    ///
+    /// Only used when `--identity` is given. Defaults to the first
+    /// hostname label of the server URL (e.g. `staging` from
+    /// `staging.atomic.storage`).
+    #[arg(long)]
+    pub server_name: Option<String>,
 }
 
 impl Command for Register {
@@ -188,11 +204,52 @@ impl Register {
                 .and_then(|v| v.as_str())
                 .unwrap_or("(unknown)");
 
+            let clean_server_url = self.server_url.trim_end_matches('/').to_string();
             let mut config = GlobalConfig::load().map_err(|e| {
                 CliError::Internal(anyhow::anyhow!("Failed to load global config: {e}"))
             })?;
-            config.server.url = Some(self.server_url.trim_end_matches('/').to_string());
-            config.server.default_org = Some(slug.to_string());
+
+            // When --identity is specified, register as a named server profile
+            // so the URL+identity combo is remembered automatically.
+            if self.identity.is_some() {
+                let profile_name = self
+                    .server_name
+                    .clone()
+                    .or_else(|| derive_profile_name(&clean_server_url))
+                    .unwrap_or_else(|| slug.to_string());
+
+                let profile = atomic_config::ServerConfig {
+                    url: Some(clean_server_url.clone()),
+                    default_org: Some(slug.to_string()),
+                    default_workspaces: std::collections::BTreeMap::new(),
+                    identity: Some(identity.name.clone()),
+                };
+
+                config.servers.insert(profile_name.clone(), profile);
+
+                // If there's no active named server yet, make this one active.
+                if config.default_server.is_none() && config.server.is_configured() {
+                    // Legacy [server] is already set — don't override it silently.
+                    // Just register the profile; user can activate with `atomic server set`.
+                    println!(
+                        "  Profile:   '{}' added (activate with: atomic server set {})",
+                        profile_name, profile_name
+                    );
+                } else if config.default_server.is_none() {
+                    config.default_server = Some(profile_name.clone());
+                    println!("  Profile:   '{}' (now active)", profile_name);
+                } else {
+                    println!(
+                        "  Profile:   '{}' added (activate with: atomic server set {})",
+                        profile_name, profile_name
+                    );
+                }
+            } else {
+                // Default path: update the legacy [server] block.
+                config.server.url = Some(clean_server_url.clone());
+                config.server.default_org = Some(slug.to_string());
+            }
+
             config.save().map_err(|e| {
                 CliError::Internal(anyhow::anyhow!("Failed to save global config: {e}"))
             })?;
@@ -271,6 +328,34 @@ impl Register {
     }
 }
 
+/// Derive a short profile name from a server URL.
+///
+/// `https://staging.atomic.storage` → `"staging"`
+/// `https://atomic.storage`         → `"atomic-storage"` (no subdomain)
+/// `http://localhost:8080`           → `"localhost"`
+fn derive_profile_name(server_url: &str) -> Option<String> {
+    let url = url::Url::parse(server_url).ok()?;
+    let host = url.host_str()?;
+
+    // If the host has a subdomain, use that as the profile name.
+    if let Some(dot) = host.find('.') {
+        let label = &host[..dot];
+        if !label.is_empty() && label != "www" {
+            return Some(label.to_string());
+        }
+        // No useful subdomain — fall through to full host slug.
+    }
+
+    // Slug the host: replace dots and colons with hyphens, strip port.
+    let host_no_port = host.split(':').next().unwrap_or(host);
+    let slug = host_no_port.replace('.', "-");
+    if slug.is_empty() {
+        None
+    } else {
+        Some(slug)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -305,6 +390,7 @@ mod tests {
         let cmd = Register {
             server_url: "http://localhost:8080".to_string(),
             identity: Some("alice".to_string()),
+            server_name: None,
         };
 
         assert_eq!(cmd.server_url, "http://localhost:8080");
@@ -316,8 +402,35 @@ mod tests {
         let cmd = Register {
             server_url: "http://localhost:8080".to_string(),
             identity: None,
+            server_name: None,
         };
 
         assert!(cmd.identity.is_none());
+    }
+
+    #[test]
+    fn derive_profile_name_subdomain() {
+        assert_eq!(
+            derive_profile_name("https://staging.atomic.storage"),
+            Some("staging".to_string())
+        );
+    }
+
+    #[test]
+    fn derive_profile_name_no_subdomain() {
+        // "atomic.storage" — "atomic" is the first label (subdomain of "storage")
+        // so it's used as the profile name.
+        assert_eq!(
+            derive_profile_name("https://atomic.storage"),
+            Some("atomic".to_string())
+        );
+    }
+
+    #[test]
+    fn derive_profile_name_localhost() {
+        assert_eq!(
+            derive_profile_name("http://localhost:8080"),
+            Some("localhost".to_string())
+        );
     }
 }

--- a/atomic-cli/src/commands/mod.rs
+++ b/atomic-cli/src/commands/mod.rs
@@ -98,6 +98,7 @@ pub mod clone;
 pub mod pull;
 pub mod push;
 pub mod remote;
+pub mod server;
 
 // Phase 4: Identity Management
 pub mod identity;
@@ -143,6 +144,7 @@ pub use remove::Remove;
 pub use restore::Restore;
 pub use revise::Revise;
 pub use sandbox::Sandbox;
+pub use server::ServerCmd;
 pub use split::Split;
 pub use stash::Stash;
 pub use status::Status;

--- a/atomic-cli/src/commands/org/create.rs
+++ b/atomic-cli/src/commands/org/create.rs
@@ -81,7 +81,7 @@ impl OrgCreate {
     async fn execute(&self) -> CliResult<()> {
         // Build client using current default org (doesn't matter which org
         // we're scoped to — the server creates a new org regardless).
-        let client = build_client(None).await?;
+        let client = build_client(None, None).await?;
 
         let info = atomic_teams::org::create_org(&client, &self.name, self.email.as_deref())
             .await

--- a/atomic-cli/src/commands/org/delete.rs
+++ b/atomic-cli/src/commands/org/delete.rs
@@ -103,7 +103,7 @@ impl OrgDelete {
             }
         }
 
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
 
         atomic_teams::org::delete_org(&client, &self.slug)
             .await

--- a/atomic-cli/src/commands/org/list.rs
+++ b/atomic-cli/src/commands/org/list.rs
@@ -71,7 +71,7 @@ impl Command for OrgList {
 
 impl OrgList {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let slug = client.org_slug().to_string();
 
         let info = atomic_teams::org::get_org(&client, &slug)

--- a/atomic-cli/src/commands/org/member.rs
+++ b/atomic-cli/src/commands/org/member.rs
@@ -161,7 +161,7 @@ impl Command for MemberList {
 
 impl MemberList {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let slug = client.org_slug().to_string();
 
         let members = atomic_teams::member::list_members(&client, &slug)
@@ -261,7 +261,7 @@ impl MemberAdd {
             ),
         })?;
 
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let slug = client.org_slug().to_string();
 
         let identity_id =
@@ -338,7 +338,7 @@ impl MemberUpdate {
             ),
         })?;
 
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let slug = client.org_slug().to_string();
 
         let identity_id =
@@ -409,7 +409,7 @@ impl Command for MemberRemove {
 
 impl MemberRemove {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let slug = client.org_slug().to_string();
 
         let identity_id =

--- a/atomic-cli/src/commands/org/set.rs
+++ b/atomic-cli/src/commands/org/set.rs
@@ -138,7 +138,7 @@ fn verify_org_exists(slug: &str) -> CliResult<()> {
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to create async runtime: {e}")))?;
 
     rt.block_on(async {
-        let (client, _resolved) = build_client_with_org(Some(slug)).await?;
+        let (client, _resolved) = build_client_with_org(Some(slug), None).await?;
         match atomic_teams::org::get_org(&client, slug).await {
             Ok(_) => Ok(()),
             Err(e) if is_org_not_found(&e) => Err(CliError::InvalidArgument {

--- a/atomic-cli/src/commands/org/show.rs
+++ b/atomic-cli/src/commands/org/show.rs
@@ -85,7 +85,7 @@ impl Command for OrgShow {
 
 impl OrgShow {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
 
         // Determine which slug to look up: explicit arg > client's org slug
         let slug = self.slug.as_deref().unwrap_or_else(|| client.org_slug());

--- a/atomic-cli/src/commands/org/update.rs
+++ b/atomic-cli/src/commands/org/update.rs
@@ -98,7 +98,7 @@ impl OrgUpdate {
             });
         }
 
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
 
         // Determine which slug to update: explicit arg > client's org slug.
         let slug = self.slug.as_deref().unwrap_or_else(|| client.org_slug());

--- a/atomic-cli/src/commands/org/upgrade.rs
+++ b/atomic-cli/src/commands/org/upgrade.rs
@@ -84,7 +84,7 @@ impl Command for OrgUpgrade {
 
 impl OrgUpgrade {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
 
         // Determine which slug to upgrade: explicit arg > client's org slug.
         let slug = self.slug.as_deref().unwrap_or_else(|| client.org_slug());

--- a/atomic-cli/src/commands/project/create.rs
+++ b/atomic-cli/src/commands/project/create.rs
@@ -101,6 +101,13 @@ pub struct ProjectCreate {
     /// If not specified, uses the default org from global config.
     #[arg(long)]
     pub org: Option<String>,
+
+    /// Server profile to use (e.g. "staging", "prod").
+    ///
+    /// Overrides `default_server` from `~/.atomic/config.toml`.
+    /// Use `atomic server list` to see available profiles.
+    #[arg(long)]
+    pub server: Option<String>,
 }
 
 impl ProjectCreate {
@@ -124,7 +131,8 @@ impl Command for ProjectCreate {
         })?;
 
         rt.block_on(async {
-            let (client, org_slug) = build_client_with_org(self.org.as_deref()).await?;
+            let (client, org_slug) =
+                build_client_with_org(self.org.as_deref(), self.server.as_deref()).await?;
             let workspace = resolve_workspace(&org_slug, self.workspace.as_deref())?;
             let visibility = self.parse_visibility()?;
 
@@ -208,6 +216,7 @@ mod tests {
             default_view: "main".to_string(),
             visibility: "public".to_string(),
             org: Some("acme".to_string()),
+            server: None,
         };
         assert_eq!(cmd.name, "svc");
         assert_eq!(cmd.workspace.as_deref(), Some("backend"));

--- a/atomic-cli/src/commands/project/delete.rs
+++ b/atomic-cli/src/commands/project/delete.rs
@@ -88,7 +88,7 @@ impl Command for ProjectDelete {
                 }
             }
 
-            let client = build_client(self.org.as_deref()).await?;
+            let client = build_client(self.org.as_deref(), None).await?;
 
             client
                 .delete_project(ws_slug, proj_slug)

--- a/atomic-cli/src/commands/project/init.rs
+++ b/atomic-cli/src/commands/project/init.rs
@@ -114,7 +114,7 @@ impl ProjectInit {
         })?;
 
         // 2. Build the storage client and resolve the workspace.
-        let (client, org_slug) = build_client_with_org(self.org.as_deref()).await?;
+        let (client, org_slug) = build_client_with_org(self.org.as_deref(), None).await?;
         let workspace = resolve_workspace(&org_slug, self.workspace.as_deref())?;
 
         // 3. Ensure the workspace exists — create it if necessary.

--- a/atomic-cli/src/commands/project/list.rs
+++ b/atomic-cli/src/commands/project/list.rs
@@ -55,6 +55,13 @@ pub struct ProjectList {
     #[arg(long)]
     pub org: Option<String>,
 
+    /// Server profile to use (e.g. "staging", "prod").
+    ///
+    /// Overrides `default_server` from `~/.atomic/config.toml`.
+    /// Use `atomic server list` to see available profiles.
+    #[arg(long)]
+    pub server: Option<String>,
+
     /// Output format: `table` or `json`.
     #[arg(long, default_value = "table")]
     pub format: String,
@@ -67,7 +74,8 @@ impl Command for ProjectList {
         })?;
 
         rt.block_on(async {
-            let (client, org_slug) = build_client_with_org(self.org.as_deref()).await?;
+            let (client, org_slug) =
+                build_client_with_org(self.org.as_deref(), self.server.as_deref()).await?;
             let workspace = resolve_workspace(&org_slug, self.workspace.as_deref())?;
 
             let projects = client.list_projects(&workspace).await.map_err(remote_err)?;
@@ -132,6 +140,7 @@ mod tests {
         let cmd = ProjectList {
             workspace: Some("ws".to_string()),
             org: None,
+            server: None,
             format: "table".to_string(),
         };
         assert_eq!(cmd.format, "table");
@@ -142,6 +151,7 @@ mod tests {
         let cmd = ProjectList {
             workspace: Some("my-workspace".to_string()),
             org: Some("acme".to_string()),
+            server: None,
             format: "json".to_string(),
         };
         assert_eq!(cmd.workspace.as_deref(), Some("my-workspace"));
@@ -154,6 +164,7 @@ mod tests {
         let cmd = ProjectList {
             workspace: None,
             org: None,
+            server: None,
             format: "table".to_string(),
         };
         assert!(cmd.workspace.is_none());

--- a/atomic-cli/src/commands/project/mod.rs
+++ b/atomic-cli/src/commands/project/mod.rs
@@ -228,6 +228,7 @@ mod tests {
         let list = list::ProjectList {
             workspace: Some("ws".to_string()),
             org: None,
+            server: None,
             format: "table".to_string(),
         };
         assert_eq!(check_variant(&ProjectCommands::List(list)), "list");
@@ -240,6 +241,7 @@ mod tests {
             default_view: "dev".to_string(),
             visibility: "private".to_string(),
             org: None,
+            server: None,
         };
         assert_eq!(check_variant(&ProjectCommands::Create(create)), "create");
     }

--- a/atomic-cli/src/commands/project/show.rs
+++ b/atomic-cli/src/commands/project/show.rs
@@ -79,7 +79,7 @@ impl Command for ProjectShow {
 
         rt.block_on(async {
             let (ws_slug, proj_slug) = parse_project_path(&self.slug)?;
-            let client = build_client(self.org.as_deref()).await?;
+            let client = build_client(self.org.as_deref(), None).await?;
 
             let project = client
                 .get_project(ws_slug, proj_slug)

--- a/atomic-cli/src/commands/project/update.rs
+++ b/atomic-cli/src/commands/project/update.rs
@@ -94,7 +94,7 @@ impl Command for ProjectUpdate {
         })?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref()).await?;
+            let client = build_client(self.org.as_deref(), None).await?;
 
             let req = UpdateProjectRequest {
                 name: self.name.clone(),

--- a/atomic-cli/src/commands/pull/command.rs
+++ b/atomic-cli/src/commands/pull/command.rs
@@ -153,6 +153,16 @@ pub struct Pull {
     /// Useful for pre-fetching changes or examining them before applying.
     #[arg(long)]
     pub download_only: bool,
+
+    /// Identity to use for authentication.
+    ///
+    /// Overrides the identity inferred from the remote URL subdomain and
+    /// the `identity` field in the remote's config entry.  Must match a
+    /// locally stored identity name (see `atomic identity list`).
+    ///
+    /// Example: `atomic pull --identity alice-staging`
+    #[arg(long)]
+    pub identity: Option<String>,
 }
 
 impl Pull {
@@ -177,6 +187,7 @@ impl Pull {
             insecure: false,
             timeout: DEFAULT_TIMEOUT_SECS,
             download_only: false,
+            identity: None,
         }
     }
 
@@ -228,22 +239,28 @@ impl Pull {
         self
     }
 
+    /// Builder: set an explicit identity name override.
+    pub fn with_identity(mut self, identity: impl Into<String>) -> Self {
+        self.identity = Some(identity.into());
+        self
+    }
+
     // Internal Helper Methods
 
-    /// Resolve the remote URL from the remote name or return as-is if it's a URL.
+    /// Resolve the remote URL and any identity hint from the `--identity` flag.
     ///
-    /// If the remote string looks like a URL (contains "://"), it's returned as-is.
-    /// Otherwise, it's treated as a remote name and looked up in the repository
-    /// configuration.
-    fn resolve_remote_url(&self, repo: &Repository) -> CliResult<String> {
+    /// Returns `(url, identity_hint)` where `identity_hint` comes solely from
+    /// the `--identity` CLI flag. If absent, `attach_identity` falls back to
+    /// URL-subdomain inference.
+    fn resolve_remote_url(&self, repo: &Repository) -> CliResult<(String, Option<String>)> {
         // If it looks like a URL, use it directly
         if self.remote.contains("://") {
-            return Ok(self.remote.clone());
+            return Ok((self.remote.clone(), self.identity.clone()));
         }
 
         // Look up named remote in repository configuration
         match repo.get_remote(&self.remote) {
-            Ok(entry) => Ok(entry.url),
+            Ok(entry) => Ok((entry.url, self.identity.clone())),
             Err(atomic_repository::RepositoryError::RemoteNotFound { .. }) => {
                 Err(CliError::RemoteNotFound {
                     name: self.remote.clone(),
@@ -273,14 +290,18 @@ impl Pull {
 
     /// Build the HTTP remote configuration.
     ///
-    /// Creates an `HttpRemoteConfig` with the timeout and security settings
-    /// specified by the user.
-    async fn build_remote_config(&self, remote_url: &str) -> HttpRemoteConfig {
+    /// `identity_hint` — explicit identity name to use (from `--identity` or
+    /// `RemoteEntry.identity`). When `None`, falls back to URL-based inference.
+    async fn build_remote_config(
+        &self,
+        remote_url: &str,
+        identity_hint: Option<&str>,
+    ) -> HttpRemoteConfig {
         let config = HttpRemoteConfig::new()
             .with_timeout(Duration::from_secs(self.timeout))
             .danger_accept_invalid_certs(self.insecure);
 
-        crate::commands::auth::attach_identity(config, remote_url).await
+        crate::commands::auth::attach_identity(config, remote_url, identity_hint).await
     }
 
     /// Display the dry run preview.
@@ -352,8 +373,8 @@ impl Pull {
         let repo_root = find_repository_root()?;
         let repo = Repository::open(&repo_root).map_err(CliError::Repository)?;
 
-        // Resolve remote URL
-        let remote_url = self.resolve_remote_url(&repo)?;
+        // Resolve remote URL and identity hint
+        let (remote_url, identity_hint) = self.resolve_remote_url(&repo)?;
 
         // Determine views
         let local_view = self.get_local_view(&repo);
@@ -368,7 +389,9 @@ impl Pull {
 
         // Connect to remote
         let spinner = create_spinner("Connecting to remote...");
-        let config = self.build_remote_config(&remote_url).await;
+        let config = self
+            .build_remote_config(&remote_url, identity_hint.as_deref())
+            .await;
         let remote = HttpRemote::with_config(&remote_url, config).map_err(|e| {
             finish_error(&spinner, "Failed to connect");
             convert_remote_error(e, &remote_url)
@@ -889,7 +912,7 @@ mod tests {
     async fn test_build_remote_config_default() {
         let pull = Pull::new();
         let config = pull
-            .build_remote_config("http://test.localhost:8080/code")
+            .build_remote_config("http://test.localhost:8080/code", None)
             .await;
 
         // HttpRemoteConfig doesn't expose fields directly, so we just verify
@@ -902,7 +925,7 @@ mod tests {
     async fn test_build_remote_config_custom_timeout() {
         let pull = Pull::new().with_timeout(120);
         let config = pull
-            .build_remote_config("http://test.localhost:8080/code")
+            .build_remote_config("http://test.localhost:8080/code", None)
             .await;
         assert!(std::mem::size_of_val(&config) > 0);
     }
@@ -912,7 +935,7 @@ mod tests {
     async fn test_build_remote_config_insecure() {
         let pull = Pull::new().with_insecure(true);
         let config = pull
-            .build_remote_config("http://test.localhost:8080/code")
+            .build_remote_config("http://test.localhost:8080/code", None)
             .await;
         assert!(std::mem::size_of_val(&config) > 0);
     }

--- a/atomic-cli/src/commands/push/command.rs
+++ b/atomic-cli/src/commands/push/command.rs
@@ -121,6 +121,16 @@ pub struct Push {
     /// Request timeout in seconds.
     #[arg(long, default_value_t = DEFAULT_TIMEOUT_SECS)]
     pub timeout: u64,
+
+    /// Identity to use for authentication.
+    ///
+    /// Overrides the identity inferred from the remote URL subdomain and
+    /// the `identity` field in the remote's config entry.  Must match a
+    /// locally stored identity name (see `atomic identity list`).
+    ///
+    /// Example: `atomic push --identity alice-staging`
+    #[arg(long)]
+    pub identity: Option<String>,
 }
 
 impl Push {
@@ -145,6 +155,7 @@ impl Push {
             all: false,
             insecure: false,
             timeout: DEFAULT_TIMEOUT_SECS,
+            identity: None,
         }
     }
 
@@ -196,31 +207,26 @@ impl Push {
         self
     }
 
-    /// Resolve the remote URL.
+    /// Builder: set an explicit identity name override.
+    pub fn with_identity(mut self, identity: impl Into<String>) -> Self {
+        self.identity = Some(identity.into());
+        self
+    }
+
+    /// Resolve the remote URL and any identity hint from the `--identity` flag.
     ///
-    /// If the remote is a URL (contains "://"), returns it directly.
-    /// Otherwise, looks up the named remote in the repository configuration.
-    ///
-    /// # Arguments
-    ///
-    /// * `repo` - The repository to look up configuration from
-    ///
-    /// # Returns
-    ///
-    /// The resolved remote URL.
-    ///
-    /// # Errors
-    ///
-    /// Returns `CliError::RemoteNotFound` if the named remote doesn't exist.
-    fn resolve_remote_url(&self, repo: &Repository) -> CliResult<String> {
+    /// Returns `(url, identity_hint)` where `identity_hint` comes solely from
+    /// the `--identity` CLI flag. If absent, `attach_identity` falls back to
+    /// URL-subdomain inference.
+    fn resolve_remote_url(&self, repo: &Repository) -> CliResult<(String, Option<String>)> {
         // If it looks like a URL, use it directly
         if self.remote.contains("://") {
-            return Ok(self.remote.clone());
+            return Ok((self.remote.clone(), self.identity.clone()));
         }
 
         // Look up named remote in repository configuration
         match repo.get_remote(&self.remote) {
-            Ok(entry) => Ok(entry.url),
+            Ok(entry) => Ok((entry.url, self.identity.clone())),
             Err(atomic_repository::RepositoryError::RemoteNotFound { .. }) => {
                 Err(CliError::RemoteNotFound {
                     name: self.remote.clone(),
@@ -249,12 +255,19 @@ impl Push {
     }
 
     /// Build the HTTP remote configuration.
-    async fn build_remote_config(&self, remote_url: &str) -> HttpRemoteConfig {
+    ///
+    /// `identity_hint` — explicit identity name to use (from `--identity` or
+    /// `RemoteEntry.identity`). When `None`, falls back to URL-based inference.
+    async fn build_remote_config(
+        &self,
+        remote_url: &str,
+        identity_hint: Option<&str>,
+    ) -> HttpRemoteConfig {
         let config = HttpRemoteConfig::new()
             .with_timeout(Duration::from_secs(self.timeout))
             .danger_accept_invalid_certs(self.insecure);
 
-        crate::commands::auth::attach_identity(config, remote_url).await
+        crate::commands::auth::attach_identity(config, remote_url, identity_hint).await
     }
 
     /// Display the dry run preview.
@@ -295,8 +308,8 @@ impl Push {
         let repo_root = find_repository_root()?;
         let repo = Repository::open(&repo_root).map_err(CliError::Repository)?;
 
-        // Resolve remote URL
-        let remote_url = self.resolve_remote_url(&repo)?;
+        // Resolve remote URL and identity hint
+        let (remote_url, identity_hint) = self.resolve_remote_url(&repo)?;
 
         // Determine views
         let local_view = self.get_local_view(&repo);
@@ -320,7 +333,9 @@ impl Push {
 
         // Connect to remote
         let spinner = create_spinner("Connecting to remote...");
-        let config = self.build_remote_config(&remote_url).await;
+        let config = self
+            .build_remote_config(&remote_url, identity_hint.as_deref())
+            .await;
         let remote = HttpRemote::with_config(&remote_url, config).map_err(|e| {
             finish_error(&spinner, "Failed to connect");
             convert_remote_error(e, &remote_url)
@@ -923,7 +938,7 @@ mod tests {
     async fn test_build_remote_config_default() {
         let push = Push::new();
         let config = push
-            .build_remote_config("http://test.localhost:8080/code")
+            .build_remote_config("http://test.localhost:8080/code", None)
             .await;
 
         assert_eq!(config.timeout, Duration::from_secs(DEFAULT_TIMEOUT_SECS));
@@ -934,7 +949,7 @@ mod tests {
     async fn test_build_remote_config_custom_timeout() {
         let push = Push::new().with_timeout(120);
         let config = push
-            .build_remote_config("http://test.localhost:8080/code")
+            .build_remote_config("http://test.localhost:8080/code", None)
             .await;
 
         assert_eq!(config.timeout, Duration::from_secs(120));
@@ -944,7 +959,7 @@ mod tests {
     async fn test_build_remote_config_insecure() {
         let push = Push::new().with_insecure(true);
         let config = push
-            .build_remote_config("http://test.localhost:8080/code")
+            .build_remote_config("http://test.localhost:8080/code", None)
             .await;
 
         assert!(config.danger_accept_invalid_certs);

--- a/atomic-cli/src/commands/server/mod.rs
+++ b/atomic-cli/src/commands/server/mod.rs
@@ -1,0 +1,500 @@
+//! Server profile management commands.
+//!
+//! This module provides commands for managing named server profiles in
+//! `~/.atomic/config.toml`. Server profiles let you switch between
+//! environments (staging, production, local) with a single flag or by
+//! setting a default.
+//!
+//! # Available Subcommands
+//!
+//! - `server` (no args) — List all configured server profiles
+//! - `server add <name> <url>` — Add a new server profile
+//! - `server set <name>` — Switch the active default server profile
+//! - `server show [name]` — Show details for a profile
+//! - `server remove <name>` — Remove a server profile
+//! - `server set-identity <name> <identity>` — Bind an identity to a profile
+//!
+//! # Examples
+//!
+//! ```bash
+//! # List server profiles
+//! atomic server
+//!
+//! # Add a staging profile
+//! atomic server add staging https://staging.atomic.storage --identity alice-staging
+//!
+//! # Switch to staging
+//! atomic server set staging
+//!
+//! # Switch back to production (legacy [server] block)
+//! atomic server set --default
+//!
+//! # Show the active profile
+//! atomic server show
+//!
+//! # Bind an identity to an existing profile
+//! atomic server set-identity prod alice-prod
+//! ```
+
+use clap::{Parser, Subcommand};
+
+use atomic_config::{GlobalConfig, ServerConfig};
+
+use crate::commands::Command;
+use crate::error::{CliError, CliResult};
+use crate::output::{print_hint, print_success};
+
+// Server Command
+
+/// Manage named server profiles.
+///
+/// Server profiles let you store multiple atomic-storage server configurations
+/// (e.g. staging and production) and switch between them easily. Each profile
+/// can have its own URL, default org, and identity.
+///
+/// Profiles are stored under `[servers.*]` in `~/.atomic/config.toml`.
+/// Management commands use the active profile (set with `atomic server set`)
+/// unless you override it per-command with `--server <name>`.
+#[derive(Debug, Clone, Parser)]
+#[command(name = "server")]
+pub struct ServerCmd {
+    /// Subcommand to execute.
+    #[command(subcommand)]
+    pub command: Option<ServerSubcommand>,
+}
+
+/// Server subcommands.
+#[derive(Debug, Clone, Subcommand)]
+pub enum ServerSubcommand {
+    /// Add a new server profile.
+    #[command(name = "add")]
+    Add(ServerAdd),
+
+    /// Switch the active default server profile.
+    ///
+    /// Use `--default` to clear the named profile and revert to the legacy
+    /// `[server]` block.
+    #[command(name = "set")]
+    Set(ServerSet),
+
+    /// Show details for a server profile.
+    ///
+    /// Without a name, shows the currently active profile.
+    #[command(name = "show")]
+    Show(ServerShow),
+
+    /// Remove a server profile.
+    #[command(name = "remove", visible_alias = "rm")]
+    Remove(ServerRemove),
+
+    /// Bind an identity to a server profile.
+    ///
+    /// Management commands targeting this server will use the specified
+    /// identity instead of the global default.
+    #[command(name = "set-identity")]
+    SetIdentity(ServerSetIdentity),
+}
+
+// Subcommand Structs
+
+/// Add a new server profile.
+#[derive(Debug, Clone, Parser)]
+pub struct ServerAdd {
+    /// Name for the new server profile (e.g. "staging", "prod").
+    #[arg(value_name = "NAME")]
+    pub name: String,
+
+    /// Base URL of the atomic-storage server.
+    #[arg(value_name = "URL")]
+    pub url: String,
+
+    /// Default organization slug for this server.
+    #[arg(long)]
+    pub org: Option<String>,
+
+    /// Identity name to use when connecting to this server.
+    #[arg(long)]
+    pub identity: Option<String>,
+
+    /// Make this the active default server immediately.
+    #[arg(long)]
+    pub set_default: bool,
+}
+
+/// Switch the active default server profile.
+#[derive(Debug, Clone, Parser)]
+pub struct ServerSet {
+    /// Name of the server profile to make active.
+    ///
+    /// Omit (with `--default`) to clear the named profile and revert to
+    /// the legacy `[server]` block.
+    #[arg(value_name = "NAME", required_unless_present = "revert")]
+    pub name: Option<String>,
+
+    /// Revert to the legacy `[server]` block (clear `default_server`).
+    #[arg(long = "default", conflicts_with = "name")]
+    pub revert: bool,
+}
+
+/// Show details for a server profile.
+#[derive(Debug, Clone, Parser)]
+pub struct ServerShow {
+    /// Name of the profile to show. Defaults to the active profile.
+    #[arg(value_name = "NAME")]
+    pub name: Option<String>,
+}
+
+/// Remove a server profile.
+#[derive(Debug, Clone, Parser)]
+pub struct ServerRemove {
+    /// Name of the server profile to remove.
+    #[arg(value_name = "NAME")]
+    pub name: String,
+}
+
+/// Bind an identity to a server profile.
+#[derive(Debug, Clone, Parser)]
+pub struct ServerSetIdentity {
+    /// Name of the server profile to update.
+    #[arg(value_name = "NAME")]
+    pub name: String,
+
+    /// Identity name to bind. Use an empty string or `--clear` to remove.
+    #[arg(value_name = "IDENTITY", required_unless_present = "clear")]
+    pub identity: Option<String>,
+
+    /// Remove the identity binding (revert to global default).
+    #[arg(long, conflicts_with = "identity")]
+    pub clear: bool,
+}
+
+// Implementation
+
+impl ServerCmd {
+    /// List all configured server profiles.
+    fn list_servers(&self) -> CliResult<()> {
+        let config = GlobalConfig::load()
+            .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load config: {}", e)))?;
+
+        if config.servers.is_empty() {
+            print_hint(
+                "No named server profiles configured.\n  \
+                 Use 'atomic server add <name> <url>' to add one.\n  \
+                 The legacy [server] block is always available as the default.",
+            );
+            if config.server.is_configured() {
+                println!();
+                println!(
+                    "  Active server (legacy): {}",
+                    config.server.url.as_deref().unwrap_or("(none)")
+                );
+                if let Some(ref org) = config.server.default_org {
+                    println!("  Default org:            {}", org);
+                }
+            }
+            return Ok(());
+        }
+
+        let active = config.default_server.as_deref();
+
+        for (name, profile) in &config.servers {
+            let is_active = Some(name.as_str()) == active;
+            let active_marker = if is_active { " *" } else { "" };
+            let url = profile.url.as_deref().unwrap_or("(no url)");
+            let org = profile
+                .default_org
+                .as_deref()
+                .map(|o| format!(", org: {}", o))
+                .unwrap_or_default();
+            let identity = profile
+                .identity
+                .as_deref()
+                .map(|i| format!(", identity: {}", i))
+                .unwrap_or_default();
+
+            println!("{}{}\t{}{}{}", name, active_marker, url, org, identity);
+        }
+
+        if active.is_none() {
+            println!();
+            print_hint("No named profile is active — using the legacy [server] block.");
+            print_hint("Run 'atomic server set <name>' to activate a profile.");
+        }
+
+        Ok(())
+    }
+
+    /// Add a new server profile.
+    fn add_server(&self, add: &ServerAdd) -> CliResult<()> {
+        if !add.url.contains("://") {
+            return Err(CliError::InvalidArgument {
+                message: format!(
+                    "Invalid URL '{}': must include a scheme (e.g. https://)",
+                    add.url
+                ),
+            });
+        }
+
+        let mut config = GlobalConfig::load()
+            .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load config: {}", e)))?;
+
+        if config.servers.contains_key(&add.name) {
+            return Err(CliError::InvalidArgument {
+                message: format!(
+                    "Server profile '{}' already exists. \
+                     Use 'atomic server set-identity' or 'atomic server remove' to modify it.",
+                    add.name
+                ),
+            });
+        }
+
+        let profile = ServerConfig {
+            url: Some(add.url.trim_end_matches('/').to_string()),
+            default_org: add.org.clone(),
+            default_workspaces: std::collections::BTreeMap::new(),
+            identity: add.identity.clone(),
+        };
+
+        config.servers.insert(add.name.clone(), profile);
+
+        if add.set_default {
+            config.default_server = Some(add.name.clone());
+        }
+
+        config
+            .save()
+            .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to save config: {}", e)))?;
+
+        print_success(&format!("Server profile '{}' added", add.name));
+        println!("  URL:      {}", add.url);
+        if let Some(ref org) = add.org {
+            println!("  Org:      {}", org);
+        }
+        if let Some(ref identity) = add.identity {
+            println!("  Identity: {}", identity);
+        }
+        if add.set_default {
+            println!();
+            print_success(&format!("'{}' is now the active server", add.name));
+        } else {
+            println!();
+            print_hint(&format!(
+                "To make this your default: atomic server set {}",
+                add.name
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Switch the active default server profile.
+    fn set_server(&self, set: &ServerSet) -> CliResult<()> {
+        let mut config = GlobalConfig::load()
+            .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load config: {}", e)))?;
+
+        if set.revert {
+            config.default_server = None;
+            config
+                .save()
+                .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to save config: {}", e)))?;
+            print_success("Reverted to legacy [server] block");
+            return Ok(());
+        }
+
+        let name = set.name.as_deref().unwrap();
+
+        if !config.servers.contains_key(name) {
+            return Err(CliError::InvalidArgument {
+                message: format!(
+                    "Server profile '{}' not found.\n  \
+                     Use 'atomic server add {} <url>' to create it.",
+                    name, name
+                ),
+            });
+        }
+
+        config.default_server = Some(name.to_string());
+        config
+            .save()
+            .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to save config: {}", e)))?;
+
+        print_success(&format!("Active server is now '{}'", name));
+
+        let profile = &config.servers[name];
+        if let Some(ref url) = profile.url {
+            println!("  URL:      {}", url);
+        }
+        if let Some(ref org) = profile.default_org {
+            println!("  Org:      {}", org);
+        }
+        if let Some(ref identity) = profile.identity {
+            println!("  Identity: {}", identity);
+        }
+
+        Ok(())
+    }
+
+    /// Show details for a server profile.
+    fn show_server(&self, show: &ServerShow) -> CliResult<()> {
+        let config = GlobalConfig::load()
+            .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load config: {}", e)))?;
+
+        let (name, profile) = if let Some(ref n) = show.name {
+            // Explicit name
+            let p = config
+                .servers
+                .get(n)
+                .ok_or_else(|| CliError::InvalidArgument {
+                    message: format!("Server profile '{}' not found.", n),
+                })?;
+            (n.as_str(), p)
+        } else if let Some(ref active) = config.default_server {
+            // Active named profile
+            let p = config
+                .servers
+                .get(active)
+                .ok_or_else(|| CliError::InvalidArgument {
+                    message: format!("Default server profile '{}' not found in config.", active),
+                })?;
+            (active.as_str(), p)
+        } else {
+            // Legacy block — show it directly
+            println!("Active server: (legacy [server] block)");
+            println!(
+                "  URL:      {}",
+                config.server.url.as_deref().unwrap_or("(not configured)")
+            );
+            println!(
+                "  Org:      {}",
+                config
+                    .server
+                    .default_org
+                    .as_deref()
+                    .unwrap_or("(not configured)")
+            );
+            if let Some(ref identity) = config.server.identity {
+                println!("  Identity: {}", identity);
+            } else {
+                println!("  Identity: (global default)");
+            }
+            if !config.server.default_workspaces.is_empty() {
+                println!("  Workspaces:");
+                for (org, ws) in &config.server.default_workspaces {
+                    println!("    {} → {}", org, ws);
+                }
+            }
+            return Ok(());
+        };
+
+        let is_active = config.default_server.as_deref() == Some(name);
+        println!(
+            "Server profile: {}{}",
+            name,
+            if is_active { " (active)" } else { "" }
+        );
+        println!(
+            "  URL:      {}",
+            profile.url.as_deref().unwrap_or("(not configured)")
+        );
+        println!(
+            "  Org:      {}",
+            profile.default_org.as_deref().unwrap_or("(not configured)")
+        );
+        if let Some(ref identity) = profile.identity {
+            println!("  Identity: {}", identity);
+        } else {
+            println!("  Identity: (global default)");
+        }
+        if !profile.default_workspaces.is_empty() {
+            println!("  Workspaces:");
+            for (org, ws) in &profile.default_workspaces {
+                println!("    {} → {}", org, ws);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Remove a server profile.
+    fn remove_server(&self, remove: &ServerRemove) -> CliResult<()> {
+        let mut config = GlobalConfig::load()
+            .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load config: {}", e)))?;
+
+        if config.servers.remove(&remove.name).is_none() {
+            return Err(CliError::InvalidArgument {
+                message: format!("Server profile '{}' not found.", remove.name),
+            });
+        }
+
+        // Clear default_server if it pointed to the removed profile
+        if config.default_server.as_deref() == Some(&remove.name) {
+            config.default_server = None;
+            println!(
+                "Note: '{}' was the active server. Reverted to legacy [server] block.",
+                remove.name
+            );
+        }
+
+        config
+            .save()
+            .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to save config: {}", e)))?;
+
+        print_success(&format!("Server profile '{}' removed", remove.name));
+        Ok(())
+    }
+
+    /// Bind (or clear) an identity for a server profile.
+    fn set_identity_for_server(&self, cmd: &ServerSetIdentity) -> CliResult<()> {
+        let mut config = GlobalConfig::load()
+            .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load config: {}", e)))?;
+
+        let profile =
+            config
+                .servers
+                .get_mut(&cmd.name)
+                .ok_or_else(|| CliError::InvalidArgument {
+                    message: format!(
+                        "Server profile '{}' not found. \
+                     Use 'atomic server add {} <url>' to create it.",
+                        cmd.name, cmd.name
+                    ),
+                })?;
+
+        if cmd.clear {
+            profile.identity = None;
+            config
+                .save()
+                .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to save config: {}", e)))?;
+            print_success(&format!(
+                "Identity cleared for server profile '{}'",
+                cmd.name
+            ));
+            print_hint("Management commands will now use the global default identity.");
+        } else {
+            let identity_name = cmd.identity.as_deref().unwrap();
+            profile.identity = Some(identity_name.to_string());
+            config
+                .save()
+                .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to save config: {}", e)))?;
+            print_success(&format!(
+                "Identity '{}' bound to server profile '{}'",
+                identity_name, cmd.name
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+impl Command for ServerCmd {
+    fn run(&self) -> CliResult<()> {
+        match &self.command {
+            None => self.list_servers(),
+            Some(ServerSubcommand::Add(add)) => self.add_server(add),
+            Some(ServerSubcommand::Set(set)) => self.set_server(set),
+            Some(ServerSubcommand::Show(show)) => self.show_server(show),
+            Some(ServerSubcommand::Remove(remove)) => self.remove_server(remove),
+            Some(ServerSubcommand::SetIdentity(cmd)) => self.set_identity_for_server(cmd),
+        }
+    }
+}

--- a/atomic-cli/src/commands/team/create.rs
+++ b/atomic-cli/src/commands/team/create.rs
@@ -117,7 +117,7 @@ impl TeamCreate {
             })
             .transpose()?;
 
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let org_slug = client.org_slug().to_string();
 
         let info = atomic_teams::team::create_team(

--- a/atomic-cli/src/commands/team/delete.rs
+++ b/atomic-cli/src/commands/team/delete.rs
@@ -105,7 +105,7 @@ impl TeamDelete {
             }
         }
 
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let org_slug = client.org_slug().to_string();
 
         atomic_teams::team::delete_team(&client, &org_slug, &self.slug)

--- a/atomic-cli/src/commands/team/list.rs
+++ b/atomic-cli/src/commands/team/list.rs
@@ -73,7 +73,7 @@ impl Command for TeamList {
 
 impl TeamList {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let slug = client.org_slug().to_string();
 
         let teams = atomic_teams::team::list_teams(&client, &slug)

--- a/atomic-cli/src/commands/team/member.rs
+++ b/atomic-cli/src/commands/team/member.rs
@@ -168,7 +168,7 @@ impl Command for TeamMemberList {
 
 impl TeamMemberList {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let org_slug = client.org_slug().to_string();
 
         let members =
@@ -282,7 +282,7 @@ impl TeamMemberAdd {
             ),
         })?;
 
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let org_slug = client.org_slug().to_string();
 
         let identity_id =
@@ -372,7 +372,7 @@ impl TeamMemberUpdate {
             ),
         })?;
 
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let org_slug = client.org_slug().to_string();
 
         let identity_id =
@@ -475,7 +475,7 @@ impl TeamMemberRemove {
             }
         }
 
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let org_slug = client.org_slug().to_string();
 
         let identity_id =

--- a/atomic-cli/src/commands/team/show.rs
+++ b/atomic-cli/src/commands/team/show.rs
@@ -86,7 +86,7 @@ impl Command for TeamShow {
 
 impl TeamShow {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let org_slug = client.org_slug().to_string();
 
         let info = atomic_teams::team::get_team(&client, &org_slug, &self.slug)

--- a/atomic-cli/src/commands/team/update.rs
+++ b/atomic-cli/src/commands/team/update.rs
@@ -131,7 +131,7 @@ impl TeamUpdate {
             })
             .transpose()?;
 
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let org_slug = client.org_slug().to_string();
 
         let info = atomic_teams::team::update_team(

--- a/atomic-cli/src/commands/workspace/create.rs
+++ b/atomic-cli/src/commands/workspace/create.rs
@@ -81,7 +81,7 @@ impl Command for WorkspaceCreate {
         })?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref()).await?;
+            let client = build_client(self.org.as_deref(), None).await?;
 
             let visibility = self.parse_visibility()?;
 

--- a/atomic-cli/src/commands/workspace/delete.rs
+++ b/atomic-cli/src/commands/workspace/delete.rs
@@ -90,7 +90,7 @@ impl Command for WorkspaceDelete {
                 }
             }
 
-            let (client, org_slug) = build_client_with_org(self.org.as_deref()).await?;
+            let (client, org_slug) = build_client_with_org(self.org.as_deref(), None).await?;
 
             client
                 .delete_workspace(&self.slug)

--- a/atomic-cli/src/commands/workspace/list.rs
+++ b/atomic-cli/src/commands/workspace/list.rs
@@ -44,6 +44,13 @@ pub struct WorkspaceList {
     #[arg(long)]
     pub org: Option<String>,
 
+    /// Server profile to use (e.g. "staging", "prod").
+    ///
+    /// Overrides `default_server` from `~/.atomic/config.toml`.
+    /// Use `atomic server list` to see available profiles.
+    #[arg(long)]
+    pub server: Option<String>,
+
     /// Output format (`table` or `json`).
     #[arg(long, default_value = "table")]
     pub format: String,
@@ -53,6 +60,7 @@ impl Default for WorkspaceList {
     fn default() -> Self {
         Self {
             org: None,
+            server: None,
             format: "table".to_string(),
         }
     }
@@ -79,7 +87,7 @@ impl Command for WorkspaceList {
         })?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref()).await?;
+            let client = build_client(self.org.as_deref(), self.server.as_deref()).await?;
             let workspaces = client.list_workspaces().await.map_err(remote_err)?;
 
             if self.format == "json" {

--- a/atomic-cli/src/commands/workspace/set.rs
+++ b/atomic-cli/src/commands/workspace/set.rs
@@ -186,7 +186,7 @@ fn verify_workspace_exists(org_slug: &str, workspace_slug: &str) -> CliResult<()
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to create async runtime: {e}")))?;
 
     rt.block_on(async {
-        let (client, _resolved) = build_client_with_org(Some(org_slug)).await?;
+        let (client, _resolved) = build_client_with_org(Some(org_slug), None).await?;
         match client.get_workspace(workspace_slug).await {
             Ok(_) => Ok(()),
             Err(e) if e.is_not_found() => Err(CliError::InvalidArgument {

--- a/atomic-cli/src/commands/workspace/show.rs
+++ b/atomic-cli/src/commands/workspace/show.rs
@@ -68,7 +68,7 @@ impl Command for WorkspaceShow {
             .map_err(|e| CliError::Internal(anyhow::anyhow!("{}", e)))?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref()).await?;
+            let client = build_client(self.org.as_deref(), None).await?;
             let ws = client.get_workspace(&self.slug).await.map_err(remote_err)?;
 
             if self.format == "json" {

--- a/atomic-cli/src/commands/workspace/update.rs
+++ b/atomic-cli/src/commands/workspace/update.rs
@@ -79,7 +79,7 @@ impl Command for WorkspaceUpdate {
         })?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref()).await?;
+            let client = build_client(self.org.as_deref(), None).await?;
 
             let req = UpdateWorkspaceRequest {
                 name: self.name.clone(),

--- a/atomic-cli/src/main.rs
+++ b/atomic-cli/src/main.rs
@@ -78,6 +78,7 @@ use commands::{
     Restore,
     Revise,
     Sandbox,
+    ServerCmd,
     Split,
     Stash,
     Status,
@@ -484,6 +485,32 @@ enum Commands {
     /// ```
     Remote(Remote),
 
+    /// Manage server profiles (staging, production, etc.).
+    ///
+    /// Server profiles let you store multiple atomic-storage server
+    /// configurations and switch between them easily. Each profile
+    /// can have its own URL, default org, and identity.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// # List configured profiles
+    /// atomic server
+    ///
+    /// # Add a staging profile
+    /// atomic server add staging https://staging.atomic.storage --identity alice-staging
+    ///
+    /// # Switch to staging
+    /// atomic server set staging
+    ///
+    /// # Show active profile
+    /// atomic server show
+    ///
+    /// # Bind an identity to a profile
+    /// atomic server set-identity prod alice-prod
+    /// ```
+    Server(ServerCmd),
+
     /// Manage remote workspaces.
     ///
     /// Workspaces are organizational containers for projects on a remote
@@ -766,6 +793,8 @@ fn main() {
         Commands::Identity(identity) => identity.run(),
 
         Commands::Remote(remote) => remote.run(),
+
+        Commands::Server(server) => server.run(),
 
         Commands::Workspace(workspace) => workspace.run(),
 

--- a/atomic-config/src/lib.rs
+++ b/atomic-config/src/lib.rs
@@ -98,6 +98,16 @@ pub struct ServerConfig {
     /// and produces stable diffs.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub default_workspaces: BTreeMap<String, String>,
+
+    /// Identity name to use when authenticating to this server.
+    ///
+    /// If set, management commands targeting this server use this identity
+    /// instead of the global default. Set automatically during
+    /// `atomic identity register` when `--identity` is specified.
+    ///
+    /// Example: `identity = "alice-staging"`
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity: Option<String>,
 }
 
 impl ServerConfig {
@@ -164,9 +174,41 @@ pub struct GlobalConfig {
     #[serde(default)]
     pub workspace: WorkspaceConfig,
 
-    /// Remote server configuration for atomic-storage.
+    /// Default remote server configuration for atomic-storage.
+    ///
+    /// This is the server used when no `--server` flag is given and no
+    /// `default_server` points to a named server in `servers`.
     #[serde(default)]
     pub server: ServerConfig,
+
+    /// Named server profiles (e.g. "staging", "prod").
+    ///
+    /// Each entry is a full `ServerConfig` with its own URL, default org,
+    /// workspaces, and optional identity override.
+    ///
+    /// ```toml
+    /// [servers.staging]
+    /// url = "https://staging.atomic.storage"
+    /// default_org = "alice"
+    /// identity = "alice-staging"
+    ///
+    /// [servers.prod]
+    /// url = "https://atomic.storage"
+    /// default_org = "alice"
+    /// identity = "alice-prod"
+    /// ```
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub servers: BTreeMap<String, ServerConfig>,
+
+    /// Name of the active server profile from `servers`.
+    ///
+    /// When set, management commands use `servers[default_server]` instead
+    /// of `server`. Switch with `atomic server set <name>` or pass
+    /// `--server <name>` per-command.
+    ///
+    /// When `None`, the legacy `[server]` block is used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_server: Option<String>,
 }
 
 fn default_channel_name() -> String {
@@ -182,7 +224,59 @@ impl Default for GlobalConfig {
             pager: None,
             workspace: WorkspaceConfig::default(),
             server: ServerConfig::default(),
+            servers: BTreeMap::new(),
+            default_server: None,
         }
+    }
+}
+
+impl GlobalConfig {
+    /// Resolve the effective server config, honouring the optional name override.
+    ///
+    /// Resolution order:
+    /// 1. `server_override` (from `--server <name>` CLI flag)
+    /// 2. `default_server` (from `~/.atomic/config.toml`)
+    /// 3. Legacy `server` block
+    ///
+    /// Returns `(server_config, Option<name>)` — the name is `Some` when a
+    /// named profile was resolved, `None` for the legacy block.
+    pub fn resolve_server<'a>(
+        &'a self,
+        server_override: Option<&'a str>,
+    ) -> Result<(&'a ServerConfig, Option<&'a str>), String> {
+        // 1. Explicit --server flag
+        if let Some(name) = server_override {
+            return self
+                .servers
+                .get(name)
+                .map(|s| (s, Some(name)))
+                .ok_or_else(|| {
+                    format!(
+                        "Server profile '{}' not found. \
+                         Use 'atomic server list' to see available profiles, \
+                         or 'atomic server add {0} <url>' to create it.",
+                        name
+                    )
+                });
+        }
+
+        // 2. Configured default server name
+        if let Some(ref name) = self.default_server {
+            return self
+                .servers
+                .get(name.as_str())
+                .map(|s| (s, Some(name.as_str())))
+                .ok_or_else(|| {
+                    format!(
+                        "Default server profile '{}' not found in servers map. \
+                         Run 'atomic server set <name>' to fix.",
+                        name
+                    )
+                });
+        }
+
+        // 3. Legacy [server] block
+        Ok((&self.server, None))
     }
 }
 
@@ -370,6 +464,7 @@ mod tests {
             url: Some("https://atomic.storage".to_string()),
             default_org: Some("alice".to_string()),
             default_workspaces: BTreeMap::new(),
+            identity: None,
         };
         assert!(config.is_configured());
 
@@ -378,6 +473,7 @@ mod tests {
             url: Some("https://atomic.storage".to_string()),
             default_org: None,
             default_workspaces: BTreeMap::new(),
+            identity: None,
         };
         assert!(!partial.is_configured());
 
@@ -386,6 +482,7 @@ mod tests {
             url: None,
             default_org: Some("alice".to_string()),
             default_workspaces: BTreeMap::new(),
+            identity: None,
         };
         assert!(!partial.is_configured());
     }
@@ -396,6 +493,7 @@ mod tests {
             url: Some("https://atomic.storage".to_string()),
             default_org: Some("alice".to_string()),
             default_workspaces: BTreeMap::new(),
+            identity: None,
         };
         assert_eq!(
             config.org_base_url("alice"),
@@ -413,6 +511,7 @@ mod tests {
             url: Some("http://localhost:8080".to_string()),
             default_org: None,
             default_workspaces: BTreeMap::new(),
+            identity: None,
         };
         assert_eq!(
             config.org_base_url("alice"),
@@ -426,6 +525,7 @@ mod tests {
             url: Some("https://atomic.storage".to_string()),
             default_org: Some("alice".to_string()),
             default_workspaces: BTreeMap::new(),
+            identity: None,
         };
         assert_eq!(
             config.default_org_base_url(),
@@ -437,6 +537,7 @@ mod tests {
             url: Some("https://atomic.storage".to_string()),
             default_org: None,
             default_workspaces: BTreeMap::new(),
+            identity: None,
         };
         assert!(config.default_org_base_url().is_none());
     }
@@ -447,6 +548,7 @@ mod tests {
             url: Some("https://atomic.storage".to_string()),
             default_org: Some("alice".to_string()),
             default_workspaces: BTreeMap::new(),
+            identity: None,
         };
 
         let toml_str = toml::to_string_pretty(&config).unwrap();
@@ -470,6 +572,7 @@ mod tests {
                 url: Some("https://atomic.storage".to_string()),
                 default_org: Some("alice".to_string()),
                 default_workspaces: BTreeMap::new(),
+                identity: None,
             },
             ..GlobalConfig::default()
         };
@@ -493,6 +596,7 @@ mod tests {
             url: Some("https://atomic.storage".to_string()),
             default_org: Some("alice".to_string()),
             default_workspaces: BTreeMap::new(),
+            identity: None,
         };
         let toml_str = toml::to_string_pretty(&config).unwrap();
         assert!(!toml_str.contains("default_workspaces"));
@@ -508,6 +612,7 @@ mod tests {
             url: Some("https://atomic.storage".to_string()),
             default_org: Some("alice".to_string()),
             default_workspaces: workspaces,
+            identity: None,
         };
 
         let toml_str = toml::to_string_pretty(&config).unwrap();


### PR DESCRIPTION
## Summary

Add named server profiles (staging, prod, etc.) and per-remote identity binding so switching between environments is a one-time config change — not something you have to remember every time.

The design is **identity-first**: switching your active identity automatically activates the server profile bound to it. The `atomic server` command exists for explicit management, but you rarely need it once configured.

Per-remote identity binding was intentionally left out — it adds complexity without solving a problem that server profiles + URL-subdomain inference don't already handle.

## Problem

Previously:
- One global `[server]` block — no way to configure staging vs production
- Management commands always used the global default identity regardless of which server you were targeting
- No way to switch environments without manually tracking which identity + server to switch separately

## Solution

### Switching identity automatically switches server

Register once per environment, binding an identity to each:

```
atomic identity register https://atomic.storage
atomic identity register https://staging.atomic.storage --identity alice-staging
```

After that, **switching identities automatically switches the active server**:

```
atomic identity default alice-staging
# → Set 'alice-staging' as default identity
# → Server profile 'staging' activated (bound to identity 'alice-staging')

atomic workspace list     # hits staging, uses alice-staging automatically
atomic push               # same, via URL subdomain inference

atomic identity default alice
# → Set 'alice' as default identity
# → (no server binding — reverts to legacy [server] block)
```

The auto-activation fires at both `atomic identity default <name>` and `atomic identity new --set-default`. It's a non-fatal side effect printed as a hint.

### Config it produces (`~/.atomic/config.toml`)

```toml
[server]                          # legacy default, still works
url = "https://atomic.storage"
default_org = "alice"

default_server = "staging"       # set automatically when switching to alice-staging

[servers.staging]
url = "https://staging.atomic.storage"
default_org = "alice"
identity = "alice-staging"

[servers.prod]
url = "https://atomic.storage"
default_org = "alice"
identity = "alice-prod"
```

### Explicit management when needed: `atomic server`

```
atomic server                              # list profiles, * marks active
atomic server add staging <url> \
  --identity alice-staging --set-default
atomic server set staging                  # explicit switch without identity switch
atomic server set --default                # revert to legacy [server] block
atomic server show [name]
atomic server remove <name>
atomic server set-identity prod alice-prod # rebind identity for a profile
```

### `--server` flag on management commands

One-off targeting without changing the active default:

```
atomic project list --server prod
atomic workspace list --server staging
```

### `--identity` flag on push/pull

One-off VCS auth override (does not persist, no per-remote config needed):

```
atomic push --identity alice-staging
atomic pull --identity alice-prod
```

## Changes

### `atomic-config`
- `ServerConfig`: new `identity: Option<String>` field
- `GlobalConfig`: new `servers: BTreeMap<String, ServerConfig>` + `default_server: Option<String>`
- `GlobalConfig::resolve_server(override)` — 3-level: `--server` → `default_server` → legacy `[server]`
- Fully backward-compatible

### `atomic-repository`
- No changes to `RemoteEntry` — kept simple, no identity field

### Auth (`atomic-cli`)
- `attach_identity()` takes `identity_override: Option<&str>`
- Priority: `--identity` flag → URL userinfo → URL subdomain

### Identity commands — auto-activation hook
- `activate_server_for_identity(name)` called after every default identity change
- Scans `config.servers` for a profile whose `identity == name`, activates it, prints hint

### `atomic identity register`
- When `--identity` is given, auto-creates a named server profile
- Profile name derived from first hostname label (`staging.atomic.storage` → `staging`)
- Use `--server-name <custom>` to override

## Tests

All 1517 existing tests pass. New tests for `derive_profile_name`.