### PR TITLE
feat(canonical): the real standards layer — PROV-O, JSON-LD context, inline directives, SHACL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,10 +147,12 @@ version = "0.8.0"
 dependencies = [
  "atomic-identity",
  "blake3",
+ "bs58",
  "chrono",
  "data-encoding",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
 ]
 
@@ -400,6 +402,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,7 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "atomic-agent",
+ "atomic-canonical",
  "atomic-config",
  "atomic-core",
  "atomic-identity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ rayon = "1.10"
 fastcdc = "3.1"
 
 # Hashing & Crypto
+bs58 = "0.5"
 blake3 = "1.5"
 ed25519-dalek = { version = "2.1", features = ["serde"] }
 rand = "0.8"

--- a/atomic-canonical/Cargo.toml
+++ b/atomic-canonical/Cargo.toml
@@ -12,6 +12,7 @@ rust-version.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 blake3 = { workspace = true }
+bs58 = { workspace = true }
 chrono = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }

--- a/atomic-canonical/Cargo.toml
+++ b/atomic-canonical/Cargo.toml
@@ -13,6 +13,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 blake3 = { workspace = true }
 chrono = { workspace = true }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 data-encoding = { workspace = true }
 atomic-identity = { workspace = true }

--- a/atomic-canonical/ns/ctx.jsonld
+++ b/atomic-canonical/ns/ctx.jsonld
@@ -1,0 +1,82 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "atom": "https://atomic.dev/ns#",
+    "prov": "http://www.w3.org/ns/prov#",
+    "sec": "https://w3id.org/security#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+    "Intent": "atom:Intent",
+    "AcceptanceCriterion": "atom:AcceptanceCriterion",
+    "Task": "atom:Task",
+    "ScopeItem": "atom:ScopeItem",
+    "Constraint": "atom:Constraint",
+    "Ref": "atom:Ref",
+    "Memory": "atom:Memory",
+
+    "humanKey": "atom:humanKey",
+    "title": "atom:title",
+    "status": "atom:status",
+    "priority": "atom:priority",
+    "view": "atom:view",
+    "why": "atom:why",
+    "text": "atom:text",
+    "contentHash": "atom:contentHash",
+    "createdAt": { "@id": "atom:createdAt", "@type": "xsd:dateTime" },
+    "attributedTo": { "@id": "atom:attributedTo", "@type": "@id" },
+
+    "motivatedBy": { "@id": "atom:motivatedBy", "@type": "@id" },
+    "informedBy": { "@id": "atom:informedBy", "@type": "@id" },
+    "hasAcceptanceCriterion": "atom:hasAcceptanceCriterion",
+    "hasTask": "atom:hasTask",
+    "hasScopeIn": "atom:hasScopeIn",
+    "hasScopeOut": "atom:hasScopeOut",
+    "hasConstraint": "atom:hasConstraint",
+    "dependsOn": "atom:dependsOn",
+
+    "acStatus": "atom:acStatus",
+    "verifiedBy": { "@id": "atom:verifiedBy", "@type": "@id" },
+    "evidence": { "@id": "atom:evidence", "@type": "@id" },
+
+    "taskStatus": "atom:taskStatus",
+    "touchesFile": "atom:touchesFile",
+    "satisfies": { "@id": "atom:satisfies", "@type": "@id" },
+
+    "to": { "@id": "atom:to", "@type": "@id" },
+    "edge": "atom:edge",
+
+    "memoryKind": "atom:memoryKind",
+    "about": { "@id": "atom:about", "@type": "@id" },
+    "supersedes": { "@id": "atom:supersedes", "@type": "@id" },
+    "previousRevision": { "@id": "atom:previousRevision", "@type": "@id" },
+
+    "proof": "sec:proof",
+    "DataIntegrityProof": "sec:DataIntegrityProof",
+    "cryptosuite": "sec:cryptosuite",
+    "verificationMethod": { "@id": "sec:verificationMethod", "@type": "@id" },
+    "proofPurpose": "sec:proofPurpose",
+    "proofValue": "sec:proofValue",
+
+    "Activity": "prov:Activity",
+    "SoftwareAgent": "prov:SoftwareAgent",
+    "Person": "prov:Person",
+    "wasAssociatedWith": { "@id": "prov:wasAssociatedWith", "@type": "@id" },
+    "actedOnBehalfOf": { "@id": "prov:actedOnBehalfOf", "@type": "@id" },
+    "used": { "@id": "prov:used", "@type": "@id" },
+    "generated": { "@id": "prov:generated", "@type": "@id" },
+    "startedAtTime": { "@id": "prov:startedAtTime", "@type": "xsd:dateTime" },
+    "endedAtTime": { "@id": "prov:endedAtTime", "@type": "xsd:dateTime" },
+
+    "sessionId": "atom:sessionId",
+    "runId": "atom:runId",
+    "agentName": "atom:agentName",
+    "agentDisplayName": "atom:agentDisplayName",
+    "model": "atom:model",
+    "vendor": "atom:vendor",
+    "turnCount": { "@id": "atom:turnCount", "@type": "xsd:integer" },
+    "turnParent": { "@id": "atom:turnParent", "@type": "@id" },
+    "partOfRun": { "@id": "atom:partOfRun", "@type": "@id" },
+    "ownerSessionId": "atom:ownerSessionId",
+    "workItem": { "@id": "atom:workItem", "@type": "@id" }
+  }
+}

--- a/atomic-canonical/shapes/atomic-shapes.ttl
+++ b/atomic-canonical/shapes/atomic-shapes.ttl
@@ -1,0 +1,191 @@
+# SHACL shapes for the Recording-the-Why canonical nodes — the formal gate.
+#
+# These are real SHACL (evaluated by pyshacl over the JSON-LD projection),
+# the tier-2 companion to the always-on Rust gate in `gate.rs`:
+#   tier 1 (gate.rs)  — fast, in-process, runs in the agent inner loop;
+#   tier 2 (this file) — authoritative W3C SHACL conformance, run at status
+#                        transitions / CI via `shacl.rs`.
+#
+# The two tiers enforce the same rules; this file is the portable,
+# regulator-readable statement of them. Presence is enforced, content is
+# left honest: nothing here grades the prose of a why or a memory.
+
+@prefix sh:   <http://www.w3.org/ns/shacl#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix atom: <https://atomic.dev/ns#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix sec:  <https://w3id.org/security#> .
+
+# Prefix declarations for SPARQL-based constraints.
+<https://atomic.dev/ns/shapes> a owl:Ontology ;
+    sh:declare [ sh:prefix "atom" ; sh:namespace "https://atomic.dev/ns#"^^xsd:anyURI ] ;
+    sh:declare [ sh:prefix "sec" ; sh:namespace "https://w3id.org/security#"^^xsd:anyURI ] .
+
+#####################################################################
+# IntentShape — the gate for atom:Intent
+#####################################################################
+atom:IntentShape
+    a sh:NodeShape ;
+    sh:targetClass atom:Intent ;
+
+    # status: closed vocabulary, exactly one. The ontology refusing any
+    # value it does not recognize.
+    sh:property [
+        sh:path atom:status ;
+        sh:in ( "backlog" "todo" "in_progress" "done" ) ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "status must be exactly one of the known states" ;
+    ] ;
+
+    # authorship must be an identity IRI (a DID), not free text. The
+    # stronger sh:class prov:Agent check needs the identity graph joined
+    # in — that lands with the store-backed resolver.
+    sh:property [
+        sh:path atom:attributedTo ;
+        sh:minCount 1 ;
+        sh:nodeKind sh:IRI ;
+        sh:message "attributedTo must be an identity IRI (did:...), not a string" ;
+    ] ;
+
+    # a cryptographic proof must be present.
+    sh:property [
+        sh:path sec:proof ;
+        sh:minCount 1 ;
+        sh:message "intent must carry a Data Integrity proof" ;
+    ] ;
+
+    # the why must exist. Presence enforced; content honest — no shape on
+    # the prose itself, ever.
+    sh:property [
+        sh:path atom:why ;
+        sh:minCount 1 ;
+        sh:minLength 1 ;
+        sh:message "the why must exist (an empty why we can see beats a fake why we trust)" ;
+    ] ;
+
+    # every acceptance criterion must itself satisfy its shape.
+    sh:property [
+        sh:path atom:hasAcceptanceCriterion ;
+        sh:node atom:AcceptanceCriterionShape ;
+    ] .
+
+#####################################################################
+# AcceptanceCriterionShape — a checked box must carry its evidence
+#####################################################################
+atom:AcceptanceCriterionShape
+    a sh:NodeShape ;
+    sh:targetClass atom:AcceptanceCriterion ;
+
+    sh:property [
+        sh:path atom:acStatus ;
+        sh:in ( "open" "met" ) ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "acStatus must be 'open' or 'met'" ;
+    ] ;
+
+    # The load-bearing rule (SHACL-SPARQL): if it is met, it must say who
+    # verified it and link the evidence. A bare checked box cannot pass.
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:message "a met acceptance criterion must carry verifiedBy and evidence" ;
+        sh:prefixes <https://atomic.dev/ns/shapes> ;
+        sh:select """
+            SELECT $this WHERE {
+                $this atom:acStatus "met" .
+                FILTER NOT EXISTS {
+                    $this atom:verifiedBy ?who .
+                    $this atom:evidence   ?ev .
+                }
+            }
+        """ ;
+    ] .
+
+#####################################################################
+# MemoryShape — durable context with a typed kind and a revision chain
+#####################################################################
+atom:MemoryShape
+    a sh:NodeShape ;
+    sh:targetClass atom:Memory ;
+
+    sh:property [
+        sh:path atom:memoryKind ;
+        sh:in ( "constraint" "preference" "lesson" "context" ) ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "memory kind must be one of the known types" ;
+    ] ;
+
+    sh:property [
+        sh:path atom:status ;
+        sh:in ( "active" "superseded" "retracted" ) ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "memory status must be one of the known states" ;
+    ] ;
+
+    sh:property [
+        sh:path atom:text ;
+        sh:minCount 1 ;
+        sh:minLength 1 ;
+        sh:message "memory must carry its text (presence enforced; content honest)" ;
+    ] ;
+
+    sh:property [
+        sh:path atom:attributedTo ;
+        sh:minCount 1 ;
+        sh:nodeKind sh:IRI ;
+        sh:message "author must be an identity IRI" ;
+    ] ;
+
+    sh:property [
+        sh:path sec:proof ;
+        sh:minCount 1 ;
+        sh:message "memory must carry a Data Integrity proof" ;
+    ] .
+
+#####################################################################
+# PROV projection shapes — the provenance graph stays well-formed
+#####################################################################
+atom:ActivityShape
+    a sh:NodeShape ;
+    sh:targetClass prov:Activity ;
+
+    sh:property [
+        sh:path prov:wasAssociatedWith ;
+        sh:minCount 1 ;
+        sh:nodeKind sh:IRI ;
+        sh:message "every activity must be associated with an agent" ;
+    ] ;
+
+    sh:property [
+        sh:path prov:startedAtTime ;
+        sh:datatype xsd:dateTime ;
+        sh:maxCount 1 ;
+        sh:message "startedAtTime must be an xsd:dateTime" ;
+    ] ;
+
+    sh:property [
+        sh:path prov:endedAtTime ;
+        sh:datatype xsd:dateTime ;
+        sh:maxCount 1 ;
+        sh:message "endedAtTime must be an xsd:dateTime" ;
+    ] .
+
+atom:SoftwareAgentShape
+    a sh:NodeShape ;
+    sh:targetClass prov:SoftwareAgent ;
+
+    sh:property [
+        sh:path atom:agentName ;
+        sh:minCount 1 ;
+        sh:message "a software agent must carry its registry name" ;
+    ] ;
+
+    sh:property [
+        sh:path prov:actedOnBehalfOf ;
+        sh:nodeKind sh:IRI ;
+        sh:message "delegation must point at an agent/person IRI" ;
+    ] .

--- a/atomic-canonical/shapes/atomic-shapes.ttl
+++ b/atomic-canonical/shapes/atomic-shapes.ttl
@@ -69,6 +69,12 @@ atom:IntentShape
     sh:property [
         sh:path atom:hasAcceptanceCriterion ;
         sh:node atom:AcceptanceCriterionShape ;
+    ] ;
+
+    # every task must itself satisfy its shape.
+    sh:property [
+        sh:path atom:hasTask ;
+        sh:node atom:TaskShape ;
     ] .
 
 #####################################################################
