### PR TITLE
fix(agent): fire recording hooks inside sandboxes

### DIFF
--- a/atomic-agent/src/hooks/claude_code/mod.rs
+++ b/atomic-agent/src/hooks/claude_code/mod.rs
@@ -330,7 +330,8 @@ const HOOK_DEFS: &[(&str, &str, &str)] = &[
 fn install_hooks_into(hooks: &mut ClaudeHooks, _settings_path: &Path) -> AgentResult<usize> {
     let mut count = 0;
     for (_label, matcher, verb) in HOOK_DEFS {
-        let command = format!("test -d .atomic && {} {} || true", ATOMIC_HOOK_PREFIX, verb);
+        let command =
+            crate::hooks::guarded_hook_command(&format!("{} {}", ATOMIC_HOOK_PREFIX, verb));
 
         let matchers = match *verb {
             "session-start" => &mut hooks.session_start,

--- a/atomic-agent/src/hooks/claude_code/tests.rs
+++ b/atomic-agent/src/hooks/claude_code/tests.rs
@@ -271,12 +271,16 @@ mod tests {
         assert!(is_atomic_hook(
             "atomic agent hooks claude-code user-prompt-submit"
         ));
-        // Guarded format (current)
+        // Guarded format (legacy, `.atomic`-only)
         assert!(is_atomic_hook(
             "test -d .atomic && atomic agent hooks claude-code stop || true"
         ));
         assert!(is_atomic_hook(
             "test -d .atomic && atomic agent hooks claude-code user-prompt-submit || true"
+        ));
+        // Sandbox-aware guarded format (current)
+        assert!(is_atomic_hook(
+            "test -d .atomic || test -f .atomic-sandbox && atomic agent hooks claude-code stop || true"
         ));
         // Non-atomic commands
         assert!(!is_atomic_hook("entire hooks claude-code stop"));

--- a/atomic-agent/src/hooks/codex.rs
+++ b/atomic-agent/src/hooks/codex.rs
@@ -344,12 +344,8 @@ fn install_hooks_at(path: &Path, force: bool) -> AgentResult<usize> {
 
     let mut installed = 0;
     for spec in CODEX_HOOK_DEFS {
-        if add_hook(
-            &mut config.hooks,
-            spec.event,
-            spec.command,
-            spec.status_message,
-        ) {
+        let command = crate::hooks::guarded_hook_command(spec.command);
+        if add_hook(&mut config.hooks, spec.event, &command, spec.status_message) {
             installed += 1;
         }
     }
@@ -615,30 +611,33 @@ struct HookDef {
     status_message: Option<&'static str>,
 }
 
+/// Codex hook definitions. `command` holds the bare `atomic agent hooks …`
+/// invocation; the shell guard is applied by [`crate::hooks::guarded_hook_command`]
+/// at install time so the guard stays in one place across all agents.
 const CODEX_HOOK_DEFS: &[HookDef] = &[
     HookDef {
         event: "SessionStart",
-        command: "test -d .atomic && atomic agent hooks codex session-start || true",
+        command: "atomic agent hooks codex session-start",
         status_message: Some("Atomic: tracking session"),
     },
     HookDef {
         event: "UserPromptSubmit",
-        command: "test -d .atomic && atomic agent hooks codex user-prompt-submit || true",
+        command: "atomic agent hooks codex user-prompt-submit",
         status_message: None,
     },
     HookDef {
         event: "Stop",
-        command: "test -d .atomic && atomic agent hooks codex stop || true",
+        command: "atomic agent hooks codex stop",
         status_message: None,
     },
     HookDef {
         event: "PreToolUse",
-        command: "test -d .atomic && atomic agent hooks codex pre-tool || true",
+        command: "atomic agent hooks codex pre-tool",
         status_message: None,
     },
     HookDef {
         event: "PostToolUse",
-        command: "test -d .atomic && atomic agent hooks codex post-tool || true",
+        command: "atomic agent hooks codex post-tool",
         status_message: None,
     },
 ];

--- a/atomic-agent/src/hooks/gemini_cli.rs
+++ b/atomic-agent/src/hooks/gemini_cli.rs
@@ -409,7 +409,8 @@ impl GeminiCliHook {
 
         let mut count = 0;
         for (event_key, matcher, verb, hook_name) in &hook_defs {
-            let command = format!("test -d .atomic && {} {} || true", ATOMIC_HOOK_PREFIX, verb);
+            let command =
+                crate::hooks::guarded_hook_command(&format!("{} {}", ATOMIC_HOOK_PREFIX, verb));
 
             let matchers = match *event_key {
                 "session_start" => &mut hooks.session_start,
@@ -1153,12 +1154,16 @@ mod tests {
             "atomic agent hooks gemini-cli session-start"
         ));
         assert!(is_atomic_hook("atomic agent hooks gemini-cli after-agent"));
-        // Guarded format
+        // Guarded format (legacy, `.atomic`-only)
         assert!(is_atomic_hook(
             "test -d .atomic && atomic agent hooks gemini-cli session-start || true"
         ));
         assert!(is_atomic_hook(
             "test -d .atomic && atomic agent hooks gemini-cli after-agent || true"
+        ));
+        // Sandbox-aware guarded format (current)
+        assert!(is_atomic_hook(
+            "test -d .atomic || test -f .atomic-sandbox && atomic agent hooks gemini-cli session-start || true"
         ));
         // Non-atomic
         assert!(!is_atomic_hook("my-custom-hook --on-stop"));

--- a/atomic-agent/src/hooks/manifest.rs
+++ b/atomic-agent/src/hooks/manifest.rs
@@ -21,10 +21,10 @@
 //!   "command_prefix": "atomic agent hooks codex",
 //!   "hooks": {
 //!     "SessionStart": [
-//!       { "hooks": [ { "type": "command", "command": "test -d .atomic && atomic agent hooks codex session-start || true", "statusMessage": "Atomic: tracking session" } ] }
+//!       { "hooks": [ { "type": "command", "command": "test -d .atomic || test -f .atomic-sandbox && atomic agent hooks codex session-start || true", "statusMessage": "Atomic: tracking session" } ] }
 //!     ],
 //!     "Stop": [
-//!       { "hooks": [ { "type": "command", "command": "test -d .atomic && atomic agent hooks codex stop || true" } ] }
+//!       { "hooks": [ { "type": "command", "command": "test -d .atomic || test -f .atomic-sandbox && atomic agent hooks codex stop || true" } ] }
 //!     ]
 //!   }
 //! }

--- a/atomic-agent/src/hooks/mod.rs
+++ b/atomic-agent/src/hooks/mod.rs
@@ -76,6 +76,35 @@ use std::path::Path;
 use crate::error::{AgentError, AgentResult};
 use crate::event::{HookType, TurnEvent};
 
+// Hook command guard
+
+/// Wrap an `atomic agent hooks …` invocation in the shell guard that installed
+/// hooks run behind.
+///
+/// The hook must only fire where Atomic's graph is reachable, but it must fire
+/// in **both** kinds of working tree:
+///
+/// * a canonical checkout, which has a `.atomic/` directory; and
+/// * an agent sandbox, which has **no** `.atomic/` of its own — only a
+///   `.atomic-sandbox` pointer file to the canonical graph.
+///
+/// Guarding on `.atomic` alone silently drops all provenance for sandboxed
+/// agents (the guard is false, so the recorder never runs). Adding the sandbox
+/// arm lets the hook fire there too; `atomic agent hooks` then resolves the
+/// pointer and records into the canonical graph.
+///
+/// POSIX `&&`/`||` are equal-precedence and left-associative, so
+/// `test -d .atomic || test -f .atomic-sandbox && CMD || true` parses as
+/// `(((test -d .atomic || test -f .atomic-sandbox) && CMD) || true)` — the
+/// recorder runs when either marker is present, and a recorder failure is
+/// swallowed so the agent turn is never blocked.
+pub(crate) fn guarded_hook_command(inner: &str) -> String {
+    format!(
+        "test -d .atomic || test -f {pointer} && {inner} || true",
+        pointer = atomic_repository::SANDBOX_POINTER,
+    )
+}
+
 // AgentHook Trait
 
 /// Trait for agent hook adapters.


### PR DESCRIPTION
## Problem

`atomic agent enable` installs recording hooks guarded with:

```sh
test -d .atomic && atomic agent hooks <agent> <verb> || true
```

An agent **sandbox** working tree (`atomic sandbox create`) has no `.atomic/` directory of its own — it carries only a `.atomic-sandbox` pointer file to the canonical graph. So inside a sandbox the guard is always false, the recorder never runs, and **every turn's provenance is silently dropped**.

## Fix

Widen the guard to fire when either marker is present:

```sh
test -d .atomic || test -f .atomic-sandbox && atomic agent hooks <agent> <verb> || true
```

POSIX `&&`/`||` are equal-precedence and left-associative, so this parses as `(((test -d .atomic || test -f .atomic-sandbox) && CMD) || true)`:

| State | Recorder runs? |
|---|---|
| neither marker | no |
| `.atomic-sandbox` pointer only (sandbox) | **yes** |
| `.atomic/` dir only (canonical checkout) | yes |
| recorder itself fails | turn not blocked (`|| true`, exit 0) |

`atomic agent hooks` already resolves the sandbox pointer via `Repository::open` and records into the canonical graph, so nothing else needs to change on the runtime side.

## Details

- Centralized the guard in `hooks::guarded_hook_command` so **claude-code**, **gemini-cli**, and **codex** share one definition (previously duplicated as literals / `format!` calls in each adapter). The sandbox-pointer filename comes from `atomic_repository::SANDBOX_POINTER`.
- Hook detection (`is_installed`, `is_atomic_hook`, uninstall) is substring-based on the `atomic agent hooks <agent>` prefix, so already-installed **legacy** hooks are still recognized for status/uninstall/`--force` reinstall.
- Updated the manifest doc example and the `is_atomic_hook` tests to cover the new format.

## Testing

- `cargo test -p atomic-agent hooks::` — 414 passed
- `cargo test -p atomic-cli agent` — 59 passed
- Verified guard precedence for all four states in a real shell.