### PR TITLE
fix(push): resolve auth identity by server, honor --identity, case-insensitive match

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-agent"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "atomic-core",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "atomic-agent",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-config"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-identity"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "atomic-config",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-remote"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-repository"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "atomic-config",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-semantic"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-teams"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "atomic-remote",
  "chrono",

--- a/atomic-cli/src/commands/auth.rs
+++ b/atomic-cli/src/commands/auth.rs
@@ -67,7 +67,10 @@ fn configured_server_identities() -> Vec<(String, String)> {
     let mut pairs = Vec::new();
     let mut consider = |server: &atomic_config::ServerConfig| {
         if let (Some(url), Some(identity)) = (server.url.as_ref(), server.identity.as_ref()) {
-            if let Some(host) = Url::parse(url).ok().and_then(|u| u.host_str().map(String::from)) {
+            if let Some(host) = Url::parse(url)
+                .ok()
+                .and_then(|u| u.host_str().map(String::from))
+            {
                 pairs.push((host, identity.clone()));
             }
         }
@@ -623,7 +626,10 @@ mod tests {
     fn servers() -> Vec<(String, String)> {
         vec![
             ("atomic.storage".to_string(), "Aaron".to_string()),
-            ("staging.atomic.storage".to_string(), "aaron-staging".to_string()),
+            (
+                "staging.atomic.storage".to_string(),
+                "aaron-staging".to_string(),
+            ),
         ]
     }
 

--- a/atomic-cli/src/commands/auth.rs
+++ b/atomic-cli/src/commands/auth.rs
@@ -9,16 +9,145 @@
 //! for the minting mechanics.
 //!
 //! Identity resolution order:
-//! 1. Explicit override — `identity_override` from `--identity` flag or
-//!    `RemoteEntry.identity` config field.
+//! 1. Explicit override — `identity_override` from the `--identity` flag.
 //! 2. URL userinfo — `http://bob@alice.localhost:8080/...` → identity "bob"
-//! 3. Subdomain — `http://alice.localhost:8080/...` → identity "alice"
+//! 3. Configured server binding — a `[servers.*]`/`[server]` profile whose host
+//!    is the longest suffix of the remote host supplies its `identity`. Identity
+//!    follows the server you registered with, so any tenant under it resolves
+//!    without `--identity`.
+//! 4. Subdomain — `http://alice.localhost:8080/...` → identity "alice" (legacy
+//!    last resort).
 
-use atomic_identity::IdentityStore;
+use atomic_identity::{Identity, IdentityStore};
 use atomic_remote::HttpRemoteConfig;
 use url::Url;
 
 use crate::error::{CliError, CliResult};
+
+/// Resolve the identity name to authenticate as.
+///
+/// Priority:
+/// 1. An explicit override (the `--identity` flag).
+/// 2. URL userinfo (`http://bob@host/...`).
+/// 3. A configured server profile whose host is the longest dot-boundary
+///    suffix of the remote host (`[servers.prod] url=... identity=...`). This is
+///    the binding that makes pushes to *any* tenant under a server you've
+///    registered with ("just works" without `--identity`): identity follows the
+///    server, not the tenant subdomain.
+/// 4. The remote host's leading subdomain label (`http://bob.host/...`) — the
+///    legacy heuristic, kept only as a last resort.
+///
+/// Returns `None` only when there is no override and nothing inferable from the
+/// URL or config.
+fn resolve_identity_name_with_override(
+    remote_url: &str,
+    identity_override: Option<&str>,
+) -> Option<String> {
+    if let Some(name) = identity_override {
+        return Some(name.to_string());
+    }
+    resolve_identity_from_url(remote_url, &configured_server_identities())
+}
+
+/// Collect `(server_host, identity)` pairs from the global config — both the
+/// default `[server]` block and every named `[servers.*]` profile — that
+/// declare an identity. Servers without an identity binding are skipped.
+///
+/// Returns an empty list when no config exists or it can't be read, so
+/// resolution degrades cleanly to URL-based inference.
+fn configured_server_identities() -> Vec<(String, String)> {
+    let config = match atomic_config::GlobalConfig::load() {
+        Ok(c) => c,
+        Err(e) => {
+            log::debug!("Could not load global config for server identities: {e}");
+            return Vec::new();
+        }
+    };
+
+    let mut pairs = Vec::new();
+    let mut consider = |server: &atomic_config::ServerConfig| {
+        if let (Some(url), Some(identity)) = (server.url.as_ref(), server.identity.as_ref()) {
+            if let Some(host) = Url::parse(url).ok().and_then(|u| u.host_str().map(String::from)) {
+                pairs.push((host, identity.clone()));
+            }
+        }
+    };
+
+    consider(&config.server);
+    for server in config.servers.values() {
+        consider(server);
+    }
+    pairs
+}
+
+/// Pure identity resolution from a URL plus the configured server bindings.
+///
+/// userinfo → server-host match (longest suffix) → first-label subdomain.
+/// Split from the config-loading wrapper so it can be unit-tested without a
+/// config file on disk.
+fn resolve_identity_from_url(remote_url: &str, servers: &[(String, String)]) -> Option<String> {
+    let url = Url::parse(remote_url).ok()?;
+
+    // 1. Explicit in the URL: http://bob@host/...
+    let username = url.username();
+    if !username.is_empty() {
+        return Some(username.to_string());
+    }
+
+    let host = url.host_str()?;
+
+    // 2. Configured server binding: identity follows the server (apex), so any
+    //    tenant under it resolves to the same identity.
+    if let Some(identity) = match_server_identity(host, servers) {
+        return Some(identity);
+    }
+
+    // 3. Legacy: treat the first DNS label as the identity name.
+    extract_subdomain(host)
+}
+
+/// Pick the identity bound to the configured server whose host is the longest
+/// dot-boundary suffix of `remote_host`.
+///
+/// Longest-suffix wins so a more specific server (`staging.atomic.storage`)
+/// beats a broader one (`atomic.storage`) for hosts under both — e.g.
+/// `x.staging.atomic.storage` resolves to the staging identity, not prod.
+fn match_server_identity(remote_host: &str, servers: &[(String, String)]) -> Option<String> {
+    servers
+        .iter()
+        .filter(|(server_host, _)| host_is_under(remote_host, server_host))
+        .max_by_key(|(server_host, _)| server_host.len())
+        .map(|(_, identity)| identity.clone())
+}
+
+/// Whether `remote_host` is the server host itself or a subdomain of it,
+/// matching only on dot boundaries (so `notatomic.storage` does NOT match
+/// `atomic.storage`). Comparison is case-insensitive (DNS is).
+fn host_is_under(remote_host: &str, server_host: &str) -> bool {
+    let remote = remote_host.to_ascii_lowercase();
+    let server = server_host.to_ascii_lowercase();
+    remote == server || remote.ends_with(&format!(".{server}"))
+}
+
+/// Load a local identity by name, falling back to a case-insensitive match.
+///
+/// Tenant slugs are lowercase (e.g. `aaron`), but locally stored identities are
+/// free-form and frequently mixed-case (e.g. `Aaron`). A subdomain-inferred
+/// name would therefore never match the local identity on a strict comparison.
+/// An exact match always wins; otherwise the first identity whose name matches
+/// case-insensitively is returned.
+fn load_identity_lenient(store: &IdentityStore, name: &str) -> Option<Identity> {
+    if let Ok(identity) = store.load_by_name(name) {
+        return Some(identity);
+    }
+
+    let wanted = name.to_lowercase();
+    store
+        .list()
+        .ok()?
+        .into_iter()
+        .find(|identity| identity.name.to_lowercase() == wanted)
+}
 
 /// Attach a Bearer JWT auth header to the remote config.
 ///
@@ -35,18 +164,16 @@ pub async fn attach_identity(
     remote_url: &str,
     identity_override: Option<&str>,
 ) -> HttpRemoteConfig {
-    // Priority 1: explicit override (from --identity or RemoteEntry.identity)
-    let identity_name = if let Some(name) = identity_override {
-        log::debug!("Using explicit identity override: {}", name);
-        name.to_string()
-    } else {
-        // Priority 2/3: infer from URL userinfo or subdomain
-        match resolve_identity_name(remote_url) {
-            Some(name) => name,
-            None => {
-                log::debug!("No identity resolvable from URL: {}", remote_url);
-                return config;
-            }
+    if identity_override.is_some() {
+        log::debug!("Using explicit identity override: {:?}", identity_override);
+    }
+
+    // Priority 1: explicit override (--identity); 2/3: URL userinfo or subdomain.
+    let identity_name = match resolve_identity_name_with_override(remote_url, identity_override) {
+        Some(name) => name,
+        None => {
+            log::debug!("No identity resolvable from URL: {}", remote_url);
+            return config;
         }
     };
 
@@ -60,10 +187,12 @@ pub async fn attach_identity(
         }
     };
 
-    let identity = match store.load_by_name(&identity_name) {
-        Ok(id) => id,
-        Err(e) => {
-            log::debug!("Identity '{}' not found in store: {}", identity_name, e);
+    // Match by name, tolerating tenant-slug/identity-name case differences
+    // (e.g. the `aaron` subdomain selecting the local `Aaron` identity).
+    let identity = match load_identity_lenient(&store, &identity_name) {
+        Some(id) => id,
+        None => {
+            log::debug!("Identity '{}' not found in store", identity_name);
             return config;
         }
     };
@@ -108,10 +237,14 @@ pub async fn attach_identity(
 #[derive(Debug, PartialEq, Eq)]
 pub enum CredentialIssue {
     /// No identity could be resolved from the remote URL (no userinfo and no
-    /// subdomain). We can't know who to authenticate as.
+    /// subdomain) and `--identity` was not supplied. We can't know who to
+    /// authenticate as.
     NoIdentityInUrl,
     /// An identity name was resolved, but no such identity exists locally.
-    IdentityNotFound { name: String },
+    /// `from_flag` records whether the name came from the `--identity` flag
+    /// (vs. being inferred from the remote URL), so the message can point the
+    /// user at the right knob.
+    IdentityNotFound { name: String, from_flag: bool },
     /// The identity exists but its signing keypair could not be loaded, so no
     /// token can be minted.
     KeypairUnavailable { name: String },
@@ -126,11 +259,28 @@ impl CredentialIssue {
         match self {
             CredentialIssue::NoIdentityInUrl => format!(
                 "Not authenticated for {REMEDY_PREFIX}: could not determine an \
-                 identity from the remote URL. {REMEDY_SUFFIX}"
+                 identity from the remote URL, and no --identity was given. \
+                 Pass --identity <NAME> (see `atomic identity list`). {REMEDY_SUFFIX}"
             ),
-            CredentialIssue::IdentityNotFound { name } => format!(
-                "Not authenticated for {REMEDY_PREFIX}: identity '{name}' is not \
-                 registered on this machine. {REMEDY_SUFFIX}"
+            // When the name was inferred from the URL, the fix is usually to
+            // pass --identity explicitly; when it came from --identity, the
+            // name itself is wrong. Tailor the hint to the source.
+            CredentialIssue::IdentityNotFound {
+                name,
+                from_flag: false,
+            } => format!(
+                "Not authenticated for {REMEDY_PREFIX}: identity '{name}' \
+                 (inferred from the remote URL) is not registered on this \
+                 machine. Pass --identity <NAME> to select a local identity \
+                 (see `atomic identity list`). {REMEDY_SUFFIX}"
+            ),
+            CredentialIssue::IdentityNotFound {
+                name,
+                from_flag: true,
+            } => format!(
+                "Not authenticated for {REMEDY_PREFIX}: --identity '{name}' does \
+                 not match any identity on this machine (see `atomic identity \
+                 list`). {REMEDY_SUFFIX}"
             ),
             CredentialIssue::KeypairUnavailable { name } => format!(
                 "Not authenticated for {REMEDY_PREFIX}: could not load the signing \
@@ -149,19 +299,23 @@ const REMEDY_SUFFIX: &str =
 /// push proceed into a confusing 404 (which the server returns for private
 /// projects the caller isn't authorized to see).
 ///
-/// Returns `Ok(())` when an identity is resolvable from the URL, exists in the
-/// local store, and has a loadable signing keypair.
-pub fn check_push_credentials(remote_url: &str) -> CliResult<()> {
+/// Returns `Ok(())` when an identity is resolvable (from `--identity` or the
+/// URL), exists in the local store, and has a loadable signing keypair.
+///
+/// `identity_override` is the `--identity` flag value; it takes priority over
+/// any identity inferred from the URL, exactly as [`attach_identity`] resolves
+/// it. The two must agree, or the fail-fast check here would reject a push that
+/// `attach_identity` would have authenticated.
+pub fn check_push_credentials(remote_url: &str, identity_override: Option<&str>) -> CliResult<()> {
     let store = IdentityStore::open_default()
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to open identity store: {e}")))?;
 
     let issue = evaluate_push_credentials(
-        resolve_identity_name(remote_url),
-        |name| store.load_by_name(name).is_ok(),
+        resolve_identity_name_with_override(remote_url, identity_override),
+        identity_override.is_some(),
+        |name| load_identity_lenient(&store, name).is_some(),
         |name| {
-            store
-                .load_by_name(name)
-                .ok()
+            load_identity_lenient(&store, name)
                 .map(|id| store.load_keypair(&id.id, None).is_ok())
                 .unwrap_or(false)
         },
@@ -178,7 +332,8 @@ pub fn check_push_credentials(remote_url: &str) -> CliResult<()> {
 /// Pure decision core for [`check_push_credentials`], split out so it can be
 /// unit-tested without touching the on-disk identity store.
 ///
-/// * `identity_name` — the identity resolved from the URL, if any.
+/// * `identity_name` — the resolved identity (override or URL-inferred), if any.
+/// * `from_flag` — whether `identity_name` came from `--identity` (vs. the URL).
 /// * `identity_exists` — whether an identity with the given name is in the store.
 /// * `keypair_loadable` — whether that identity's signing keypair can be loaded.
 ///
@@ -186,6 +341,7 @@ pub fn check_push_credentials(remote_url: &str) -> CliResult<()> {
 /// first problem encountered.
 fn evaluate_push_credentials(
     identity_name: Option<String>,
+    from_flag: bool,
     identity_exists: impl Fn(&str) -> bool,
     keypair_loadable: impl Fn(&str) -> bool,
 ) -> Option<CredentialIssue> {
@@ -195,7 +351,7 @@ fn evaluate_push_credentials(
     };
 
     if !identity_exists(&name) {
-        return Some(CredentialIssue::IdentityNotFound { name });
+        return Some(CredentialIssue::IdentityNotFound { name, from_flag });
     }
 
     if !keypair_loadable(&name) {
@@ -230,20 +386,13 @@ fn apex_server_url(remote_url: &str) -> Option<String> {
     }
 }
 
-/// Extract the identity name from a remote URL.
+/// Extract the identity name from a remote URL alone (no server config).
 ///
 /// Tries URL userinfo first (`bob@host`), then the subdomain (`bob.host`).
+/// This is the config-free path; [`resolve_identity_name_with_override`] layers
+/// the `--identity` override and configured server bindings on top.
 fn resolve_identity_name(remote_url: &str) -> Option<String> {
-    let url = Url::parse(remote_url).ok()?;
-
-    // 1. Explicit: http://bob@alice.localhost:8080/...
-    let username = url.username();
-    if !username.is_empty() {
-        return Some(username.to_string());
-    }
-
-    // 2. Implicit: http://alice.localhost:8080/... → "alice"
-    extract_subdomain(url.host_str()?)
+    resolve_identity_from_url(remote_url, &[])
 }
 
 /// Extract the first subdomain label from a host string.
@@ -363,6 +512,7 @@ mod tests {
     fn creds_ok_when_identity_resolves_and_keypair_loads() {
         let issue = evaluate_push_credentials(
             Some("alice".to_string()),
+            false,
             |_| true, // identity exists
             |_| true, // keypair loadable
         );
@@ -372,7 +522,7 @@ mod tests {
     #[test]
     fn creds_fail_when_no_identity_in_url() {
         // A bare host with no userinfo and no subdomain resolves to no identity.
-        let issue = evaluate_push_credentials(None, |_| true, |_| true);
+        let issue = evaluate_push_credentials(None, false, |_| true, |_| true);
         assert_eq!(issue, Some(CredentialIssue::NoIdentityInUrl));
     }
 
@@ -380,13 +530,15 @@ mod tests {
     fn creds_fail_when_identity_missing_from_store() {
         let issue = evaluate_push_credentials(
             Some("alice".to_string()),
+            false,
             |_| false, // identity not in store
             |_| true,
         );
         assert_eq!(
             issue,
             Some(CredentialIssue::IdentityNotFound {
-                name: "alice".to_string()
+                name: "alice".to_string(),
+                from_flag: false,
             })
         );
     }
@@ -398,6 +550,7 @@ mod tests {
         // this self-signed-JWT model means "cannot sign right now".
         let issue = evaluate_push_credentials(
             Some("alice".to_string()),
+            false,
             |_| true,  // identity exists
             |_| false, // keypair unavailable
         );
@@ -416,6 +569,11 @@ mod tests {
             CredentialIssue::NoIdentityInUrl,
             CredentialIssue::IdentityNotFound {
                 name: "alice".to_string(),
+                from_flag: false,
+            },
+            CredentialIssue::IdentityNotFound {
+                name: "alice".to_string(),
+                from_flag: true,
             },
             CredentialIssue::KeypairUnavailable {
                 name: "alice".to_string(),
@@ -425,5 +583,126 @@ mod tests {
             assert!(msg.contains("Not authenticated"));
             assert!(msg.contains("atomic identity register"));
         }
+    }
+
+    // -- identity override resolution --
+
+    #[test]
+    fn override_takes_priority_over_subdomain() {
+        // The whole point of --identity: it wins over the host's DNS label.
+        let name = resolve_identity_name_with_override(
+            "https://aaron.atomic.storage/workspaces/w/projects/p/code",
+            Some("Aaron"),
+        );
+        assert_eq!(name.as_deref(), Some("Aaron"));
+    }
+
+    #[test]
+    fn override_wins_even_on_apex_host() {
+        // Apex host has no usable subdomain, but --identity still resolves.
+        let name = resolve_identity_name_with_override(
+            "https://atomic.storage/workspaces/w/projects/p/code",
+            Some("Aaron"),
+        );
+        assert_eq!(name.as_deref(), Some("Aaron"));
+    }
+
+    #[test]
+    fn no_override_falls_back_to_subdomain() {
+        // Use the pure resolver with no configured servers — the wrapper loads
+        // the real global config, which is not hermetic for a unit test.
+        let name = resolve_identity_from_url(
+            "https://aaron.atomic.storage/workspaces/w/projects/p/code",
+            &[],
+        );
+        assert_eq!(name.as_deref(), Some("aaron"));
+    }
+
+    // -- configured server-host identity binding --
+
+    fn servers() -> Vec<(String, String)> {
+        vec![
+            ("atomic.storage".to_string(), "Aaron".to_string()),
+            ("staging.atomic.storage".to_string(), "aaron-staging".to_string()),
+        ]
+    }
+
+    #[test]
+    fn host_is_under_matches_self_and_subdomains_on_dot_boundary() {
+        assert!(host_is_under("atomic.storage", "atomic.storage")); // exact
+        assert!(host_is_under("aaron.atomic.storage", "atomic.storage")); // tenant
+        assert!(host_is_under("a.b.atomic.storage", "atomic.storage")); // nested
+        assert!(host_is_under("ATOMIC.STORAGE", "atomic.storage")); // case-insensitive
+                                                                    // Not a dot-boundary suffix — must NOT match.
+        assert!(!host_is_under("notatomic.storage", "atomic.storage"));
+        assert!(!host_is_under("atomic.storage.evil.com", "atomic.storage"));
+    }
+
+    #[test]
+    fn any_tenant_under_a_server_resolves_to_that_servers_identity() {
+        for host in [
+            "aaron.atomic.storage",
+            "bradley.atomic.storage",
+            "atomic.atomic.storage",
+            "atomic.storage", // apex direct
+        ] {
+            let url = format!("https://{host}/workspaces/w/projects/p/code");
+            assert_eq!(
+                resolve_identity_from_url(&url, &servers()).as_deref(),
+                Some("Aaron"),
+                "host {host} should bind to the prod identity"
+            );
+        }
+    }
+
+    #[test]
+    fn longest_suffix_wins_so_staging_beats_prod() {
+        // Every staging host also ends in `atomic.storage`; the more specific
+        // server must win.
+        for host in ["x.staging.atomic.storage", "staging.atomic.storage"] {
+            let url = format!("https://{host}/workspaces/w/projects/p/code");
+            assert_eq!(
+                resolve_identity_from_url(&url, &servers()).as_deref(),
+                Some("aaron-staging"),
+                "host {host} should bind to the staging identity"
+            );
+        }
+    }
+
+    #[test]
+    fn userinfo_beats_configured_server() {
+        // An explicit user in the URL is a stronger, per-invocation signal.
+        let url = "https://bob@aaron.atomic.storage/workspaces/w/projects/p/code";
+        assert_eq!(
+            resolve_identity_from_url(url, &servers()).as_deref(),
+            Some("bob")
+        );
+    }
+
+    #[test]
+    fn falls_back_to_subdomain_when_no_server_matches() {
+        // A host under no configured server keeps the legacy behaviour.
+        let url = "https://someone.example.com/workspaces/w/projects/p/code";
+        assert_eq!(
+            resolve_identity_from_url(url, &servers()).as_deref(),
+            Some("someone")
+        );
+    }
+
+    #[test]
+    fn override_resolves_when_subdomain_label_is_unregistered() {
+        // Regression: the subdomain label ("aaron") is not a local identity
+        // name, but the explicit --identity ("Aaron") is — the override must be
+        // what gets evaluated, not the label.
+        let issue = evaluate_push_credentials(
+            resolve_identity_name_with_override(
+                "https://aaron.atomic.storage/workspaces/w/projects/p/code",
+                Some("Aaron"),
+            ),
+            true,
+            |name| name == "Aaron", // only "Aaron" exists locally
+            |name| name == "Aaron",
+        );
+        assert_eq!(issue, None);
     }
 }

--- a/atomic-cli/src/commands/push/command.rs
+++ b/atomic-cli/src/commands/push/command.rs
@@ -329,7 +329,7 @@ impl Push {
         // deliberately masked), which surfaces as a misleading "view not found".
         // Catching the missing credential here gives the user an accurate,
         // actionable error instead.
-        crate::commands::auth::check_push_credentials(&remote_url)?;
+        crate::commands::auth::check_push_credentials(&remote_url, identity_hint.as_deref())?;
 
         // Connect to remote
         let spinner = create_spinner("Connecting to remote...");


### PR DESCRIPTION
## The bug

`atomic push` derived the auth identity from the remote host's **first DNS label** and required a locally-stored identity whose **name** equalled that label. So pushing to any tenant whose slug differed from a local identity name failed with `identity '<slug>' is not registered on this machine` — including:

- the **normal case** (local identity `Aaron`, tenant slug `aaron`) — failed on case;
- the **apex host** `atomic.storage` — inferred identity `atomic`;
- every **cross-tenant** push (e.g. a project shared with you in someone else's tenant).

Two defects compounded it:

1. **`--identity` was ignored by the pre-push credential gate.** `check_push_credentials` resolved the identity solely from the URL and ran *before* `attach_identity` (which did honor `--identity`), so the push died at the gate first.
2. **Name match was case-sensitive**, pushing users toward hand-copying `~/.atomic/identities/<Name>-<ID>/` (private key and all) under a renamed folder to satisfy the gate.

## The model

**Identity belongs to the server you registered your key with, not to the tenant subdomain.** Your key is registered once per server, and the server authorizes you by public key across every tenant you can reach (`aaron.`, `bradley.`, `atomic.` …). The minted JWT carries only your public key — no tenant, no server — so who you authenticate as must follow the *server*, with the tenant label playing no part. Resolution now reflects that.

## Resolution order (`atomic-cli/src/commands/auth.rs`)

1. **`--identity` flag** — explicit override.
2. **URL userinfo** — `http://bob@host/...`.
3. **Configured server binding** — the `[server]` / `[servers.*]` profile (from `~/.atomic/config.toml`, added in #92) whose host is the **longest dot-boundary suffix** of the remote host supplies its `identity`. With:
   ```toml
   [servers.prod]
   url = "https://atomic.storage"
   identity = "Aaron"
   ```
   pushes to `aaron.atomic.storage`, `bradley.atomic.storage`, `atomic.atomic.storage`, and `atomic.storage` (apex) all resolve to `Aaron` **with no flag**. Longest-suffix matching keeps `staging.atomic.storage` distinct from `atomic.storage`, and dot-boundary matching prevents `notatomic.storage` from matching `atomic.storage`.
4. **First-label subdomain inference** — legacy last resort, now **case-insensitive** so slug `aaron` matches local identity `Aaron`.

`--identity` is therefore only needed when you want a *different* identity than the server's bound one.

### Supporting changes

- `check_push_credentials` now takes the identity override and uses the same resolver, so the fail-fast gate and `attach_identity` always agree (previously the gate rejected pushes the auth path would have accepted).
- `load_identity_lenient`: exact name match, then case-insensitive fallback.
- Errors now state whether the name came from `--identity` or was inferred from the URL, and point at `--identity <NAME>` / `atomic identity list` instead of dead-ending at `atomic identity register` (which returns `409` when the tenant already exists).

### Out of scope

- **Per-remote `identity` binding** (`RemoteEntry.identity`): the #92 commit message mentions it, but the struct/commands were never landed and it isn't needed for server-based resolution. Left for a follow-up.
- **Key-based selection** (match a local secret key against the tenant's server-registered public key): the server only verifies the self-signed JWT signature — there's no client-side challenge endpoint returning an expected key, so this would need a new server protocol.

## Verification

- 27 auth unit tests pass, including new coverage for: override-beats-subdomain, override-on-apex-host, any-tenant-under-a-server → that server's identity, longest-suffix (staging beats prod), dot-boundary safety, userinfo-beats-config, and fallback-to-subdomain.
- 72 push tests pass; clippy clean.
- **Live**: `atomic push https://bradley.atomic.storage/.../code` (cross-tenant, **no `--identity`**) now logs `Resolved identity name: Aaron` and authenticates as Aaron — failing only on the server-side authorization check rather than client-side identity resolution.

(Cargo.lock change is the `0.7.0 → 0.8.0` version-bump catching up to the already-committed Cargo.toml bump.)