### PR TITLE
fix(push): actionable error + pre-push credential check instead of misleading 'view not found' on a masked 404

### DIFF
--- a/atomic-cli/src/commands/auth.rs
+++ b/atomic-cli/src/commands/auth.rs
@@ -16,6 +16,8 @@ use atomic_identity::IdentityStore;
 use atomic_remote::HttpRemoteConfig;
 use url::Url;
 
+use crate::error::{CliError, CliResult};
+
 /// Attach a Bearer JWT auth header to the remote config by resolving the
 /// identity from the URL and logging in for a token.
 ///
@@ -73,6 +75,118 @@ pub async fn attach_identity(config: HttpRemoteConfig, remote_url: &str) -> Http
             config
         }
     }
+}
+
+/// What went wrong (if anything) when checking for usable push credentials.
+///
+/// Authentication for atomic-storage is a *self-signed* EdDSA JWT: the CLI
+/// mints a fresh, short-lived token per request by signing with the identity's
+/// Ed25519 private key (see [`crate::commands::token`]). There is no stored
+/// token to inspect for expiry — a token is only ever created at the moment of
+/// use and is valid for its full TTL. So "having usable credentials" reduces to
+/// three local conditions, each a distinct failure with its own remedy:
+///
+/// 1. an identity is resolvable from the remote URL,
+/// 2. that identity exists in the local store, and
+/// 3. its keypair can be loaded (so a token can actually be signed).
+#[derive(Debug, PartialEq, Eq)]
+pub enum CredentialIssue {
+    /// No identity could be resolved from the remote URL (no userinfo and no
+    /// subdomain). We can't know who to authenticate as.
+    NoIdentityInUrl,
+    /// An identity name was resolved, but no such identity exists locally.
+    IdentityNotFound { name: String },
+    /// The identity exists but its signing keypair could not be loaded, so no
+    /// token can be minted.
+    KeypairUnavailable { name: String },
+}
+
+impl CredentialIssue {
+    /// Render an actionable, accurate error message for this issue.
+    ///
+    /// All messages point at registering an identity, since that is the single
+    /// command that establishes a usable credential for a remote.
+    fn message(&self) -> String {
+        match self {
+            CredentialIssue::NoIdentityInUrl => format!(
+                "Not authenticated for {REMEDY_PREFIX}: could not determine an \
+                 identity from the remote URL. {REMEDY_SUFFIX}"
+            ),
+            CredentialIssue::IdentityNotFound { name } => format!(
+                "Not authenticated for {REMEDY_PREFIX}: identity '{name}' is not \
+                 registered on this machine. {REMEDY_SUFFIX}"
+            ),
+            CredentialIssue::KeypairUnavailable { name } => format!(
+                "Not authenticated for {REMEDY_PREFIX}: could not load the signing \
+                 key for identity '{name}'. {REMEDY_SUFFIX}"
+            ),
+        }
+    }
+}
+
+const REMEDY_PREFIX: &str = "this remote";
+const REMEDY_SUFFIX: &str =
+    "Register your identity with the server first: `atomic identity register <server-url>`.";
+
+/// Verify, before a push begins, that the client can produce credentials for
+/// `remote_url`. Fails fast with an actionable error instead of letting the
+/// push proceed into a confusing 404 (which the server returns for private
+/// projects the caller isn't authorized to see).
+///
+/// Returns `Ok(())` when an identity is resolvable from the URL, exists in the
+/// local store, and has a loadable signing keypair.
+pub fn check_push_credentials(remote_url: &str) -> CliResult<()> {
+    let store = IdentityStore::open_default()
+        .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to open identity store: {e}")))?;
+
+    let issue = evaluate_push_credentials(
+        resolve_identity_name(remote_url),
+        |name| store.load_by_name(name).is_ok(),
+        |name| {
+            store
+                .load_by_name(name)
+                .ok()
+                .map(|id| store.load_keypair(&id.id, None).is_ok())
+                .unwrap_or(false)
+        },
+    );
+
+    match issue {
+        Some(issue) => Err(CliError::AuthenticationFailed {
+            remote: format!("{remote_url}: {}", issue.message()),
+        }),
+        None => Ok(()),
+    }
+}
+
+/// Pure decision core for [`check_push_credentials`], split out so it can be
+/// unit-tested without touching the on-disk identity store.
+///
+/// * `identity_name` — the identity resolved from the URL, if any.
+/// * `identity_exists` — whether an identity with the given name is in the store.
+/// * `keypair_loadable` — whether that identity's signing keypair can be loaded.
+///
+/// Returns `None` when credentials are usable, or `Some(issue)` describing the
+/// first problem encountered.
+fn evaluate_push_credentials(
+    identity_name: Option<String>,
+    identity_exists: impl Fn(&str) -> bool,
+    keypair_loadable: impl Fn(&str) -> bool,
+) -> Option<CredentialIssue> {
+    let name = match identity_name {
+        Some(n) => n,
+        None => return Some(CredentialIssue::NoIdentityInUrl),
+    };
+
+    if !identity_exists(&name) {
+        return Some(CredentialIssue::IdentityNotFound { name });
+    }
+
+    if !keypair_loadable(&name) {
+        return Some(CredentialIssue::KeypairUnavailable { name });
+    }
+
+    None
 }
 
 /// Derive the apex server URL (scheme + host without the leading subdomain