@@ -101,6 +107,26 @@ atom:AcceptanceCriterionShape
                 }
             }
         """ ;
+    ] .
+
+#####################################################################
+# TaskShape — a decomposed work item carries exactly one status
+#####################################################################
+# The task-status value set is not yet a closed vocabulary (the doc
+# does not enumerate it), so this shape checks cardinality only — a
+# sh:in lands together with the vocab registry entry. `satisfies` is
+# not shape-checked here: the @context coerces it to an IRI, so a
+# nodeKind constraint cannot fire; resolution ("does the criterion
+# exist?") is a graph-join check for the store-backed milestone.
+atom:TaskShape
+    a sh:NodeShape ;
+    sh:targetClass atom:Task ;
+
+    sh:property [
+        sh:path atom:taskStatus ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "a task carries exactly one status" ;
     ] .
 
 #####################################################################

--- a/atomic-canonical/src/context.rs
+++ b/atomic-canonical/src/context.rs
@@ -103,8 +103,7 @@ mod tests {
         match value {
             Value::Object(map) => {
                 for (key, v) in map {
-                    if !key.starts_with('@') && !terms.contains_key(key) && !missing.contains(key)
-                    {
+                    if !key.starts_with('@') && !terms.contains_key(key) && !missing.contains(key) {
                         missing.push(key.clone());
                     }
                     collect_missing(v, terms, missing);

--- a/atomic-canonical/src/context.rs
+++ b/atomic-canonical/src/context.rs
@@ -1,0 +1,217 @@
+//! The JSON-LD `@context` document — the term→IRI mapping that makes the
+//! canonical nodes real linked data instead of JSON with LD-looking keys.
+//!
+//! Nodes reference the context by URL ([`crate::node::CONTEXT_URL`]); this
+//! module ships the document itself (embedded at compile time) so local
+//! tooling never needs the URL to resolve. [`inline_context`] swaps the URL
+//! for the full mapping — that is what the SHACL gate feeds to an RDF
+//! processor, which makes every gate run double as a JSON-LD conformance
+//! check of our output.
+//!
+//! Closure discipline: the context is a closed term registry like
+//! [`crate::vocab`]. A serialized key with no term here would silently drop
+//! out of the RDF projection, so the coverage test walks fully-populated
+//! nodes and fails on any unmapped key.
+
+use serde_json::Value;
+
+/// The raw `ctx.jsonld` document (the file `@context` wrapper included).
+pub const CONTEXT_JSON: &str = include_str!("../ns/ctx.jsonld");
+
+/// The parsed context document: `{"@context": {...}}`.
+pub fn context_document() -> Value {
+    serde_json::from_str(CONTEXT_JSON).expect("ctx.jsonld is valid JSON")
+}
+
+/// The inner `@context` term map.
+pub fn context_terms() -> Value {
+    context_document()
+        .get("@context")
+        .cloned()
+        .expect("ctx.jsonld has an @context key")
+}
+
+/// Replace a node's `"@context": "<url>"` with the embedded term map, so the
+/// document is self-contained for offline RDF processing (rdflib/pyshacl
+/// cannot fetch `atomic.dev`). Non-object values pass through unchanged.
+pub fn inline_context(value: &Value) -> Value {
+    let mut value = value.clone();
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert("@context".to_string(), context_terms());
+    }
+    value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::CONTEXT_URL;
+
+    /// Every serialized key of every node type must have a term in the
+    /// context (or be a JSON-LD keyword). An unmapped key would silently
+    /// vanish from the RDF projection — the opposite of a closed vocabulary.
+    #[test]
+    fn context_covers_every_serialized_key() {
+        let terms = context_terms();
+        let terms = terms.as_object().unwrap();
+
+        let mut missing = Vec::new();
+        for node in fixtures() {
+            collect_missing(&node, terms, &mut missing);
+        }
+        assert!(
+            missing.is_empty(),
+            "serialized keys with no @context term: {missing:?}"
+        );
+    }
+
+    /// Every `@type` string value used by our nodes must also resolve.
+    #[test]
+    fn context_covers_every_type_value() {
+        let terms = context_terms();
+        let terms = terms.as_object().unwrap();
+        for ty in [
+            "Intent",
+            "AcceptanceCriterion",
+            "Task",
+            "ScopeItem",
+            "Constraint",
+            "Ref",
+            "Memory",
+            "DataIntegrityProof",
+            "Activity",
+            "SoftwareAgent",
+            "Person",
+        ] {
+            assert!(terms.contains_key(ty), "@type '{ty}' has no context term");
+        }
+    }
+
+    #[test]
+    fn inline_context_replaces_url_with_terms() {
+        let node = serde_json::json!({ "@context": CONTEXT_URL, "@type": "Intent" });
+        let inlined = inline_context(&node);
+        assert!(inlined["@context"].is_object());
+        assert_eq!(inlined["@context"]["atom"], "https://atomic.dev/ns#");
+    }
+
+    fn collect_missing(
+        value: &Value,
+        terms: &serde_json::Map<String, Value>,
+        missing: &mut Vec<String>,
+    ) {
+        match value {
+            Value::Object(map) => {
+                for (key, v) in map {
+                    if !key.starts_with('@') && !terms.contains_key(key) && !missing.contains(key)
+                    {
+                        missing.push(key.clone());
+                    }
+                    collect_missing(v, terms, missing);
+                }
+            }
+            Value::Array(items) => {
+                for item in items {
+                    collect_missing(item, terms, missing);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Fully-populated fixtures: every optional field set, every collection
+    /// non-empty, so every serializable key appears.
+    fn fixtures() -> Vec<Value> {
+        let intent_md = "\
+---
+id: WORD-5
+uid: 019efe85
+title: Add name prompt modal
+status: done
+priority: medium
+view: proud-moon-a08a
+motivatedBy: urn:atomic:decision:01J8Z9K2QF
+informedBy: [urn:atomic:memory:01J8ZC4R8T]
+attributedTo: did:atomic:lee
+created_at: 2026-06-25T11:24:25Z
+---
+
+:::why
+Local-only per :ref[the storage constraint]{to=urn:atomic:memory:01J8ZC edge=depends}.
+:::
+
+:::acceptance-criterion{#WORD-5-ac-1 status=met verifiedBy=did:atomic:lee evidence=urn:atomic:change:01J8ZE}
+On first load, the app presents a modal.
+:::
+
+:::task{#WORD-5-1 status=done satisfies=WORD-5-ac-1}
+Add name capture state.
+::file-ref{path=src/App.tsx}
+:::
+
+:::scope-in
+src/App.tsx state and markup.
+:::
+
+:::scope-out
+Persistence across reloads.
+:::
+
+:::constraint
+Keep it local.
+:::
+
+:::ref{#WORD-5-dep-1 to=urn:atomic:intent:019efe80 edge=blockedBy}
+:::
+";
+        let (fm, body) = crate::lift::parse_markdown(intent_md).unwrap();
+        let intent = crate::lift::lift_intent(&fm, &body).unwrap();
+
+        let memory_md = "\
+---
+id: mem-storage
+uid: 01J8ZC4R8T
+kind: constraint
+status: active
+about: [urn:atomic:module:storage]
+supersedes: urn:atomic:memory:00OLD
+previousRevision: urn:atomic:memory:00OLD
+attributedTo: did:atomic:lee
+created_at: 2026-05-02T09:14:00Z
+---
+
+:::memory
+Multi-region writes must converge with no single ordering authority.
+:::
+";
+        let (fm, body) = crate::lift::parse_markdown(memory_md).unwrap();
+        let memory = crate::memory::lift_memory(&fm, &body).unwrap();
+
+        let kp = atomic_identity::keypair::KeyPair::generate();
+        let id = atomic_identity::identity::Identity::new("t", &kp);
+        let intent = crate::proof::attest(intent, &id, &kp);
+        let memory = crate::proof::attest_memory(memory, &id, &kp);
+
+        let prov = crate::prov::provenance_graph(&crate::prov::ProvenanceInput {
+            session_id: "sess-1".into(),
+            agent_name: "claude-code".into(),
+            agent_display_name: "Claude Code".into(),
+            agent_vendor: "anthropic".into(),
+            model: "claude-fable-5".into(),
+            started_at: "2026-07-01T22:11:00Z".into(),
+            ended_at: Some("2026-07-01T22:14:00Z".into()),
+            view: Some("sherpa-run-x".into()),
+            change_hashes: vec!["W5GSLAVO".into()],
+            used: vec!["urn:atomic:intent:019efe85".into()],
+            managed_run: Some(crate::prov::ManagedRunInput {
+                run_id: "run-1".into(),
+                owner_agent: "sherpa".into(),
+                owner_session_id: "sherpa-s1".into(),
+                work_item_id: Some("NONA-7".into()),
+            }),
+            person: Some("did:atomic:lee".into()),
+        });
+
+        vec![intent.to_value(), memory.to_value(), prov]
+    }
+}

--- a/atomic-canonical/src/did.rs
+++ b/atomic-canonical/src/did.rs
@@ -11,13 +11,19 @@
 //! confirms the DID belongs to that key. The store-backed resolver arrives in
 //! M1 when this wires into the vault.
 //!
-//! NOTE (open question, deferred): PROV / Data-Integrity tooling generally
-//! assumes `did:key` (multibase+multicodec). `did:atomic` is chosen for M0 for
-//! simplicity and in-tree consistency; `proof.rs` keeps the method swappable.
+//! `did:atomic` stays the in-tree method (it matches atomic's identity
+//! model), and [`did_key_for_public_key`] additionally provides the standard
+//! `did:key` representation of the same key — multicodec `ed25519-pub`
+//! (0xed 0x01) + the 32-byte key, multibase base58btc — for interop with
+//! Data-Integrity tooling that resolves `did:key` natively. Verification
+//! accepts either method for the same key.
 
 use atomic_identity::keypair::PublicKey;
 
 pub const DID_ATOMIC_PREFIX: &str = "did:atomic:";
+pub const DID_KEY_PREFIX: &str = "did:key:";
+/// Multicodec prefix for an Ed25519 public key (varint 0xed01).
+const MULTICODEC_ED25519_PUB: [u8; 2] = [0xed, 0x01];
 
 /// Build the `did:atomic:...` identifier for a public key.
 pub fn did_for_public_key(public_key: &PublicKey) -> String {
@@ -27,6 +33,16 @@ pub fn did_for_public_key(public_key: &PublicKey) -> String {
         DID_ATOMIC_PREFIX,
         data_encoding::BASE32_NOPAD.encode(fingerprint.as_bytes())
     )
+}
+
+/// Build the standard `did:key` identifier for an Ed25519 public key
+/// (multicodec `ed25519-pub` + key bytes, base58btc multibase). Always
+/// starts `did:key:z6Mk` for Ed25519 keys.
+pub fn did_key_for_public_key(public_key: &PublicKey) -> String {
+    let mut bytes = Vec::with_capacity(2 + public_key.as_bytes().len());
+    bytes.extend_from_slice(&MULTICODEC_ED25519_PUB);
+    bytes.extend_from_slice(public_key.as_bytes());
+    format!("{}z{}", DID_KEY_PREFIX, bs58::encode(bytes).into_string())
 }
 
 /// The verification method id used in a proof (`<did>#key-1`).
@@ -39,9 +55,10 @@ pub fn did_from_verification_method(vm: &str) -> &str {
     vm.split('#').next().unwrap_or(vm)
 }
 
-/// Does this DID correspond to the given public key?
+/// Does this DID correspond to the given public key? Accepts either the
+/// in-tree `did:atomic` fingerprint or the standard `did:key` form.
 pub fn did_matches_public_key(did: &str, public_key: &PublicKey) -> bool {
-    did == did_for_public_key(public_key)
+    did == did_for_public_key(public_key) || did == did_key_for_public_key(public_key)
 }
 
 #[cfg(test)]
@@ -59,6 +76,24 @@ mod tests {
 
         let other = KeyPair::generate();
         assert!(!did_matches_public_key(&did, &other.public));
+    }
+
+    #[test]
+    fn did_key_has_ed25519_multicodec_shape_and_verifies() {
+        let kp = KeyPair::generate();
+        let did_key = did_key_for_public_key(&kp.public);
+        // Ed25519 multicodec + base58btc always yields the z6Mk prefix.
+        assert!(
+            did_key.starts_with("did:key:z6Mk"),
+            "unexpected did:key form: {did_key}"
+        );
+        assert_eq!(did_key, did_key_for_public_key(&kp.public), "stable");
+        // Either representation of the same key verifies.
+        assert!(did_matches_public_key(&did_key, &kp.public));
+        assert!(did_matches_public_key(&did_for_public_key(&kp.public), &kp.public));
+
+        let other = KeyPair::generate();
+        assert!(!did_matches_public_key(&did_key, &other.public));
     }
 
     #[test]

--- a/atomic-canonical/src/did.rs
+++ b/atomic-canonical/src/did.rs
@@ -90,7 +90,10 @@ mod tests {
         assert_eq!(did_key, did_key_for_public_key(&kp.public), "stable");
         // Either representation of the same key verifies.
         assert!(did_matches_public_key(&did_key, &kp.public));
-        assert!(did_matches_public_key(&did_for_public_key(&kp.public), &kp.public));
+        assert!(did_matches_public_key(
+            &did_for_public_key(&kp.public),
+            &kp.public
+        ));
 
         let other = KeyPair::generate();
         assert!(!did_matches_public_key(&did_key, &other.public));

--- a/atomic-canonical/src/directive.rs
+++ b/atomic-canonical/src/directive.rs
@@ -2,11 +2,17 @@
 //!
 //! The body's typed structure is explicit and local: the lift reads a node's
 //! type off the directive name, never off heading position (the fragile
-//! "positional lift" the doc rejects). M0 supports:
+//! "positional lift" the doc rejects). All three directive forms are supported:
 //!   - container: `:::name{#id key=value ...}` … prose … `:::`
 //!   - leaf:      `::name{key=value ...}`  (edges only, no body)
+//!   - inline:    `:name[label]{key=value ...}`  (names a node inside prose)
 //!
-//! Inline directives are deferred (not needed for the Intent slice).
+//! Inline directives are recognized *inside container prose* and surface as
+//! children of the container while the prose keeps them verbatim — the graph
+//! stores the edge, the render resolves it (reference, don't embed). Because
+//! prose is the unconstrained slot, an inline pattern whose name is not in
+//! [`vocab::INLINE_DIRECTIVE_NAMES`] stays prose instead of erroring (a reason
+//! mentioning `did:atomic:lee` or `foo:bar[0]` must never fail the lift).
 
 use std::collections::BTreeMap;
 
@@ -21,7 +27,9 @@ pub struct Directive {
     pub attrs: BTreeMap<String, String>,
     /// Prose inside a container directive (trimmed). Empty for leaf directives.
     pub body: String,
-    /// Leaf directives nested inside this container (e.g. `::file-ref`).
+    /// The `[label]` of an inline directive. `None` for container/leaf forms.
+    pub label: Option<String>,
+    /// Leaf and inline directives nested inside this container.
     pub children: Vec<Directive>,
 }
 
@@ -77,11 +85,16 @@ pub fn parse(body: &str) -> Result<Vec<Directive>> {
                     "unterminated container directive ':::{name}' (missing closing ':::')"
                 )));
             }
+            let body = body_lines.join("\n").trim().to_string();
+            // Inline directives inside the prose surface as children; the
+            // prose keeps them verbatim (store the edge, render resolves it).
+            children.extend(parse_inline(&body)?);
             out.push(Directive {
                 name,
                 id,
                 attrs,
-                body: body_lines.join("\n").trim().to_string(),
+                body,
+                label: None,
                 children,
             });
         } else if trimmed.starts_with("::") {
@@ -112,8 +125,85 @@ fn parse_leaf(line: &str) -> Result<Option<Directive>> {
         id,
         attrs,
         body: String::new(),
+        label: None,
         children: Vec::new(),
     }))
+}
+
+/// Extract inline directives (`:name[label]{attrs}`) from running prose.
+///
+/// Recognition rules keep prose safe:
+/// - the `:` must sit at a word boundary (start of text, or after a
+///   non-alphanumeric character) — so `did:atomic:lee` never matches;
+/// - the name must be immediately followed by `[label]` — a bare `:word`
+///   is prose;
+/// - the name must be in the inline registry — `:unknown[x]` stays prose,
+///   because prose is the unconstrained slot.
+pub fn parse_inline(text: &str) -> Result<Vec<Directive>> {
+    let bytes = text.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b':' {
+            i += 1;
+            continue;
+        }
+        // Word boundary: previous byte must not be alphanumeric or ':' (which
+        // would make this the tail of a URN/DID or a block-directive marker).
+        if i > 0 {
+            let prev = bytes[i - 1] as char;
+            if prev.is_ascii_alphanumeric() || prev == ':' {
+                i += 1;
+                continue;
+            }
+        }
+        // Read the name: [a-z0-9-]+ immediately after ':'.
+        let name_start = i + 1;
+        let mut j = name_start;
+        while j < bytes.len() && (bytes[j].is_ascii_alphanumeric() || bytes[j] == b'-') {
+            j += 1;
+        }
+        if j == name_start || j >= bytes.len() || bytes[j] != b'[' {
+            i += 1;
+            continue;
+        }
+        let name = &text[name_start..j];
+        if !vocab::is_known_inline_directive(name) {
+            i += 1;
+            continue;
+        }
+        // Label: up to the matching ']' (no nesting in labels).
+        let label_start = j + 1;
+        let Some(label_len) = text[label_start..].find(']') else {
+            return Err(CanonicalError::Directive(format!(
+                "unterminated inline directive ':{name}[' (missing closing ']')"
+            )));
+        };
+        let label = text[label_start..label_start + label_len].to_string();
+        let mut end = label_start + label_len + 1;
+        // Optional immediate `{attrs}`.
+        let mut attrs_src = "";
+        if bytes.get(end) == Some(&b'{') {
+            let Some(close) = text[end + 1..].find('}') else {
+                return Err(CanonicalError::Directive(format!(
+                    "unterminated inline directive ':{name}[…]{{' (missing closing '}}')"
+                )));
+            };
+            attrs_src = &text[end + 1..end + 1 + close];
+            end = end + 1 + close + 1;
+        }
+        let (id, attrs) = parse_attrs(attrs_src)?;
+        out.push(Directive {
+            name: name.to_string(),
+            id,
+            attrs,
+            body: String::new(),
+            label: Some(label),
+            children: Vec::new(),
+        });
+        i = end;
+    }
+    Ok(out)
 }
 
 fn check_known(name: &str) -> Result<()> {
@@ -233,5 +323,56 @@ mod tests {
     fn unterminated_container_is_error() {
         let body = ":::why{}\nno close here";
         assert!(parse(body).is_err());
+    }
+
+    // Inline directives
+
+    #[test]
+    fn inline_ref_in_container_prose_becomes_child() {
+        let body = ":::why\nWe follow :ref[the storage decision]{to=urn:atomic:memory:01J edge=depends} here.\n:::";
+        let ds = parse(body).unwrap();
+        let why = &ds[0];
+        // Prose keeps the inline verbatim (reference, don't embed).
+        assert!(why.body.contains(":ref[the storage decision]"));
+        assert_eq!(why.children.len(), 1);
+        let r = &why.children[0];
+        assert_eq!(r.name, "ref");
+        assert_eq!(r.label.as_deref(), Some("the storage decision"));
+        assert_eq!(r.attr("to"), Some("urn:atomic:memory:01J"));
+        assert_eq!(r.attr("edge"), Some("depends"));
+    }
+
+    #[test]
+    fn inline_parse_extracts_multiple() {
+        let text = "see :ref[a]{to=urn:atomic:intent:1 edge=depends} and :ref[b]{to=urn:atomic:intent:2 edge=blockedBy}";
+        let ds = parse_inline(text).unwrap();
+        assert_eq!(ds.len(), 2);
+        assert_eq!(ds[0].label.as_deref(), Some("a"));
+        assert_eq!(ds[1].attr("edge"), Some("blockedBy"));
+    }
+
+    #[test]
+    fn dids_urns_and_unregistered_names_stay_prose() {
+        // Colons inside identifiers must never match (word boundary), and an
+        // unregistered inline name is prose, not an error.
+        let text = "did:atomic:lee wrote urn:atomic:intent:x; :unknown[thing]{a=b} and foo:bar[0] stay prose";
+        let ds = parse_inline(text).unwrap();
+        assert!(ds.is_empty(), "got {ds:?}");
+    }
+
+    #[test]
+    fn inline_without_label_bracket_is_prose() {
+        let ds = parse_inline("a plain :ref mention with no bracket").unwrap();
+        assert!(ds.is_empty());
+    }
+
+    #[test]
+    fn unterminated_inline_label_is_error() {
+        assert!(parse_inline("bad :ref[never closed").is_err());
+    }
+
+    #[test]
+    fn unterminated_inline_attrs_is_error() {
+        assert!(parse_inline("bad :ref[x]{to=urn:atomic:intent:1").is_err());
     }
 }

--- a/atomic-canonical/src/directive.rs
+++ b/atomic-canonical/src/directive.rs
@@ -206,6 +206,84 @@ pub fn parse_inline(text: &str) -> Result<Vec<Directive>> {
     Ok(out)
 }
 
+/// Reject a REGISTERED directive name embedded mid-prose with an attrs
+/// brace (e.g. `… ::file-ref{path=x} …` inside a sentence). The block
+/// parser only reads directives at line start, so an embedded one would
+/// silently stay prose and its edge would be lost. Unregistered names stay
+/// prose (the inline rule); `std::fs` and `foo::ref{...}` never match — the
+/// colon run must not follow an identifier character.
+pub fn check_embedded_directives(text: &str) -> Result<()> {
+    let mut in_fence = false;
+    for raw_line in text.lines() {
+        let line = strip_html_comments(raw_line);
+        let t = line.trim_start();
+        if t.starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        // Lines the block parser handles itself (directive opens/closes).
+        if in_fence || t.starts_with(':') {
+            continue;
+        }
+        let bytes = line.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] != b':' {
+                i += 1;
+                continue;
+            }
+            let start = i;
+            while i < bytes.len() && bytes[i] == b':' {
+                i += 1;
+            }
+            let run = i - start;
+            if !(2..=3).contains(&run) {
+                continue;
+            }
+            if start > 0 {
+                let prev = bytes[start - 1];
+                if prev.is_ascii_alphanumeric() || prev == b'_' {
+                    continue;
+                }
+            }
+            let name_start = i;
+            while i < bytes.len()
+                && (bytes[i].is_ascii_lowercase() || bytes[i].is_ascii_digit() || bytes[i] == b'-')
+            {
+                i += 1;
+            }
+            if i == name_start || i >= bytes.len() || bytes[i] != b'{' {
+                continue;
+            }
+            let name = &line[name_start..i];
+            if vocab::is_known_directive(name) {
+                return Err(CanonicalError::Directive(format!(
+                    "directive '{}{name}' is embedded in prose — block \
+                     directives must start their own line",
+                    ":".repeat(run)
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Drop `<!-- … -->` spans so template guidance comments never trip the
+/// embedded-directive check.
+fn strip_html_comments(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut rest = line;
+    while let Some(open) = rest.find("<!--") {
+        out.push_str(&rest[..open]);
+        match rest[open..].find("-->") {
+            Some(close) => rest = &rest[open + close + 3..],
+            None => return out,
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
 fn check_known(name: &str) -> Result<()> {
     if !vocab::is_known_directive(name) {
         return Err(CanonicalError::Directive(format!(
@@ -374,5 +452,31 @@ mod tests {
     #[test]
     fn unterminated_inline_attrs_is_error() {
         assert!(parse_inline("bad :ref[x]{to=urn:atomic:intent:1").is_err());
+    }
+
+    #[test]
+    fn embedded_known_leaf_in_prose_is_error() {
+        let body = ":::task{#t1 status=open}\nUpdate ::file-ref{path=Cargo.toml} early.\n:::";
+        let err = check_embedded_directives(body).unwrap_err();
+        assert!(
+            err.to_string().contains("must start their own line"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn rust_paths_and_suffixed_names_stay_prose() {
+        check_embedded_directives("use std::fs::read; also foo::ref{x} stays.").unwrap();
+    }
+
+    #[test]
+    fn unregistered_embedded_name_stays_prose() {
+        check_embedded_directives("try ::made-up{x=1} here").unwrap();
+    }
+
+    #[test]
+    fn template_comments_and_fences_are_exempt() {
+        check_embedded_directives("<!-- Name touched files with ::file-ref{path=...} -->").unwrap();
+        check_embedded_directives("```\n::file-ref{path=x}\n```").unwrap();
     }
 }

--- a/atomic-canonical/src/error.rs
+++ b/atomic-canonical/src/error.rs
@@ -19,6 +19,9 @@ pub enum CanonicalError {
     #[error("signature verification failed: {0}")]
     Verification(String),
 
+    #[error("shacl validation error: {0}")]
+    Shacl(String),
+
     #[error("identity error: {0}")]
     Identity(#[from] atomic_identity::IdentityError),
 }

--- a/atomic-canonical/src/gate.rs
+++ b/atomic-canonical/src/gate.rs
@@ -20,7 +20,7 @@ use crate::node::CanonicalNode;
 use crate::vocab;
 
 /// A single shape violation.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct Violation {
     /// The `@id` of the focus node (or sub-node) that failed.
     pub focus_node: String,
@@ -33,7 +33,7 @@ pub struct Violation {
 }
 
 /// The result of validating a node.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct ValidationReport {
     pub conforms: bool,
     pub results: Vec<Violation>,

--- a/atomic-canonical/src/gate.rs
+++ b/atomic-canonical/src/gate.rs
@@ -56,7 +56,11 @@ impl std::fmt::Display for ValidationReport {
         writeln!(f, "conforms: no ({} violation(s))", self.results.len())?;
         for v in &self.results {
             let path = v.path.as_deref().unwrap_or("-");
-            writeln!(f, "  ✗ [{}] {} ({}): {}", v.shape, v.focus_node, path, v.message)?;
+            writeln!(
+                f,
+                "  ✗ [{}] {} ({}): {}",
+                v.shape, v.focus_node, path, v.message
+            )?;
         }
         Ok(())
     }
@@ -378,7 +382,10 @@ mod tests {
         assert!(!report.conforms);
         for path in ["proof", "attributedTo", "text"] {
             assert!(
-                report.results.iter().any(|v| v.path.as_deref() == Some(path)),
+                report
+                    .results
+                    .iter()
+                    .any(|v| v.path.as_deref() == Some(path)),
                 "expected a violation on {path}"
             );
         }

--- a/atomic-canonical/src/jcs.rs
+++ b/atomic-canonical/src/jcs.rs
@@ -9,12 +9,14 @@
 //! hash (`hash.rs`) and the Data Integrity proof (`proof.rs`) go through
 //! `canonicalize`, so the two can never drift.
 //!
-//! Scope note (M0): object-key sorting is by UTF-8 byte order. RFC 8785
-//! specifies sorting by UTF-16 code units; for the ASCII property names in
-//! our vocabulary the two orderings are identical. Numbers are emitted via
-//! `serde_json`'s formatter, which is exact for the integer/simple values we
-//! use. Both are revisited if the vocabulary ever admits non-ASCII keys or
-//! floating-point payloads.
+//! Object keys are sorted by UTF-16 code units as RFC 8785 §3.2.3 specifies
+//! (not by UTF-8 bytes — the two differ once keys leave the BMP, e.g. an
+//! emoji key sorts after `\u{ff61}` in UTF-8 but before it in UTF-16).
+//!
+//! Scope note: numbers are emitted via `serde_json`'s formatter, which
+//! matches RFC 8785 for the integer values our vocabulary admits; the full
+//! ECMAScript number-to-string algorithm is only needed if floating-point
+//! payloads are ever admitted.
 
 use serde_json::Value;
 
@@ -44,7 +46,7 @@ fn write_value(out: &mut String, value: &Value) {
         }
         Value::Object(map) => {
             let mut keys: Vec<&String> = map.keys().collect();
-            keys.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
+            keys.sort_by(|a, b| a.encode_utf16().cmp(b.encode_utf16()));
             out.push('{');
             for (i, key) in keys.iter().enumerate() {
                 if i > 0 {
@@ -94,5 +96,18 @@ mod tests {
     fn escapes_strings() {
         let v = json!({ "k": "a\"b\nc" });
         assert_eq!(canonicalize(&v), r#"{"k":"a\"b\nc"}"#);
+    }
+
+    /// RFC 8785 §3.2.3: keys sort by UTF-16 code units. A supplementary-plane
+    /// key (😀, surrogate pair D83D DE00) must sort BEFORE U+FF61 (｡) — the
+    /// opposite of UTF-8 byte order, where 😀 (F0 9F …) follows ｡ (EF BD A1).
+    #[test]
+    fn keys_sort_by_utf16_code_units_not_utf8_bytes() {
+        let v = json!({ "\u{ff61}": 1, "😀": 2 });
+        assert_eq!(
+            canonicalize(&v),
+            "{\"😀\":2,\"\u{ff61}\":1}",
+            "supplementary-plane keys must sort by UTF-16 code units"
+        );
     }
 }

--- a/atomic-canonical/src/lib.rs
+++ b/atomic-canonical/src/lib.rs
@@ -28,8 +28,8 @@
 //! **non-production dev identities**. Key-at-rest encryption must land before
 //! any attested node is trusted in a real/shared setting.
 
-pub mod did;
 pub mod context;
+pub mod did;
 pub mod directive;
 pub mod error;
 pub mod gate;
@@ -47,9 +47,7 @@ pub mod vocab;
 pub use error::{CanonicalError, Result};
 pub use gate::{validate_intent, validate_memory, ValidationReport, Violation};
 pub use memory::MemoryNode;
-pub use node::{
-    AcceptanceCriterion, CanonicalNode, Constraint, Proof, Ref, ScopeItem, Task,
-};
+pub use node::{AcceptanceCriterion, CanonicalNode, Constraint, Proof, Ref, ScopeItem, Task};
 pub use render::{render, render_memory, Target};
 
 use atomic_identity::identity::Identity;
@@ -70,7 +68,10 @@ pub fn lift_and_attest(
 }
 
 /// Verify an attested node's content hash and signature against a public key.
-pub fn verify(node: &CanonicalNode, public_key: &atomic_identity::keypair::PublicKey) -> Result<()> {
+pub fn verify(
+    node: &CanonicalNode,
+    public_key: &atomic_identity::keypair::PublicKey,
+) -> Result<()> {
     proof::verify(node, public_key)
 }
 

--- a/atomic-canonical/src/lib.rs
+++ b/atomic-canonical/src/lib.rs
@@ -29,6 +29,7 @@
 //! any attested node is trusted in a real/shared setting.
 
 pub mod did;
+pub mod context;
 pub mod directive;
 pub mod error;
 pub mod gate;
@@ -38,6 +39,7 @@ pub mod lift;
 pub mod memory;
 pub mod node;
 pub mod proof;
+pub mod prov;
 pub mod render;
 pub mod vocab;
 

--- a/atomic-canonical/src/lib.rs
+++ b/atomic-canonical/src/lib.rs
@@ -41,6 +41,7 @@ pub mod node;
 pub mod proof;
 pub mod prov;
 pub mod render;
+pub mod shacl;
 pub mod vocab;
 
 pub use error::{CanonicalError, Result};

--- a/atomic-canonical/src/lift.rs
+++ b/atomic-canonical/src/lift.rs
@@ -37,6 +37,7 @@ pub(crate) const LIFTED_INTENT_DIRECTIVES: &[&str] = &[
 
 /// Lift an intent from its frontmatter spine and markdown body.
 pub fn lift_intent(frontmatter: &Map<String, Value>, body: &str) -> Result<CanonicalNode> {
+    directive::check_embedded_directives(body)?;
     let human_key = require_str(frontmatter, "id")?;
     let uid = opt_str(frontmatter, "uid").unwrap_or_else(|| slug(&human_key));
     let node_id = format!("urn:atomic:intent:{uid}");

--- a/atomic-canonical/src/lift.rs
+++ b/atomic-canonical/src/lift.rs
@@ -57,6 +57,14 @@ pub fn lift_intent(frontmatter: &Map<String, Value>, body: &str) -> Result<Canon
     let mut constraint_n = 0usize;
 
     for d in &directives {
+        // Inline (and nested-leaf) `:ref` children of any container sit on the
+        // intent's dependency chain, same rules as a top-level `:::ref`. The
+        // container prose keeps the inline mention verbatim.
+        for child in &d.children {
+            if child.name == "ref" {
+                deps.push(lift_ref(child)?);
+            }
+        }
         match d.name.as_str() {
             "why" => {
                 // Single authoring site: first `:::why` wins; the reason is
@@ -375,6 +383,24 @@ Do not touch the global keyboard handler.
         // No @type/@id emitted when the directive carries no #id.
         assert!(node.depends_on[0].type_.is_none());
         assert!(node.depends_on[0].id.is_none());
+    }
+
+    #[test]
+    fn lifts_inline_ref_from_why_prose() {
+        let body = ":::why\nLocal-only per :ref[the storage constraint]{to=urn:atomic:memory:01J8ZC edge=depends}, not a profile system.\n:::";
+        let node = lift_intent(&fm(), body).unwrap();
+        // The reason keeps the inline mention verbatim…
+        assert!(node.why.as_deref().unwrap().contains(":ref[the storage constraint]"));
+        // …and the edge lands on the dependency chain, typed and validated.
+        assert_eq!(node.depends_on.len(), 1);
+        assert_eq!(node.depends_on[0].to, "urn:atomic:memory:01J8ZC");
+        assert_eq!(node.depends_on[0].edge, "depends");
+    }
+
+    #[test]
+    fn inline_ref_with_bad_edge_is_error() {
+        let body = ":::why\nsee :ref[x]{to=urn:atomic:memory:1 edge=verifiedBy}\n:::";
+        assert!(lift_intent(&fm(), body).is_err());
     }
 
     #[test]

--- a/atomic-canonical/src/lift.rs
+++ b/atomic-canonical/src/lift.rs
@@ -138,10 +138,9 @@ pub fn lift_intent(frontmatter: &Map<String, Value>, body: &str) -> Result<Canon
 }
 
 fn lift_ac(d: &Directive, human_key: &str, n: usize) -> Result<AcceptanceCriterion> {
-    let local = d
-        .id
-        .clone()
-        .unwrap_or_else(|| format!("{}-ac-{n}", slug(human_key)));
+    let local =
+        d.id.clone()
+            .unwrap_or_else(|| format!("{}-ac-{n}", slug(human_key)));
     Ok(AcceptanceCriterion {
         type_: NodeType::AcceptanceCriterion.as_str().to_string(),
         id: as_urn("ac", &local),
@@ -153,10 +152,9 @@ fn lift_ac(d: &Directive, human_key: &str, n: usize) -> Result<AcceptanceCriteri
 }
 
 fn lift_task(d: &Directive, human_key: &str, n: usize) -> Task {
-    let local = d
-        .id
-        .clone()
-        .unwrap_or_else(|| format!("{}-{n}", slug(human_key)));
+    let local =
+        d.id.clone()
+            .unwrap_or_else(|| format!("{}-{n}", slug(human_key)));
     let mut touches: Vec<String> = Vec::new();
     if let Some(f) = d.attr("touchesFile") {
         touches.push(f.to_string());
@@ -186,10 +184,9 @@ fn lift_task(d: &Directive, human_key: &str, n: usize) -> Task {
 /// `kind` is "scope-in" or "scope-out" and drives the generated id slug.
 /// Prose body is the unconstrained narrative (never graded).
 fn lift_scope(d: &Directive, human_key: &str, kind: &str, n: usize) -> ScopeItem {
-    let local = d
-        .id
-        .clone()
-        .unwrap_or_else(|| format!("{}-{kind}-{n}", slug(human_key)));
+    let local =
+        d.id.clone()
+            .unwrap_or_else(|| format!("{}-{kind}-{n}", slug(human_key)));
     ScopeItem {
         type_: NodeType::ScopeItem.as_str().to_string(),
         id: as_urn("scope", &local),
@@ -199,10 +196,9 @@ fn lift_scope(d: &Directive, human_key: &str, kind: &str, n: usize) -> ScopeItem
 
 /// Lift a `:::constraint` container into a `Constraint`.
 fn lift_constraint(d: &Directive, human_key: &str, n: usize) -> Constraint {
-    let local = d
-        .id
-        .clone()
-        .unwrap_or_else(|| format!("{}-constraint-{n}", slug(human_key)));
+    let local =
+        d.id.clone()
+            .unwrap_or_else(|| format!("{}-constraint-{n}", slug(human_key)));
     Constraint {
         type_: NodeType::Constraint.as_str().to_string(),
         id: as_urn("constraint", &local),
@@ -269,9 +265,11 @@ fn str_array(fm: &Map<String, Value>, key: &str) -> Vec<String> {
             .iter()
             .filter_map(|v| v.as_str().map(str::to_string))
             .collect(),
-        Some(Value::String(s)) if !s.is_empty() => {
-            s.split(',').map(|p| p.trim().to_string()).filter(|p| !p.is_empty()).collect()
-        }
+        Some(Value::String(s)) if !s.is_empty() => s
+            .split(',')
+            .map(|p| p.trim().to_string())
+            .filter(|p| !p.is_empty())
+            .collect(),
         _ => Vec::new(),
     }
 }
@@ -283,7 +281,10 @@ pub fn parse_markdown(doc: &str) -> Result<(Map<String, Value>, String)> {
     // Normalize CRLF so a Windows-authored file parses identically to LF —
     // otherwise the "---\n" prefix match fails and the whole doc is silently
     // treated as body with empty frontmatter.
-    let normalized = doc.strip_prefix('\u{feff}').unwrap_or(doc).replace("\r\n", "\n");
+    let normalized = doc
+        .strip_prefix('\u{feff}')
+        .unwrap_or(doc)
+        .replace("\r\n", "\n");
     let doc = normalized.as_str();
     let rest = match doc.strip_prefix("---\n") {
         Some(r) => r,
@@ -366,10 +367,22 @@ Do not touch the global keyboard handler.
         assert_eq!(node.has_constraint.len(), 2);
 
         // Ids are well-formed urns generated from the slug + ordinal.
-        assert_eq!(node.has_scope_in[0].id, "urn:atomic:scope:word-5-scope-in-1");
-        assert_eq!(node.has_scope_out[0].id, "urn:atomic:scope:word-5-scope-out-1");
-        assert_eq!(node.has_constraint[0].id, "urn:atomic:constraint:word-5-constraint-1");
-        assert_eq!(node.has_constraint[1].id, "urn:atomic:constraint:word-5-constraint-2");
+        assert_eq!(
+            node.has_scope_in[0].id,
+            "urn:atomic:scope:word-5-scope-in-1"
+        );
+        assert_eq!(
+            node.has_scope_out[0].id,
+            "urn:atomic:scope:word-5-scope-out-1"
+        );
+        assert_eq!(
+            node.has_constraint[0].id,
+            "urn:atomic:constraint:word-5-constraint-1"
+        );
+        assert_eq!(
+            node.has_constraint[1].id,
+            "urn:atomic:constraint:word-5-constraint-2"
+        );
         assert!(node.has_scope_in[0].text.contains("src/App.tsx"));
     }
 
@@ -390,7 +403,11 @@ Do not touch the global keyboard handler.
         let body = ":::why\nLocal-only per :ref[the storage constraint]{to=urn:atomic:memory:01J8ZC edge=depends}, not a profile system.\n:::";
         let node = lift_intent(&fm(), body).unwrap();
         // The reason keeps the inline mention verbatim…
-        assert!(node.why.as_deref().unwrap().contains(":ref[the storage constraint]"));
+        assert!(node
+            .why
+            .as_deref()
+            .unwrap()
+            .contains(":ref[the storage constraint]"));
         // …and the edge lands on the dependency chain, typed and validated.
         assert_eq!(node.depends_on.len(), 1);
         assert_eq!(node.depends_on[0].to, "urn:atomic:memory:01J8ZC");

--- a/atomic-canonical/src/memory.rs
+++ b/atomic-canonical/src/memory.rs
@@ -64,12 +64,24 @@ pub struct MemoryNode {
     // no empty JSON-LD keys leak into the hash.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub supersedes: Option<String>,
-    #[serde(rename = "previousRevision", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "previousRevision",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub previous_revision: Option<String>,
 
-    #[serde(rename = "contentHash", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "contentHash",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub content_hash: Option<String>,
-    #[serde(rename = "attributedTo", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "attributedTo",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub attributed_to: Option<String>,
     #[serde(rename = "createdAt")]
     pub created_at: String,
@@ -120,10 +132,9 @@ pub fn lift_memory(frontmatter: &Map<String, Value>, body: &str) -> Result<Memor
         .ok_or_else(|| CanonicalError::Lift("memory frontmatter missing 'uid' (or 'id')".into()))?;
     let node_id = as_memory_urn(&uid);
 
-    let memory_kind = require_str(frontmatter, "memoryKind")
-        .or_else(|_| require_str(frontmatter, "kind"))?;
-    let status =
-        opt_str(frontmatter, "status").unwrap_or_else(|| "active".to_string());
+    let memory_kind =
+        require_str(frontmatter, "memoryKind").or_else(|_| require_str(frontmatter, "kind"))?;
+    let status = opt_str(frontmatter, "status").unwrap_or_else(|| "active".to_string());
 
     // Single authoring site: the first `:::memory` container's body is
     // authoritative; the surrounding prose is ignored. Only when no container
@@ -209,7 +220,8 @@ fn as_memory_urn(local: &str) -> String {
 }
 
 fn require_str(fm: &Map<String, Value>, key: &str) -> Result<String> {
-    opt_str(fm, key).ok_or_else(|| CanonicalError::Lift(format!("memory frontmatter missing '{key}'")))
+    opt_str(fm, key)
+        .ok_or_else(|| CanonicalError::Lift(format!("memory frontmatter missing '{key}'")))
 }
 
 fn opt_str(fm: &Map<String, Value>, key: &str) -> Option<String> {

--- a/atomic-canonical/src/memory.rs
+++ b/atomic-canonical/src/memory.rs
@@ -127,6 +127,7 @@ impl MemoryNode {
 /// container directive if present (single authoring site), else falls back to
 /// the whole trimmed body.
 pub fn lift_memory(frontmatter: &Map<String, Value>, body: &str) -> Result<MemoryNode> {
+    crate::directive::check_embedded_directives(body)?;
     let uid = opt_str(frontmatter, "uid")
         .or_else(|| opt_str(frontmatter, "id"))
         .ok_or_else(|| CanonicalError::Lift("memory frontmatter missing 'uid' (or 'id')".into()))?;

--- a/atomic-canonical/src/node.rs
+++ b/atomic-canonical/src/node.rs
@@ -26,7 +26,11 @@ pub struct AcceptanceCriterion {
     pub text: String,
     #[serde(rename = "acStatus")]
     pub ac_status: String,
-    #[serde(rename = "verifiedBy", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "verifiedBy",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub verified_by: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub evidence: Option<String>,
@@ -128,7 +132,11 @@ pub struct CanonicalNode {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub view: Option<String>,
 
-    #[serde(rename = "motivatedBy", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "motivatedBy",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub motivated_by: Option<String>,
     #[serde(rename = "informedBy", default, skip_serializing_if = "Vec::is_empty")]
     pub informed_by: Vec<String>,
@@ -148,7 +156,11 @@ pub struct CanonicalNode {
     pub has_scope_in: Vec<ScopeItem>,
     #[serde(rename = "hasScopeOut", default, skip_serializing_if = "Vec::is_empty")]
     pub has_scope_out: Vec<ScopeItem>,
-    #[serde(rename = "hasConstraint", default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        rename = "hasConstraint",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub has_constraint: Vec<Constraint>,
     #[serde(rename = "dependsOn", default, skip_serializing_if = "Vec::is_empty")]
     pub depends_on: Vec<Ref>,
@@ -157,9 +169,17 @@ pub struct CanonicalNode {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub why: Option<String>,
 
-    #[serde(rename = "contentHash", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "contentHash",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub content_hash: Option<String>,
-    #[serde(rename = "attributedTo", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "attributedTo",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub attributed_to: Option<String>,
     #[serde(rename = "createdAt")]
     pub created_at: String,

--- a/atomic-canonical/src/proof.rs
+++ b/atomic-canonical/src/proof.rs
@@ -237,16 +237,29 @@ mod tests {
 
         // The generic path filled the excluded-later fields.
         let obj = attested.as_object().unwrap();
-        assert!(obj.get(PROP_CONTENT_HASH).unwrap().as_str().unwrap().starts_with("blake3:"));
+        assert!(obj
+            .get(PROP_CONTENT_HASH)
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .starts_with("blake3:"));
         assert!(obj.get(PROP_PROOF).is_some());
-        assert!(obj.get(PROP_ATTRIBUTED_TO).unwrap().as_str().unwrap().starts_with("did:atomic:"));
+        assert!(obj
+            .get(PROP_ATTRIBUTED_TO)
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .starts_with("did:atomic:"));
 
         // Verifies with the right key, independent of CanonicalNode.
         verify_value(&attested, &kp.public).expect("generic verify should succeed");
 
         // Tamper a signed field → the stored contentHash no longer matches.
         let mut tampered = attested.clone();
-        tampered.as_object_mut().unwrap().insert("status".into(), Value::String("done".into()));
+        tampered
+            .as_object_mut()
+            .unwrap()
+            .insert("status".into(), Value::String("done".into()));
         let err = verify_value(&tampered, &kp.public).unwrap_err();
         assert!(
             matches!(err, CanonicalError::HashMismatch { .. }),

--- a/atomic-canonical/src/proof.rs
+++ b/atomic-canonical/src/proof.rs
@@ -5,10 +5,8 @@
 //! and sign over the same canonical bytes the content hash uses, via the one
 //! `jcs` entry point — so hash and signature can never disagree.
 //!
-//! `proofValue` is a multibase string. We use base32-upper (`B`) via
-//! `data-encoding` (already in-tree) rather than base58btc (`z`) to avoid an
-//! extra dependency; it is a valid multibase encoding and the prefix is
-//! swappable when a base58 dependency is admitted.
+//! `proofValue` is a multibase string in base58btc (`z`), as the
+//! `eddsa-jcs-2022` cryptosuite specifies.
 
 use atomic_identity::identity::Identity;
 use atomic_identity::keypair::{KeyPair, PublicKey};
@@ -25,8 +23,8 @@ use crate::node::{CanonicalNode, Proof};
 pub const CRYPTOSUITE: &str = "eddsa-jcs-2022";
 pub const PROOF_TYPE: &str = "DataIntegrityProof";
 pub const PROOF_PURPOSE: &str = "assertionMethod";
-/// Multibase prefix for base32-upper, no padding.
-const MULTIBASE_BASE32_UPPER: char = 'B';
+/// Multibase prefix for base58btc — the encoding `eddsa-jcs-2022` specifies.
+const MULTIBASE_BASE58_BTC: char = 'z';
 
 /// Canonical property names. Hardcoded because the closed vocabulary
 /// standardizes them across *all* node types (Intent, Memory, and any future
@@ -188,25 +186,25 @@ pub fn verify_memory(node: &MemoryNode, public_key: &PublicKey) -> Result<()> {
 
 fn encode_proof_value(signature: &Signature) -> String {
     let mut s = String::new();
-    s.push(MULTIBASE_BASE32_UPPER);
-    s.push_str(&data_encoding::BASE32_NOPAD.encode(signature.as_bytes()));
+    s.push(MULTIBASE_BASE58_BTC);
+    s.push_str(&bs58::encode(signature.as_bytes()).into_string());
     s
 }
 
 fn decode_proof_value(value: &str) -> Result<Signature> {
     let mut chars = value.chars();
     match chars.next() {
-        Some(MULTIBASE_BASE32_UPPER) => {}
+        Some(MULTIBASE_BASE58_BTC) => {}
         _ => {
             return Err(CanonicalError::Proof(format!(
                 "unsupported multibase prefix in proofValue: {value:.4}…"
             )))
         }
     }
-    let body = &value[MULTIBASE_BASE32_UPPER.len_utf8()..];
-    let bytes = data_encoding::BASE32_NOPAD
-        .decode(body.as_bytes())
-        .map_err(|e| CanonicalError::Proof(format!("bad base32 proofValue: {e}")))?;
+    let body = &value[MULTIBASE_BASE58_BTC.len_utf8()..];
+    let bytes = bs58::decode(body)
+        .into_vec()
+        .map_err(|e| CanonicalError::Proof(format!("bad base58btc proofValue: {e}")))?;
     Signature::from_slice(&bytes).map_err(|e| CanonicalError::Proof(e.to_string()))
 }
 

--- a/atomic-canonical/src/prov.rs
+++ b/atomic-canonical/src/prov.rs
@@ -93,7 +93,10 @@ pub fn provenance_graph(input: &ProvenanceInput) -> Value {
     if let Some(ended) = &input.ended_at {
         activity.insert("endedAtTime".into(), json!(ended));
     }
-    activity.insert("wasAssociatedWith".into(), json!(agent_iri(&input.agent_name)));
+    activity.insert(
+        "wasAssociatedWith".into(),
+        json!(agent_iri(&input.agent_name)),
+    );
     if !input.used.is_empty() {
         activity.insert("used".into(), json!(input.used));
     }
@@ -217,7 +220,10 @@ mod tests {
 
         let activity = find(&g, "urn:atomic:activity:session:inner-1");
         assert_eq!(activity["@type"], "Activity");
-        assert_eq!(activity["wasAssociatedWith"], "urn:atomic:agent:claude-code");
+        assert_eq!(
+            activity["wasAssociatedWith"],
+            "urn:atomic:agent:claude-code"
+        );
         assert_eq!(activity["generated"][0], "urn:atomic:change:W5GSLAVO");
         assert_eq!(activity["used"][0], "urn:atomic:intent:019efe85");
         assert_eq!(activity["partOfRun"], "urn:atomic:run:run-1");
@@ -267,7 +273,11 @@ mod tests {
         // …but the orchestrator's person edge is absent, not invented.
         let orchestrator = find(&g, "urn:atomic:agent:sherpa");
         assert!(orchestrator.get("actedOnBehalfOf").is_none());
-        assert!(g["@graph"].as_array().unwrap().iter().all(|n| n["@type"] != "Person"));
+        assert!(g["@graph"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|n| n["@type"] != "Person"));
     }
 
     #[test]

--- a/atomic-canonical/src/prov.rs
+++ b/atomic-canonical/src/prov.rs
@@ -1,0 +1,285 @@
+//! W3C PROV projection — the provenance graph as PROV-DM, serialized with
+//! PROV-O vocabulary in JSON-LD.
+//!
+//! Per "Recording the Why": every agent action is a `prov:Activity`,
+//! associated with a `prov:SoftwareAgent` that `actedOnBehalfOf` an
+//! orchestrator and ultimately a `prov:Person`. The graph for a session is a
+//! *named graph* — one addressable unit you can hand to an auditor whole.
+//!
+//! PROV-DM mapping:
+//! - a recorded agent **session** is a `prov:Activity` (started/ended times,
+//!   `prov:used` inputs, `prov:generated` change entities,
+//!   `prov:wasAssociatedWith` its agent);
+//! - the **executor** is a `prov:SoftwareAgent`;
+//! - a **managed run** (Sherpa's `lifecycle begin`, carried on the session as
+//!   the `managed_run` stamp) is itself a `prov:Activity` associated with the
+//!   orchestrator agent, and the delegation chain is expressed with
+//!   `prov:actedOnBehalfOf` (Agent → Agent): executor → orchestrator → person;
+//! - the **person** is a `prov:Person` identified by DID.
+//!
+//! `atom:partOfRun` links the session activity to the run activity — PROV-DM
+//! has no standard sub-activity relation, so this stays a namespaced term
+//! rather than overloading `prov:wasInformedBy` (which means communication,
+//! not containment).
+//!
+//! This module is a projection (a compile target): it takes plain input data
+//! — in production, an `AgentSession` file — and emits the JSON-LD value.
+//! Nothing here is hand-authored.
+
+use serde_json::{json, Map, Value};
+
+use crate::node::CONTEXT_URL;
+
+/// The managed-run stamp carried by a session recorded under an orchestrator
+/// (mirrors `atomic-agent`'s `ManagedRunStamp`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedRunInput {
+    pub run_id: String,
+    pub owner_agent: String,
+    pub owner_session_id: String,
+    pub work_item_id: Option<String>,
+}
+
+/// Everything the projection needs about one recorded session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProvenanceInput {
+    pub session_id: String,
+    pub agent_name: String,
+    pub agent_display_name: String,
+    pub agent_vendor: String,
+    pub model: String,
+    /// RFC 3339 timestamps.
+    pub started_at: String,
+    pub ended_at: Option<String>,
+    /// The view the session recorded onto.
+    pub view: Option<String>,
+    /// Base32 change hashes recorded by the session (become
+    /// `urn:atomic:change:<hash>` entities).
+    pub change_hashes: Vec<String>,
+    /// Inputs the activity `prov:used` (intent/memory URNs), when known.
+    pub used: Vec<String>,
+    pub managed_run: Option<ManagedRunInput>,
+    /// The person the work was ultimately performed for, as a DID.
+    pub person: Option<String>,
+}
+
+/// IRI builders — one place so the graph and its consumers cannot drift.
+pub fn session_activity_iri(session_id: &str) -> String {
+    format!("urn:atomic:activity:session:{session_id}")
+}
+pub fn agent_iri(agent_name: &str) -> String {
+    format!("urn:atomic:agent:{agent_name}")
+}
+pub fn run_activity_iri(run_id: &str) -> String {
+    format!("urn:atomic:run:{run_id}")
+}
+pub fn change_iri(hash: &str) -> String {
+    format!("urn:atomic:change:{hash}")
+}
+pub fn graph_iri(session_id: &str) -> String {
+    format!("urn:atomic:provgraph:session:{session_id}")
+}
+
+/// Project a session into its PROV-O named graph.
+pub fn provenance_graph(input: &ProvenanceInput) -> Value {
+    let mut graph: Vec<Value> = Vec::new();
+
+    // The session activity.
+    let mut activity = Map::new();
+    activity.insert("@type".into(), json!("Activity"));
+    activity.insert("@id".into(), json!(session_activity_iri(&input.session_id)));
+    activity.insert("sessionId".into(), json!(input.session_id));
+    activity.insert("startedAtTime".into(), json!(input.started_at));
+    if let Some(ended) = &input.ended_at {
+        activity.insert("endedAtTime".into(), json!(ended));
+    }
+    activity.insert("wasAssociatedWith".into(), json!(agent_iri(&input.agent_name)));
+    if !input.used.is_empty() {
+        activity.insert("used".into(), json!(input.used));
+    }
+    if !input.change_hashes.is_empty() {
+        let changes: Vec<String> = input.change_hashes.iter().map(|h| change_iri(h)).collect();
+        activity.insert("generated".into(), json!(changes));
+    }
+    if let Some(view) = &input.view {
+        activity.insert("view".into(), json!(view));
+    }
+    if let Some(run) = &input.managed_run {
+        activity.insert("partOfRun".into(), json!(run_activity_iri(&run.run_id)));
+    }
+    graph.push(Value::Object(activity));
+
+    // The executor agent, with its delegation edge.
+    let mut executor = Map::new();
+    executor.insert("@type".into(), json!("SoftwareAgent"));
+    executor.insert("@id".into(), json!(agent_iri(&input.agent_name)));
+    executor.insert("agentName".into(), json!(input.agent_name));
+    if !input.agent_display_name.is_empty() {
+        executor.insert("agentDisplayName".into(), json!(input.agent_display_name));
+    }
+    if !input.agent_vendor.is_empty() {
+        executor.insert("vendor".into(), json!(input.agent_vendor));
+    }
+    if !input.model.is_empty() {
+        executor.insert("model".into(), json!(input.model));
+    }
+    match (&input.managed_run, &input.person) {
+        // Managed: executor acted on behalf of the orchestrator.
+        (Some(run), _) => {
+            executor.insert("actedOnBehalfOf".into(), json!(agent_iri(&run.owner_agent)));
+        }
+        // Direct with a known person: executor acted on behalf of them.
+        (None, Some(person)) => {
+            executor.insert("actedOnBehalfOf".into(), json!(person));
+        }
+        (None, None) => {}
+    }
+    graph.push(Value::Object(executor));
+
+    // The managed run: an orchestration activity + the orchestrator agent.
+    if let Some(run) = &input.managed_run {
+        let mut run_activity = Map::new();
+        run_activity.insert("@type".into(), json!("Activity"));
+        run_activity.insert("@id".into(), json!(run_activity_iri(&run.run_id)));
+        run_activity.insert("runId".into(), json!(run.run_id));
+        run_activity.insert("ownerSessionId".into(), json!(run.owner_session_id));
+        run_activity.insert(
+            "wasAssociatedWith".into(),
+            json!(agent_iri(&run.owner_agent)),
+        );
+        if let Some(work_item) = &run.work_item_id {
+            run_activity.insert("workItem".into(), json!(work_item));
+        }
+        graph.push(Value::Object(run_activity));
+
+        let mut owner = Map::new();
+        owner.insert("@type".into(), json!("SoftwareAgent"));
+        owner.insert("@id".into(), json!(agent_iri(&run.owner_agent)));
+        owner.insert("agentName".into(), json!(run.owner_agent));
+        if let Some(person) = &input.person {
+            owner.insert("actedOnBehalfOf".into(), json!(person));
+        }
+        graph.push(Value::Object(owner));
+    }
+
+    // The person.
+    if let Some(person) = &input.person {
+        graph.push(json!({ "@type": "Person", "@id": person }));
+    }
+
+    json!({
+        "@context": CONTEXT_URL,
+        "@id": graph_iri(&input.session_id),
+        "@graph": graph,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn managed_input() -> ProvenanceInput {
+        ProvenanceInput {
+            session_id: "inner-1".into(),
+            agent_name: "claude-code".into(),
+            agent_display_name: "Claude Code".into(),
+            agent_vendor: "anthropic".into(),
+            model: "claude-fable-5".into(),
+            started_at: "2026-07-01T22:11:00Z".into(),
+            ended_at: Some("2026-07-01T22:14:00Z".into()),
+            view: Some("sherpa-run-x".into()),
+            change_hashes: vec!["W5GSLAVO".into()],
+            used: vec!["urn:atomic:intent:019efe85".into()],
+            managed_run: Some(ManagedRunInput {
+                run_id: "run-1".into(),
+                owner_agent: "sherpa".into(),
+                owner_session_id: "sherpa-s1".into(),
+                work_item_id: Some("NONA-7".into()),
+            }),
+            person: Some("did:atomic:lee".into()),
+        }
+    }
+
+    fn find<'a>(graph: &'a Value, id: &str) -> &'a Value {
+        graph["@graph"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|n| n["@id"] == id)
+            .unwrap_or_else(|| panic!("no node {id}"))
+    }
+
+    #[test]
+    fn managed_session_projects_full_delegation_chain() {
+        let g = provenance_graph(&managed_input());
+
+        assert_eq!(g["@id"], "urn:atomic:provgraph:session:inner-1");
+
+        let activity = find(&g, "urn:atomic:activity:session:inner-1");
+        assert_eq!(activity["@type"], "Activity");
+        assert_eq!(activity["wasAssociatedWith"], "urn:atomic:agent:claude-code");
+        assert_eq!(activity["generated"][0], "urn:atomic:change:W5GSLAVO");
+        assert_eq!(activity["used"][0], "urn:atomic:intent:019efe85");
+        assert_eq!(activity["partOfRun"], "urn:atomic:run:run-1");
+        assert_eq!(activity["startedAtTime"], "2026-07-01T22:11:00Z");
+
+        // The PROV delegation chain: executor → orchestrator → person.
+        let executor = find(&g, "urn:atomic:agent:claude-code");
+        assert_eq!(executor["@type"], "SoftwareAgent");
+        assert_eq!(executor["actedOnBehalfOf"], "urn:atomic:agent:sherpa");
+
+        let orchestrator = find(&g, "urn:atomic:agent:sherpa");
+        assert_eq!(orchestrator["actedOnBehalfOf"], "did:atomic:lee");
+
+        let run = find(&g, "urn:atomic:run:run-1");
+        assert_eq!(run["@type"], "Activity");
+        assert_eq!(run["wasAssociatedWith"], "urn:atomic:agent:sherpa");
+        assert_eq!(run["workItem"], "NONA-7");
+
+        let person = find(&g, "did:atomic:lee");
+        assert_eq!(person["@type"], "Person");
+    }
+
+    #[test]
+    fn direct_session_delegates_straight_to_person() {
+        let mut input = managed_input();
+        input.managed_run = None;
+        let g = provenance_graph(&input);
+
+        let executor = find(&g, "urn:atomic:agent:claude-code");
+        assert_eq!(executor["actedOnBehalfOf"], "did:atomic:lee");
+        assert!(g["@graph"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|n| n["@id"] != "urn:atomic:agent:sherpa"));
+    }
+
+    #[test]
+    fn unknown_person_omits_delegation_not_fakes_it() {
+        let mut input = managed_input();
+        input.person = None;
+        let g = provenance_graph(&input);
+
+        // Executor still delegates to the orchestrator (that edge is known)…
+        let executor = find(&g, "urn:atomic:agent:claude-code");
+        assert_eq!(executor["actedOnBehalfOf"], "urn:atomic:agent:sherpa");
+        // …but the orchestrator's person edge is absent, not invented.
+        let orchestrator = find(&g, "urn:atomic:agent:sherpa");
+        assert!(orchestrator.get("actedOnBehalfOf").is_none());
+        assert!(g["@graph"].as_array().unwrap().iter().all(|n| n["@type"] != "Person"));
+    }
+
+    #[test]
+    fn empty_collections_are_omitted() {
+        let mut input = managed_input();
+        input.change_hashes.clear();
+        input.used.clear();
+        input.ended_at = None;
+        let g = provenance_graph(&input);
+        let activity = find(&g, "urn:atomic:activity:session:inner-1");
+        assert!(activity.get("generated").is_none());
+        assert!(activity.get("used").is_none());
+        assert!(activity.get("endedAtTime").is_none());
+    }
+}

--- a/atomic-canonical/src/shacl.rs
+++ b/atomic-canonical/src/shacl.rs
@@ -17,7 +17,6 @@
 //! Engine resolution: `ATOMIC_PYSHACL` env var, else `pyshacl` on PATH.
 //! Callers use [`is_available`] to decide whether tier 2 can run here.
 
-use std::io::Write;
 use std::process::{Command, Stdio};
 
 use serde_json::Value;

--- a/atomic-canonical/src/shacl.rs
+++ b/atomic-canonical/src/shacl.rs
@@ -123,9 +123,7 @@ mod tests {
         if is_available() {
             true
         } else {
-            eprintln!(
-                "shacl tests SKIPPED — no pyshacl (set ATOMIC_PYSHACL or install pyshacl)"
-            );
+            eprintln!("shacl tests SKIPPED — no pyshacl (set ATOMIC_PYSHACL or install pyshacl)");
             false
         }
     }
@@ -150,7 +148,11 @@ mod tests {
             "status=met verifiedBy=did:atomic:lee evidence=urn:atomic:change:01J8ZE",
         );
         let report = validate_value(&value).unwrap();
-        assert!(report.conforms, "expected conformance, got:\n{}", report.report);
+        assert!(
+            report.conforms,
+            "expected conformance, got:\n{}",
+            report.report
+        );
     }
 
     #[test]
@@ -162,7 +164,10 @@ mod tests {
         // a bare checked box cannot pass the gate.
         let value = attested_intent("status=met");
         let report = validate_value(&value).unwrap();
-        assert!(!report.conforms, "a met AC without evidence must not conform");
+        assert!(
+            !report.conforms,
+            "a met AC without evidence must not conform"
+        );
         assert!(
             report.report.contains("verifiedBy and evidence"),
             "violation must come from the met-needs-evidence constraint:\n{}",
@@ -195,7 +200,11 @@ mod tests {
         let mut value = crate::proof::attest_memory(node, &id, &kp).to_value();
 
         let report = validate_value(&value).unwrap();
-        assert!(report.conforms, "valid memory must conform:\n{}", report.report);
+        assert!(
+            report.conforms,
+            "valid memory must conform:\n{}",
+            report.report
+        );
 
         value["memoryKind"] = serde_json::json!("vibe");
         let report = validate_value(&value).unwrap();
@@ -229,7 +238,11 @@ mod tests {
             person: Some("did:atomic:lee".into()),
         });
         let report = validate_value(&g).unwrap();
-        assert!(report.conforms, "PROV graph must conform:\n{}", report.report);
+        assert!(
+            report.conforms,
+            "PROV graph must conform:\n{}",
+            report.report
+        );
     }
 
     #[test]
@@ -247,7 +260,14 @@ mod tests {
             }]
         });
         let report = validate_value(&g).unwrap();
-        assert!(!report.conforms, "an activity with no agent must not conform");
-        assert!(report.report.contains("associated with an agent"), "{}", report.report);
+        assert!(
+            !report.conforms,
+            "an activity with no agent must not conform"
+        );
+        assert!(
+            report.report.contains("associated with an agent"),
+            "{}",
+            report.report
+        );
     }
 }

--- a/atomic-canonical/src/shacl.rs
+++ b/atomic-canonical/src/shacl.rs
@@ -1,0 +1,253 @@
+//! Tier-2 formal validation: real W3C SHACL over the JSON-LD projection.
+//!
+//! The Rust gate (`gate.rs`) is tier 1 — fast, in-process, always on, the
+//! agent inner loop's forcing function. This module is tier 2: it feeds the
+//! node (with the `@context` inlined so the document is self-contained) and
+//! `shapes/atomic-shapes.ttl` to **pyshacl**, a conformant SHACL engine over
+//! rdflib. Per the team decision, we do not hand-roll a SHACL evaluator and
+//! we do not bet on immature Rust SHACL crates — the formal check runs where
+//! a real engine exists (status transitions, CI, circuit-breaker stages),
+//! not in the interactive inner loop.
+//!
+//! Because pyshacl must first parse the document as JSON-LD to RDF, every
+//! tier-2 run doubles as a JSON-LD conformance check of our projection: a
+//! broken context or an unmapped key surfaces as missing triples and a
+//! failed shape, not a silent pass.
+//!
+//! Engine resolution: `ATOMIC_PYSHACL` env var, else `pyshacl` on PATH.
+//! Callers use [`is_available`] to decide whether tier 2 can run here.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use serde_json::Value;
+
+use crate::context;
+use crate::error::{CanonicalError, Result};
+
+/// The SHACL shapes graph (Turtle), embedded at compile time.
+pub const SHAPES_TURTLE: &str = include_str!("../shapes/atomic-shapes.ttl");
+
+/// The result of a tier-2 SHACL run.
+#[derive(Debug, Clone)]
+pub struct ShaclReport {
+    /// `sh:conforms` — the document satisfies every shape.
+    pub conforms: bool,
+    /// The engine's human-readable validation report (violations, messages,
+    /// source shapes). Empty violations section when conforming.
+    pub report: String,
+}
+
+/// Resolve the pyshacl executable: `ATOMIC_PYSHACL`, else `pyshacl` on PATH.
+fn pyshacl_cmd() -> String {
+    std::env::var("ATOMIC_PYSHACL").unwrap_or_else(|_| "pyshacl".to_string())
+}
+
+/// Whether a SHACL engine is available in this environment.
+pub fn is_available() -> bool {
+    Command::new(pyshacl_cmd())
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Validate a canonical JSON-LD value against the embedded shapes with a real
+/// SHACL engine. The value's `@context` URL is replaced by the embedded term
+/// map first, so the engine never needs the network.
+pub fn validate_value(value: &Value) -> Result<ShaclReport> {
+    let data = context::inline_context(value);
+    let data_json = serde_json::to_string(&data)
+        .map_err(|e| CanonicalError::Shacl(format!("failed to serialize data graph: {e}")))?;
+
+    let dir = tempfile::tempdir()
+        .map_err(|e| CanonicalError::Shacl(format!("failed to create temp dir: {e}")))?;
+    let shapes_path = dir.path().join("atomic-shapes.ttl");
+    let data_path = dir.path().join("data.jsonld");
+    std::fs::write(&shapes_path, SHAPES_TURTLE)
+        .map_err(|e| CanonicalError::Shacl(format!("failed to write shapes: {e}")))?;
+    std::fs::write(&data_path, data_json)
+        .map_err(|e| CanonicalError::Shacl(format!("failed to write data graph: {e}")))?;
+
+    let output = Command::new(pyshacl_cmd())
+        .arg("--shacl")
+        .arg(&shapes_path)
+        .args(["--shacl-file-format", "turtle"])
+        .args(["--data-file-format", "json-ld"])
+        .args(["--format", "human"])
+        .arg(&data_path)
+        .stdin(Stdio::null())
+        .output()
+        .map_err(|e| CanonicalError::Shacl(format!("failed to run '{}': {e}", pyshacl_cmd())))?;
+
+    let mut report = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // pyshacl prints "Conforms: True/False" in the human report and exits
+    // non-zero on violations. Anything without a conforms verdict is an
+    // engine/parse error (e.g. the document failed to parse as JSON-LD) and
+    // must surface as an error, never as a pass.
+    let conforms = if report.contains("Conforms: True") {
+        true
+    } else if report.contains("Conforms: False") {
+        false
+    } else {
+        return Err(CanonicalError::Shacl(format!(
+            "pyshacl produced no conformance verdict (exit: {:?})\nstdout: {}\nstderr: {}",
+            output.status.code(),
+            report.trim(),
+            stderr.trim(),
+        )));
+    };
+
+    if !stderr.trim().is_empty() {
+        report.push_str("\n[stderr] ");
+        report.push_str(stderr.trim());
+    }
+
+    Ok(ShaclReport { conforms, report })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use atomic_identity::identity::Identity;
+    use atomic_identity::keypair::KeyPair;
+
+    /// Skip tier-2 tests (with a note) where no engine is installed, so plain
+    /// `cargo test` passes everywhere; CI/dev run them with
+    /// `ATOMIC_PYSHACL=<venv>/bin/pyshacl`.
+    fn engine() -> bool {
+        if is_available() {
+            true
+        } else {
+            eprintln!(
+                "shacl tests SKIPPED — no pyshacl (set ATOMIC_PYSHACL or install pyshacl)"
+            );
+            false
+        }
+    }
+
+    fn attested_intent(ac_attrs: &str) -> Value {
+        let md = format!(
+            "---\nid: WORD-5\ntitle: Add name prompt modal\nstatus: done\ncreated_at: 2026-06-25T11:24:25Z\n---\n\n:::why\nLocal-only modal over a persisted profile.\n:::\n\n:::acceptance-criterion{{#WORD-5-ac-1 {ac_attrs}}}\nOn first load, the app presents a modal.\n:::\n"
+        );
+        let (fm, body) = crate::lift::parse_markdown(&md).unwrap();
+        let node = crate::lift::lift_intent(&fm, &body).unwrap();
+        let kp = KeyPair::generate();
+        let id = Identity::new("lee", &kp);
+        crate::proof::attest(node, &id, &kp).to_value()
+    }
+
+    #[test]
+    fn conforming_intent_passes_real_shacl() {
+        if !engine() {
+            return;
+        }
+        let value = attested_intent(
+            "status=met verifiedBy=did:atomic:lee evidence=urn:atomic:change:01J8ZE",
+        );
+        let report = validate_value(&value).unwrap();
+        assert!(report.conforms, "expected conformance, got:\n{}", report.report);
+    }
+
+    #[test]
+    fn met_criterion_without_evidence_fails_the_sparql_constraint() {
+        if !engine() {
+            return;
+        }
+        // The load-bearing rule, enforced by a real SHACL-SPARQL constraint:
+        // a bare checked box cannot pass the gate.
+        let value = attested_intent("status=met");
+        let report = validate_value(&value).unwrap();
+        assert!(!report.conforms, "a met AC without evidence must not conform");
+        assert!(
+            report.report.contains("verifiedBy and evidence"),
+            "violation must come from the met-needs-evidence constraint:\n{}",
+            report.report
+        );
+    }
+
+    #[test]
+    fn unknown_status_fails_sh_in() {
+        if !engine() {
+            return;
+        }
+        let mut value = attested_intent("status=open");
+        value["status"] = serde_json::json!("shipped");
+        let report = validate_value(&value).unwrap();
+        assert!(!report.conforms);
+        assert!(report.report.contains("known states"), "{}", report.report);
+    }
+
+    #[test]
+    fn memory_with_unknown_kind_fails() {
+        if !engine() {
+            return;
+        }
+        let md = "---\nid: mem-1\nkind: constraint\nstatus: active\ncreated_at: 2026-05-02T09:14:00Z\n---\n\n:::memory\nNo single ordering authority.\n:::\n";
+        let (fm, body) = crate::lift::parse_markdown(md).unwrap();
+        let node = crate::memory::lift_memory(&fm, &body).unwrap();
+        let kp = KeyPair::generate();
+        let id = Identity::new("lee", &kp);
+        let mut value = crate::proof::attest_memory(node, &id, &kp).to_value();
+
+        let report = validate_value(&value).unwrap();
+        assert!(report.conforms, "valid memory must conform:\n{}", report.report);
+
+        value["memoryKind"] = serde_json::json!("vibe");
+        let report = validate_value(&value).unwrap();
+        assert!(!report.conforms, "unknown memory kind must not conform");
+    }
+
+    #[test]
+    fn prov_graph_conforms_and_is_real_rdf() {
+        if !engine() {
+            return;
+        }
+        // The PROV projection parses as JSON-LD (rdflib) and satisfies the
+        // Activity/SoftwareAgent shapes — the delegation chain included.
+        let g = crate::prov::provenance_graph(&crate::prov::ProvenanceInput {
+            session_id: "inner-1".into(),
+            agent_name: "claude-code".into(),
+            agent_display_name: "Claude Code".into(),
+            agent_vendor: "anthropic".into(),
+            model: "claude-fable-5".into(),
+            started_at: "2026-07-01T22:11:00Z".into(),
+            ended_at: Some("2026-07-01T22:14:00Z".into()),
+            view: Some("sherpa-run-x".into()),
+            change_hashes: vec!["W5GSLAVO".into()],
+            used: vec!["urn:atomic:intent:019efe85".into()],
+            managed_run: Some(crate::prov::ManagedRunInput {
+                run_id: "run-1".into(),
+                owner_agent: "sherpa".into(),
+                owner_session_id: "sherpa-s1".into(),
+                work_item_id: Some("NONA-7".into()),
+            }),
+            person: Some("did:atomic:lee".into()),
+        });
+        let report = validate_value(&g).unwrap();
+        assert!(report.conforms, "PROV graph must conform:\n{}", report.report);
+    }
+
+    #[test]
+    fn prov_activity_missing_agent_fails() {
+        if !engine() {
+            return;
+        }
+        let g = serde_json::json!({
+            "@context": crate::node::CONTEXT_URL,
+            "@id": "urn:atomic:provgraph:session:x",
+            "@graph": [{
+                "@type": "Activity",
+                "@id": "urn:atomic:activity:session:x",
+                "startedAtTime": "2026-07-01T22:11:00Z"
+            }]
+        });
+        let report = validate_value(&g).unwrap();
+        assert!(!report.conforms, "an activity with no agent must not conform");
+        assert!(report.report.contains("associated with an agent"), "{}", report.report);
+    }
+}

--- a/atomic-canonical/src/shacl.rs
+++ b/atomic-canonical/src/shacl.rs
@@ -188,6 +188,39 @@ mod tests {
     }
 
     #[test]
+    fn task_without_status_fails_task_shape() {
+        if !engine() {
+            return;
+        }
+        let md = "---\nid: WORD-5\ntitle: t\nstatus: done\ncreated_at: 2026-06-25T11:24:25Z\n---\n\n:::why\na reason\n:::\n\n:::task{#WORD-5-1 status=done}\nAdd modal.\n:::\n";
+        let (fm, body) = crate::lift::parse_markdown(md).unwrap();
+        let node = crate::lift::lift_intent(&fm, &body).unwrap();
+        let kp = KeyPair::generate();
+        let id = Identity::new("lee", &kp);
+        let mut value = crate::proof::attest(node, &id, &kp).to_value();
+
+        let report = validate_value(&value).unwrap();
+        assert!(
+            report.conforms,
+            "task with status conforms:\n{}",
+            report.report
+        );
+
+        // Strip the task's status: TaskShape's cardinality must reject it.
+        value["hasTask"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("taskStatus");
+        let report = validate_value(&value).unwrap();
+        assert!(!report.conforms, "a task without a status must not conform");
+        assert!(
+            report.report.contains("exactly one status"),
+            "violation must come from TaskShape:\n{}",
+            report.report
+        );
+    }
+
+    #[test]
     fn memory_with_unknown_kind_fails() {
         if !engine() {
             return;

--- a/atomic-canonical/src/vocab.rs
+++ b/atomic-canonical/src/vocab.rs
@@ -60,6 +60,21 @@ pub const DIRECTIVE_NAMES: &[&str] = &[
     "memory",              // container: carries a memory's body text
 ];
 
+/// Inline directive names (`:name[label]{attrs}` inside running prose).
+///
+/// Inline recognition is registry-gated the *other* way around from block
+/// directives: prose is the unconstrained slot, so a colon-pattern whose name
+/// is not registered here stays prose (never an error) — otherwise writing
+/// `did:atomic:lee[sic]` in a reason would be a parse failure. Only registered
+/// names lift; the closed-vocabulary property still holds for everything that
+/// reaches the graph.
+pub const INLINE_DIRECTIVE_NAMES: &[&str] = &["ref"];
+
+/// Is this an inline directive name the system lifts from prose?
+pub fn is_known_inline_directive(name: &str) -> bool {
+    INLINE_DIRECTIVE_NAMES.contains(&name)
+}
+
 /// Memory kinds (closed set; mirrors `MemoryShape` `sh:in`). Exactly one.
 pub const MEMORY_KIND: &[&str] = &["constraint", "preference", "lesson", "context"];
 

--- a/atomic-canonical/src/vocab.rs
+++ b/atomic-canonical/src/vocab.rs
@@ -49,15 +49,15 @@ pub const AC_STATUS: &[&str] = &["open", "met"];
 /// NOTE: `lift.rs` must only branch on these names. A directive name not in
 /// this list is a parse/gate error, never a new type the lift absorbs.
 pub const DIRECTIVE_NAMES: &[&str] = &[
-    "why",                 // container: the unconstrained reason (presence enforced, content honest)
+    "why", // container: the unconstrained reason (presence enforced, content honest)
     "acceptance-criterion", // container
-    "task",                // container
-    "scope-in",            // container
-    "scope-out",           // container
-    "constraint",          // container
-    "ref",                 // leaf: a typed dependency edge
-    "file-ref",            // leaf: a file the task touches
-    "memory",              // container: carries a memory's body text
+    "task", // container
+    "scope-in", // container
+    "scope-out", // container
+    "constraint", // container
+    "ref", // leaf: a typed dependency edge
+    "file-ref", // leaf: a file the task touches
+    "memory", // container: carries a memory's body text
 ];
 
 /// Inline directive names (`:name[label]{attrs}` inside running prose).

--- a/atomic-canonical/tests/roundtrip.rs
+++ b/atomic-canonical/tests/roundtrip.rs
@@ -57,8 +57,14 @@ fn full_round_trip_lifts_attests_gates_verifies_renders() {
     assert_eq!(node.human_key, "WORD-5");
     assert_eq!(node.has_acceptance_criterion.len(), 1);
     assert_eq!(node.has_task.len(), 1);
-    assert_eq!(node.has_acceptance_criterion[0].id, "urn:atomic:ac:WORD-5-ac-1");
-    assert_eq!(node.has_task[0].touches_file, vec!["src/App.tsx".to_string()]);
+    assert_eq!(
+        node.has_acceptance_criterion[0].id,
+        "urn:atomic:ac:WORD-5-ac-1"
+    );
+    assert_eq!(
+        node.has_task[0].touches_file,
+        vec!["src/App.tsx".to_string()]
+    );
     assert!(node.why.as_deref().unwrap().contains("local-only modal"));
 
     // Attested.
@@ -108,7 +114,10 @@ fn gate_requires_a_reason_to_be_present() {
     let node = lift_and_attest(&frontmatter(), body, &id, &kp).unwrap();
     let report = validate_intent(&node);
     assert!(!report.conforms);
-    assert!(report.results.iter().any(|v| v.path.as_deref() == Some("why")));
+    assert!(report
+        .results
+        .iter()
+        .any(|v| v.path.as_deref() == Some("why")));
 }
 
 #[test]
@@ -119,7 +128,10 @@ fn gate_rejects_unknown_status() {
     let node = lift_and_attest(&fm, ":::why{}\nr\n:::", &id, &kp).unwrap();
     let report = validate_intent(&node);
     assert!(!report.conforms);
-    assert!(report.results.iter().any(|v| v.path.as_deref() == Some("status")));
+    assert!(report
+        .results
+        .iter()
+        .any(|v| v.path.as_deref() == Some("status")));
 }
 
 #[test]
@@ -253,7 +265,11 @@ fn memory_lift_gate_attest_verify_render_end_to_end() {
     assert_eq!(node.proof.as_ref().unwrap().cryptosuite, "eddsa-jcs-2022");
 
     // Gate conforms.
-    assert!(validate_memory(&node).conforms, "gate:\n{}", validate_memory(&node));
+    assert!(
+        validate_memory(&node).conforms,
+        "gate:\n{}",
+        validate_memory(&node)
+    );
 
     // Verify.
     verify_memory(&node, &kp.public).expect("memory verification should succeed");
@@ -301,9 +317,7 @@ fn memory_falls_back_to_whole_body_without_container() {
 
 #[test]
 fn parse_markdown_then_lift() {
-    let doc = format!(
-        "---\nid: WORD-9\ntitle: \"Doc parse\"\nstatus: backlog\n---\n{BODY}"
-    );
+    let doc = format!("---\nid: WORD-9\ntitle: \"Doc parse\"\nstatus: backlog\n---\n{BODY}");
     let (fm, body) = parse_markdown(&doc).unwrap();
     assert_eq!(fm.get("id").unwrap().as_str(), Some("WORD-9"));
     let node = lift_intent(&fm, &body).unwrap();
@@ -322,9 +336,10 @@ fn injected_unknown_field_is_rejected_on_load_intent() {
     let (id, kp) = dev_identity();
     let node = lift_and_attest(&frontmatter(), BODY, &id, &kp).unwrap();
     let mut v = serde_json::to_value(&node).unwrap();
-    v.as_object_mut()
-        .unwrap()
-        .insert("actualStatus".into(), Value::String("done-but-forged".into()));
+    v.as_object_mut().unwrap().insert(
+        "actualStatus".into(),
+        Value::String("done-but-forged".into()),
+    );
     let reload: Result<atomic_canonical::CanonicalNode, _> = serde_json::from_value(v);
     assert!(reload.is_err(), "an unknown field must be rejected on load");
 }
@@ -365,16 +380,12 @@ fn tampered_proof_metadata_fails_verification() {
 fn ref_edge_is_restricted_to_dependency_subset() {
     // MINOR fix: a :::ref sits on the dependency chain, so a non-dependency edge
     // (e.g. verifiedBy) must be rejected even though it is a valid edge elsewhere.
-    let good = format!(
-        "{BODY}\n\n:::ref{{to=urn:atomic:intent:other edge=blockedBy}}\n:::"
-    );
+    let good = format!("{BODY}\n\n:::ref{{to=urn:atomic:intent:other edge=blockedBy}}\n:::");
     let node = lift_intent(&frontmatter(), &good).unwrap();
     assert_eq!(node.depends_on.len(), 1);
     assert_eq!(node.depends_on[0].edge, "blockedBy");
 
-    let bad = format!(
-        "{BODY}\n\n:::ref{{to=urn:atomic:intent:other edge=verifiedBy}}\n:::"
-    );
+    let bad = format!("{BODY}\n\n:::ref{{to=urn:atomic:intent:other edge=verifiedBy}}\n:::");
     assert!(
         lift_intent(&frontmatter(), &bad).is_err(),
         "verifiedBy is not a dependency edge"

--- a/atomic-cli/Cargo.toml
+++ b/atomic-cli/Cargo.toml
@@ -23,6 +23,7 @@ path = "src/main.rs"
 [dependencies]
 # Internal crates
 atomic-agent = { workspace = true }
+atomic-canonical = { workspace = true }
 atomic-core = { workspace = true }
 atomic-config = { workspace = true }
 atomic-identity = { workspace = true }

--- a/atomic-cli/src/commands/agent/mod.rs
+++ b/atomic-cli/src/commands/agent/mod.rs
@@ -42,6 +42,7 @@ mod disable;
 mod enable;
 mod explain;
 mod hooks;
+mod prov;
 mod status;
 
 use clap::{Args, Subcommand};
@@ -201,6 +202,19 @@ pub enum AgentCommands {
     /// invocation. It appears here for documentation purposes only.
     #[command(hide = true)]
     Hooks(hooks::Hooks),
+
+    /// Export a session's provenance as a W3C PROV-O JSON-LD graph.
+    ///
+    /// Projects a recorded session (and its managed-run stamp, when present)
+    /// into `prov:Activity` / `prov:SoftwareAgent` / `prov:actedOnBehalfOf`.
+    /// Use `--shacl` to run the tier-2 formal gate over the result.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// atomic agent prov <session-id> --person did:atomic:lee --shacl
+    /// ```
+    Prov(prov::Prov),
 }
 
 impl Command for Agent {
@@ -212,6 +226,7 @@ impl Command for Agent {
             AgentCommands::Explain(cmd) => cmd.run(),
             AgentCommands::Attest(cmd) => cmd.run(),
             AgentCommands::Hooks(cmd) => cmd.run(),
+            AgentCommands::Prov(cmd) => cmd.run(),
         }
     }
 }

--- a/atomic-cli/src/commands/agent/prov.rs
+++ b/atomic-cli/src/commands/agent/prov.rs
@@ -1,0 +1,217 @@
+//! `atomic agent prov` — export a session's provenance as a W3C PROV graph.
+//!
+//! Reads the recorded session file (`.atomic/sessions/<id>.json`) and projects
+//! it into PROV-DM serialized with PROV-O vocabulary in JSON-LD: the session
+//! as a `prov:Activity` (used/generated/associated agent), the executor as a
+//! `prov:SoftwareAgent`, and — when the session carries a managed-run stamp —
+//! the `prov:actedOnBehalfOf` delegation chain executor → orchestrator →
+//! person. This is the "hand the auditor one addressable subgraph" command
+//! from Recording the Why, fed by real recorded data.
+//!
+//! `--shacl` additionally runs the tier-2 formal gate (pyshacl) over the
+//! emitted graph and fails on non-conformance.
+
+use clap::Args;
+use serde_json::Value;
+
+use atomic_canonical::prov::{provenance_graph, ManagedRunInput, ProvenanceInput};
+use atomic_canonical::shacl;
+
+use crate::commands::{find_repository_root, Command};
+use crate::error::{CliError, CliResult};
+
+/// Export a session's provenance as a PROV-O JSON-LD graph.
+#[derive(Debug, Args)]
+pub struct Prov {
+    /// The session id (a file under `.atomic/sessions/`).
+    session_id: String,
+
+    /// The person (DID) the work was ultimately performed for. Omitted edges
+    /// are omitted from the graph, never invented.
+    #[arg(long)]
+    person: Option<String>,
+
+    /// Inputs the session used (intent/memory URNs); repeatable.
+    #[arg(long = "used")]
+    used: Vec<String>,
+
+    /// Validate the emitted graph with the tier-2 SHACL gate (pyshacl).
+    #[arg(long)]
+    shacl: bool,
+}
+
+impl Command for Prov {
+    fn run(&self) -> CliResult<()> {
+        let repo_root = find_repository_root()?;
+        let path = repo_root
+            .join(".atomic")
+            .join("sessions")
+            .join(format!("{}.json", self.session_id));
+        let raw = std::fs::read_to_string(&path).map_err(|e| CliError::InvalidArgument {
+            message: format!("no session '{}' ({}: {e})", self.session_id, path.display()),
+        })?;
+        let session: Value = serde_json::from_str(&raw).map_err(|e| CliError::InvalidArgument {
+            message: format!("session file {} is not valid JSON: {e}", path.display()),
+        })?;
+
+        let input = provenance_input(&session, &self.session_id, &self.used, &self.person)?;
+        let graph = provenance_graph(&input);
+
+        if self.shacl {
+            if !shacl::is_available() {
+                return Err(CliError::InvalidArgument {
+                    message: "no SHACL engine found — install pyshacl or set ATOMIC_PYSHACL"
+                        .to_string(),
+                });
+            }
+            let report = shacl::validate_value(&graph)
+                .map_err(|e| CliError::Internal(anyhow::anyhow!(e.to_string())))?;
+            if !report.conforms {
+                eprintln!("{}", report.report.trim());
+                return Err(CliError::InvalidArgument {
+                    message: "provenance graph does not conform to the SHACL shapes".to_string(),
+                });
+            }
+            eprintln!("SHACL: conforms");
+        }
+
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&graph)
+                .expect("provenance graph serialization is infallible")
+        );
+        Ok(())
+    }
+}
+
+/// Map a raw session file into the projection input. Reads the JSON
+/// generically (not the typed `AgentSession`) so sessions written by builds
+/// with or without the managed-run stamp both export — absent fields are
+/// omitted edges, never errors.
+fn provenance_input(
+    session: &Value,
+    session_id: &str,
+    used: &[String],
+    person: &Option<String>,
+) -> CliResult<ProvenanceInput> {
+    let str_of = |key: &str| -> String {
+        session
+            .get(key)
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string()
+    };
+
+    let started_at = str_of("started_at");
+    if started_at.is_empty() {
+        return Err(CliError::InvalidArgument {
+            message: format!("session '{session_id}' carries no started_at"),
+        });
+    }
+
+    let managed_run = session.get("managed_run").and_then(|m| {
+        Some(ManagedRunInput {
+            run_id: m.get("run_id")?.as_str()?.to_string(),
+            owner_agent: m.get("owner_agent")?.as_str()?.to_string(),
+            owner_session_id: m
+                .get("owner_session_id")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            work_item_id: m
+                .get("work_item_id")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+        })
+    });
+
+    Ok(ProvenanceInput {
+        session_id: session_id.to_string(),
+        agent_name: str_of("agent_name"),
+        agent_display_name: str_of("agent_display_name"),
+        agent_vendor: str_of("agent_vendor"),
+        model: str_of("model"),
+        started_at,
+        ended_at: session
+            .get("ended_at")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        view: session
+            .get("view_name")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        change_hashes: session
+            .get("recorded_change_hashes")
+            .and_then(Value::as_array)
+            .map(|a| {
+                a.iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default(),
+        used: used.to_vec(),
+        managed_run,
+        person: person.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn session_json() -> Value {
+        json!({
+            "session_id": "prov-demo",
+            "view_name": "quiet-ridge-cb69",
+            "agent_name": "claude-code",
+            "agent_display_name": "Claude Code",
+            "agent_vendor": "anthropic",
+            "model": "",
+            "started_at": "2026-07-02T12:53:52.160912Z",
+            "ended_at": null,
+            "recorded_change_hashes": ["RCPDVOCN"],
+            "managed_run": {
+                "run_id": "run-9",
+                "owner_agent": "sherpa",
+                "owner_session_id": "sherpa-s1",
+                "work_item_id": "NONA-7"
+            }
+        })
+    }
+
+    #[test]
+    fn maps_real_session_shape_including_stamp() {
+        let input = provenance_input(
+            &session_json(),
+            "prov-demo",
+            &["urn:atomic:intent:x".to_string()],
+            &Some("did:atomic:lee".to_string()),
+        )
+        .unwrap();
+        assert_eq!(input.agent_name, "claude-code");
+        assert_eq!(input.view.as_deref(), Some("quiet-ridge-cb69"));
+        assert_eq!(input.change_hashes, vec!["RCPDVOCN"]);
+        let run = input.managed_run.unwrap();
+        assert_eq!(run.run_id, "run-9");
+        assert_eq!(run.owner_agent, "sherpa");
+        assert_eq!(run.work_item_id.as_deref(), Some("NONA-7"));
+    }
+
+    #[test]
+    fn session_without_stamp_maps_without_run() {
+        let mut s = session_json();
+        s.as_object_mut().unwrap().remove("managed_run");
+        let input = provenance_input(&s, "prov-demo", &[], &None).unwrap();
+        assert!(input.managed_run.is_none());
+        assert!(input.person.is_none());
+    }
+
+    #[test]
+    fn missing_started_at_is_an_error() {
+        let mut s = session_json();
+        s.as_object_mut().unwrap().remove("started_at");
+        assert!(provenance_input(&s, "x", &[], &None).is_err());
+    }
+}

--- a/atomic-cli/src/commands/canonical/intent.rs
+++ b/atomic-cli/src/commands/canonical/intent.rs
@@ -1,0 +1,241 @@
+//! `atomic intent` — scaffold, render, and validate canonical intents.
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+use atomic_canonical::render::{render, Target};
+use atomic_canonical::{gate, lift, proof};
+
+use crate::commands::Command;
+use crate::error::{CliError, CliResult};
+
+use super::{finish_validate, now_rfc3339, resolve_signing_identity, write_new_file};
+
+/// Author and validate canonical intents (markdown + typed directives).
+#[derive(Debug, Args)]
+#[command(arg_required_else_help = true)]
+pub struct Intent {
+    #[command(subcommand)]
+    command: IntentCommands,
+}
+
+#[derive(Debug, Subcommand)]
+enum IntentCommands {
+    /// Scaffold a new intent from the feature template.
+    ///
+    /// The frontmatter spine is pre-filled and the directive blocks are
+    /// stubbed — you can only scaffold types the closed registry knows.
+    /// The prose inside each block stays yours.
+    New(New),
+
+    /// Render an intent as formatted text (a pure projection of the node).
+    Show(Show),
+
+    /// Lift, attest, and validate an intent against the gate.
+    ///
+    /// Tier-1 (in-process shapes) always runs; `--shacl` also runs the
+    /// tier-2 formal gate (pyshacl) over the JSON-LD projection. The source
+    /// file is never rewritten — attestation happens in-memory so the gate
+    /// can check authorship and proof.
+    Validate(Validate),
+}
+
+#[derive(Debug, Args)]
+struct New {
+    /// Human key for the intent (e.g. WORD-5).
+    key: String,
+
+    /// Title for the intent.
+    #[arg(long, default_value = "")]
+    title: String,
+
+    /// Output path. Defaults to `<KEY>.md` in the current directory.
+    #[arg(long)]
+    out: Option<PathBuf>,
+}
+
+#[derive(Debug, Args)]
+struct Show {
+    /// Path to the intent markdown file.
+    file: PathBuf,
+}
+
+#[derive(Debug, Args)]
+struct Validate {
+    /// Path to the intent markdown file.
+    file: PathBuf,
+
+    /// Also run the tier-2 formal SHACL gate (pyshacl).
+    #[arg(long)]
+    shacl: bool,
+
+    /// Write the attested canonical JSON-LD to this path.
+    #[arg(long)]
+    emit: Option<PathBuf>,
+
+    /// Machine-readable output (the validation report as JSON).
+    #[arg(long)]
+    json: bool,
+
+    /// Sign with this identity instead of the default.
+    #[arg(long)]
+    identity: Option<String>,
+
+    /// Password for the identity's secret key, when protected.
+    #[arg(long)]
+    password: Option<String>,
+}
+
+impl Command for Intent {
+    fn run(&self) -> CliResult<()> {
+        match &self.command {
+            IntentCommands::New(cmd) => cmd.run(),
+            IntentCommands::Show(cmd) => cmd.run(),
+            IntentCommands::Validate(cmd) => cmd.run(),
+        }
+    }
+}
+
+impl New {
+    fn run(&self) -> CliResult<()> {
+        let key = self.key.trim();
+        if key.is_empty() {
+            return Err(CliError::InvalidArgument {
+                message: "intent key cannot be empty".to_string(),
+            });
+        }
+        let out = self
+            .out
+            .clone()
+            .unwrap_or_else(|| PathBuf::from(format!("{key}.md")));
+        let content = feature_template(key, &self.title);
+        write_new_file(&out, &content)?;
+        println!(
+            "next: edit the directive blocks, then `atomic intent validate {}`",
+            out.display()
+        );
+        Ok(())
+    }
+}
+
+impl Show {
+    fn run(&self) -> CliResult<()> {
+        let node = lift_from_file(&self.file)?;
+        println!("{}", render(&node, Target::Cli));
+        Ok(())
+    }
+}
+
+impl Validate {
+    fn run(&self) -> CliResult<()> {
+        let node = lift_from_file(&self.file)?;
+        let (identity, keypair) =
+            resolve_signing_identity(self.identity.as_deref(), self.password.as_deref())?;
+        let attested = proof::attest(node, &identity, &keypair);
+        let report = gate::validate_intent(&attested);
+        finish_validate(
+            "intent",
+            report,
+            &attested.to_value(),
+            self.shacl,
+            self.emit.as_deref(),
+            self.json,
+        )
+    }
+}
+
+fn lift_from_file(path: &PathBuf) -> CliResult<atomic_canonical::node::CanonicalNode> {
+    let raw = std::fs::read_to_string(path).map_err(|e| CliError::InvalidArgument {
+        message: format!("cannot read {}: {e}", path.display()),
+    })?;
+    let (frontmatter, body) =
+        lift::parse_markdown(&raw).map_err(|e| CliError::InvalidArgument {
+            message: e.to_string(),
+        })?;
+    lift::lift_intent(&frontmatter, &body).map_err(|e| CliError::InvalidArgument {
+        message: e.to_string(),
+    })
+}
+
+/// The feature template: pre-filled spine, stubbed directive blocks,
+/// unconstrained prose slots. Guidance lives in HTML comments the lift
+/// ignores.
+fn feature_template(key: &str, title: &str) -> String {
+    let uid = uuid::Uuid::new_v4();
+    let created_at = now_rfc3339();
+    let slug = key.to_lowercase();
+    format!(
+        "---\n\
+         id: {key}\n\
+         uid: {uid}\n\
+         title: {title}\n\
+         status: backlog\n\
+         priority: medium\n\
+         created_at: {created_at}\n\
+         ---\n\
+         \n\
+         :::why\n\
+         <!-- The reason, in your own words. Presence is enforced; content is yours. -->\n\
+         :::\n\
+         \n\
+         :::acceptance-criterion{{#{slug}-ac-1 status=open}}\n\
+         <!-- What \"done\" looks like. When met: status=met verifiedBy=<did> evidence=<urn:atomic:change:...> -->\n\
+         :::\n\
+         \n\
+         :::task{{#{slug}-1 status=open satisfies={slug}-ac-1}}\n\
+         <!-- A decomposed work item. Name touched files with ::file-ref{{path=...}} -->\n\
+         :::\n\
+         \n\
+         :::scope-in\n\
+         <!-- What this intent covers. -->\n\
+         :::\n\
+         \n\
+         :::scope-out\n\
+         <!-- What it explicitly does not — boundaries the agent must respect. -->\n\
+         :::\n\
+         \n\
+         :::constraint\n\
+         <!-- A rule the implementation must respect. -->\n\
+         :::\n"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn feature_template_lifts_cleanly() {
+        let md = feature_template("WORD-5", "Add name prompt modal");
+        let (fm, body) = lift::parse_markdown(&md).unwrap();
+        let node = lift::lift_intent(&fm, &body).unwrap();
+        assert_eq!(node.human_key, "WORD-5");
+        assert_eq!(node.status, "backlog");
+        assert_eq!(node.has_acceptance_criterion.len(), 1);
+        assert_eq!(node.has_acceptance_criterion[0].ac_status, "open");
+        assert_eq!(node.has_task.len(), 1);
+        assert_eq!(node.has_scope_in.len(), 1);
+        assert_eq!(node.has_scope_out.len(), 1);
+        assert_eq!(node.has_constraint.len(), 1);
+        // The why block exists (prose slot present, even while empty of prose).
+        assert!(node.why.is_some());
+    }
+
+    #[test]
+    fn template_only_scaffolds_registry_types() {
+        // Every directive the template stubs must be in the closed registry.
+        let md = feature_template("X-1", "t");
+        for line in md.lines() {
+            if let Some(rest) = line.strip_prefix(":::") {
+                let name = rest.split(['{', ' ']).next().unwrap_or("");
+                if !name.is_empty() {
+                    assert!(
+                        atomic_canonical::vocab::is_known_directive(name),
+                        "template stubs unknown directive '{name}'"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/atomic-cli/src/commands/canonical/intent.rs
+++ b/atomic-cli/src/commands/canonical/intent.rs
@@ -133,7 +133,21 @@ impl Validate {
         let (identity, keypair) =
             resolve_signing_identity(self.identity.as_deref(), self.password.as_deref())?;
         let attested = proof::attest(node, &identity, &keypair);
-        let report = gate::validate_intent(&attested);
+        let mut report = gate::validate_intent(&attested);
+
+        // Evidence URNs must resolve to real changes when a repository is
+        // reachable; presence alone is checked by the gate.
+        let evidence: Vec<(String, String)> = attested
+            .has_acceptance_criterion
+            .iter()
+            .filter_map(|ac| ac.evidence.clone().map(|e| (ac.id.clone(), e)))
+            .collect();
+        let repo_root = crate::commands::find_repository_root().ok();
+        let extra = super::check_evidence_resolution(&evidence, repo_root.as_deref());
+        if !extra.is_empty() {
+            report.conforms = false;
+            report.results.extend(extra);
+        }
         finish_validate(
             "intent",
             report,

--- a/atomic-cli/src/commands/canonical/memory.rs
+++ b/atomic-cli/src/commands/canonical/memory.rs
@@ -1,0 +1,225 @@
+//! `atomic memory` — scaffold, render, and validate canonical memories.
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+use atomic_canonical::render::{render_memory, Target};
+use atomic_canonical::{gate, lift, memory, proof, vocab};
+
+use crate::commands::Command;
+use crate::error::{CliError, CliResult};
+
+use super::{finish_validate, now_rfc3339, resolve_signing_identity, write_new_file};
+
+/// Author and validate canonical memories (durable, reusable context).
+#[derive(Debug, Args)]
+#[command(arg_required_else_help = true)]
+pub struct Memory {
+    #[command(subcommand)]
+    command: MemoryCommands,
+}
+
+#[derive(Debug, Subcommand)]
+enum MemoryCommands {
+    /// Scaffold a new memory with the kind, about edges, and spine pre-filled.
+    ///
+    /// The body is open for the memory text — a constraint, a preference, a
+    /// lesson, or context worth carrying forward.
+    New(New),
+
+    /// Render a memory as formatted text.
+    Show(Show),
+
+    /// Lift, attest, and validate a memory against the gate.
+    ///
+    /// Tier-1 always runs; `--shacl` also runs the tier-2 formal gate
+    /// (pyshacl). The source file is never rewritten.
+    Validate(Validate),
+}
+
+#[derive(Debug, Args)]
+struct New {
+    /// Name for the memory (used for the file and the id).
+    name: String,
+
+    /// Memory kind: constraint, preference, lesson, or context.
+    #[arg(long)]
+    kind: String,
+
+    /// Modules/domains this memory is about (comma-separated).
+    #[arg(long, value_delimiter = ',')]
+    about: Vec<String>,
+
+    /// Output path. Defaults to `<NAME>.md` in the current directory.
+    #[arg(long)]
+    out: Option<PathBuf>,
+}
+
+#[derive(Debug, Args)]
+struct Show {
+    /// Path to the memory markdown file.
+    file: PathBuf,
+}
+
+#[derive(Debug, Args)]
+struct Validate {
+    /// Path to the memory markdown file.
+    file: PathBuf,
+
+    /// Also run the tier-2 formal SHACL gate (pyshacl).
+    #[arg(long)]
+    shacl: bool,
+
+    /// Write the attested canonical JSON-LD to this path.
+    #[arg(long)]
+    emit: Option<PathBuf>,
+
+    /// Machine-readable output (the validation report as JSON).
+    #[arg(long)]
+    json: bool,
+
+    /// Sign with this identity instead of the default.
+    #[arg(long)]
+    identity: Option<String>,
+
+    /// Password for the identity's secret key, when protected.
+    #[arg(long)]
+    password: Option<String>,
+}
+
+impl Command for Memory {
+    fn run(&self) -> CliResult<()> {
+        match &self.command {
+            MemoryCommands::New(cmd) => cmd.run(),
+            MemoryCommands::Show(cmd) => cmd.run(),
+            MemoryCommands::Validate(cmd) => cmd.run(),
+        }
+    }
+}
+
+impl New {
+    fn run(&self) -> CliResult<()> {
+        let name = self.name.trim();
+        if name.is_empty() {
+            return Err(CliError::InvalidArgument {
+                message: "memory name cannot be empty".to_string(),
+            });
+        }
+        // Closed vocabulary reaches the author at scaffold time: you can only
+        // scaffold kinds the registry knows.
+        if !vocab::is_known_memory_kind(&self.kind) {
+            return Err(CliError::InvalidArgument {
+                message: format!(
+                    "unknown memory kind '{}' — known kinds: {}",
+                    self.kind,
+                    vocab::MEMORY_KIND.join(", ")
+                ),
+            });
+        }
+        let out = self
+            .out
+            .clone()
+            .unwrap_or_else(|| PathBuf::from(format!("{name}.md")));
+        let content = memory_template(name, &self.kind, &self.about);
+        write_new_file(&out, &content)?;
+        println!(
+            "next: write the memory text inside :::memory, then `atomic memory validate {}`",
+            out.display()
+        );
+        Ok(())
+    }
+}
+
+impl Show {
+    fn run(&self) -> CliResult<()> {
+        let node = lift_from_file(&self.file)?;
+        println!("{}", render_memory(&node, Target::Cli));
+        Ok(())
+    }
+}
+
+impl Validate {
+    fn run(&self) -> CliResult<()> {
+        let node = lift_from_file(&self.file)?;
+        let (identity, keypair) =
+            resolve_signing_identity(self.identity.as_deref(), self.password.as_deref())?;
+        let attested = proof::attest_memory(node, &identity, &keypair);
+        let report = gate::validate_memory(&attested);
+        finish_validate(
+            "memory",
+            report,
+            &attested.to_value(),
+            self.shacl,
+            self.emit.as_deref(),
+            self.json,
+        )
+    }
+}
+
+fn lift_from_file(path: &PathBuf) -> CliResult<memory::MemoryNode> {
+    let raw = std::fs::read_to_string(path).map_err(|e| CliError::InvalidArgument {
+        message: format!("cannot read {}: {e}", path.display()),
+    })?;
+    let (frontmatter, body) =
+        lift::parse_markdown(&raw).map_err(|e| CliError::InvalidArgument {
+            message: e.to_string(),
+        })?;
+    memory::lift_memory(&frontmatter, &body).map_err(|e| CliError::InvalidArgument {
+        message: e.to_string(),
+    })
+}
+
+/// The memory template: kind/about/spine pre-filled, the body open.
+fn memory_template(name: &str, kind: &str, about: &[String]) -> String {
+    let uid = uuid::Uuid::new_v4();
+    let created_at = now_rfc3339();
+    let about_line = if about.is_empty() {
+        String::new()
+    } else {
+        format!("about: [{}]\n", about.join(", "))
+    };
+    format!(
+        "---\n\
+         id: {name}\n\
+         uid: {uid}\n\
+         kind: {kind}\n\
+         status: active\n\
+         {about_line}\
+         created_at: {created_at}\n\
+         ---\n\
+         \n\
+         :::memory\n\
+         <!-- The durable context worth carrying forward, in your own words. -->\n\
+         :::\n"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_template_lifts_cleanly() {
+        let md = memory_template(
+            "upload-assumptions",
+            "constraint",
+            &["storage".to_string(), "replication".to_string()],
+        );
+        let (fm, body) = lift::parse_markdown(&md).unwrap();
+        let node = memory::lift_memory(&fm, &body).unwrap();
+        assert_eq!(node.memory_kind, "constraint");
+        assert_eq!(node.status, "active");
+        assert_eq!(node.about, vec!["storage", "replication"]);
+        assert!(node.id.starts_with("urn:atomic:memory:"));
+    }
+
+    #[test]
+    fn memory_template_without_about_omits_the_key() {
+        let md = memory_template("m", "lesson", &[]);
+        assert!(!md.contains("about:"));
+        let (fm, body) = lift::parse_markdown(&md).unwrap();
+        let node = memory::lift_memory(&fm, &body).unwrap();
+        assert!(node.about.is_empty());
+    }
+}

--- a/atomic-cli/src/commands/canonical/mod.rs
+++ b/atomic-cli/src/commands/canonical/mod.rs
@@ -69,6 +69,50 @@ pub(crate) fn resolve_signing_identity(
     Ok((identity, keypair))
 }
 
+/// Resolve `urn:atomic:change:<hash>` evidence URNs against the change
+/// store at `repo_root`. Returns one violation per URN that does not
+/// resolve. With no repository (`None`) the check is skipped — the gate
+/// still enforces presence; resolution needs a change store.
+pub(crate) fn check_evidence_resolution(
+    evidence: &[(String, String)],
+    repo_root: Option<&std::path::Path>,
+) -> Vec<atomic_canonical::gate::Violation> {
+    use atomic_core::types::{Base32, Hash};
+
+    let mut violations = Vec::new();
+    if evidence.is_empty() {
+        return violations;
+    }
+    let Some(root) = repo_root else {
+        eprintln!("note: evidence resolution skipped — not inside an Atomic repository");
+        return violations;
+    };
+    let repo = match atomic_repository::Repository::open_readonly(root) {
+        Ok(repo) => repo,
+        Err(e) => {
+            eprintln!("note: evidence resolution skipped — cannot open repository: {e}");
+            return violations;
+        }
+    };
+    for (focus, urn) in evidence {
+        let Some(hash_str) = urn.strip_prefix("urn:atomic:change:") else {
+            continue; // non-change URNs are out of scope here
+        };
+        let resolved = Hash::from_base32(hash_str.as_bytes())
+            .map(|h| repo.has_change(&h))
+            .unwrap_or(false);
+        if !resolved {
+            violations.push(atomic_canonical::gate::Violation {
+                focus_node: focus.clone(),
+                shape: "EvidenceResolution".to_string(),
+                path: Some("evidence".to_string()),
+                message: format!("evidence {urn} does not resolve to a change in this repository"),
+            });
+        }
+    }
+    violations
+}
+
 /// Shared validate output: tier-1 (always) + tier-2 (when requested).
 #[derive(Debug, serde::Serialize)]
 pub(crate) struct ValidateOutput {
@@ -186,4 +230,43 @@ pub(crate) fn write_new_file(path: &std::path::Path, content: &str) -> CliResult
 
 pub(crate) fn now_rfc3339() -> String {
     chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+#[cfg(test)]
+mod evidence_tests {
+    use super::check_evidence_resolution;
+
+    fn ev(urn: &str) -> Vec<(String, String)> {
+        vec![("urn:atomic:ac:x-ac-1".to_string(), urn.to_string())]
+    }
+
+    #[test]
+    fn no_repo_skips_without_violations() {
+        let v = check_evidence_resolution(&ev("urn:atomic:change:AAAA"), None);
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn unresolvable_urn_in_repo_is_a_violation() {
+        let dir = tempfile::tempdir().unwrap();
+        atomic_repository::Repository::init(dir.path()).unwrap();
+        let v = check_evidence_resolution(
+            &ev("urn:atomic:change:XXX5YG4CV4XJL7JV3RRK6RHLJRTA4BW5ET4AACFDTKZQEMYJYGCQ"),
+            Some(dir.path()),
+        );
+        assert_eq!(v.len(), 1);
+        assert!(
+            v[0].message.contains("does not resolve"),
+            "{}",
+            v[0].message
+        );
+    }
+
+    #[test]
+    fn non_change_urns_are_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        atomic_repository::Repository::init(dir.path()).unwrap();
+        let v = check_evidence_resolution(&ev("urn:atomic:intent:abc"), Some(dir.path()));
+        assert!(v.is_empty());
+    }
 }

--- a/atomic-cli/src/commands/canonical/mod.rs
+++ b/atomic-cli/src/commands/canonical/mod.rs
@@ -1,0 +1,189 @@
+//! Canonical authoring commands — the CLI surface Recording the Why names:
+//!
+//! ```text
+//! atomic intent new WORD-5 --title "Add name prompt modal"
+//! atomic intent show WORD-5.md
+//! atomic intent validate WORD-5.md --shacl
+//! atomic memory new upload-assumptions --kind constraint --about storage
+//! atomic memory validate upload-assumptions.md --shacl
+//! ```
+//!
+//! The flow is the doc's validation loop for agents: author markdown
+//! (frontmatter spine + typed directives) → the lift extracts the canonical
+//! JSON-LD node → attest with your atomic identity (in-memory; the source
+//! file is never rewritten) → the tier-1 gate checks the shapes → `--shacl`
+//! additionally runs the tier-2 formal gate (pyshacl). Failures come back
+//! structured (`--json`), so an agent can fix the surface and resubmit.
+//!
+//! Templates constrain the spine and the directive blocks, never the prose —
+//! the moment you template the reason you're templating the fake.
+
+mod intent;
+mod memory;
+
+pub use intent::Intent;
+pub use memory::Memory;
+
+use atomic_identity::keypair::KeyPair;
+use atomic_identity::{Identity, IdentityStore};
+
+use crate::error::{CliError, CliResult};
+
+/// Resolve the signing identity: `--identity <name>` when given, else the
+/// store's default. The keypair is required because validation attests the
+/// lifted node in-memory (the gate demands a proof — authorship is part of
+/// what "valid" means).
+pub(crate) fn resolve_signing_identity(
+    identity_name: Option<&str>,
+    password: Option<&str>,
+) -> CliResult<(Identity, KeyPair)> {
+    let store = IdentityStore::open_default().map_err(|e| {
+        CliError::Internal(anyhow::anyhow!(
+            "identity store not available: {e}. Create one with `atomic identity new`."
+        ))
+    })?;
+
+    let identity = match identity_name {
+        Some(name) => store
+            .load_by_name(name)
+            .map_err(|_| CliError::IdentityNotFound(name.to_string()))?,
+        None => store
+            .get_default()
+            .ok()
+            .flatten()
+            .ok_or_else(|| CliError::InvalidArgument {
+                message: "no default identity. Set one with `atomic identity default <name>` \
+                          or pass --identity <name>."
+                    .to_string(),
+            })?,
+    };
+
+    let keypair = store.load_keypair(&identity.id, password).map_err(|e| {
+        CliError::Internal(anyhow::anyhow!(
+            "could not load the secret key for '{}': {e}. If the key is \
+             password-protected, pass --password.",
+            identity.name
+        ))
+    })?;
+
+    Ok((identity, keypair))
+}
+
+/// Shared validate output: tier-1 (always) + tier-2 (when requested).
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct ValidateOutput {
+    /// Tier-1 (in-process gate) conformance.
+    pub conforms: bool,
+    pub violations: Vec<atomic_canonical::gate::Violation>,
+
+    /// Tier-2 (pyshacl) result, present when `--shacl` ran.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shacl: Option<ShaclOutput>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct ShaclOutput {
+    pub conforms: bool,
+    pub report: String,
+}
+
+/// Run the shared tail of a validate command: tier-1 report, optional tier-2,
+/// optional canonical emit, human or JSON output, non-zero exit on any
+/// non-conformance. `value` must already be attested.
+pub(crate) fn finish_validate(
+    label: &str,
+    report: atomic_canonical::gate::ValidationReport,
+    value: &serde_json::Value,
+    run_shacl: bool,
+    emit: Option<&std::path::Path>,
+    json: bool,
+) -> CliResult<()> {
+    if let Some(path) = emit {
+        let pretty = serde_json::to_string_pretty(value)
+            .expect("canonical value serialization is infallible");
+        std::fs::write(path, pretty).map_err(|e| {
+            CliError::Internal(anyhow::anyhow!("failed to write {}: {e}", path.display()))
+        })?;
+        eprintln!("canonical JSON-LD written to {}", path.display());
+    }
+
+    let shacl = if run_shacl {
+        if !atomic_canonical::shacl::is_available() {
+            return Err(CliError::InvalidArgument {
+                message: "no SHACL engine found — install pyshacl or set ATOMIC_PYSHACL"
+                    .to_string(),
+            });
+        }
+        let result = atomic_canonical::shacl::validate_value(value)
+            .map_err(|e| CliError::Internal(anyhow::anyhow!(e.to_string())))?;
+        Some(ShaclOutput {
+            conforms: result.conforms,
+            report: result.report,
+        })
+    } else {
+        None
+    };
+
+    let output = ValidateOutput {
+        conforms: report.conforms,
+        violations: report.results,
+        shacl,
+    };
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&output).unwrap());
+    } else {
+        if output.conforms {
+            println!("{label}: tier-1 gate: Conforms");
+        } else {
+            println!("{label}: tier-1 gate: DOES NOT CONFORM");
+            for v in &output.violations {
+                let path = v.path.as_deref().unwrap_or("-");
+                println!(
+                    "  ✗ [{}] {} ({}): {}",
+                    v.shape, v.focus_node, path, v.message
+                );
+            }
+        }
+        if let Some(shacl) = &output.shacl {
+            println!(
+                "{label}: tier-2 SHACL: {}",
+                if shacl.conforms {
+                    "Conforms"
+                } else {
+                    "DOES NOT CONFORM"
+                }
+            );
+            if !shacl.conforms {
+                println!("{}", shacl.report.trim());
+            }
+        }
+    }
+
+    let all_conform = output.conforms && output.shacl.as_ref().map(|s| s.conforms).unwrap_or(true);
+    if all_conform {
+        Ok(())
+    } else {
+        Err(CliError::InvalidArgument {
+            message: format!("{label} does not conform to the gate"),
+        })
+    }
+}
+
+/// Refuse to overwrite an existing file when scaffolding.
+pub(crate) fn write_new_file(path: &std::path::Path, content: &str) -> CliResult<()> {
+    if path.exists() {
+        return Err(CliError::InvalidArgument {
+            message: format!("{} already exists — not overwriting", path.display()),
+        });
+    }
+    std::fs::write(path, content).map_err(|e| {
+        CliError::Internal(anyhow::anyhow!("failed to write {}: {e}", path.display()))
+    })?;
+    println!("created {}", path.display());
+    Ok(())
+}
+
+pub(crate) fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}

--- a/atomic-cli/src/commands/mod.rs
+++ b/atomic-cli/src/commands/mod.rs
@@ -68,6 +68,7 @@ use crate::error::{CliError, CliResult};
 
 // Phase 2: Core Local Commands
 pub mod add;
+pub mod canonical;
 pub mod change;
 pub mod diff;
 pub mod doctor;
@@ -124,6 +125,7 @@ pub mod team;
 // Re-export command structs for convenience
 pub use add::Add;
 pub use agent::Agent;
+pub use canonical::{Intent, Memory};
 pub use change::ChangeCmd;
 pub use clone::Clone;
 pub use diff::Diff;

--- a/atomic-cli/src/main.rs
+++ b/atomic-cli/src/main.rs
@@ -66,7 +66,9 @@ use commands::{
     Identity,
     Init,
     Insert,
+    Intent,
     Log,
+    Memory,
     Move,
     ProjectCmd,
     Pull,
@@ -694,6 +696,31 @@ enum Commands {
     /// ```
     Vault(Vault),
 
+    /// Author and validate canonical intents (markdown + typed directives).
+    ///
+    /// The Recording-the-Why authoring loop: scaffold from a template,
+    /// write the directive blocks, validate against the gate (tier-1 in
+    /// process, tier-2 SHACL with --shacl).
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// atomic intent new WORD-5 --title "Add name prompt modal"
+    /// atomic intent validate WORD-5.md --shacl
+    /// atomic intent show WORD-5.md
+    /// ```
+    Intent(Intent),
+
+    /// Author and validate canonical memories (durable, reusable context).
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// atomic memory new upload-assumptions --kind constraint --about storage
+    /// atomic memory validate upload-assumptions.md --shacl
+    /// ```
+    Memory(Memory),
+
     /// Remove the last change from the current view.
     ///
     /// The change is removed from the view's change log but NOT deleted
@@ -815,6 +842,8 @@ fn main() {
         Commands::Query(query) => query.run(),
 
         Commands::Vault(vault) => vault.run(),
+        Commands::Intent(cmd) => cmd.run(),
+        Commands::Memory(cmd) => cmd.run(),
     };
 
     // Handle errors with user-friendly output

--- a/docs/acp-adapter-and-noname-gui.md
+++ b/docs/acp-adapter-and-noname-gui.md
@@ -1,0 +1,434 @@
+# ACP Adapter、Atomic Agent Package 和 noname GUI 的关系
+
+这份文档解释 noname/Sherpa 2.0 里几个容易混淆的概念：
+
+- ACP adapter 是什么
+- `atomic-agent` 是什么
+- `atomic-codex` / `atomic-claude` 是什么
+- noname GUI 为什么需要本机安装这些东西
+- Ask 时到底是谁调用谁
+
+## 一句话结论
+
+当前 noname 的 Ask 流程不是直接运行 `atomic-agent`。
+
+当前流程是：
+
+```text
+noname GUI
+  -> noname Rust backend
+  -> spawn 本机 ACP adapter，比如 codex-acp / claude-acp
+  -> adapter 驱动真实 agent，比如 Codex / Claude
+  -> agent 读代码、回答、改文件
+  -> noname 外层用 Atomic lifecycle/hooks 记录 change
+```
+
+所以本地要让 Ask 可用，通常需要两类东西：
+
+```text
+1. ACP adapter binary
+   例如 codex-acp、claude-acp
+
+2. Atomic agent package
+   例如 atomic-codex、atomic-claude
+```
+
+## ACP adapter 是什么
+
+ACP 是 Agent Client Protocol。它的作用是让 GUI 用同一种协议和不同 agent 对话。
+
+不同 agent 原本有不同的启动方式、输入格式、流式输出格式、tool-call 格式。ACP adapter 把这些差异统一起来。
+
+可以理解成：
+
+```text
+noname speaks ACP
+
+codex-acp       translates ACP <-> Codex
+claude-acp      translates ACP <-> Claude
+opencode adapter translates ACP <-> OpenCode
+```
+
+ACP adapter 负责：
+
+- 启动真实 agent runtime
+- 接收 noname 发来的 prompt
+- 把 agent 输出转成统一的 ACP event
+- 把 tool call / permission request / final response 流式返回给 noname
+
+ACP adapter 不负责 Atomic 记录。
+
+Atomic 记录由 noname 外层调用：
+
+```text
+atomic agent lifecycle begin
+atomic agent hooks sherpa session-start
+atomic agent hooks sherpa turn-start
+atomic agent hooks sherpa turn-end --json
+atomic agent hooks sherpa session-end
+atomic agent lifecycle end
+```
+
+## `atomic-agent` 是什么
+
+仓库：`atomicdotdev/atomic-agents`
+
+里面有两个相关 crate：
+
+```text
+atomic-agent-harness
+atomic-agent
+```
+
+### `atomic-agent-harness`
+
+这是今天 noname 真正在用的部分。
+
+noname 通过它把 registry id 映射成本机可执行命令：
+
+```text
+codex-acp  -> command: codex-acp
+claude-acp -> command: claude-acp
+opencode   -> command: opencode
+```
+
+代码路径大致是：
+
+```text
+noname/src-tauri/src/acp.rs
+  -> atomic_agent_harness::spawn::agent_for_registry_id(...)
+```
+
+也就是说，如果 Ask 选择 codex，noname 后端会找 PATH 里的：
+
+```bash
+codex-acp
+```
+
+如果 Ask 选择 claude，noname 后端会找 PATH 里的：
+
+```bash
+claude-acp
+```
+
+### `atomic-agent`
+
+这个名字容易误导。它看起来像“通用 Atomic agent runtime”，但当前还不是 noname Ask 使用的 runtime。
+
+目前 `atomic-agent` binary 的代码仍然是：
+
+```text
+load package
+print package info
+TODO: Start ACP agent server over stdio
+```
+
+所以现在 noname 不是运行：
+
+```bash
+atomic-agent --package atomic-codex
+```
+
+而是运行真实的 ACP adapter：
+
+```bash
+codex-acp
+claude-acp
+```
+
+长期如果 `atomic-agent` 实现了 ACP server，它可以成为更统一的 runtime。但这不是当前实现。
+
+## `atomic-codex` / `atomic-claude` 是什么
+
+仓库：
+
+- `atomicdotdev/atomic-codex`
+- `atomicdotdev/atomic-claude`
+
+它们是 Atomic agent package，不是 ACP adapter。
+
+它们的作用是让对应 agent “Atomic-aware”：
+
+- 提供 agent prompt
+- 提供 Atomic skills
+- 提供 hook manifest
+- 安装/注册 Codex 或 Claude 的 Atomic hooks
+
+例如：
+
+```text
+atomic-codex
+  -> AGENTS.md
+  -> skills/
+  -> hooks/codex.atomic-hooks.json
+  -> install.sh installs into ~/.codex
+
+atomic-claude
+  -> CLAUDE.md
+  -> agents/
+  -> skills/
+  -> hooks/claude-code.atomic-hooks.json
+  -> install.sh installs into ~/.claude
+```
+
+它们不等于 `codex-acp` / `claude-acp`。
+
+## 当前 GUI 为什么显示 38 个 agent，但 Ask 是 0
+
+Settings 里的 `All (38)` 来自 ACP 公共 registry。
+
+这只是说明 registry 知道这些 agent，例如：
+
+```text
+codex
+claude
+opencode
+gemini
+cline
+```
+
+但是 Ask 只显示本机已经安装 Atomic integration package 的 agent。
+
+当前 noname 默认检查目录：
+
+```text
+~/Projects/agents
+```
+
+它会看有没有：
+
+```text
+~/Projects/agents/atomic-codex
+~/Projects/agents/atomic-claude
+~/Projects/agents/atomic-opencode
+```
+
+所以：
+
+```text
+Settings: All (38)
+```
+
+表示 ACP registry 有 38 个 agent。
+
+```text
+Settings: Atomic (0)
+Ask: No ACP agents found
+```
+
+表示本机默认 agents 目录里没有可用的 Atomic package。
+
+## 本机要让 Codex 出现在 Ask，需要什么
+
+需要两件事：
+
+```text
+1. codex-acp 在 PATH 上
+2. ~/Projects/agents/atomic-codex 存在
+```
+
+示意：
+
+```bash
+command -v codex-acp
+test -d ~/Projects/agents/atomic-codex
+```
+
+`codex-acp` 是 noname 要 spawn 的进程。
+
+`atomic-codex` 是 GUI 用来判断 codex 是否有 Atomic integration 的 package，同时它安装 Codex 的 Atomic prompt、skills、hooks。
+
+## 本机要让 Claude 出现在 Ask，需要什么
+
+同样需要两件事：
+
+```text
+1. claude-acp 在 PATH 上
+2. ~/Projects/agents/atomic-claude 存在
+```
+
+示意：
+
+```bash
+command -v claude-acp
+test -d ~/Projects/agents/atomic-claude
+```
+
+注意：`@agentclientprotocol/claude-agent-acp` 这个 npm package 当前暴露的 binary 名可能是：
+
+```text
+claude-agent-acp
+```
+
+但 noname harness 当前找的是：
+
+```text
+claude-acp
+```
+
+所以本地测试时可能需要一个兼容 symlink：
+
+```bash
+ln -s /opt/homebrew/bin/claude-agent-acp /opt/homebrew/bin/claude-acp
+```
+
+长期应该修 harness 映射，让它使用真实 binary 名，避免用户手动建 symlink。
+
+## Ask 时完整调用链
+
+以 Codex 为例：
+
+```text
+用户在 noname GUI 点 Ask
+  |
+  v
+noname frontend 调 Tauri command: acp_ask
+  |
+  v
+noname Rust backend 生成 session_id
+  |
+  v
+atomic agent lifecycle begin --owner sherpa --session <session_id> --json
+  |
+  v
+atomic agent hooks sherpa session-start
+  |
+  v
+atomic agent hooks sherpa turn-start
+  |
+  v
+noname spawn codex-acp
+  |
+  v
+codex-acp 驱动 Codex
+  |
+  v
+Codex 回答或改文件
+  |
+  v
+ACP events 流回 noname
+  |
+  v
+atomic agent hooks sherpa turn-end --json
+  |
+  v
+Atomic 返回 recorded/change_hash/view/files
+  |
+  v
+noname 保存 run sidecar 并更新 GUI
+  |
+  v
+atomic agent hooks sherpa session-end
+  |
+  v
+atomic agent lifecycle end
+```
+
+关键点：
+
+```text
+codex-acp / claude-acp 负责执行 agent
+noname/Sherpa 负责外层 lifecycle
+Atomic hooks/lifecycle 负责记录 change
+```
+
+## 为什么需要 managed lifecycle
+
+如果用户直接在终端运行 Codex：
+
+```text
+Codex owns lifecycle
+Codex hooks record the turn
+```
+
+这没问题。
+
+但如果 noname/Sherpa 启动 codex-acp：
+
+```text
+Sherpa owns lifecycle
+codex-acp/Codex is inner executor
+```
+
+这时如果 Codex 自己的 Atomic hooks 也记录，就会发生 double orchestration：
+
+```text
+inner Codex hook records the change first
+outer Sherpa turn-end sees nothing
+```
+
+所以我们加了 managed lifecycle：
+
+```text
+atomic agent lifecycle begin --owner sherpa ...
+```
+
+在这个 lifecycle 期间：
+
+- owner 是 `sherpa`，Sherpa hook 正常运行
+- inner agent 例如 `codex` / `claude-code` 的 hook no-op
+- 最终 change 由 Sherpa 的 `turn-end --json` 记录并返回给 GUI
+
+这样 GUI 才能拿到：
+
+```json
+{
+  "recorded": true,
+  "change_hash": "...",
+  "view": "...",
+  "files": ["..."]
+}
+```
+
+## 当前本机测试需要的安装状态
+
+为了让 noname GUI 的 Ask 能显示 Codex 和 Claude：
+
+```text
+~/Projects/agents/atomic-codex
+~/Projects/agents/atomic-claude
+```
+
+并且 PATH 上有：
+
+```text
+codex-acp
+claude-acp
+```
+
+安装 package 后还需要运行它们的 install script：
+
+```bash
+cd ~/Projects/agents/atomic-codex
+./install.sh
+
+cd ~/Projects/agents/atomic-claude
+./install.sh
+```
+
+这些脚本会安装 hooks/skills 到：
+
+```text
+~/.codex
+~/.claude
+```
+
+## 产品上的改进方向
+
+当前 GUI 依赖用户手动准备：
+
+```text
+ACP adapter binary
+Atomic package directory
+package install script
+```
+
+这对开发测试可以接受，但不是最终产品体验。
+
+更好的产品方向是：
+
+- Settings 里显示 “missing adapter” 和 “missing package” 的具体原因
+- 提供一键安装 / 修复按钮
+- harness 使用真实 binary 名，例如 `claude-agent-acp`
+- 长期让 `atomic-agent` 成为统一 ACP runtime，减少用户需要安装的分散组件
+

--- a/docs/sherpa-lifecycle-sentinel-design.md
+++ b/docs/sherpa-lifecycle-sentinel-design.md
@@ -1,0 +1,120 @@
+# Lifecycle-ownership sentinel — design summary
+
+> Status: **design, pre-implementation.** Replaces the failed env-based suppression
+> (`ATOMIC_HOOKS_SUPPRESSED`). Write this down, confirm no holes, THEN implement.
+
+## Why env failed (the baseline)
+
+The env approach (`ATOMIC_HOOKS_SUPPRESSED=1` injected into the codex-acp child)
+does **not** survive to the inner hook process. Verified twice (sherpa-e2e binary
+and the integration binary), real codex-acp, global hooks on:
+
+```
+turn-end JSON:  {"recorded":false, "change_hash":null, "files":[]}
+
+codex   session  view=rough-bloom-30b6  turn=1  recorded=[AMOO37KB…]  ← inner stole the change
+sherpa  session  view=shy-river-125e    turn=1  recorded=[]            ← outer empty
+```
+
+Root cause: codex CLI runs the hooks.json commands (`atomic agent hooks codex …`)
+under its own `shell_environment_policy` (not `inherit=all` by default), which
+strips our injected env. An env probe inserted into hooks.json never fired with
+our var set; the codex transcript shows no `atomic`/`hooks` exec at all — the
+integration is internal to codex CLI. So **env is the wrong signal carrier**; it
+is filtered by the very process we need to reach. A filesystem signal is not
+filtered by an env policy.
+
+## Verified premises (checked against real code, not assumed)
+
+1. **Hook process knows its own agent.** `Hooks { agent_name: String, verb: String }`
+   (atomic-cli/src/commands/agent/hooks.rs:81-86). It is a CLI positional arg, always
+   present: `atomic agent hooks codex pre-tool` → agent_name=`codex`; the outer
+   `atomic agent hooks sherpa turn-end` → agent_name=`sherpa`. So owner-vs-other
+   discrimination is feasible. ✅
+2. **Outer Sherpa uses the SAME entry.** noname/bridge shells out to
+   `atomic agent hooks sherpa <verb>` (bridge.rs). So a naïve "sentinel exists →
+   no-op" would suppress the OUTER too (self-destruct). The owner_agent field is
+   mandatory, not optional. ✅ (this is Codex's key warning, confirmed real)
+3. **Same cwd.** bridge dispatches with `.current_dir(cwd)`; codex runs with
+   cwd=project too. Both inner and outer hooks run in the project repo, both can
+   read `.atomic/…`. So the sentinel must live in the repo and discriminate by
+   owner_agent — there is no cwd separation to exploit. ✅
+4. **Sentinel lifecycle hook points exist.** acp.rs already has finally-style
+   session_start (line 210) / session_end (line 457) cleanup. Sentinel create goes
+   right after a successful session_start switch; delete goes in the same cleanup
+   path that always runs session_end. ✅
+
+## Two additional constraints I found (not in Codex's note)
+
+A. **`find_repository_root()` returns `Err` (not panic) outside a repo**
+   (commands/mod.rs:237). The sentinel check must therefore treat "no repo root"
+   as "no sentinel → proceed normally", NOT as suppress. A user running plain
+   codex in a non-atomic dir must be unaffected. (hooks.json already guards with
+   `test -d .atomic && … || true`, but the in-binary check must be safe too.)
+
+B. **Order of operations in `run()` needs adjusting.** Today: env-gate (131) →
+   read stdin (137) → … → find_repository_root (188). Codex wants the sentinel
+   check before reading stdin but it needs repo root. So we must MOVE a
+   repo-root lookup ahead of the stdin read for the sentinel check. Keep it
+   tolerant: if repo root errs, skip the sentinel check and fall through to the
+   existing flow (which reads stdin then does its own repo lookup).
+
+## The sentinel
+
+- **Path:** `.atomic/agent-hooks-owner.json` (repo-local, NOT /tmp, NOT env).
+- **Schema:**
+  ```json
+  {
+    "owner_agent": "sherpa",
+    "session_id": "<uuid>",
+    "created_at": <unix_secs>,
+    "expires_at": <unix_secs>
+  }
+  ```
+- **Stale protection:** `expires_at` guards against a noname crash leaving the
+  repo permanently suppressed. If `now > expires_at`, the sentinel is ignored
+  (treated as absent). Pick a generous TTL (e.g. 1 hour) — long enough for a real
+  ACP turn, short enough that a crashed run self-heals.
+
+## atomic hook check (engine, hooks.rs `run()`)
+
+```
+fn run():
+    if env ATOMIC_HOOKS_SUPPRESSED set: return Ok(())          # keep as belt-and-suspenders
+    repo = find_repository_root()                              # tolerant: Err → skip sentinel
+    if repo ok:
+        s = read .atomic/agent-hooks-owner.json                # absent/parse-err → skip
+        if s present and now <= s.expires_at and s.owner_agent != self.agent_name:
+            return Ok(())                                      # inner agent → no-op, exit 0, silent
+        # owner_agent == self.agent_name (outer sherpa) → fall through, record normally
+        # expired → fall through (and ideally ignore/cleanup)
+    read stdin … normal dispatch (unchanged)
+```
+
+Key property: **owner (sherpa) falls through and records; non-owner (codex/claude/
+opencode) no-ops.** Exit 0, silent — never make the agent think the hook failed.
+
+## noname side (bridge + acp.rs)
+
+- Before the ACP child runs (after session_start switches view), write the
+  sentinel with `owner_agent="sherpa"`, the run's session_id, created_at=now,
+  expires_at=now+TTL.
+- In the same always-run cleanup that calls session_end, **delete** the sentinel.
+- Keep the existing env injection too? Optional — harmless belt-and-suspenders,
+  but the sentinel is the load-bearing mechanism now. (Leaning: keep env-gate in
+  the engine as a second lever, drop the noname env injection to avoid implying it
+  works. TBD.)
+
+## Merge gate (unchanged — must pass before merge)
+
+Same real E2E: global codex hooks ON, codex-acp really edits a file, outer sherpa
+turn-end returns `recorded:true + change_hash + view + files`, and `view list`
+shows NO nested codex view stealing the change. Compare against the failed
+baseline above.
+
+## Open question for review
+
+- TTL value + whether an expired sentinel should be actively deleted by the next
+  hook that sees it (self-cleaning) vs just ignored.
+- Do we keep the noname→child env injection as a belt-and-suspenders, or remove it
+  so the mechanism is unambiguously the sentinel?


### PR DESCRIPTION
## What

Adds the canonical standards layer for Recording the Why.

This PR makes intents, memories, and provenance machine-readable without making humans author raw JSON-LD:

- Markdown frontmatter + typed directives for intent/memory source files.
- Canonical JSON-LD output with a real `@context`.
- EdDSA/JCS proofs over the canonical form.
- Tier-1 in-process validation gates.
- Optional tier-2 SHACL validation through `pyshacl`.
- PROV-O export for recorded agent sessions with `atomic agent prov`.
- New authoring commands: `atomic intent ...` and `atomic memory ...`.

It also tightens two important cases:

- registered directives embedded mid-sentence are rejected instead of silently becoming prose;
- acceptance-criterion evidence like `urn:atomic:change:<hash>` is checked against the local change store when running inside a repo.

## Why

Loose markdown is easy to write, but hard to validate or turn into a graph. This gives us a middle path:

- humans and agents still write markdown;
- Atomic can lift it into typed graph nodes;
- validators can reject missing evidence, unknown directives, or invalid state;
- provenance can be exported in a standard PROV/JSON-LD shape.

This is the foundation for reusable Memories, structured Intents, and future circuit-breaker validation.

## Tested locally

I tested the current PR head with the real `atomic` binary, not just unit tests.

Package checks:

```bash
cargo fmt --check
cargo test -p atomic-canonical
cargo test -p atomic-cli
```

Results:

- `atomic-canonical`: 61 unit tests + 18 roundtrip tests passed.
- `atomic-cli`: 1544 unit tests + 9 integration tests passed.

Real CLI authoring flow in an isolated temp HOME/workdir:

```bash
atomic identity new tester --email tester@example.com --set-default
atomic intent new WORD-5 --title "Add name prompt modal"
atomic intent show WORD-5.md
atomic intent validate WORD-5.md --json --emit intent.jsonld
atomic memory new upload-assumptions --kind constraint --about src/upload.ts
atomic memory show upload-assumptions.md
atomic memory validate upload-assumptions.md --json --emit memory.jsonld
```

Both intent and memory validation passed and emitted signed canonical JSON-LD.

SHACL path:

- Verified the failure case when `pyshacl` is missing: `--shacl` exits with a clear install/config error.
- Installed `pyshacl` in a temporary venv and set `ATOMIC_PYSHACL`.
- Re-ran:

```bash
atomic intent validate WORD-5.md --shacl --json
atomic memory validate upload-assumptions.md --shacl --json
```

Both returned `Conforms: True`.

PROV export path:

```bash
atomic init --no-vault <temp-repo>
# wrote a minimal .atomic/sessions/prov-demo.json fixture
atomic agent prov prov-demo --person did:atomic:tester --used urn:atomic:intent:WORD-5 --shacl
```

This emitted PROV-O JSON-LD and SHACL reported conforms.
