### PR TITLE
fix(vault): align embedded atomic-vault skill template with hook-owned recording

### DIFF
--- a/atomic-repository/vault/skills/atomic-vault.md
+++ b/atomic-repository/vault/skills/atomic-vault.md
@@ -114,9 +114,10 @@ atomic vault memory show architecture
 To save new knowledge, write a markdown file to `.vault/memory/` and
 then run `atomic vault sync` to persist it to the database.
 
-## Version Control
+## Version Control (Read-Only)
 
-The vault is tracked by the same Atomic VCS as the code:
+The vault is tracked by the same Atomic VCS as the code. You inspect state
+and history — you do **not** write to version control yourself:
 
 ```
 # Check repo status
@@ -128,6 +129,24 @@ atomic log
 # Show working copy diff
 atomic diff
 ```
+
+## Views and Recording Are Not Yours to Manage
+
+You do **not** create or switch views, and you do **not** run `atomic add`,
+`atomic record`, or `atomic insert` — the integration's hooks and the
+workflow orchestrator own all of that:
+
+- **Session start** puts you on the right view automatically (a forked
+  draft view, a provisioned sandbox view, or a managed run's declared
+  view — depending on how you were launched).
+- **Turn end** records automatically with full AI provenance (model,
+  session, decision graph).
+- **Session end** restores the original view.
+- **Merging into a shared view** (`atomic insert`) is a human/orchestrator
+  decision made at review time — never run it yourself.
+
+To review what the hooks recorded, use the read-only commands above
+(`atomic log`, `atomic diff`).
 
 ## Workflow
 
@@ -148,38 +167,28 @@ atomic diff
    atomic vault goal start --intent PROJ-1
    ```
 
-4. **Create a draft view** for isolated work:
-   ```
-   atomic view create <goal-name> --draft
-   atomic view switch <goal-name>
-   ```
-
-5. **Search and explore** using grep + knowledge graph together:
+4. **Search and explore** using grep + knowledge graph together:
    ```
    grep "worker_threads" --type rs
    atomic vault query search "worker_threads Builder"
    atomic vault query neighbors "entity:src/builder.rs:worker_threads:42"
    ```
 
-6. **Make changes** using read, edit, write tools
+5. **Make changes** using read, edit, write tools. Recording happens
+   automatically at turn end — do not run `atomic record`.
 
-7. **Record** your changes:
+6. **Sync vault edits** after changing any vault markdown file:
    ```
-   atomic record -m "Add max_worker_threads option to Builder"
+   atomic vault sync
    ```
 
-8. **Stop the goal** when done:
+7. **Stop the goal** when done:
    ```
    atomic vault goal stop --promote
    ```
 
-9. **Review**: The draft view stays alive for review.
+8. **Review** what was recorded (read-only):
    ```
-   atomic view switch <goal-name>
+   atomic log
    atomic diff
    ```
-
-10. **Merge** when approved:
-    ```
-    atomic insert from-view <goal-name> --to-view dev
-    ```


### PR DESCRIPTION
## What

Rewrites the `atomic-vault` skill template (`atomic-repository/vault/skills/atomic-vault.md`) — the agent-facing doc that `vault init` materializes into every repo at `.vault/skills/`. One file, no code changes.

- **"Version Control" becomes "Version Control (Read-Only)"** — agents inspect state and history (`status`, `log`, `diff`); they don't write to VCS themselves.
- **New section: "Views and Recording Are Not Yours to Manage"** — session-start puts the agent on the right view (forked draft, sandbox, or a managed run's declared view), turn-end records with full AI provenance, session-end restores the view. Merging into a shared view (`atomic insert`) is a human/orchestrator decision made at review time — never the agent's.
- **Workflow steps corrected** — removes `view create --draft` / `view switch` / `record -m` / `insert from-view` from the agent's instructions; vault markdown edits are persisted with `atomic vault sync` (the correct mechanism) instead of `record`.

## Why

The old template instructed agents to run the lifecycle by hand, which is the root cause behind "should we suppress the atomic skill?": hooks put the agent on a managed view at session start, then the skill told it to create and switch to its *own* view and record there — "it also then creates its own view and does its own thing with our skill", verbatim.

Concretely, an agent following the old instructions could:

1. **Break managed-run linkage** — `view switch` escapes the run's declared view, so the harvest misses the run's output.
2. **Double-record** — manual `record` plus the turn-end hook produce duplicate changes, and the manual one carries no AI provenance (model, session, decision graph).
3. **Bypass review** — `insert from-view` merges into a shared view with no human approval, violating the Explore → Intent → Approve → Insert model.

Fixing the *instructions* removes the rogue actor without any suppression machinery. This composes with atomic#96 (adoption: recording attribution stays correct even under orchestration) and noname#11 (build runs don't receive vault-writing skills at all).

## Compatibility

- **Human CLI users: unaffected.** No command behavior changes — this is documentation for agents.
- **Existing repos: unaffected.** `vault_install_defaults` is idempotent and never overwrites existing entries (`vault_defaults.rs` — installs only when `vault_retrieve(path)` is `None`). Repos that already ran `vault init` keep their current skill text; only newly initialized vaults get the new template. (Whether we want a refresh path for existing vaults is a fair follow-up question.)
- **The one real behavior change:** an agent *without* hooks enabled that reads this template will no longer self-record — under the old text it recorded manually (dirty but recorded: no provenance, possibly unreviewed inserts); under the new text nothing records until the user runs `atomic agent enable`. That's the intended position — recording belongs to the hooks — but reviewers may want a fallback line in the template telling the agent to surface "changes are not being recorded; enable hooks" to the user.