@@ -225,5 +339,75 @@ mod tests {
     #[test]
     fn extract_subdomain_empty_label() {
         assert_eq!(extract_subdomain(".localhost"), None);
+    }
+
+    // -- pre-push credential check --
+
+    #[test]
+    fn creds_ok_when_identity_resolves_and_keypair_loads() {
+        let issue = evaluate_push_credentials(
+            Some("alice".to_string()),
+            |_| true, // identity exists
+            |_| true, // keypair loadable
+        );
+        assert_eq!(issue, None);
+    }
+
+    #[test]
+    fn creds_fail_when_no_identity_in_url() {
+        // A bare host with no userinfo and no subdomain resolves to no identity.
+        let issue = evaluate_push_credentials(None, |_| true, |_| true);
+        assert_eq!(issue, Some(CredentialIssue::NoIdentityInUrl));
+    }
+
+    #[test]
+    fn creds_fail_when_identity_missing_from_store() {
+        let issue = evaluate_push_credentials(
+            Some("alice".to_string()),
+            |_| false, // identity not in store
+            |_| true,
+        );
+        assert_eq!(
+            issue,
+            Some(CredentialIssue::IdentityNotFound {
+                name: "alice".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn creds_fail_when_keypair_cannot_load() {
+        // Identity exists but its signing key can't be loaded — no token can be
+        // minted. This stands in for an "expired"/unusable credential, which in
+        // this self-signed-JWT model means "cannot sign right now".
+        let issue = evaluate_push_credentials(
+            Some("alice".to_string()),
+            |_| true,  // identity exists
+            |_| false, // keypair unavailable
+        );
+        assert_eq!(
+            issue,
+            Some(CredentialIssue::KeypairUnavailable {
+                name: "alice".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn credential_issue_messages_are_actionable() {
+        // Every issue must name the remedy so the failure is self-explanatory.
+        for issue in [
+            CredentialIssue::NoIdentityInUrl,
+            CredentialIssue::IdentityNotFound {
+                name: "alice".to_string(),
+            },
+            CredentialIssue::KeypairUnavailable {
+                name: "alice".to_string(),
+            },
+        ] {
+            let msg = issue.message();
+            assert!(msg.contains("Not authenticated"));
+            assert!(msg.contains("atomic identity register"));
+        }
     }
 }

--- a/atomic-cli/src/commands/push/command.rs
+++ b/atomic-cli/src/commands/push/command.rs
@@ -310,6 +310,14 @@ impl Push {
             hint(&remote_url)
         );
 
+        // Fail fast if we have no usable credentials for this remote. A push is
+        // a write that always requires auth; without a credential the server's
+        // negotiation endpoints return an ambiguous 404 (private projects are
+        // deliberately masked), which surfaces as a misleading "view not found".
+        // Catching the missing credential here gives the user an accurate,
+        // actionable error instead.
+        crate::commands::auth::check_push_credentials(&remote_url)?;
+
         // Connect to remote
         let spinner = create_spinner("Connecting to remote...");
         let config = self.build_remote_config(&remote_url).await;

--- a/atomic-cli/src/commands/push/helpers.rs
+++ b/atomic-cli/src/commands/push/helpers.rs
@@ -361,6 +361,27 @@ fn format_bytes(bytes: u64) -> String {
 
 // Error Conversion
 
+/// Build the user-facing message for a "not found" (HTTP 404) response during
+/// a push.
+///
+/// The server deliberately masks private projects: it returns 404 to callers
+/// who are not authenticated/authorized rather than revealing that the project
+/// exists. Because a push is a write that always requires auth, a 404 almost
+/// always means the caller's credentials are missing/expired or they lack push
+/// access — not that the project/view is genuinely absent. The message spells
+/// out both possibilities and points at the remedy.
+///
+/// `target` describes what was not found, e.g. `"project/view 'dev'"` or
+/// `"the project"`.
+fn not_found_push_message(target: &str) -> String {
+    format!(
+        "Remote returned 'not found' for {target}. This means either it \
+         doesn't exist, or you're not authenticated/authorized to push to it. \
+         Make sure your identity is registered with the server \
+         (`atomic identity register <server-url>`) and that you have push access."
+    )
+}
+
 /// Convert a remote error to a CLI error.
 ///
 /// Maps the various remote error types to appropriate CLI error types
@@ -383,12 +404,19 @@ pub fn convert_remote_error(err: RemoteError, url: &str) -> CliError {
         RemoteError::AuthenticationFailed { .. } => CliError::AuthenticationFailed {
             remote: url.to_string(),
         },
+        // A 404 on a push is ambiguous. Private projects are deliberately
+        // masked: the server returns "not found" to anyone who isn't
+        // authenticated/authorized, so a missing project and a private one we
+        // can't see are indistinguishable on the wire. A push is a *write* that
+        // always requires auth, so the most likely cause is missing/expired
+        // credentials — not a genuinely-absent project/view. Say so, and point
+        // at the remedy, instead of the misleading "view not found".
         RemoteError::RepositoryNotFound { .. } => CliError::RemoteError {
-            message: "Repository not found on remote".to_string(),
+            message: not_found_push_message("the project"),
             url: Some(url.to_string()),
         },
         RemoteError::ViewNotFound { view } => CliError::RemoteError {
-            message: format!("View '{}' not found on remote", view),
+            message: not_found_push_message(&format!("project/view '{}'", view)),
             url: Some(url.to_string()),
         },
         RemoteError::ChangeNotFound { hash } => CliError::ChangeNotFound { hash },
@@ -598,12 +626,20 @@ mod tests {
 
     #[test]
     fn test_convert_repo_not_found() {
+        // A 404 for the repository/project on a push is ambiguous (the server
+        // masks private projects), so the message must point at auth rather
+        // than implying the project is simply absent.
         let err = RemoteError::repo_not_found("http://example.com/repo");
         let cli_err = convert_remote_error(err, "http://example.com/repo");
 
         match cli_err {
             CliError::RemoteError { message, .. } => {
+                let lower = message.to_lowercase();
                 assert!(message.contains("not found"));
+                // Mentions the authentication/authorization possibility.
+                assert!(lower.contains("authenticated") || lower.contains("authorized"));
+                // Points at the remedy.
+                assert!(message.contains("atomic identity register"));
             }
             _ => panic!("Expected RemoteError"),
         }
@@ -611,13 +647,21 @@ mod tests {
 
     #[test]
     fn test_convert_view_not_found() {
+        // The server returns 404 both for a genuinely-missing view and for a
+        // private one the caller can't see. On a push (a write that needs
+        // auth) the message must name the view *and* explain that this may be
+        // an auth/authorization problem, with the remedy to run identity
+        // register — not the misleading "view not found".
         let err = RemoteError::view_not_found("main");
         let cli_err = convert_remote_error(err, "http://example.com");
 
         match cli_err {
             CliError::RemoteError { message, .. } => {
+                let lower = message.to_lowercase();
                 assert!(message.contains("main"));
                 assert!(message.contains("not found"));
+                assert!(lower.contains("authenticated") || lower.contains("authorized"));
+                assert!(message.contains("atomic identity register"));
             }
             _ => panic!("Expected RemoteError"),
         }


### PR DESCRIPTION
## Problem

`atomic push` to a private project on a server that returns **404** for unauthenticated/unauthorized callers surfaced the misleading error **\"View '<view>' not found\"**. Users read this as \"the view is missing\" when the real cause was missing/expired credentials or lack of push access.

The server returns 404 for private projects **on purpose** — it masks private-project existence so an unauthorized caller can't even learn that a project exists. That masking is intentional and is **not** changed here. A genuinely-absent project and a private-but-unauthorized one are indistinguishable on the wire, so the client must stop presenting the 404 as a definitive \"not found\".

Root cause: in `atomic-remote`, `get_state`/`get_changelist` map `404 → RemoteError::ViewNotFound`. The push error-conversion (`push/helpers.rs`) then turned that into `\"View '<view>' not found on remote\"`.

## Fix (client-only)

**Part 1 — clearer push error on a 404.** In the push error-conversion path, `ViewNotFound`/`RepositoryNotFound` now render an accurate, actionable message: it explains the result is ambiguous (doesn't exist **or** you're not authenticated/authorized) and points at the remedy. A push is a write that always requires auth, so this framing is correct for the push path. Pull and clone are deliberately left unchanged — a 404 there can legitimately mean \"view absent\".

New message:
> Remote returned 'not found' for project/view '<view>'. This means either it doesn't exist, or you're not authenticated/authorized to push to it. Make sure your identity is registered with the server (`atomic identity register <server-url>`) and that you have push access.

**Part 2 — pre-push credential check (fail fast).** Before push negotiation, the command verifies the client can produce credentials for the target remote and fails fast with `Not authenticated for <remote> ...` otherwise — instead of marching into the ambiguous 404.

How credentials/expiry are determined: atomic-storage authenticates with **self-signed, short-lived EdDSA JWTs minted per request** from the identity's Ed25519 private key (`commands/token.rs`). There is **no stored token** to inspect for expiry — a token only exists at the moment of use and is always fresh for its full 5-minute TTL. So \"usable credentials\" reduces to three local conditions: (1) an identity is resolvable from the remote URL, (2) it exists in the local identity store, and (3) its signing keypair can be loaded. The decision core is a pure, unit-tested helper (`evaluate_push_credentials`); the wiring helper is `check_push_credentials`. This is a fail-fast guard, not a new interactive auth flow.

## Tests
- Updated `test_convert_view_not_found` and `test_convert_repo_not_found` (push) to assert the message mentions authentication/authorization and the `atomic identity register` remedy.
- Added unit tests for the credential check: missing identity in URL, identity not in store, keypair not loadable (each → actionable error), and the valid case (proceeds).

## Validation (matches CI)
- `cargo build -p atomic-cli -p atomic-remote` ✅
- `cargo clippy -p atomic-cli -p atomic-remote -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅
- `cargo test -p atomic-cli -p atomic-remote` ✅ (1519 + 192 + doctests pass)
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p atomic-cli -p atomic-remote --no-deps` ✅

Could not exercise the end-to-end path against a live server/credentials; verified via unit tests and the full touched-crate test suites.