### PR TITLE
fix(agent): don't switch views on session-start inside a sandbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-agent"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "atomic-core",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "atomic-agent",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-config"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-identity"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "atomic-config",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-remote"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-repository"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "atomic-config",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-semantic"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-teams"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "atomic-remote",
  "chrono",

--- a/atomic-agent/src/turn/orchestrator/session_start.rs
+++ b/atomic-agent/src/turn/orchestrator/session_start.rs
@@ -159,6 +159,25 @@ impl TurnOrchestrator {
         // still work, it just won't have the parent's history.
         if session.parent_view.is_none() {
             match atomic_repository::Repository::open_existing(&self.repo_root) {
+                Ok(repo) if repo.is_sandbox() => {
+                    // A sandbox is a materialized copy of the project; `record`
+                    // writes to the *canonical* graph (shared pristine +
+                    // changes), on the view named in the `.atomic-sandbox`
+                    // pointer. The agent is already on that view, so adopt it
+                    // for recording and do NOT fork or switch:
+                    //   * create_view_from would inject a spurious view into
+                    //     the canonical graph, and
+                    //   * set_current_view writes the *canonical*
+                    //     .atomic/current_view, clobbering the real user's
+                    //     current view.
+                    let current = repo.current_view().to_string();
+                    log::info!(
+                        "Sandbox session {}: recording on provisioned view '{}' (no fork/switch)",
+                        session_id,
+                        current,
+                    );
+                    session.view_name = current;
+                }
                 Ok(mut repo) => {
                     let current = repo.current_view().to_string();
                     session.set_parent_view(&current);
@@ -267,7 +286,19 @@ impl TurnOrchestrator {
                 {
                     let current = repo.current_view().to_string();
 
-                    if current != "dev" && current != "main" && current != "release" {
+                    if repo.is_sandbox() {
+                        // Sandboxes already operate on the view named in their
+                        // pointer file and record into the canonical graph.
+                        // Adopt that view verbatim; never fork or switch
+                        // (set_current_view writes the canonical
+                        // .atomic/current_view the sandbox shares).
+                        log::info!(
+                            "Fallback sandbox session {} adopting provisioned view '{}'",
+                            session_id,
+                            current,
+                        );
+                        session.view_name = current;
+                    } else if current != "dev" && current != "main" && current != "release" {
                         // Adopt the existing agent view (session-start
                         // likely created it before this fallback ran).
                         log::info!(

--- a/atomic-agent/src/turn/orchestrator/tests.rs
+++ b/atomic-agent/src/turn/orchestrator/tests.rs
@@ -132,6 +132,57 @@ async fn test_session_start_resumes_ended_session() {
     assert_eq!(session.turn_count, 3); // preserved
 }
 
+#[tokio::test]
+async fn test_session_start_in_sandbox_adopts_view_without_forking() {
+    // Canonical repository with a distinct view the sandbox operates on.
+    let canonical = TempDir::new().unwrap();
+    let mut repo = Repository::init(canonical.path()).unwrap();
+    let user_view = repo.current_view().to_string(); // "dev"
+    repo.create_view_from("agent-sbx", &user_view).unwrap();
+
+    // Provision a sandbox working tree bound to the agent view.
+    let sandbox_dir = TempDir::new().unwrap();
+    repo.provision_sandbox(sandbox_dir.path(), "agent-sbx")
+        .unwrap();
+    drop(repo); // release the canonical pristine lock before reopening
+
+    // Sanity: the sandbox opens on its provisioned view.
+    let sbx = Repository::open_existing(sandbox_dir.path()).unwrap();
+    assert!(sbx.is_sandbox());
+    assert_eq!(sbx.current_view(), "agent-sbx");
+    drop(sbx);
+
+    // Orchestrator rooted at the sandbox working tree (mirrors the hook path).
+    let session_store = SessionStore::for_repo(sandbox_dir.path()).unwrap();
+    let watcher = FallbackWatcher::new(WatcherConfig::new(sandbox_dir.path()));
+    let mut orch =
+        TurnOrchestrator::with_watcher(sandbox_dir.path(), session_store, Box::new(watcher));
+
+    orch.dispatch(session_start_event("sess-sbx"))
+        .await
+        .unwrap();
+
+    // The session records on the sandbox's own view — not a freshly forked one.
+    let session = orch.session_store.load("sess-sbx").unwrap().unwrap();
+    assert_eq!(session.view_name, "agent-sbx");
+    assert!(
+        session.parent_view.is_none(),
+        "sandbox session must not fork a child view"
+    );
+
+    // The canonical graph is untouched: no spurious agent view was forked and
+    // the current view was not repointed.
+    let canonical_after = Repository::open_existing(canonical.path()).unwrap();
+    let mut views = canonical_after.list_views().unwrap();
+    views.sort();
+    assert_eq!(
+        views,
+        vec!["agent-sbx".to_string(), user_view.clone()],
+        "sandbox session must not fork a new view into the canonical graph"
+    );
+    assert_eq!(canonical_after.current_view(), user_view);
+}
+
 // TurnStart tests
 
 #[tokio::test]

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -193,6 +193,12 @@ pub struct Repository {
     pristine: Arc<Pristine>,
     /// The change store for persisting changes
     change_store: ChangeStore,
+    /// Whether this handle was opened for an agent sandbox (via
+    /// [`Repository::open_sandbox`]). A sandbox's `dot_dir`/`pristine`/
+    /// `change_store` point at the canonical repository while `current_view`
+    /// holds the sandbox's view (from its pointer file); it must not repoint
+    /// the canonical `current_view` on disk.
+    is_sandbox: bool,
 }
 
 impl std::fmt::Debug for Repository {
@@ -203,6 +209,7 @@ impl std::fmt::Debug for Repository {
             .field("current_view", &self.current_view)
             .field("pristine", &"<Pristine>")
             .field("change_store", &self.change_store)
+            .field("is_sandbox", &self.is_sandbox)
             .finish()
     }
 }
@@ -285,6 +292,7 @@ default = "{}"
             current_view: DEFAULT_VIEW.to_string(),
             pristine,
             change_store,
+            is_sandbox: false,
         })
     }
 
@@ -327,6 +335,7 @@ default = "{}"
             current_view,
             pristine,
             change_store,
+            is_sandbox: false,
         })
     }
 
@@ -363,6 +372,7 @@ default = "{}"
             current_view,
             pristine,
             change_store,
+            is_sandbox: false,
         })
     }
 
