### PR TITLE
fix(status): classify re-created cross-view files as Added, not invisible

### DIFF
--- a/atomic-agent/src/turn/orchestrator/tests.rs
+++ b/atomic-agent/src/turn/orchestrator/tests.rs
@@ -769,3 +769,78 @@ fn test_orchestrator_debug() {
     assert!(debug.contains("TurnOrchestrator"));
     assert!(debug.contains("repo_root"));
 }
+
+#[tokio::test]
+async fn test_file_recorded_on_another_view_records_again_on_new_view() {
+    // Regression (found doing real work in a real repo): the tracking TREE
+    // is global, but status's tree scan SKIPPED files whose creating change
+    // is not visible on the current view. A file recorded by an earlier
+    // session on ANOTHER view, then re-created on disk under a new view,
+    // fell into a permanent gap: status called it untracked-and-clean while
+    // `add` refused it (TREE already tracks it) — so `record` could never
+    // see it again (false EmptyTurn forever).
+    let dir = TempDir::new().unwrap();
+    Repository::init(dir.path()).unwrap();
+
+    // Session A records shared.rs on its own per-session view.
+    let store_a = SessionStore::for_repo(dir.path()).unwrap();
+    let watcher_a = FallbackWatcher::new(WatcherConfig::new(dir.path()));
+    let mut orch_a = TurnOrchestrator::with_watcher(dir.path(), store_a, Box::new(watcher_a));
+    orch_a.set_agent("claude-code", "Claude Code");
+    orch_a
+        .dispatch(session_start_event("sess-A"))
+        .await
+        .unwrap();
+    orch_a
+        .dispatch(turn_start_event("sess-A", "create shared"))
+        .await
+        .unwrap();
+    fs::write(dir.path().join("shared.rs"), "fn shared() {}\n").unwrap();
+    let ra = orch_a.dispatch(turn_end_event("sess-A")).await.unwrap();
+    assert!(ra.was_recorded(), "session A must record shared.rs");
+    orch_a.dispatch(session_end_event("sess-A")).await.unwrap();
+
+    // Session end re-materializes the parent view; shared.rs (recorded only
+    // on session A's view) leaves the working tree. Tolerate either.
+    let _ = fs::remove_file(dir.path().join("shared.rs"));
+
+    // Session B on a NEW view: turn 1 records something else (the view now
+    // exists), turn 2 re-creates the SAME file session A recorded.
+    let store_b = SessionStore::for_repo(dir.path()).unwrap();
+    let watcher_b = FallbackWatcher::new(WatcherConfig::new(dir.path()));
+    let mut orch_b = TurnOrchestrator::with_watcher(dir.path(), store_b, Box::new(watcher_b));
+    orch_b.set_agent("claude-code", "Claude Code");
+    orch_b
+        .dispatch(session_start_event("sess-B"))
+        .await
+        .unwrap();
+
+    orch_b
+        .dispatch(turn_start_event("sess-B", "unrelated work"))
+        .await
+        .unwrap();
+    fs::write(dir.path().join("other.rs"), "fn other() {}\n").unwrap();
+    let rb1 = orch_b.dispatch(turn_end_event("sess-B")).await.unwrap();
+    assert!(rb1.was_recorded(), "session B turn 1 must record");
+
+    orch_b
+        .dispatch(turn_start_event("sess-B", "recreate shared"))
+        .await
+        .unwrap();
+    fs::write(dir.path().join("shared.rs"), "fn shared_v2() {}\n").unwrap();
+    let rb2 = orch_b.dispatch(turn_end_event("sess-B")).await.unwrap();
+    assert!(
+        rb2.was_recorded(),
+        "re-creating a file another view already tracks must record — \
+         regression: add=already-tracked + status=untracked ⇒ false EmptyTurn"
+    );
+    let outcome = rb2.change_recorded.as_ref().unwrap();
+    assert!(
+        outcome
+            .recorded_file_list()
+            .iter()
+            .any(|f| f.contains("shared.rs")),
+        "the re-created file itself must be in the recorded change: {:?}",
+        outcome.recorded_file_list()
+    );
+}

