### PR TITLE
feat(agent): managed lifecycle runs — keyed store, view adoption, run stamping

### DIFF
--- a/atomic-agent/src/turn/orchestrator/mod.rs
+++ b/atomic-agent/src/turn/orchestrator/mod.rs
@@ -73,8 +73,40 @@ use crate::error::AgentResult;
 use crate::event::{HookType, TurnEvent};
 use crate::record::TurnRecordOutcome;
 use crate::turn::phase::Phase;
-use crate::turn::session::SessionStore;
+use crate::turn::session::{ManagedRunStamp, SessionStore};
 use crate::watcher::{self, FileWatcher, WatcherConfig};
+
+// ═══════════════════════════════════════════════════════════════════════
+// ManagedRunContext
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Context for a managed lifecycle run, injected by the CLI hook handler.
+///
+/// When an outer orchestrator (e.g. Sherpa/noname) has declared a managed
+/// run via `atomic agent lifecycle begin`, the hook handler resolves the
+/// governing lifecycle and passes its context here. The orchestrator then:
+///
+/// - stamps every session it CREATES with [`ManagedRunStamp`] (sessions
+///   that already existed are never re-attributed), and
+/// - if the run declares a `view`, new sessions ADOPT that view instead of
+///   forking a fresh haikunator view, so recorded changes land where the
+///   run owner expects them.
+///
+/// Hooks are never suppressed under a managed run — every participant
+/// records through the same pipeline, and correlation lives in the stamp.
+#[derive(Clone, Debug)]
+pub struct ManagedRunContext {
+    /// The correlation stamp written onto sessions born under this run.
+    pub stamp: ManagedRunStamp,
+
+    /// View declared by the run owner. New sessions adopt it (fork-from-
+    /// current mechanics with a deterministic name). `None` — sessions fork
+    /// their usual per-session view and are only stamped.
+    ///
+    /// Inside a sandbox the provisioned sandbox view always wins; a
+    /// conflicting declared view is logged and ignored.
+    pub view: Option<String>,
+}
 
 // ═══════════════════════════════════════════════════════════════════════
 // DispatchResult
@@ -209,6 +241,12 @@ pub struct TurnOrchestrator {
 
     /// Human-readable agent display name (e.g., "Claude Code").
     pub(crate) agent_display_name: String,
+
+    /// Managed-run context, when a governing lifecycle covers this hook.
+    ///
+    /// Set by the CLI hook handler via [`set_managed_run`](Self::set_managed_run).
+    /// `None` for direct agent usage — behavior is unchanged.
+    pub(crate) managed_run: Option<ManagedRunContext>,
 }
 
 impl TurnOrchestrator {
@@ -239,6 +277,7 @@ impl TurnOrchestrator {
             watcher,
             agent_name: "unknown".to_string(),
             agent_display_name: "Unknown Agent".to_string(),
+            managed_run: None,
         })
     }
 
@@ -257,6 +296,7 @@ impl TurnOrchestrator {
             watcher,
             agent_name: "unknown".to_string(),
             agent_display_name: "Unknown Agent".to_string(),
+            managed_run: None,
         }
     }
 