@@ -423,6 +433,7 @@ default = "{}"
             current_view,
             pristine,
             change_store,
+            is_sandbox: false,
         })
     }
 
@@ -460,6 +471,7 @@ default = "{}"
             current_view,
             pristine,
             change_store,
+            is_sandbox: false,
         })
     }
 
@@ -539,6 +551,17 @@ default = "{}"
     #[inline]
     pub fn current_view(&self) -> &str {
         &self.current_view
+    }
+
+    /// Whether this handle was opened for an agent sandbox.
+    ///
+    /// A sandbox records into the canonical graph on the view named in its
+    /// pointer file (held in `current_view`, never written back to the
+    /// canonical `current_view` on disk), so callers must not fork a new view
+    /// or repoint the current view for it.
+    #[inline]
+    pub fn is_sandbox(&self) -> bool {
+        self.is_sandbox
     }
 
     /// Get the config file path.

--- a/atomic-repository/src/repository/sandbox.rs
+++ b/atomic-repository/src/repository/sandbox.rs
@@ -161,6 +161,7 @@ impl Repository {
             current_view: view.to_string(),
             pristine,
             change_store,
+            is_sandbox: true,
         })
     }
 


### PR DESCRIPTION
## The bug

When an agent runs inside a **sandbox** and fires `atomic agent hooks … session-start`, the orchestrator switched it onto a brand-new agent view — but the agent is *already* on the view it was provisioned to work in.

A sandbox is a materialized copy of the project. Its `Repository` handle points `root` at the sandbox working tree, but `dot_dir` / `pristine` / `change_store` all point at the **canonical** repository — `atomic record` writes to the canonical graph, on the view named in the `.atomic-sandbox` pointer file. `handle_session_start` (and the `load_or_create_session` fallback) treated the sandbox like an ordinary working tree:

1. `create_view_from(<new-view>, <current>)` — injected a **spurious view into the canonical graph**, and
2. `set_current_view(<new-view>)` — writes `self.dot_dir/current_view`, which for a sandbox is the **canonical** `current_view`, **clobbering the real user's current view** on disk.

## The fix

- `Repository::is_sandbox()` — a new accessor backed by an `is_sandbox` flag set only by `open_sandbox` (all other constructors set `false`).
- In `handle_session_start` and the `load_or_create_session` fallback, when `is_sandbox()` is true, **adopt the sandbox's provisioned view** for recording and skip the fork + switch entirely.

## Verification

- New test `test_session_start_in_sandbox_adopts_view_without_forking`: provisions a real sandbox, dispatches `session-start`, and asserts the session records on the sandbox's own view, forks no child, and leaves the canonical view set and `current_view` untouched.
- Full `atomic-agent` + `atomic-repository` suites pass; `cargo fmt --check` and `clippy` clean (the 4 remaining clippy warnings are pre-existing in `provenance_summary.rs`).