--- a/atomic-agent/src/turn/orchestrator/tests.rs
+++ b/atomic-agent/src/turn/orchestrator/tests.rs
@@ -772,13 +772,6 @@ fn test_orchestrator_debug() {
 
 #[tokio::test]
 async fn test_file_recorded_on_another_view_records_again_on_new_view() {
-    // Regression (found doing real work in a real repo): the tracking TREE
-    // is global, but status's tree scan SKIPPED files whose creating change
-    // is not visible on the current view. A file recorded by an earlier
-    // session on ANOTHER view, then re-created on disk under a new view,
-    // fell into a permanent gap: status called it untracked-and-clean while
-    // `add` refused it (TREE already tracks it) — so `record` could never
-    // see it again (false EmptyTurn forever).
     let dir = TempDir::new().unwrap();
     Repository::init(dir.path()).unwrap();
 
@@ -800,12 +793,10 @@ async fn test_file_recorded_on_another_view_records_again_on_new_view() {
     assert!(ra.was_recorded(), "session A must record shared.rs");
     orch_a.dispatch(session_end_event("sess-A")).await.unwrap();
 
-    // Session end re-materializes the parent view; shared.rs (recorded only
-    // on session A's view) leaves the working tree. Tolerate either.
+    // Session A's file should not be present on the parent view.
     let _ = fs::remove_file(dir.path().join("shared.rs"));
 
-    // Session B on a NEW view: turn 1 records something else (the view now
-    // exists), turn 2 re-creates the SAME file session A recorded.
+    // Session B re-creates the same path on a different view.
     let store_b = SessionStore::for_repo(dir.path()).unwrap();
     let watcher_b = FallbackWatcher::new(WatcherConfig::new(dir.path()));
     let mut orch_b = TurnOrchestrator::with_watcher(dir.path(), store_b, Box::new(watcher_b));

--- a/atomic-repository/src/repository/status.rs
+++ b/atomic-repository/src/repository/status.rs
@@ -88,20 +88,9 @@ impl Repository {
         for result in tree_iter {
             let (path, inode) = result.map_err(|e| RepositoryError::Database(e.to_string()))?;
 
-            // View filter: files whose creating change is not on the
-            // current view belong to other views. When such a file is
-            // absent from the working copy it is skipped entirely — it
-            // must not appear in this view's status (e.g. as Deleted).
-            //
-            // But when the working copy HAS the file (it was re-created
-            // on this view after a switch), it is new content FOR THIS
-            // VIEW and must classify as Added. Skipping it here opened a
-            // permanent gap: `add` refuses it (the TREE already tracks
-            // it) while status called it untracked-and-clean, so `record`
-            // could never see it again. Fall through with has_graph=false
-            // so the classifier reports Added. The extra disk stat only
-            // runs for cross-view files, which exist on disk only after a
-            // re-create — rare.
+            // Cross-view entries are hidden from this view unless the file
+            // exists on disk again. In that case it is new content for the
+            // current view and should classify as Added.
             let has_graph = if let Ok(Some(position)) = txn.inode_position(inode) {
                 if let Some(ref ids) = current_view_change_ids {
                     if !position.change.is_root() && !ids.contains(&position.change) {

--- a/atomic-repository/src/repository/status.rs
+++ b/atomic-repository/src/repository/status.rs
@@ -88,19 +88,37 @@ impl Repository {
         for result in tree_iter {
             let (path, inode) = result.map_err(|e| RepositoryError::Database(e.to_string()))?;
 
-            // View filter: skip files whose creating change is not on
-            // the current view.  Files in TREE without a graph position
-            // must be classified as Added, not Clean.  Files whose
-            // creating change is not in the current view's filter are
-            // skipped entirely — they belong to other views and must not
-            // appear in this view's status.
+            // View filter: files whose creating change is not on the
+            // current view belong to other views. When such a file is
+            // absent from the working copy it is skipped entirely — it
+            // must not appear in this view's status (e.g. as Deleted).
+            //
+            // But when the working copy HAS the file (it was re-created
+            // on this view after a switch), it is new content FOR THIS
+            // VIEW and must classify as Added. Skipping it here opened a
+            // permanent gap: `add` refuses it (the TREE already tracks
+            // it) while status called it untracked-and-clean, so `record`
+            // could never see it again. Fall through with has_graph=false
+            // so the classifier reports Added. The extra disk stat only
+            // runs for cross-view files, which exist on disk only after a
+            // re-create — rare.
             let has_graph = if let Ok(Some(position)) = txn.inode_position(inode) {
                 if let Some(ref ids) = current_view_change_ids {
                     if !position.change.is_root() && !ids.contains(&position.change) {
-                        continue;
+                        let on_disk = self
+                            .root
+                            .join(normalize_tracked_path(&path, &self.root))
+                            .is_file();
+                        if !on_disk {
+                            continue;
+                        }
+                        false
+                    } else {
+                        true
                     }
+                } else {
+                    true
                 }
-                true
             } else {
                 false
             };


### PR DESCRIPTION
## What

Fixes a status bug with files that appear on multiple views.

If a file was first recorded on one view, then later re-created on another view, `atomic status` could skip it. That made `record` think there was nothing to save, even though the file existed on disk.

This PR treats that file as `Added` on the current view when it exists in the working copy.

## Why

Managed runs and sandboxed workflows often work on different views. If two runs touch the same file path, the later run must still be recordable.

Without this fix, a real agent turn could end as a false `EmptyTurn` and lose the change from the current view.

## Verified

Added a regression test with two orchestrator sessions on different views. The second session re-creates the same file path and now records it correctly.