@@ -268,6 +308,26 @@ impl TurnOrchestrator {
     pub fn set_agent(&mut self, name: impl Into<String>, display_name: impl Into<String>) {
         self.agent_name = name.into();
         self.agent_display_name = display_name.into();
+    }
+
+    /// Attach the managed-run context for this hook invocation.
+    ///
+    /// Called by the CLI hook handler when a governing managed lifecycle
+    /// covers the hook's working directory. Sessions created during this
+    /// dispatch are stamped with the run context and, if the run declares a
+    /// view, adopt it instead of forking (see [`ManagedRunContext`]).
+    pub fn set_managed_run(&mut self, context: ManagedRunContext) {
+        self.managed_run = Some(context);
+    }
+
+    /// The view declared by the governing managed run, if any.
+    pub(crate) fn managed_view(&self) -> Option<&str> {
+        self.managed_run.as_ref().and_then(|m| m.view.as_deref())
+    }
+
+    /// The stamp to write onto sessions born under the managed run.
+    pub(crate) fn managed_stamp(&self) -> Option<ManagedRunStamp> {
+        self.managed_run.as_ref().map(|m| m.stamp.clone())
     }
 
     /// Returns the repository root path.

--- a/atomic-agent/src/turn/orchestrator/mod.rs
+++ b/atomic-agent/src/turn/orchestrator/mod.rs
@@ -80,31 +80,19 @@ use crate::watcher::{self, FileWatcher, WatcherConfig};
 // ManagedRunContext
 // ═══════════════════════════════════════════════════════════════════════
 
-/// Context for a managed lifecycle run, injected by the CLI hook handler.
+/// Context for a managed lifecycle run (`atomic agent lifecycle begin`),
+/// injected by the CLI hook handler.
 ///
-/// When an outer orchestrator (e.g. Sherpa/noname) has declared a managed
-/// run via `atomic agent lifecycle begin`, the hook handler resolves the
-/// governing lifecycle and passes its context here. The orchestrator then:
-///
-/// - stamps every session it CREATES with [`ManagedRunStamp`] (sessions
-///   that already existed are never re-attributed), and
-/// - if the run declares a `view`, new sessions ADOPT that view instead of
-///   forking a fresh haikunator view, so recorded changes land where the
-///   run owner expects them.
-///
-/// Hooks are never suppressed under a managed run — every participant
-/// records through the same pipeline, and correlation lives in the stamp.
+/// Sessions CREATED under the run are stamped with [`ManagedRunStamp`] and
+/// adopt the declared view; pre-existing sessions are never re-attributed.
 #[derive(Clone, Debug)]
 pub struct ManagedRunContext {
     /// The correlation stamp written onto sessions born under this run.
     pub stamp: ManagedRunStamp,
 
-    /// View declared by the run owner. New sessions adopt it (fork-from-
-    /// current mechanics with a deterministic name). `None` — sessions fork
-    /// their usual per-session view and are only stamped.
-    ///
-    /// Inside a sandbox the provisioned sandbox view always wins; a
-    /// conflicting declared view is logged and ignored.
+    /// View declared by the run owner; `None` = sessions fork their usual
+    /// per-session view. Inside a sandbox the provisioned sandbox view
+    /// always wins over a conflicting declared view.
     pub view: Option<String>,
 }
 
@@ -242,10 +230,8 @@ pub struct TurnOrchestrator {
     /// Human-readable agent display name (e.g., "Claude Code").
     pub(crate) agent_display_name: String,
 
-    /// Managed-run context, when a governing lifecycle covers this hook.
-    ///
-    /// Set by the CLI hook handler via [`set_managed_run`](Self::set_managed_run).
-    /// `None` for direct agent usage — behavior is unchanged.
+    /// Managed-run context when a governing lifecycle covers this hook;
+    /// `None` for direct agent usage (behavior unchanged).
     pub(crate) managed_run: Option<ManagedRunContext>,
 }
 
@@ -266,14 +252,9 @@ impl TurnOrchestrator {
     pub async fn new(repo_root: impl Into<PathBuf>) -> AgentResult<Self> {
         let repo_root = repo_root.into();
 
-        // Sessions are canonical metadata, not working-tree state. Inside a
-        // sandbox `repo_root` is the sandbox working tree, which has no graph
-        // of its own — writing session files under it strands them (and their
-        // attestations/run stamps) in a throwaway `.atomic/` that dies with
-        // the sandbox, and `lifecycle end`'s harvest (which scans the
-        // canonical session store for run stamps) never sees them. Resolve
-        // through the sandbox pointer; for a normal repository this is the
-        // same `.atomic`.
+        // Sessions must live in the canonical `.atomic`, not a sandbox's
+        // throwaway one — `lifecycle end` harvests run stamps from the
+        // canonical session store. Same directory for a normal repository.
         let session_store = match atomic_repository::Repository::canonical_dot_dir(&repo_root) {
             Ok(dot_dir) => SessionStore::new(dot_dir.join("sessions"))?,
             Err(_) => SessionStore::for_repo(&repo_root)?,
@@ -321,12 +302,8 @@ impl TurnOrchestrator {
         self.agent_display_name = display_name.into();
     }
 
-    /// Attach the managed-run context for this hook invocation.
-    ///
-    /// Called by the CLI hook handler when a governing managed lifecycle
-    /// covers the hook's working directory. Sessions created during this
-    /// dispatch are stamped with the run context and, if the run declares a
-    /// view, adopt it instead of forking (see [`ManagedRunContext`]).
+    /// Attach the managed-run context for this hook invocation
+    /// (see [`ManagedRunContext`]).
     pub fn set_managed_run(&mut self, context: ManagedRunContext) {
         self.managed_run = Some(context);
     }

--- a/atomic-agent/src/turn/orchestrator/mod.rs
+++ b/atomic-agent/src/turn/orchestrator/mod.rs
@@ -266,7 +266,18 @@ impl TurnOrchestrator {
     pub async fn new(repo_root: impl Into<PathBuf>) -> AgentResult<Self> {
         let repo_root = repo_root.into();
 
-        let session_store = SessionStore::for_repo(&repo_root)?;
+        // Sessions are canonical metadata, not working-tree state. Inside a
+        // sandbox `repo_root` is the sandbox working tree, which has no graph
+        // of its own — writing session files under it strands them (and their
+        // attestations/run stamps) in a throwaway `.atomic/` that dies with
+        // the sandbox, and `lifecycle end`'s harvest (which scans the
+        // canonical session store for run stamps) never sees them. Resolve
+        // through the sandbox pointer; for a normal repository this is the
+        // same `.atomic`.
+        let session_store = match atomic_repository::Repository::canonical_dot_dir(&repo_root) {
+            Ok(dot_dir) => SessionStore::new(dot_dir.join("sessions"))?,
+            Err(_) => SessionStore::for_repo(&repo_root)?,
+        };
 
         let watcher_config = WatcherConfig::new(&repo_root);
         let watcher = watcher::create_watcher(watcher_config).await?;

--- a/atomic-agent/src/turn/orchestrator/session_start.rs
+++ b/atomic-agent/src/turn/orchestrator/session_start.rs
@@ -122,11 +122,8 @@ impl TurnOrchestrator {
             }
         };
 
-        // Stamp sessions born under a managed lifecycle with the run context.
-        // The stamp is the correlation edge the run owner queries later
-        // (`atomic agent lifecycle end --json`). Only sessions CREATED here
-        // are stamped — the early return above keeps pre-existing sessions
-        // out of the run's attribution.
+        // Only sessions CREATED here get the run stamp — the early return
+        // above keeps pre-existing sessions out of the run's attribution.
         if let Some(stamp) = self.managed_stamp() {
             log::info!(
                 "Session {} runs under managed lifecycle {} (owner: {})",
@@ -207,12 +204,9 @@ impl TurnOrchestrator {
                     let current = repo.current_view().to_string();
                     session.set_parent_view(&current);
 
-                    // Under a managed lifecycle the run owner declares the
-                    // view for this run — adopt it instead of forking a fresh
-                    // per-session view, so recorded changes land where the
-                    // owner expects them. Same fork-from-current mechanics,
-                    // deterministic name (create below tolerates "already
-                    // exists" for the second session of the same run).
+                    // Adopt the run's declared view instead of forking a
+                    // per-session one. `create` below tolerates "already
+                    // exists" for the second session of the same run.
                     if let Some(declared) = self.managed_view() {
                         log::info!(
                             "Session {} adopting managed-run view '{}' (declared by lifecycle)",
@@ -310,9 +304,8 @@ impl TurnOrchestrator {
                 let vendor = vendor_from_agent_name(&self.agent_name);
                 session.agent_vendor = vendor.to_string();
 
-                // Fallback-created sessions under a managed lifecycle carry
-                // the same stamp as ones created by session-start (this is
-                // the path an owner's turn-end-only fallback recording uses).
+                // Fallback-created sessions carry the same run stamp as
+                // session-start-created ones.
                 if let Some(stamp) = self.managed_stamp() {
                     session.managed_run = Some(stamp);
                 }
@@ -346,9 +339,8 @@ impl TurnOrchestrator {
                         );
                         session.view_name = current;
                     } else if let Some(declared) = self.managed_view() {
-                        // The managed run declares the view — adopt it with
-                        // the same fork-from-current mechanics as
-                        // handle_session_start.
+                        // Adopt the run's declared view (same mechanics
+                        // as handle_session_start).
                         log::info!(
                             "Fallback session {} adopting managed-run view '{}'",
                             session_id,

--- a/atomic-agent/src/turn/orchestrator/session_start.rs
+++ b/atomic-agent/src/turn/orchestrator/session_start.rs
@@ -122,6 +122,21 @@ impl TurnOrchestrator {
             }
         };
 
+        // Stamp sessions born under a managed lifecycle with the run context.
+        // The stamp is the correlation edge the run owner queries later
+        // (`atomic agent lifecycle end --json`). Only sessions CREATED here
+        // are stamped — the early return above keeps pre-existing sessions
+        // out of the run's attribution.
+        if let Some(stamp) = self.managed_stamp() {
+            log::info!(
+                "Session {} runs under managed lifecycle {} (owner: {})",
+                session_id,
+                stamp.run_id,
+                stamp.owner_agent,
+            );
+            session.managed_run = Some(stamp);
+        }
+
         // Set transcript path if provided
         if let Some(ref path) = event.transcript_path {
             session.set_transcript_path(path);
@@ -171,6 +186,16 @@ impl TurnOrchestrator {
                     //     .atomic/current_view, clobbering the real user's
                     //     current view.
                     let current = repo.current_view().to_string();
+                    if let Some(declared) = self.managed_view() {
+                        if declared != current {
+                            log::debug!(
+                                "Managed run declares view '{}' but the sandbox is \
+                                 provisioned on '{}' — the sandbox pointer wins",
+                                declared,
+                                current,
+                            );
+                        }
+                    }
                     log::info!(
                         "Sandbox session {}: recording on provisioned view '{}' (no fork/switch)",
                         session_id,
@@ -181,6 +206,21 @@ impl TurnOrchestrator {
                 Ok(mut repo) => {
                     let current = repo.current_view().to_string();
                     session.set_parent_view(&current);
+
+                    // Under a managed lifecycle the run owner declares the
+                    // view for this run — adopt it instead of forking a fresh
+                    // per-session view, so recorded changes land where the
+                    // owner expects them. Same fork-from-current mechanics,
+                    // deterministic name (create below tolerates "already
+                    // exists" for the second session of the same run).
+                    if let Some(declared) = self.managed_view() {
+                        log::info!(
+                            "Session {} adopting managed-run view '{}' (declared by lifecycle)",
+                            session_id,
+                            declared,
+                        );
+                        session.view_name = declared.to_string();
+                    }
 
                     match repo.create_view_from(&session.view_name, &current) {
                         Ok(()) => {
@@ -270,6 +310,13 @@ impl TurnOrchestrator {
                 let vendor = vendor_from_agent_name(&self.agent_name);
                 session.agent_vendor = vendor.to_string();
 
+                // Fallback-created sessions under a managed lifecycle carry
+                // the same stamp as ones created by session-start (this is
+                // the path an owner's turn-end-only fallback recording uses).
+                if let Some(stamp) = self.managed_stamp() {
+                    session.managed_run = Some(stamp);
+                }
+
                 if let Some(ref path) = event.transcript_path {
                     session.set_transcript_path(path);
                 }
@@ -298,6 +345,36 @@ impl TurnOrchestrator {
                             current,
                         );
                         session.view_name = current;
+                    } else if let Some(declared) = self.managed_view() {
+                        // The managed run declares the view — adopt it with
+                        // the same fork-from-current mechanics as
+                        // handle_session_start.
+                        log::info!(
+                            "Fallback session {} adopting managed-run view '{}'",
+                            session_id,
+                            declared,
+                        );
+                        session.set_parent_view(&current);
+                        session.view_name = declared.to_string();
+
+                        if let Err(e) = repo.create_view_from(&session.view_name, &current) {
+                            log::debug!(
+                                "Fallback session {} could not fork view '{}' from '{}': {} (non-fatal)",
+                                session_id,
+                                session.view_name,
+                                current,
+                                e,
+                            );
+                        }
+
+                        if let Err(e) = repo.set_current_view(&session.view_name) {
+                            log::warn!(
+                                "Fallback session {} could not switch to '{}': {} (non-fatal)",
+                                session_id,
+                                session.view_name,
+                                e,
+                            );
+                        }
                     } else if current != "dev" && current != "main" && current != "release" {
                         // Adopt the existing agent view (session-start
                         // likely created it before this fallback ran).

--- a/atomic-agent/src/turn/orchestrator/tests.rs
+++ b/atomic-agent/src/turn/orchestrator/tests.rs
@@ -954,3 +954,41 @@ async fn test_preexisting_session_is_not_restamped() {
         "pre-existing sessions keep their own view"
     );
 }
+
+#[tokio::test]
+async fn test_sandbox_session_files_land_in_canonical_store() {
+    // Regression: sessions written by the REAL constructor (the hooks path)
+    // must land in the canonical .atomic/sessions — not in a throwaway
+    // .atomic/ inside the sandbox working tree — or `lifecycle end`'s
+    // stamp harvest never sees sandbox sessions.
+    let canonical = TempDir::new().unwrap();
+    let mut repo = Repository::init(canonical.path()).unwrap();
+    let user_view = repo.current_view().to_string();
+    repo.create_view_from("agent-sbx2", &user_view).unwrap();
+
+    let sandbox_dir = TempDir::new().unwrap();
+    repo.provision_sandbox(sandbox_dir.path(), "agent-sbx2")
+        .unwrap();
+    drop(repo);
+
+    let mut orch = TurnOrchestrator::new(sandbox_dir.path()).await.unwrap();
+    orch.set_agent("codex", "Codex");
+    orch.dispatch(session_start_event("sess-canon"))
+        .await
+        .unwrap();
+
+    assert!(
+        canonical
+            .path()
+            .join(".atomic/sessions/sess-canon.json")
+            .is_file(),
+        "sandbox session must be stored in the canonical session store"
+    );
+    assert!(
+        !sandbox_dir
+            .path()
+            .join(".atomic/sessions/sess-canon.json")
+            .exists(),
+        "sandbox session must not be stranded in a sandbox-local .atomic"
+    );
+}

--- a/atomic-agent/src/turn/orchestrator/tests.rs
+++ b/atomic-agent/src/turn/orchestrator/tests.rs
@@ -769,3 +769,188 @@ fn test_orchestrator_debug() {
     assert!(debug.contains("TurnOrchestrator"));
     assert!(debug.contains("repo_root"));
 }
+
+// Managed-run adoption tests
+
+fn managed_context(view: Option<&str>) -> ManagedRunContext {
+    ManagedRunContext {
+        stamp: crate::turn::session::ManagedRunStamp {
+            run_id: "run-mng-1".to_string(),
+            owner_agent: "sherpa".to_string(),
+            owner_session_id: "sherpa-sess-1".to_string(),
+            work_item_id: Some("NONA-42".to_string()),
+        },
+        view: view.map(|v| v.to_string()),
+    }
+}
+
+/// Orchestrator rooted at a real initialized repository (recording works).
+fn make_repo_orchestrator(dir: &TempDir) -> TurnOrchestrator {
+    Repository::init(dir.path()).unwrap();
+    let session_store = SessionStore::for_repo(dir.path()).unwrap();
+    let watcher = FallbackWatcher::new(WatcherConfig::new(dir.path()));
+    TurnOrchestrator::with_watcher(dir.path(), session_store, Box::new(watcher))
+}
+
+#[tokio::test]
+async fn test_session_start_adopts_declared_managed_view() {
+    let dir = TempDir::new().unwrap();
+    let mut orch = make_repo_orchestrator(&dir);
+    orch.set_agent("codex", "Codex");
+    orch.set_managed_run(managed_context(Some("sherpa-run-view")));
+
+    let result = orch
+        .dispatch(session_start_event("sess-managed"))
+        .await
+        .unwrap();
+    assert!(result
+        .message
+        .as_deref()
+        .unwrap_or("")
+        .contains("sherpa-run-view"));
+
+    let session = orch.session_store.load("sess-managed").unwrap().unwrap();
+    assert_eq!(
+        session.view_name, "sherpa-run-view",
+        "session must adopt the declared managed-run view instead of forking"
+    );
+    assert_eq!(
+        session.parent_view.as_deref(),
+        Some("dev"),
+        "parent view is remembered so session-end can restore it"
+    );
+    let stamp = session
+        .managed_run
+        .expect("session must carry the run stamp");
+    assert_eq!(stamp.run_id, "run-mng-1");
+    assert_eq!(stamp.owner_agent, "sherpa");
+    assert_eq!(stamp.work_item_id.as_deref(), Some("NONA-42"));
+
+    // The working copy switched onto the declared view.
+    let repo = Repository::open_existing(dir.path()).unwrap();
+    assert_eq!(repo.current_view(), "sherpa-run-view");
+    drop(repo);
+
+    // A full turn records onto the declared view.
+    orch.dispatch(turn_start_event("sess-managed", "do work"))
+        .await
+        .unwrap();
+    fs::write(dir.path().join("work.rs"), "fn work() {}\n").unwrap();
+    let result = orch.dispatch(turn_end_event("sess-managed")).await.unwrap();
+    assert!(
+        result.was_recorded(),
+        "turn under a managed run must record normally — nothing is suppressed"
+    );
+    assert_eq!(result.view.as_deref(), Some("sherpa-run-view"));
+
+    // Session end restores the parent view.
+    orch.dispatch(session_end_event("sess-managed"))
+        .await
+        .unwrap();
+    let repo = Repository::open_existing(dir.path()).unwrap();
+    assert_eq!(
+        repo.current_view(),
+        "dev",
+        "session-end restores the user's view"
+    );
+}
+
+#[tokio::test]
+async fn test_managed_run_without_view_stamps_but_forks_normally() {
+    let dir = TempDir::new().unwrap();
+    let mut orch = make_repo_orchestrator(&dir);
+    orch.set_agent("codex", "Codex");
+    orch.set_managed_run(managed_context(None));
+
+    orch.dispatch(session_start_event("sess-stamp-only"))
+        .await
+        .unwrap();
+
+    let session = orch.session_store.load("sess-stamp-only").unwrap().unwrap();
+    assert!(
+        session.managed_run.is_some(),
+        "session must be stamped even when the run declares no view"
+    );
+    assert_ne!(
+        session.view_name, "dev",
+        "without a declared view the session forks its usual per-session view"
+    );
+    assert_eq!(session.parent_view.as_deref(), Some("dev"));
+}
+
+#[tokio::test]
+async fn test_sandbox_session_keeps_provisioned_view_under_managed_run() {
+    // Canonical repository with a distinct view the sandbox operates on.
+    let canonical = TempDir::new().unwrap();
+    let mut repo = Repository::init(canonical.path()).unwrap();
+    let user_view = repo.current_view().to_string();
+    repo.create_view_from("agent-sbx", &user_view).unwrap();
+
+    let sandbox_dir = TempDir::new().unwrap();
+    repo.provision_sandbox(sandbox_dir.path(), "agent-sbx")
+        .unwrap();
+    drop(repo);
+
+    let session_store = SessionStore::for_repo(sandbox_dir.path()).unwrap();
+    let watcher = FallbackWatcher::new(WatcherConfig::new(sandbox_dir.path()));
+    let mut orch =
+        TurnOrchestrator::with_watcher(sandbox_dir.path(), session_store, Box::new(watcher));
+    orch.set_agent("codex", "Codex");
+    // The run declares a DIFFERENT view — the sandbox pointer must win.
+    orch.set_managed_run(managed_context(Some("some-other-view")));
+
+    orch.dispatch(session_start_event("sess-sbx-managed"))
+        .await
+        .unwrap();
+
+    let session = orch
+        .session_store
+        .load("sess-sbx-managed")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        session.view_name, "agent-sbx",
+        "inside a sandbox the provisioned view always wins over the declared one"
+    );
+    assert!(session.managed_run.is_some(), "the stamp still applies");
+
+    // The canonical current view is untouched.
+    let repo = Repository::open_existing(canonical.path()).unwrap();
+    assert_eq!(repo.current_view(), user_view);
+}
+
+#[tokio::test]
+async fn test_preexisting_session_is_not_restamped() {
+    let dir = TempDir::new().unwrap();
+    let mut orch = make_repo_orchestrator(&dir);
+    orch.set_agent("claude-code", "Claude Code");
+
+    // Session born OUTSIDE any managed run.
+    orch.dispatch(session_start_event("sess-direct"))
+        .await
+        .unwrap();
+    assert!(orch
+        .session_store
+        .load("sess-direct")
+        .unwrap()
+        .unwrap()
+        .managed_run
+        .is_none());
+
+    // A lifecycle begins afterwards; re-entering the session must NOT
+    // attribute the pre-existing session to the run.
+    orch.set_managed_run(managed_context(Some("sherpa-run-view")));
+    orch.dispatch(session_start_event("sess-direct"))
+        .await
+        .unwrap();
+
+    let session = orch.session_store.load("sess-direct").unwrap().unwrap();
+    assert!(
+        session.managed_run.is_none(),
+        "pre-existing sessions are never re-attributed to a managed run"
+    );
+    assert_ne!(
+        session.view_name, "sherpa-run-view",
+        "pre-existing sessions keep their own view"
+    );
+}

--- a/atomic-agent/src/turn/session.rs
+++ b/atomic-agent/src/turn/session.rs
@@ -63,18 +63,10 @@ use crate::turn::phase::Phase;
 
 // ManagedRunStamp
 
-/// Correlation stamp for sessions born under a managed lifecycle.
-///
-/// When an outer orchestrator (e.g. Sherpa/noname) declares a run via
-/// `atomic agent lifecycle begin`, every session created inside that run's
-/// workdir is stamped with the run context. The stamp is the queryable edge
-/// between the orchestrator's run and the sessions/changes it produced —
-/// the PROV `actedOnBehalfOf` chain: this agent's activity was performed
-/// on behalf of `owner_agent`'s run `run_id`.
-///
-/// Sessions that already existed when the lifecycle began are NOT stamped —
-/// the stamp marks sessions born within the run, so a user's own concurrent
-/// direct session is never attributed to the orchestrator.
+/// Correlation stamp for sessions born under a managed lifecycle
+/// (`atomic agent lifecycle begin`) — the edge between the orchestrator's
+/// run and the sessions/changes it produced. Pre-existing sessions are
+/// never stamped, so a concurrent direct session is not attributed.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ManagedRunStamp {
     /// The managed run id (from `lifecycle begin`).
@@ -222,11 +214,8 @@ pub struct AgentSession {
     #[serde(default)]
     pub recorded_change_hashes: Vec<atomic_core::types::Hash>,
 
-    /// Managed-run stamp, set when this session was created under a managed
-    /// lifecycle (see [`ManagedRunStamp`]). `None` for direct agent sessions.
-    ///
-    /// `atomic agent lifecycle end --json` scans session files for this stamp
-    /// to build the run summary (sessions, views, recorded change hashes).
+    /// Managed-run stamp when created under a managed lifecycle; `None` for
+    /// direct sessions. `lifecycle end --json` harvests runs from this.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub managed_run: Option<ManagedRunStamp>,
 }

--- a/atomic-agent/src/turn/session.rs
+++ b/atomic-agent/src/turn/session.rs
@@ -61,6 +61,36 @@ use serde::{Deserialize, Serialize};
 use crate::error::{AgentError, AgentResult};
 use crate::turn::phase::Phase;
 
+// ManagedRunStamp
+
+/// Correlation stamp for sessions born under a managed lifecycle.
+///
+/// When an outer orchestrator (e.g. Sherpa/noname) declares a run via
+/// `atomic agent lifecycle begin`, every session created inside that run's
+/// workdir is stamped with the run context. The stamp is the queryable edge
+/// between the orchestrator's run and the sessions/changes it produced —
+/// the PROV `actedOnBehalfOf` chain: this agent's activity was performed
+/// on behalf of `owner_agent`'s run `run_id`.
+///
+/// Sessions that already existed when the lifecycle began are NOT stamped —
+/// the stamp marks sessions born within the run, so a user's own concurrent
+/// direct session is never attributed to the orchestrator.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManagedRunStamp {
+    /// The managed run id (from `lifecycle begin`).
+    pub run_id: String,
+
+    /// The lifecycle owner agent (e.g. "sherpa").
+    pub owner_agent: String,
+
+    /// The owner's own session id for the run.
+    pub owner_session_id: String,
+
+    /// Optional work item the owner associated with the run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_item_id: Option<String>,
+}
+
 // AgentSession
 
 /// State of an agent session.
@@ -191,6 +221,14 @@ pub struct AgentSession {
     /// this field existed) loadable as an empty vec.
     #[serde(default)]
     pub recorded_change_hashes: Vec<atomic_core::types::Hash>,
+
+    /// Managed-run stamp, set when this session was created under a managed
+    /// lifecycle (see [`ManagedRunStamp`]). `None` for direct agent sessions.
+    ///
+    /// `atomic agent lifecycle end --json` scans session files for this stamp
+    /// to build the run summary (sessions, views, recorded change hashes).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub managed_run: Option<ManagedRunStamp>,
 }
 
 impl AgentSession {
@@ -232,6 +270,7 @@ impl AgentSession {
             files_touched: Vec::new(),
             current_turn_started_at: None,
             recorded_change_hashes: Vec::new(),
+            managed_run: None,
         }
     }
 
@@ -994,6 +1033,34 @@ mod tests {
         // recorded_change_hashes was added later — old session files must
         // still load with this field as an empty vec (#[serde(default)])
         assert!(loaded.recorded_change_hashes.is_empty());
+        // managed_run was added later — old session files load with None
+        assert!(loaded.managed_run.is_none());
+    }
+
+    #[test]
+    fn test_serde_roundtrip_with_managed_run_stamp() {
+        let mut s = make_session();
+        s.managed_run = Some(ManagedRunStamp {
+            run_id: "run-abc".to_string(),
+            owner_agent: "sherpa".to_string(),
+            owner_session_id: "sherpa-sess-1".to_string(),
+            work_item_id: Some("NONA-12".to_string()),
+        });
+
+        let json = serde_json::to_string_pretty(&s).unwrap();
+        let loaded: AgentSession = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.managed_run, s.managed_run);
+    }
+
+    #[test]
+    fn test_managed_run_omitted_when_none() {
+        let s = make_session();
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(
+            !json.contains("managed_run"),
+            "managed_run must be omitted for direct sessions, got: {}",
+            json
+        );
     }
 
     #[test]

--- a/atomic-cli/src/commands/agent/hooks.rs
+++ b/atomic-cli/src/commands/agent/hooks.rs
@@ -106,6 +106,9 @@ struct HookJsonResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     view: Option<String>,
     files: Vec<String>,
+    /// The managed run this hook participated in, when a lifecycle governs it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    run_id: Option<String>,
 }
 
 impl Command for Hooks {
@@ -169,6 +172,23 @@ impl Command for Hooks {
             e
         })?;
 
+        // Resolve the managed run governing this hook, if any. Hooks are
+        // never suppressed: under a managed lifecycle the session ADOPTS the
+        // run's declared view and is STAMPED with the run context, so the
+        // owner can correlate recorded changes without stealing or dropping
+        // anyone's provenance.
+        let managed = super::lifecycle::find_governing_lifecycle_for_hook(&self.agent_name);
+        if let Some(lc) = &managed {
+            log::info!(
+                "hook {} {} participates in managed run {} (owner: {}, view: {})",
+                self.agent_name,
+                self.verb,
+                lc.run_id,
+                lc.owner_agent,
+                lc.view.as_deref().unwrap_or("-"),
+            );
+        }
+
         // Create a tokio runtime for the async orchestrator
         // Hook handlers are short-lived — one runtime per invocation is fine.
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -201,6 +221,12 @@ impl Command for Hooks {
             // (e.g., "claude-code" / "Claude Code" instead of "unknown")
             orchestrator.set_agent(&agent_name, &agent_display);
 
+            // Under a managed lifecycle, sessions adopt the declared view
+            // and carry the run stamp (see lifecycle module docs).
+            if let Some(lc) = &managed {
+                orchestrator.set_managed_run(lc.to_managed_run_context());
+            }
+
             // Dispatch the event through the state machine → watcher → recorder
             let dispatch_result = orchestrator
                 .dispatch(event)
@@ -227,6 +253,7 @@ impl Command for Hooks {
 
         // Emit the recorded change hash for UI/bridge callers.
         if self.json {
+            let run_id = managed.as_ref().map(|lc| lc.run_id.clone());
             let json = match &result.change_recorded {
                 Some(outcome) => HookJsonResult {
                     session_id: result.session_id.clone(),
@@ -234,6 +261,7 @@ impl Command for Hooks {
                     change_hash: Some(outcome.hash.to_base32()),
                     view: result.view.clone(),
                     files: outcome.recorded_file_list().to_vec(),
+                    run_id,
                 },
                 None => HookJsonResult {
                     session_id: result.session_id.clone(),
@@ -241,6 +269,7 @@ impl Command for Hooks {
                     change_hash: None,
                     view: result.view.clone(),
                     files: Vec::new(),
+                    run_id,
                 },
             };
             match serde_json::to_string(&json) {
@@ -481,6 +510,7 @@ mod tests {
             change_hash: Some("ABC123".to_string()),
             view: Some("bold-creek-a3f2".to_string()),
             files: vec!["src/main.rs".to_string(), "src/lib.rs".to_string()],
+            run_id: Some("run-42".to_string()),
         };
         let parsed: serde_json::Value =
             serde_json::from_str(&serde_json::to_string(&result).unwrap()).unwrap();
@@ -491,6 +521,7 @@ mod tests {
         assert_eq!(parsed["view"], "bold-creek-a3f2");
         assert_eq!(parsed["files"][0], "src/main.rs");
         assert_eq!(parsed["files"][1], "src/lib.rs");
+        assert_eq!(parsed["run_id"], "run-42");
     }
 
     #[test]
@@ -501,6 +532,7 @@ mod tests {
             change_hash: None,
             view: None,
             files: Vec::new(),
+            run_id: None,
         };
         let json = serde_json::to_string(&result).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -514,6 +546,11 @@ mod tests {
         assert!(
             !json.contains("view"),
             "view must be omitted when None, got: {}",
+            json
+        );
+        assert!(
+            !json.contains("run_id"),
+            "run_id must be omitted outside managed runs, got: {}",
             json
         );
         assert_eq!(parsed["files"].as_array().unwrap().len(), 0);

--- a/atomic-cli/src/commands/agent/hooks.rs
+++ b/atomic-cli/src/commands/agent/hooks.rs
@@ -172,11 +172,8 @@ impl Command for Hooks {
             e
         })?;
 
-        // Resolve the managed run governing this hook, if any. Hooks are
-        // never suppressed: under a managed lifecycle the session ADOPTS the
-        // run's declared view and is STAMPED with the run context, so the
-        // owner can correlate recorded changes without stealing or dropping
-        // anyone's provenance.
+        // Resolve the managed run governing this hook, if any — hooks are
+        // never suppressed, sessions adopt the run's view + stamp.
         let managed = super::lifecycle::find_governing_lifecycle_for_hook(&self.agent_name);
         if let Some(lc) = &managed {
             log::info!(

--- a/atomic-cli/src/commands/agent/lifecycle.rs
+++ b/atomic-cli/src/commands/agent/lifecycle.rs
@@ -1,36 +1,17 @@
 //! Managed lifecycle declarations for orchestrated agent runs.
 //!
-//! An outer orchestrator such as Sherpa/noname can wrap an ACP executor
-//! (codex-acp, claude-acp, …). `atomic agent lifecycle begin` declares that
-//! run: who owns it, which executor performs it, which view the work should
-//! land on, and which working directory it covers.
+//! `lifecycle begin` declares a run (owner, executor, view, workdir). Hooks
+//! are never suppressed: sessions created under a governing run **adopt**
+//! its declared view and are **stamped** with the run context; `lifecycle
+//! end --json` harvests the summary from those stamps.
 //!
-//! Hooks are **never suppressed** under a managed lifecycle. Instead, hooks
-//! whose working directory falls inside a declared run:
+//! Lifecycles are keyed by `run_id` (one JSON file each) so concurrent runs
+//! coexist; hooks resolve the governing run by longest-matching `workdir`.
+//! The store lives in the *canonical* `.atomic` (resolved through the
+//! sandbox pointer) so sandbox hooks see project-root lifecycles.
 //!
-//! - **adopt** the run's declared view for new sessions (instead of forking a
-//!   per-session view), and
-//! - **stamp** those sessions with the run context (`managed_run` on the
-//!   session file) — the PROV `actedOnBehalfOf` edge.
-//!
-//! Every participant records through the same pipeline; correlation lives in
-//! the data, not in a lock. `lifecycle end --json` harvests the run summary
-//! (sessions, views, recorded change hashes) from the stamps.
-//!
-//! # Concurrency
-//!
-//! Lifecycles are keyed by `run_id` — one JSON file per run under
-//! `<canonical .atomic>/agent-lifecycle/`. Concurrent runs (e.g. three
-//! sandboxed builds plus an in-repo research run) coexist; hooks resolve the
-//! governing run by longest-matching `workdir`. The store lives in the
-//! *canonical* `.atomic` (resolved through the sandbox pointer), so hooks
-//! firing inside a sandbox see lifecycles declared at the project root.
-//!
-//! # Leases
-//!
-//! `expires_at` is crash protection, not a session limit: an orchestrator
-//! that dies without calling `end` leaves a lease that expires on its own.
-//! Expired lifecycles are ignored and opportunistically cleaned up.
+//! `expires_at` is crash protection, not a session limit: a dead
+//! orchestrator's lease expires on its own and is cleaned up lazily.
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/atomic-cli/src/commands/agent/lifecycle.rs
+++ b/atomic-cli/src/commands/agent/lifecycle.rs
@@ -1,0 +1,776 @@
+//! Managed lifecycle declarations for orchestrated agent runs.
+//!
+//! An outer orchestrator such as Sherpa/noname can wrap an ACP executor
+//! (codex-acp, claude-acp, …). `atomic agent lifecycle begin` declares that
+//! run: who owns it, which executor performs it, which view the work should
+//! land on, and which working directory it covers.
+//!
+//! Hooks are **never suppressed** under a managed lifecycle. Instead, hooks
+//! whose working directory falls inside a declared run:
+//!
+//! - **adopt** the run's declared view for new sessions (instead of forking a
+//!   per-session view), and
+//! - **stamp** those sessions with the run context (`managed_run` on the
+//!   session file) — the PROV `actedOnBehalfOf` edge.
+//!
+//! Every participant records through the same pipeline; correlation lives in
+//! the data, not in a lock. `lifecycle end --json` harvests the run summary
+//! (sessions, views, recorded change hashes) from the stamps.
+//!
+//! # Concurrency
+//!
+//! Lifecycles are keyed by `run_id` — one JSON file per run under
+//! `<canonical .atomic>/agent-lifecycle/`. Concurrent runs (e.g. three
+//! sandboxed builds plus an in-repo research run) coexist; hooks resolve the
+//! governing run by longest-matching `workdir`. The store lives in the
+//! *canonical* `.atomic` (resolved through the sandbox pointer), so hooks
+//! firing inside a sandbox see lifecycles declared at the project root.
+//!
+//! # Leases
+//!
+//! `expires_at` is crash protection, not a session limit: an orchestrator
+//! that dies without calling `end` leaves a lease that expires on its own.
+//! Expired lifecycles are ignored and opportunistically cleaned up.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::anyhow;
+use clap::{Args, Subcommand};
+use serde::{Deserialize, Serialize};
+
+use atomic_agent::turn::orchestrator::ManagedRunContext;
+use atomic_agent::turn::session::{ManagedRunStamp, SessionStore};
+use atomic_core::types::Base32;
+
+use crate::commands::Command;
+use crate::error::{CliError, CliResult};
+
+const LIFECYCLE_DIR: &str = "agent-lifecycle";
+const DEFAULT_TTL_SECONDS: i64 = 24 * 60 * 60;
+
+#[derive(Debug, Args)]
+#[command(arg_required_else_help = true)]
+pub struct Lifecycle {
+    #[command(subcommand)]
+    command: LifecycleCommands,
+}
+
+#[derive(Debug, Subcommand)]
+enum LifecycleCommands {
+    /// Declare a managed agent run owned by an outer orchestrator.
+    Begin(Begin),
+
+    /// Renew a managed run's lease.
+    Renew(Renew),
+
+    /// End a managed run and print its summary (sessions, changes, views).
+    End(End),
+
+    /// Show active managed runs.
+    Status(Status),
+}
+
+#[derive(Debug, Args)]
+struct Begin {
+    /// Lifecycle owner agent, e.g. "sherpa".
+    #[arg(long)]
+    owner: String,
+
+    /// Owner session id.
+    #[arg(long)]
+    session: String,
+
+    /// Executor agent whose hooks participate in this run (registry key of
+    /// the *inner* agent, e.g. "codex", "claude-code"). When set, hooks from
+    /// other non-owner agents are left untouched; when omitted, any agent
+    /// inside the workdir participates.
+    #[arg(long)]
+    executor: Option<String>,
+
+    /// Optional work item id to associate with the managed run.
+    #[arg(long)]
+    work_item: Option<String>,
+
+    /// View the run's sessions should adopt for recording. When omitted,
+    /// sessions fork their usual per-session view and are only stamped.
+    #[arg(long)]
+    view: Option<String>,
+
+    /// Working directory the run covers (a sandbox path or the repo root).
+    /// Hooks participate only when their cwd is inside it. Defaults to the
+    /// current directory.
+    #[arg(long)]
+    workdir: Option<PathBuf>,
+
+    /// Lease duration. The lease is crash protection, not a session limit.
+    #[arg(long, default_value_t = DEFAULT_TTL_SECONDS)]
+    ttl_seconds: i64,
+
+    /// Print JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Args)]
+struct Renew {
+    /// Run id returned by lifecycle begin.
+    #[arg(long)]
+    run_id: String,
+
+    /// Lease duration from now.
+    #[arg(long, default_value_t = DEFAULT_TTL_SECONDS)]
+    ttl_seconds: i64,
+
+    /// Print JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Args)]
+struct End {
+    /// Run id returned by lifecycle begin.
+    #[arg(long)]
+    run_id: String,
+
+    /// Print JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Args)]
+struct Status {
+    /// Print JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct ManagedLifecycle {
+    pub run_id: String,
+    pub owner_agent: String,
+    pub owner_session_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub executor_agent: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub view: Option<String>,
+    pub workdir: PathBuf,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub expires_at: i64,
+}
+
+impl ManagedLifecycle {
+    fn is_expired(&self, now: i64) -> bool {
+        self.expires_at <= now
+    }
+
+    fn renew(&mut self, now: i64, ttl_seconds: i64) {
+        self.updated_at = now;
+        self.expires_at = now + ttl_seconds.max(1);
+    }
+
+    /// Whether a hook from `agent_name` running in `cwd` participates in
+    /// this run: the cwd must be inside the run's workdir, and the agent
+    /// must be the owner or the declared executor (any agent when no
+    /// executor is declared).
+    fn governs(&self, cwd: &Path, agent_name: &str) -> bool {
+        if !cwd.starts_with(&self.workdir) {
+            return false;
+        }
+        if self.owner_agent == agent_name {
+            return true;
+        }
+        match self.executor_agent.as_deref() {
+            Some(executor) => executor == agent_name,
+            None => true,
+        }
+    }
+
+    /// Convert to the orchestrator context injected by the hook handler.
+    pub(super) fn to_managed_run_context(&self) -> ManagedRunContext {
+        ManagedRunContext {
+            stamp: ManagedRunStamp {
+                run_id: self.run_id.clone(),
+                owner_agent: self.owner_agent.clone(),
+                owner_session_id: self.owner_session_id.clone(),
+                work_item_id: self.work_item_id.clone(),
+            },
+            view: self.view.clone(),
+        }
+    }
+}
+
+/// One session recorded under a managed run, harvested from session stamps.
+#[derive(Debug, Serialize)]
+struct RunSessionSummary {
+    session_id: String,
+    agent_name: String,
+    view: String,
+    turn_count: u32,
+    change_hashes: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct LifecycleEndResult {
+    ended: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    lifecycle: Option<ManagedLifecycle>,
+    /// Sessions stamped with this run's id, with their recorded changes.
+    sessions: Vec<RunSessionSummary>,
+    /// All change hashes recorded under this run (across sessions).
+    change_hashes: Vec<String>,
+    /// Views those changes landed on.
+    views: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct LifecycleStatus {
+    active: bool,
+    lifecycles: Vec<ManagedLifecycle>,
+}
+
+impl Command for Lifecycle {
+    fn run(&self) -> CliResult<()> {
+        match &self.command {
+            LifecycleCommands::Begin(cmd) => cmd.run(),
+            LifecycleCommands::Renew(cmd) => cmd.run(),
+            LifecycleCommands::End(cmd) => cmd.run(),
+            LifecycleCommands::Status(cmd) => cmd.run(),
+        }
+    }
+}
+
+impl Begin {
+    fn run(&self) -> CliResult<()> {
+        let dot_dir = resolve_dot_dir()?;
+        validate_name("owner", &self.owner)?;
+        validate_name("session", &self.session)?;
+
+        let workdir = match &self.workdir {
+            Some(dir) => canonicalize_lenient(dir),
+            None => current_dir_canonical()?,
+        };
+
+        let now = now_secs();
+        let dir = lifecycle_dir(&dot_dir);
+        cleanup_expired(&dir, now);
+
+        // Idempotent begin: the same owner+session renews its existing run
+        // (noname retries begin on reconnect) instead of minting a new id.
+        let existing = list_active(&dir, now)
+            .into_iter()
+            .find(|l| l.owner_agent == self.owner && l.owner_session_id == self.session);
+
+        let lifecycle = match existing {
+            Some(mut active) => {
+                active.executor_agent = self.executor.clone();
+                active.work_item_id = self.work_item.clone();
+                active.view = self.view.clone();
+                active.workdir = workdir;
+                active.renew(now, self.ttl_seconds);
+                active
+            }
+            None => ManagedLifecycle {
+                run_id: uuid::Uuid::new_v4().to_string(),
+                owner_agent: self.owner.clone(),
+                owner_session_id: self.session.clone(),
+                executor_agent: self.executor.clone(),
+                work_item_id: self.work_item.clone(),
+                view: self.view.clone(),
+                workdir,
+                created_at: now,
+                updated_at: now,
+                expires_at: now + self.ttl_seconds.max(1),
+            },
+        };
+
+        save_lifecycle(&dir, &lifecycle)?;
+        print_lifecycle(&lifecycle, self.json)
+    }
+}
+
+impl Renew {
+    fn run(&self) -> CliResult<()> {
+        let dot_dir = resolve_dot_dir()?;
+        let dir = lifecycle_dir(&dot_dir);
+        let now = now_secs();
+
+        let mut lifecycle = load_lifecycle(&dir, &self.run_id)?
+            .filter(|l| !l.is_expired(now))
+            .ok_or_else(|| CliError::InvalidArgument {
+                message: format!("no active managed lifecycle with run_id '{}'", self.run_id),
+            })?;
+
+        lifecycle.renew(now, self.ttl_seconds);
+        save_lifecycle(&dir, &lifecycle)?;
+        print_lifecycle(&lifecycle, self.json)
+    }
+}
+
+impl End {
+    fn run(&self) -> CliResult<()> {
+        let dot_dir = resolve_dot_dir()?;
+        let dir = lifecycle_dir(&dot_dir);
+
+        let lifecycle = load_lifecycle(&dir, &self.run_id)?;
+        let ended = lifecycle.is_some();
+        remove_lifecycle(&dir, &self.run_id)?;
+
+        // Harvest the run summary from session stamps — even for an
+        // already-expired or missing lease, sessions may carry the stamp.
+        let sessions = collect_run_sessions(&dot_dir, &self.run_id);
+
+        let mut change_hashes = Vec::new();
+        let mut views = Vec::new();
+        for s in &sessions {
+            for hash in &s.change_hashes {
+                if !change_hashes.contains(hash) {
+                    change_hashes.push(hash.clone());
+                }
+            }
+            if !s.change_hashes.is_empty() && !views.contains(&s.view) {
+                views.push(s.view.clone());
+            }
+        }
+
+        let result = LifecycleEndResult {
+            ended,
+            lifecycle,
+            sessions,
+            change_hashes,
+            views,
+        };
+
+        if self.json {
+            println!("{}", serde_json::to_string(&result).unwrap());
+        } else if result.ended {
+            println!(
+                "Managed lifecycle ended: {} session(s), {} change(s) recorded.",
+                result.sessions.len(),
+                result.change_hashes.len(),
+            );
+        } else {
+            println!("No active managed lifecycle with that run id.");
+        }
+        Ok(())
+    }
+}
+
+impl Status {
+    fn run(&self) -> CliResult<()> {
+        let dot_dir = resolve_dot_dir()?;
+        let dir = lifecycle_dir(&dot_dir);
+        let lifecycles = list_active(&dir, now_secs());
+
+        if self.json {
+            let status = LifecycleStatus {
+                active: !lifecycles.is_empty(),
+                lifecycles,
+            };
+            println!("{}", serde_json::to_string(&status).unwrap());
+        } else if lifecycles.is_empty() {
+            println!("No active managed lifecycles.");
+        } else {
+            for l in lifecycles {
+                println!(
+                    "Managed run {}: owner={} session={} view={} workdir={} expires_at={}",
+                    l.run_id,
+                    l.owner_agent,
+                    l.owner_session_id,
+                    l.view.as_deref().unwrap_or("-"),
+                    l.workdir.display(),
+                    l.expires_at,
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Resolve the managed run governing a hook from `agent_name` in the current
+/// working directory. Returns `None` outside a repository, when no active
+/// lifecycle covers the cwd, or when the agent is not a participant.
+///
+/// With overlapping workdirs (an in-repo run plus a sandboxed run), the most
+/// specific (longest) workdir wins; ties go to the newest run.
+pub(super) fn find_governing_lifecycle_for_hook(agent_name: &str) -> Option<ManagedLifecycle> {
+    let cwd = current_dir_canonical().ok()?;
+    let dot_dir = atomic_repository::Repository::canonical_dot_dir(&cwd).ok()?;
+    let dir = lifecycle_dir(&dot_dir);
+    let now = now_secs();
+
+    list_active(&dir, now)
+        .into_iter()
+        .filter(|l| l.governs(&cwd, agent_name))
+        .max_by_key(|l| (l.workdir.components().count(), l.created_at))
+}
+
+fn resolve_dot_dir() -> CliResult<PathBuf> {
+    let cwd = std::env::current_dir().map_err(CliError::Io)?;
+    atomic_repository::Repository::canonical_dot_dir(&cwd).map_err(|e| {
+        CliError::Internal(anyhow!("not inside an Atomic repository or sandbox: {}", e))
+    })
+}
+
+fn lifecycle_dir(dot_dir: &Path) -> PathBuf {
+    dot_dir.join(LIFECYCLE_DIR)
+}
+
+fn lifecycle_path(dir: &Path, run_id: &str) -> PathBuf {
+    dir.join(format!("{}.json", run_id))
+}
+
+fn validate_name(label: &str, value: &str) -> CliResult<()> {
+    if value.trim().is_empty() {
+        return Err(CliError::InvalidArgument {
+            message: format!("{label} cannot be empty"),
+        });
+    }
+    Ok(())
+}
+
+fn validate_run_id(run_id: &str) -> CliResult<()> {
+    if run_id.is_empty()
+        || run_id.contains("..")
+        || run_id.contains('/')
+        || run_id.contains('\\')
+        || run_id.contains('\0')
+    {
+        return Err(CliError::InvalidArgument {
+            message: format!("invalid run id '{}'", run_id),
+        });
+    }
+    Ok(())
+}
+
+fn canonicalize_lenient(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn current_dir_canonical() -> CliResult<PathBuf> {
+    let cwd = std::env::current_dir().map_err(CliError::Io)?;
+    Ok(canonicalize_lenient(&cwd))
+}
+
+fn list_active(dir: &Path, now: i64) -> Vec<ManagedLifecycle> {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut active = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(data) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(lifecycle) = serde_json::from_str::<ManagedLifecycle>(&data) else {
+            log::warn!("skipping unparseable lifecycle file {}", path.display());
+            continue;
+        };
+        if !lifecycle.is_expired(now) {
+            active.push(lifecycle);
+        }
+    }
+    active
+}
+
+fn cleanup_expired(dir: &Path, now: i64) {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let expired = fs::read_to_string(&path)
+            .ok()
+            .and_then(|data| serde_json::from_str::<ManagedLifecycle>(&data).ok())
+            .map(|l| l.is_expired(now))
+            .unwrap_or(false);
+        if expired {
+            let _ = fs::remove_file(&path);
+        }
+    }
+}
+
+fn load_lifecycle(dir: &Path, run_id: &str) -> CliResult<Option<ManagedLifecycle>> {
+    validate_run_id(run_id)?;
+    let path = lifecycle_path(dir, run_id);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let data = fs::read_to_string(&path).map_err(|e| {
+        CliError::Internal(anyhow!(
+            "failed to read managed lifecycle '{}': {}",
+            path.display(),
+            e
+        ))
+    })?;
+    let lifecycle = serde_json::from_str(&data).map_err(|e| {
+        CliError::Internal(anyhow!(
+            "failed to parse managed lifecycle '{}': {}",
+            path.display(),
+            e
+        ))
+    })?;
+    Ok(Some(lifecycle))
+}
+
+fn save_lifecycle(dir: &Path, lifecycle: &ManagedLifecycle) -> CliResult<()> {
+    validate_run_id(&lifecycle.run_id)?;
+    fs::create_dir_all(dir)?;
+    let path = lifecycle_path(dir, &lifecycle.run_id);
+    let data = serde_json::to_vec_pretty(lifecycle)
+        .map_err(|e| CliError::Internal(anyhow!("failed to serialize managed lifecycle: {}", e)))?;
+    let tmp = path.with_extension("json.tmp");
+    fs::write(&tmp, data)?;
+    fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+fn remove_lifecycle(dir: &Path, run_id: &str) -> CliResult<()> {
+    validate_run_id(run_id)?;
+    match fs::remove_file(lifecycle_path(dir, run_id)) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(CliError::Internal(anyhow!(
+            "failed to remove managed lifecycle '{}': {}",
+            run_id,
+            e
+        ))),
+    }
+}
+
+/// Collect sessions stamped with `run_id` from the canonical session store.
+fn collect_run_sessions(dot_dir: &Path, run_id: &str) -> Vec<RunSessionSummary> {
+    let store = match SessionStore::new(dot_dir.join("sessions")) {
+        Ok(store) => store,
+        Err(e) => {
+            log::warn!("could not open session store for run summary: {}", e);
+            return Vec::new();
+        }
+    };
+    let sessions = match store.list() {
+        Ok(sessions) => sessions,
+        Err(e) => {
+            log::warn!("could not list sessions for run summary: {}", e);
+            return Vec::new();
+        }
+    };
+
+    sessions
+        .into_iter()
+        .filter(|s| {
+            s.managed_run
+                .as_ref()
+                .map(|m| m.run_id == run_id)
+                .unwrap_or(false)
+        })
+        .map(|s| RunSessionSummary {
+            session_id: s.session_id.clone(),
+            agent_name: s.agent_name.clone(),
+            view: s.view_name.clone(),
+            turn_count: s.turn_count,
+            change_hashes: s
+                .recorded_change_hashes
+                .iter()
+                .map(|h| h.to_base32())
+                .collect(),
+        })
+        .collect()
+}
+
+fn print_lifecycle(lifecycle: &ManagedLifecycle, json: bool) -> CliResult<()> {
+    if json {
+        println!("{}", serde_json::to_string(lifecycle).unwrap());
+    } else {
+        println!(
+            "Managed run {}: owner={} session={} view={} workdir={} expires_at={}",
+            lifecycle.run_id,
+            lifecycle.owner_agent,
+            lifecycle.owner_session_id,
+            lifecycle.view.as_deref().unwrap_or("-"),
+            lifecycle.workdir.display(),
+            lifecycle.expires_at,
+        );
+    }
+    Ok(())
+}
+
+fn now_secs() -> i64 {
+    chrono::Utc::now().timestamp()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use atomic_agent::turn::session::AgentSession;
+    use tempfile::TempDir;
+
+    fn lifecycle(run_id: &str, owner: &str, workdir: &Path, expires_at: i64) -> ManagedLifecycle {
+        ManagedLifecycle {
+            run_id: run_id.to_string(),
+            owner_agent: owner.to_string(),
+            owner_session_id: format!("{}-session", owner),
+            executor_agent: None,
+            work_item_id: None,
+            view: Some("sherpa-run".to_string()),
+            workdir: workdir.to_path_buf(),
+            created_at: 1,
+            updated_at: 1,
+            expires_at,
+        }
+    }
+
+    #[test]
+    fn keyed_store_holds_concurrent_runs() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path().join(LIFECYCLE_DIR);
+        let now = now_secs();
+
+        save_lifecycle(&dir, &lifecycle("run-a", "sherpa", temp.path(), now + 60)).unwrap();
+        save_lifecycle(&dir, &lifecycle("run-b", "sherpa", temp.path(), now + 60)).unwrap();
+
+        let active = list_active(&dir, now);
+        assert_eq!(active.len(), 2, "two concurrent runs must coexist");
+    }
+
+    #[test]
+    fn expired_lifecycles_are_ignored_and_cleaned() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path().join(LIFECYCLE_DIR);
+        let now = now_secs();
+
+        save_lifecycle(&dir, &lifecycle("run-old", "sherpa", temp.path(), now - 1)).unwrap();
+        save_lifecycle(&dir, &lifecycle("run-new", "sherpa", temp.path(), now + 60)).unwrap();
+
+        let active = list_active(&dir, now);
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].run_id, "run-new");
+
+        cleanup_expired(&dir, now);
+        assert!(!lifecycle_path(&dir, "run-old").exists());
+        assert!(lifecycle_path(&dir, "run-new").exists());
+    }
+
+    #[test]
+    fn governs_requires_cwd_inside_workdir() {
+        let temp = TempDir::new().unwrap();
+        let sandbox = temp.path().join("sandboxes").join("run-a");
+        std::fs::create_dir_all(&sandbox).unwrap();
+        let l = lifecycle("run-a", "sherpa", &sandbox, now_secs() + 60);
+
+        assert!(l.governs(&sandbox, "codex"));
+        assert!(l.governs(&sandbox.join("src"), "codex"));
+        assert!(
+            !l.governs(temp.path(), "codex"),
+            "a hook outside the workdir is not governed"
+        );
+    }
+
+    #[test]
+    fn declared_executor_narrows_participation() {
+        let temp = TempDir::new().unwrap();
+        let mut l = lifecycle("run-a", "sherpa", temp.path(), now_secs() + 60);
+        l.executor_agent = Some("codex".to_string());
+
+        assert!(l.governs(temp.path(), "codex"), "declared executor governs");
+        assert!(l.governs(temp.path(), "sherpa"), "owner always governs");
+        assert!(
+            !l.governs(temp.path(), "claude-code"),
+            "an unrelated agent's direct session is untouched"
+        );
+    }
+
+    #[test]
+    fn no_executor_means_any_agent_participates() {
+        let temp = TempDir::new().unwrap();
+        let l = lifecycle("run-a", "sherpa", temp.path(), now_secs() + 60);
+        assert!(l.governs(temp.path(), "claude-code"));
+    }
+
+    #[test]
+    fn most_specific_workdir_wins() {
+        let temp = TempDir::new().unwrap();
+        let sandbox = temp.path().join("sbx");
+        std::fs::create_dir_all(&sandbox).unwrap();
+        let now = now_secs();
+
+        let broad = lifecycle("run-repo", "sherpa", temp.path(), now + 60);
+        let narrow = lifecycle("run-sbx", "sherpa", &sandbox, now + 60);
+
+        let winner = [broad, narrow]
+            .into_iter()
+            .filter(|l| l.governs(&sandbox, "codex"))
+            .max_by_key(|l| (l.workdir.components().count(), l.created_at))
+            .unwrap();
+        assert_eq!(winner.run_id, "run-sbx");
+    }
+
+    #[test]
+    fn end_summary_collects_stamped_sessions() {
+        let temp = TempDir::new().unwrap();
+        let dot_dir = temp.path().join(".atomic");
+        let store = SessionStore::new(dot_dir.join("sessions")).unwrap();
+
+        let mut stamped = AgentSession::new("sess-in-run", "codex", "Codex");
+        stamped.managed_run = Some(ManagedRunStamp {
+            run_id: "run-a".to_string(),
+            owner_agent: "sherpa".to_string(),
+            owner_session_id: "sherpa-1".to_string(),
+            work_item_id: None,
+        });
+        stamped
+            .recorded_change_hashes
+            .push(atomic_core::types::Hash::of(b"change-1"));
+        store.save(&stamped).unwrap();
+
+        let direct = AgentSession::new("sess-direct", "claude-code", "Claude Code");
+        store.save(&direct).unwrap();
+
+        let sessions = collect_run_sessions(&dot_dir, "run-a");
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].session_id, "sess-in-run");
+        assert_eq!(sessions[0].agent_name, "codex");
+        assert_eq!(sessions[0].change_hashes.len(), 1);
+
+        assert!(collect_run_sessions(&dot_dir, "run-other").is_empty());
+    }
+
+    #[test]
+    fn load_rejects_path_traversal_run_ids() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path().join(LIFECYCLE_DIR);
+        assert!(load_lifecycle(&dir, "../evil").is_err());
+        assert!(load_lifecycle(&dir, "a/b").is_err());
+    }
+
+    #[test]
+    fn remove_missing_lifecycle_is_idempotent() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path().join(LIFECYCLE_DIR);
+        assert!(remove_lifecycle(&dir, "does-not-exist").is_ok());
+    }
+
+    #[test]
+    fn to_managed_run_context_maps_fields() {
+        let temp = TempDir::new().unwrap();
+        let mut l = lifecycle("run-a", "sherpa", temp.path(), now_secs() + 60);
+        l.work_item_id = Some("NONA-12".to_string());
+
+        let ctx = l.to_managed_run_context();
+        assert_eq!(ctx.stamp.run_id, "run-a");
+        assert_eq!(ctx.stamp.owner_agent, "sherpa");
+        assert_eq!(ctx.stamp.work_item_id.as_deref(), Some("NONA-12"));
+        assert_eq!(ctx.view.as_deref(), Some("sherpa-run"));
+    }
+}

--- a/atomic-cli/src/commands/agent/mod.rs
+++ b/atomic-cli/src/commands/agent/mod.rs
@@ -42,6 +42,7 @@ mod disable;
 mod enable;
 mod explain;
 mod hooks;
+mod lifecycle;
 mod status;
 
 use clap::{Args, Subcommand};
@@ -53,6 +54,7 @@ pub use attest::Attest;
 pub use disable::Disable;
 pub use enable::Enable;
 pub use explain::Explain;
+pub use lifecycle::Lifecycle;
 pub use status::AgentStatus;
 
 // Agent Command
@@ -191,6 +193,14 @@ pub enum AgentCommands {
     /// ```
     Attest(Attest),
 
+    /// Declare managed runs for orchestrated agents.
+    ///
+    /// Used by outer orchestrators such as Sherpa/noname before launching an
+    /// ACP executor. While a run is active, participating hooks adopt the
+    /// run's declared view and stamp their sessions with the run context —
+    /// nothing is suppressed; `lifecycle end --json` returns the run summary.
+    Lifecycle(Lifecycle),
+
     /// Internal hook handlers (called by agent hooks).
     ///
     /// These commands are invoked by the hooks installed in agent
@@ -211,6 +221,7 @@ impl Command for Agent {
             AgentCommands::Status(cmd) => cmd.run(),
             AgentCommands::Explain(cmd) => cmd.run(),
             AgentCommands::Attest(cmd) => cmd.run(),
+            AgentCommands::Lifecycle(cmd) => cmd.run(),
             AgentCommands::Hooks(cmd) => cmd.run(),
         }
     }

--- a/atomic-repository/vault/skills/atomic-vault.md
+++ b/atomic-repository/vault/skills/atomic-vault.md
@@ -114,9 +114,10 @@ atomic vault memory show architecture
 To save new knowledge, write a markdown file to `.vault/memory/` and
 then run `atomic vault sync` to persist it to the database.
 
-## Version Control
+## Version Control (Read-Only)
 
-The vault is tracked by the same Atomic VCS as the code:
+The vault is tracked by the same Atomic VCS as the code. You inspect state
+and history — you do **not** write to version control yourself:
 
 ```
 # Check repo status
@@ -128,6 +129,24 @@ atomic log
 # Show working copy diff
 atomic diff
 ```
+
+## Views and Recording Are Not Yours to Manage
+
+You do **not** create or switch views, and you do **not** run `atomic add`,
+`atomic record`, or `atomic insert` — the integration's hooks and the
+workflow orchestrator own all of that:
+
+- **Session start** puts you on the right view automatically (a forked
+  draft view, a provisioned sandbox view, or a managed run's declared
+  view — depending on how you were launched).
+- **Turn end** records automatically with full AI provenance (model,
+  session, decision graph).
+- **Session end** restores the original view.
+- **Merging into a shared view** (`atomic insert`) is a human/orchestrator
+  decision made at review time — never run it yourself.
+
+To review what the hooks recorded, use the read-only commands above
+(`atomic log`, `atomic diff`).
 
 ## Workflow
 
@@ -148,38 +167,28 @@ atomic diff
    atomic vault goal start --intent PROJ-1
    ```
 
-4. **Create a draft view** for isolated work:
-   ```
-   atomic view create <goal-name> --draft
-   atomic view switch <goal-name>
-   ```
-
-5. **Search and explore** using grep + knowledge graph together:
+4. **Search and explore** using grep + knowledge graph together:
    ```
    grep "worker_threads" --type rs
    atomic vault query search "worker_threads Builder"
    atomic vault query neighbors "entity:src/builder.rs:worker_threads:42"
    ```
 
-6. **Make changes** using read, edit, write tools
+5. **Make changes** using read, edit, write tools. Recording happens
+   automatically at turn end — do not run `atomic record`.
 
-7. **Record** your changes:
+6. **Sync vault edits** after changing any vault markdown file:
    ```
-   atomic record -m "Add max_worker_threads option to Builder"
+   atomic vault sync
    ```
 
-8. **Stop the goal** when done:
+7. **Stop the goal** when done:
    ```
    atomic vault goal stop --promote
    ```
 
-9. **Review**: The draft view stays alive for review.
+8. **Review** what was recorded (read-only):
    ```
-   atomic view switch <goal-name>
+   atomic log
    atomic diff
    ```
-
-10. **Merge** when approved:
-    ```
-    atomic insert from-view <goal-name> --to-view dev
-    ```


### PR DESCRIPTION
## What

Adds managed lifecycle runs for Sherpa/noname.

Sherpa can start a run with a target view/workdir. When Claude/Codex hooks fire inside that run, they do **not** create their own unrelated session view. They adopt the run's view, keep recording normally, and stamp their session with the run id.

At the end, Sherpa can call `atomic agent lifecycle end --json` and get the sessions, views, and change hashes that belong to that run.

## Why

When Sherpa launches an ACP agent, Sherpa needs to connect the agent's work back to the right Atomic view, graph, intent, memory, or future work item.

We do not want to suppress inner agent hooks, because those hooks contain useful per-turn provenance. Instead, this PR lets inner agents record normally while making their work attributable to the Sherpa run that launched them.

This also supports multiple concurrent runs because each lifecycle is keyed by run id, not by one repo-wide owner lock.

Direct Claude/Codex usage outside a managed lifecycle keeps working the same as before.

## Verified

Tested with a disposable repo: lifecycle begin -> inner agent hooks record on the declared view -> lifecycle end returns the recorded sessions/changes/views. Atomic CLI and agent tests pass.


## Also in this PR

The shipped `atomic-vault` skill template (materialized into every repo by `vault init`) still taught agents the pre-adoption workflow — create your own view, run `record` yourself, `insert from-view` when done. It now matches this PR's model: views and recording belong to the hooks, insert is a review-time decision. (Folded in from #101 — the template describes the behavior this PR implements, so they review as one story. Open question for later: the installed integration skills and the vault-materialized copies are two drifting surfaces; worth unifying.)
