### PR TITLE
fix(agent): write sandbox turn provenance into the canonical graph

### DIFF
--- a/atomic-agent/src/turn/orchestrator/provenance.rs
+++ b/atomic-agent/src/turn/orchestrator/provenance.rs
@@ -438,8 +438,27 @@ impl TurnOrchestrator {
             // Failure is still treated as non-fatal; the provenance chain
             // remains intact and the DB metadata can be rebuilt later.
 
-            let dot_dir = self.repo_root.join(atomic_repository::DOT_DIR);
-            let changes_dir = dot_dir.join("changes");
+            // Resolve the *canonical* changes dir. In a sandbox `repo_root`
+            // has no graph of its own — the pointer file names the canonical
+            // repository. Joining `.atomic` onto `repo_root` would write the
+            // graph into a throwaway dir inside the sandbox, so it would be
+            // absent from the real graph whenever the best-effort Phase 2
+            // below loses the redb write-lock race with a concurrent agent.
+            // `canonical_dot_dir` follows the pointer without opening redb, so
+            // Phase 1 stays lock-free.
+            let changes_dir =
+                match atomic_repository::Repository::canonical_dot_dir(&self.repo_root) {
+                    Ok(dot_dir) => dot_dir.join("changes"),
+                    Err(e) => {
+                        log::warn!(
+                            "Could not resolve canonical changes dir to save \
+                             provenance graph for session {}: {}",
+                            session_id,
+                            e,
+                        );
+                        return true;
+                    }
+                };
 
             // Phase 1: Filesystem write — never blocks on redb.
             let hash = match atomic_repository::ChangeStore::new(

--- a/atomic-agent/src/turn/orchestrator/tests.rs
+++ b/atomic-agent/src/turn/orchestrator/tests.rs
@@ -183,6 +183,90 @@ async fn test_session_start_in_sandbox_adopts_view_without_forking() {
     assert_eq!(canonical_after.current_view(), user_view);
 }
 
+#[tokio::test]
+async fn test_full_turn_in_sandbox_records_provenance_into_canonical_graph() {
+    // Canonical repo with a distinct view the sandbox operates on.
+    let canonical = TempDir::new().unwrap();
+    let repo = Repository::init(canonical.path()).unwrap();
+    // Default `atomic sandbox create` (no --from/--view) binds to the current
+    // shared view. Exercise that exact case.
+    let user_view = repo.current_view().to_string();
+
+    let sandbox_dir = TempDir::new().unwrap();
+    repo.provision_sandbox(sandbox_dir.path(), &user_view)
+        .unwrap();
+    drop(repo);
+
+    // Orchestrator rooted at the sandbox working tree (mirrors the hook path).
+    let session_store = SessionStore::for_repo(sandbox_dir.path()).unwrap();
+    let watcher = FallbackWatcher::new(WatcherConfig::new(sandbox_dir.path()));
+    let mut orch =
+        TurnOrchestrator::with_watcher(sandbox_dir.path(), session_store, Box::new(watcher));
+    orch.set_agent("claude-code", "Claude Code");
+
+    orch.dispatch(session_start_event("sess-sbx-prov"))
+        .await
+        .unwrap();
+    orch.dispatch(turn_start_event("sess-sbx-prov", "Create agent.txt"))
+        .await
+        .unwrap();
+
+    // Agent writes a file into its sandbox working tree.
+    fs::write(sandbox_dir.path().join("agent.txt"), "agent work\n").unwrap();
+
+    let result = orch
+        .dispatch(turn_end_event("sess-sbx-prov"))
+        .await
+        .unwrap();
+
+    assert!(
+        result.was_recorded(),
+        "a turn that created a file in the sandbox must record a change"
+    );
+    let change_hash = result.change_recorded.as_ref().unwrap().hash;
+
+    // The provenance graph file must be written into the CANONICAL change
+    // store (not a throwaway `.atomic/changes` inside the sandbox). Phase 1 of
+    // the save is the lock-free durability guarantee; if it targets the
+    // sandbox's local dir, provenance is lost whenever the best-effort Phase 2
+    // (which takes the redb write lock) loses a race with a concurrent agent.
+    let canonical_changes = atomic_repository::ChangeStore::new(
+        canonical.path().join(".atomic").join("changes"),
+        atomic_repository::DEFAULT_CACHE_CAPACITY,
+    )
+    .unwrap();
+    assert!(
+        canonical_changes.count_provenance_graphs().unwrap() >= 1,
+        "provenance graph must be written to the canonical change store"
+    );
+
+    // Nothing should be written into a sandbox-local change store.
+    let sandbox_changes = sandbox_dir.path().join(".atomic").join("changes");
+    if sandbox_changes.is_dir() {
+        let local = atomic_repository::ChangeStore::new(
+            sandbox_changes,
+            atomic_repository::DEFAULT_CACHE_CAPACITY,
+        )
+        .unwrap();
+        assert_eq!(
+            local.count_provenance_graphs().unwrap(),
+            0,
+            "provenance must not be written to a throwaway change store inside the sandbox"
+        );
+    }
+
+    // End-to-end: the change and its provenance are both registered in the
+    // canonical graph.
+    let canonical_repo = Repository::open(canonical.path()).unwrap();
+    let provenance = canonical_repo
+        .find_provenance_for_change(&change_hash)
+        .unwrap();
+    assert!(
+        !provenance.is_empty(),
+        "provenance graph for the sandbox turn must be registered in the canonical graph"
+    );
+}
+
 // TurnStart tests
 
 #[tokio::test]

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -523,6 +523,25 @@ default = "{}"
         Self::find_root(path.as_ref()).is_ok()
     }
 
+    /// Resolve the **canonical** `.atomic` directory for a working path
+    /// *without* opening the database.
+    ///
+    /// If `path` is inside an agent sandbox, follows the `.atomic-sandbox`
+    /// pointer to the canonical repository; otherwise finds the enclosing
+    /// repository root. Returns `<canonical_root>/.atomic`.
+    ///
+    /// Use this for lock-free filesystem access to the canonical graph — e.g.
+    /// writing a provenance graph through [`ChangeStore`](crate::ChangeStore) —
+    /// where opening a full [`Repository`] would take the redb lock. In a
+    /// sandbox `path/.atomic` is a throwaway local dir (or absent), so joining
+    /// `.atomic` onto the working root would miss the real graph entirely.
+    pub fn canonical_dot_dir<P: AsRef<Path>>(path: P) -> Result<PathBuf, RepositoryError> {
+        if let Some((_working, canonical, _view)) = sandbox::detect_sandbox(path.as_ref()) {
+            return Ok(Self::find_root(&canonical)?.join(DOT_DIR));
+        }
+        Ok(Self::find_root(path.as_ref())?.join(DOT_DIR))
+    }
+
     /// Get the repository root path.
     #[inline]
     pub fn root(&self) -> &Path {

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -531,7 +531,7 @@ default = "{}"
     /// repository root. Returns `<canonical_root>/.atomic`.
     ///
     /// Use this for lock-free filesystem access to the canonical graph — e.g.
-    /// writing a provenance graph through [`ChangeStore`](crate::ChangeStore) —
+    /// writing a provenance graph through [`ChangeStore`] —
     /// where opening a full [`Repository`] would take the redb lock. In a
     /// sandbox `path/.atomic` is a throwaway local dir (or absent), so joining
     /// `.atomic` onto the working root would miss the real graph entirely.


### PR DESCRIPTION
## Context

Follow-up to #99.  It turned out **not** to be the view-switch change in #99 — provenance is created in both the old and new session-start paths (verified by reproducing both). The real bug is older and sandbox-specific, in how the provenance graph is persisted.

## The bug

`save_turn_provenance` splits the save into two phases:

- **Phase 1** — a lock-free filesystem write of the provenance graph via `ChangeStore` (the durability guarantee; never blocks on redb).
- **Phase 2** — best-effort redb registration (REV_DEPS / session tables) so queries like `find_provenance_for_change` work.

Phase 1 derived its change store from `repo_root/.atomic/changes`. Inside an agent **sandbox**, `repo_root` is the sandbox working tree, which has **no graph of its own** — the canonical graph lives wherever the `.atomic-sandbox` pointer points. So Phase 1 wrote the provenance graph into a **throwaway `.atomic/changes` inside the sandbox**.

Phase 2 *does* target the canonical graph, but it takes the redb **write lock** and is best-effort. Whenever it loses the lock race with a concurrent agent — the entire reason sandboxes exist — the turn's provenance was **silently lost from the real graph**, leaving only an orphan inside the sandbox.

(This is why single-threaded tests looked fine: with no contention, Phase 2 succeeded and covered for Phase 1.)

## The fix

- New `Repository::canonical_dot_dir(path)` — resolves the **canonical** `.atomic` dir by following the `.atomic-sandbox` pointer, **without opening redb** (stays lock-free).
- Phase 1 now resolves its change store through it, so provenance is written into the canonical change store directly. Phase 2 is unchanged.

## Verification

- New regression test `test_full_turn_in_sandbox_records_provenance_into_canonical_graph`: provisions a real sandbox (bound to the default shared view), drives a full session-start → turn → turn-end cycle, and asserts the provenance graph lands in the **canonical** change store and **never** in a sandbox-local one. It fails on `dev` (provenance in the sandbox dir) and passes with this fix.
- Full `atomic-agent` + `atomic-repository` suites pass; fmt clean; clippy clean (the 4 remaining warnings pre-exist in `provenance_summary.rs`).