### PR TITLE
Fix materialization bug

### DIFF
--- a/.vault/intents/gentle-waterfall-143b/019eeff2-a885-7370-b599-a5b3b3e5c58a/1/intent.md
+++ b/.vault/intents/gentle-waterfall-143b/019eeff2-a885-7370-b599-a5b3b3e5c58a/1/intent.md
@@ -1,0 +1,55 @@
+---
+created_by: continuouslee <lee@atomic.dev>
+goals: []
+id: ATOM-2
+priority: medium
+status: done
+title: Explain identity mapping to change records
+view: gentle-waterfall-143b
+entry_type: intent
+content_hash: QO36VLRYWKOIWLGTMNXOCTV3RBLZQGCDOWNYCSGH23M5UFPBM7JQ
+created_at: 2026-06-22T15:30:21.541422+00:00
+updated_at: 2026-06-22T15:30:21.541422+00:00
+---
+# Explain identity mapping to change records
+
+**ID:** ATOM-2 · **Priority:** medium · **Status:** backlog
+**Created by:** continuouslee <lee@atomic.dev> · **Created:** 2026-06-22T15:28:57.094530+00:00
+
+---
+
+## Problem
+
+REPLACE with what is broken or missing, and why it matters. Not a solution description.
+
+## Acceptance Criteria
+
+- [ ] REPLACE with first testable criterion
+- [ ] REPLACE with second testable criterion
+
+## Scope
+
+**In:**
+- REPLACE with specific crate, module, or component
+
+**Out:**
+- REPLACE with what is explicitly excluded
+
+## Constraints
+
+- REPLACE with technical limits, compatibility requirements, or design decisions
+
+## Dependencies
+
+None
+
+## TODOs
+
+- [ ] `ATOM-2/1` REPLACE with first independently executable task
+  **Files:** REPLACE with specific file paths from codebase search
+  **Criteria:** REPLACE with how to verify this TODO is done
+
+- [ ] `ATOM-2/2` REPLACE with second task
+  **Files:** REPLACE with specific file paths
+  **Criteria:** REPLACE with verification criteria
+  **Depends:** `ATOM-2/1` (if dependent, otherwise omit this line)

--- a/.vault/intents/tight-storm-0847/019eef64-2859-7ed1-8b32-dc3e837f6611/1/intent.md
+++ b/.vault/intents/tight-storm-0847/019eef64-2859-7ed1-8b32-dc3e837f6611/1/intent.md
@@ -1,0 +1,66 @@
+---
+created_by: continuouslee <lee@atomic.dev>
+goals: []
+id: ATOM-1
+priority: medium
+status: done
+title: Understand B-tree graph building
+view: tight-storm-0847
+entry_type: intent
+content_hash: 7TC3V3WDMX6ZFKXHX7PLECD223TEXS2TAW4KXTNJPAUQXM3GKFBA
+created_at: 2026-06-22T13:15:22.910549+00:00
+updated_at: 2026-06-22T13:15:22.910549+00:00
+---
+# Understand B-tree graph building
+
+**ID:** ATOM-1 · **Priority:** medium · **Status:** backlog
+**Created by:** continuouslee <lee@atomic.dev> · **Created:** 2026-06-22T12:53:50.551571+00:00
+
+---
+
+## Problem
+
+Explain how Atomic's persistent B-tree storage records are assembled into the
+runtime graph model developers see when reading files, diffing, or traversing
+history. The answer needs to connect the storage tables, graph node/edge keys,
+inode indexing, view filters, and traversal rules clearly enough to be useful
+for future implementation work.
+
+## Acceptance Criteria
+
+- [x] Identify the B-tree tables involved in graph construction.
+- [x] Explain how vertices and edges are encoded and resolved during traversal.
+- [x] Describe how views filter the ambient graph.
+- [x] Call out the key ambiguity around positions versus vertices.
+
+## Scope
+
+**In:**
+- `atomic-core` pristine storage and graph traversal concepts.
+- `atomic-repository` read/diff-facing interpretation where relevant.
+
+**Out:**
+- Code changes or behavior modifications.
+- A full CRDT semantic-layer implementation walkthrough.
+
+## Constraints
+
+- Use Atomic CLI and vault context only for repository operations.
+- Keep the explanation grounded in the project documentation and KG-discovered
+  code structure.
+
+## Dependencies
+
+None
+
+## TODOs
+
+- [x] `ATOM-1/1` Inspect graph storage and traversal symbols
+  **Files:** `atomic-core/src/pristine/**`, `atomic-core/src/types/**`
+  **Criteria:** Relevant graph entities and tables are identified.
+
+- [x] `ATOM-1/2` Provide concise conceptual explanation
+  **Files:** No code changes.
+  **Criteria:** User receives a clear answer connecting B-tree layout to graph
+  construction and traversal.
+  **Depends:** `ATOM-1/1`

--- a/.vault/memory/MEMORY.md
+++ b/.vault/memory/MEMORY.md
@@ -1,0 +1,13 @@
+---
+name: MEMORY
+type: index
+entry_type: memory
+content_hash: BYRJSIU5XUJKBSZNM6PJ2MBLIRVJP27P27PG24BPQGUAGDUJAL3Q
+created_at: 2026-06-16T22:21:17.849281+00:00
+updated_at: 2026-06-16T22:21:17.849281+00:00
+---
+# Project Memory
+
+This file indexes shared project knowledge. Each entry links to a detailed file.
+
+<!-- Add entries as: - [Title](filename.md) — description -->

--- a/.vault/prompts/system_prompt.md
+++ b/.vault/prompts/system_prompt.md
@@ -1,0 +1,146 @@
+---
+description: Default system prompt for the AI coding agent
+name: System Prompt
+entry_type: skill
+content_hash: HEKIL47UDSCUO6TJ43ZNESO6KFZXZ3WR6PPOIUJDDBONQGFHSH6A
+created_at: 2026-06-16T22:21:17.840228+00:00
+updated_at: 2026-06-16T22:21:17.840228+00:00
+---
+You are Pi, a CLI coding agent. Use your tools to help the user with software engineering tasks.
+
+# Tools
+
+You have: `grep`, `read`, `find`, `edit`, `write`, `bash`, and `atomic`.
+
+- `atomic` interacts with the Atomic VCS, project vault, and knowledge graph. **Use this first for code exploration.** The KG has indexed every function, struct, trait, and module in the project with their signatures, callers, and change history.
+- `grep` searches file contents (powered by ripgrep). Use this for literal text search when the KG doesn't have what you need, or to find specific strings/patterns.
+- `read` reads a file — but ONLY files discovered by a prior `grep` call. `.vault/` files are exempt from this restriction.
+- `find` locates files by name/glob pattern (powered by fd).
+- `edit` makes exact text replacements. `oldText` must match exactly including whitespace.
+- `write` creates new files.
+- `bash` runs shell commands. Only use for git, tests, builds — not for searching or reading files.
+
+Call multiple tools in parallel when there are no dependencies between them.
+
+# Workflow
+
+Every task follows this pattern:
+
+1. **KG first — search the knowledge graph.** The KG knows every function, struct, and module in the project. Start here:
+   ```
+   atomic vault query search "worker_threads Builder"
+   ```
+   This returns entity nodes with signatures, file locations, and metadata — often enough to plan your edit without reading any files.
+
+2. **Explore structure with neighbors.** When the KG search finds a relevant entity, explore its connections:
+   ```
+   atomic vault query neighbors entity:src/runtime/builder.rs:worker_threads:42
+   ```
+   This shows: who calls it, what changes modified it, what files define it, and what intents link to it.
+
+3. **grep only when needed.** Use grep for:
+   - Literal strings the KG doesn't index (error messages, config values, magic numbers)
+   - Pattern matching (regex)
+   - Finding all call sites of a function (when KG CALLS edges are incomplete)
+
+4. **Read only what you must.** After KG + grep narrow the scope, read only the specific functions you need to understand or edit. Don't read entire files.
+
+5. **Edit last.** Combine all changes to the same file in one edit call.
+
+**Do NOT default to grep → read → edit.** The KG is faster, cheaper, and gives you structural context that grep cannot. A KG `neighbors` query on one entity tells you more than reading 500 lines of source.
+
+# Knowledge Graph
+
+The project's knowledge graph indexes:
+- **Entities**: every function, struct, trait, enum, impl, const extracted by tree-sitter
+- **Files**: every tracked file
+- **Changes**: every recorded change with author and message
+- **Views**: branch-like perspectives on the graph
+- **Goals**: development sessions
+- **Intents**: JIRA-style work items
+
+## KG Commands
+
+| Command | Use when |
+|---------|----------|
+| `atomic vault query search "text"` | Finding functions, types, files by keyword |
+| `atomic vault query neighbors entity:file:name:line` | Understanding a function's callers, changes, relationships |
+| `atomic vault query neighbors change:HASH` | Seeing what a change modified |
+| `atomic vault query neighbors file:path` | Seeing what entities a file defines |
+| `atomic vault query ask "question"` | Complex questions (RAG — needs API key) |
+
+## Node ID Format
+
+- `entity:src/runtime/builder.rs:Builder:50` — struct at line 50
+- `entity:src/runtime/builder.rs:worker_threads:142` — function at line 142
+- `file:src/runtime/builder.rs` — a tracked file
+- `change:ABCD1234` — a recorded change (12-char hash prefix)
+- `view:master` — a view
+- `intent:TOKI-1` — a work item
+- `goal:swift-meadow-a3f2` — a development session
+
+# Goals and Intents
+
+When asked to work on a task, follow this exact sequence:
+
+1. **Check existing intents first** — do NOT create duplicates:
+   ```
+   atomic vault intent list
+   ```
+
+2. **Create exactly ONE intent** (never retry on error — check the list instead):
+   ```
+   command: "vault intent create", args: {"title": "Clear description", "priority": "high"}
+   ```
+
+3. **Explore the code using the KG** to build a plan:
+   ```
+   command: "vault query search", args: {"query": "worker_threads Builder runtime"}
+   command: "vault query neighbors entity:src/runtime/builder.rs:worker_threads:142"
+   ```
+
+4. **Write your plan INTO the intent file.** This is required — do NOT just describe the plan in chat. Use `edit` to fill in `.vault/intents/<id>/intent.md` with:
+   - **Description**: What's the problem?
+   - **Acceptance Criteria**: Concrete checkboxes.
+   - **Files to Modify**: Table of files and changes from your KG exploration.
+   - **Approach**: Step-by-step plan referencing specific functions.
+   - **Test Strategy**: How to verify.
+   - **Notes**: Findings from code exploration.
+
+   **The intent file IS the deliverable of your planning phase.**
+
+5. **Start a goal** linked to the intent, then create a draft view for isolated work:
+   ```
+   command: "vault goal start", args: {"intent": "TOKI-1"}
+   command: "view create my-goal --draft"
+   command: "view switch my-goal"
+   ```
+
+6. When done, record and promote:
+   ```
+   command: "record", args: {"message": "Add max_worker_threads option to Builder"}
+   command: "vault goal stop my-goal", args: {"promote": true}
+   ```
+
+# Code Changes
+
+- Read before editing. Match existing style, naming, indentation
+- Minimal changes only — don't refactor, add comments, or improve code beyond what was asked
+- Don't add error handling, abstractions, or features that weren't requested
+- Don't create files unless necessary. Prefer editing existing files
+- After editing, record your changes with `atomic record`
+
+# Safety
+
+- Confirm with user before destructive/irreversible actions (delete, force-push, rm -rf)
+- Never expose secrets or API keys in code or output
+
+# Output
+
+Be concise. Lead with action, not reasoning. No preamble or filler. If you can say it in one sentence, do. Reference code as `file_path:line_number`. No emojis unless asked.
+
+# Context Management
+
+Old tool results are automatically cleared from context to free up space. The 2 most recent tool results are always kept in full. Older results are replaced with one-line summaries.
+
+When working with tool results, write down important information in your response text (file paths, function signatures, key findings). Only your written notes survive context compaction.

--- a/.vault/skills/atomic-vault.md
+++ b/.vault/skills/atomic-vault.md
@@ -1,0 +1,193 @@
+---
+description: How to use the project vault for goals, intents, and shared memory
+name: Atomic Vault
+entry_type: skill
+content_hash: KFV3MJULZHJMKSTY3HNCDNZSFDALMYTAFMHEWGLR4JQNNMZ5WYYQ
+created_at: 2026-06-16T22:21:17.843890+00:00
+updated_at: 2026-06-16T22:21:17.843890+00:00
+---
+---
+name: Atomic Vault
+description: How to use the project vault for goals, intents, and shared memory
+---
+
+# Atomic Vault
+
+This project has an Atomic vault — a shared knowledge store at `.vault/`.
+Use the `atomic` tool to interact with it.
+
+## Goals (Development Sessions)
+
+Goals track your work sessions. Start one when you begin working, stop when done.
+
+```
+# Start a goal (generates a name like "swift-meadow-a3f2")
+atomic vault goal start --developer "your name"
+
+# Start with a linked intent
+atomic vault goal start --intent PIMO-1
+
+# Stop and promote (marks as completed for the team)
+atomic vault goal stop --promote
+
+# Stop and suspend (can resume later)
+atomic vault goal stop
+
+# Resume a previous goal
+atomic vault goal resume swift-meadow-a3f2
+
+# List goals
+atomic vault goal list --status active
+atomic vault goal list --status all
+```
+
+## Intents (JIRA-style Tasks)
+
+Intents are units of work with auto-generated IDs (e.g., PIMO-1, PIMO-2).
+
+**IMPORTANT: Create ONE intent per task. Check existing intents first.**
+
+### Creating an Intent
+
+1. **Check if the intent already exists:**
+   ```
+   atomic vault intent list
+   ```
+
+2. **Create exactly ONE intent** (do NOT retry if the CLI errors — check the list):
+   ```
+   atomic vault intent create --title "Fix authentication" --priority high
+   ```
+   This returns an ID like PROJ-1 and creates a scaffold file at `.vault/intents/proj-1/intent.md`.
+
+3. **Write your plan into the intent file.** The scaffold has sections to fill in:
+   ```
+   edit .vault/intents/proj-1/intent.md using the .vault/templates/intent.md template
+   ```
+   Replace the HTML comment placeholders in each section:
+   - **Description**: What's the problem? Link to the GitHub issue.
+   - **Preconditions**: What must be true before starting?
+   - **Acceptance Criteria**: Concrete checkboxes — what does "done" look like?
+   - **Files to Modify**: Table of files, what changes, and why.
+   - **Approach**: Step-by-step plan referencing specific functions from the KG.
+   - **Test Strategy**: How will you verify each criterion?
+   - **Notes**: Findings from code exploration, trade-offs, open questions.
+
+   The intent file IS the deliverable — a reviewer reads it to understand the full plan.
+
+4. **Update status as you work:**
+   ```
+   atomic vault intent update PROJ-1 --status in-progress
+   atomic vault intent update PROJ-1 --status review
+   atomic vault intent update PROJ-1 --status done
+   ```
+
+### Intent Workflow Example
+
+```
+# Check existing intents first
+atomic vault intent list
+
+# Create ONE intent
+atomic vault intent create --title "Add max_worker_threads option" --priority high
+# → returns TOKI-1
+
+# Explore the code to build the plan
+atomic vault query search "worker_threads Builder"
+atomic vault query neighbors "entity:src/runtime/builder.rs:worker_threads:42"
+
+# Write the plan into the intent file — fill in every section
+edit .vault/intents/toki-1/intent.md
+# Fill in: Description, Preconditions, Acceptance Criteria,
+# Files to Modify (table), Approach (steps), Test Strategy, Notes
+
+# Link a goal and start working
+atomic vault goal start --intent TOKI-1
+```
+
+Intent statuses: backlog → planned → in-progress → review → done
+
+## Memory (Shared Knowledge)
+
+Memory files persist project knowledge across sessions and developers.
+
+```
+# List memory files
+atomic vault memory list
+
+# Read a memory file
+atomic vault memory show architecture
+```
+
+To save new knowledge, write a markdown file to `.vault/memory/` and
+then run `atomic vault sync` to persist it to the database.
+
+## Version Control
+
+The vault is tracked by the same Atomic VCS as the code:
+
+```
+# Check repo status
+atomic status
+
+# View change history
+atomic log
+
+# Show working copy diff
+atomic diff
+```
+
+## Workflow
+
+1. **Check existing intents**: Don't create duplicates.
+   ```
+   atomic vault intent list
+   ```
+
+2. **Create ONE intent** with a clear title. Then explore the code and write a plan into the intent file:
+   ```
+   atomic vault intent create --title "Fix issue #42: description"
+   # Explore with grep + KG queries
+   # Edit .vault/intents/proj-N/intent.md with your plan
+   ```
+
+3. **Start a goal** linked to the intent:
+   ```
+   atomic vault goal start --intent PROJ-1
+   ```
+
+4. **Create a draft view** for isolated work:
+   ```
+   atomic view create <goal-name> --draft
+   atomic view switch <goal-name>
+   ```
+
+5. **Search and explore** using grep + knowledge graph together:
+   ```
+   grep "worker_threads" --type rs
+   atomic vault query search "worker_threads Builder"
+   atomic vault query neighbors "entity:src/builder.rs:worker_threads:42"
+   ```
+
+6. **Make changes** using read, edit, write tools
+
+7. **Record** your changes:
+   ```
+   atomic record -m "Add max_worker_threads option to Builder"
+   ```
+
+8. **Stop the goal** when done:
+   ```
+   atomic vault goal stop --promote
+   ```
+
+9. **Review**: The draft view stays alive for review.
+   ```
+   atomic view switch <goal-name>
+   atomic diff
+   ```
+
+10. **Merge** when approved:
+    ```
+    atomic insert from-view <goal-name> --to-view dev
+    ```

--- a/.vault/skills/code-intelligence.md
+++ b/.vault/skills/code-intelligence.md
@@ -1,0 +1,144 @@
+---
+description: Use the knowledge graph to understand code structure, not just text matches
+name: Code Intelligence
+entry_type: skill
+content_hash: K6OX4CAVWSXYE4KDD6YRWZMJBCVJ7NOIV7PK2J6UZ5QWXYBOFIKQ
+created_at: 2026-06-16T22:21:17.846222+00:00
+updated_at: 2026-06-16T22:21:17.846222+00:00
+---
+---
+name: Code Intelligence
+description: Use the knowledge graph to understand code structure before reading files
+---
+
+# Code Intelligence
+
+The project has a knowledge graph (KG) with every function, struct, trait, enum,
+and module indexed by tree-sitter. **Search the KG first, not grep.**
+
+## The Pattern: KG search → neighbors → targeted read
+
+### Step 1: Search the KG with SIMPLE terms
+
+Use one or two keywords, not long phrases. Simpler queries return better results:
+
+✅ Good: `atomic vault query search "worker_threads"`
+✅ Good: `atomic vault query search "Builder"`
+❌ Bad:  `atomic vault query search "Builder multithread worker_threads tokio::main"`
+
+Run multiple simple searches in parallel instead of one complex query.
+
+### Step 2: Read the `id` field from the results — this is the ONLY source of truth
+
+```
+CRITICAL RULE: You MUST copy the "id" field VERBATIM from search results.
+NEVER construct, guess, or modify an entity ID. If the search didn't
+return it, the ID does not exist.
+```
+
+Example: search returns this result:
+```json
+{"id": "entity:tokio/src/runtime/builder.rs:worker_threads:509", ...}
+```
+
+✅ CORRECT — copy the id exactly as returned:
+```
+atomic vault query neighbors entity:tokio/src/runtime/builder.rs:worker_threads:509
+```
+
+❌ WRONG — you guessed the line number:
+```
+atomic vault query neighbors entity:tokio/src/runtime/builder.rs:worker_threads:356
+```
+
+❌ WRONG — you guessed the path:
+```
+atomic vault query neighbors entity:src/runtime/builder.rs:worker_threads
+```
+
+❌ WRONG — the search didn't return this ID:
+```
+atomic vault query neighbors entity:tokio/src/runtime/builder.rs:Builder:44
+```
+
+If you need an entity that didn't appear in search results, do another search
+with different terms — do NOT guess the ID.
+
+### Step 3: Use neighbors on IDs you found
+
+The neighbors query returns:
+- **DEFINES edges**: which file defines this entity
+- **MODIFIES edges**: which changes touched it (who, when, commit message)
+- **Connected entities**: other functions in the same file
+
+### Step 4: Explore the file's entities
+
+To see ALL functions/structs in a file, query neighbors on the file node:
+
+```
+atomic vault query neighbors file:tokio/src/runtime/builder.rs
+```
+
+This returns every entity the file defines — all functions, structs, traits,
+impls, constants. Much faster than reading the file.
+
+### Step 5: Read only what you must
+
+After KG search + neighbors narrow the scope, read only the specific function
+body you need to understand or edit. Don't read entire files.
+
+## When to use KG vs grep vs read
+
+| I need to... | Use |
+|---|---|
+| Find functions/types by name | `atomic vault query search "name"` |
+| See a function's signature and location | KG search (summary field has the signature) |
+| See what file defines a function | `atomic vault query neighbors entity:...` → DEFINES edge |
+| See what changes modified a function | `atomic vault query neighbors entity:...` → MODIFIES edge |
+| See all functions in a file | `atomic vault query neighbors file:path` |
+| See what a change touched | `atomic vault query neighbors change:HASH` |
+| Find a literal string or error message | `grep "exact string"` |
+| Find regex patterns | `grep "pattern"` |
+| Read function implementation details | `read file` (only after KG narrows the scope) |
+
+## Searching tips
+
+- **Search broadly first**: `atomic vault query search "worker_threads"` finds entities, files, AND changes
+- **Use file: prefix to explore a file**: `atomic vault query neighbors file:src/runtime/builder.rs`
+- **Chain searches**: search → get IDs → neighbors on those IDs → find connected IDs → neighbors again
+- **The search returns at most 10 results** — use specific terms to narrow down
+
+## Entity ID Format
+
+Entity IDs are structured as `entity:{file_path}:{name}:{line_number}`:
+
+```
+entity:tokio/src/runtime/builder.rs:worker_threads:509    — function at line 509
+entity:tokio/src/runtime/builder.rs:Builder:50             — struct at line 50
+entity:tokio-macros/src/entry.rs:set_worker_threads:126    — method at line 126
+```
+
+The line number comes from the AST extraction and is stable for the current
+version of the code. **Always get IDs from search results, never construct them.**
+
+## Planning an Intent with KG
+
+When creating an intent, use the KG to build a concrete plan:
+
+1. Search for the relevant concept:
+   ```
+   atomic vault query search "worker_threads Builder multithread"
+   ```
+
+2. For each relevant entity in the results, explore its neighbors:
+   ```
+   atomic vault query neighbors entity:tokio/src/runtime/builder.rs:worker_threads:509
+   atomic vault query neighbors file:tokio/src/runtime/builder.rs
+   atomic vault query neighbors file:tokio-macros/src/entry.rs
+   ```
+
+3. Now you know the exact files, functions, and signatures involved.
+   Write this into the intent's **Files to Modify** table and **Approach** section.
+
+4. Only `read` the function bodies you need to understand the implementation
+   details for your plan.

--- a/atomic-agent/src/hooks/opencode.rs
+++ b/atomic-agent/src/hooks/opencode.rs
@@ -354,6 +354,26 @@ impl OpenCodeHook {
             .filter(|s| !s.is_empty())
             .unwrap_or_else(|| format!("opencode-{}", uuid_short()))
     }
+
+    /// Path to the global OpenCode config directory (`~/.config/opencode/`).
+    ///
+    /// OpenCode uses the XDG-style `~/.config/opencode/` path on all
+    /// platforms (including macOS, where `dirs::config_dir()` returns
+    /// `~/Library/Application Support/`), so we construct it from the
+    /// home directory.
+    fn global_config_dir() -> Option<std::path::PathBuf> {
+        dirs::home_dir().map(|h| h.join(".config").join("opencode"))
+    }
+
+    /// Check whether the `atomic-opencode` plugin is installed globally.
+    ///
+    /// Returns `true` if `~/.config/opencode/plugins/atomic-hooks.ts` exists
+    /// (as a file or valid symlink).
+    fn is_plugin_installed() -> bool {
+        Self::global_config_dir()
+            .map(|d| d.join("plugins").join("atomic-hooks.ts").exists())
+            .unwrap_or(false)
+    }
 }
 
 impl Default for OpenCodeHook {
@@ -557,7 +577,14 @@ impl AgentHook for OpenCodeHook {
     }
 
     fn install(&self, _repo_root: &Path) -> AgentResult<usize> {
-        Ok(0) // Installation handled by atomic-opencode package
+        // OpenCode hooks are managed by the atomic-opencode package, not
+        // by writing files into the repo.  Report 1 if the plugin is
+        // already present so that `enable` shows a success message.
+        if Self::is_plugin_installed() {
+            Ok(1)
+        } else {
+            Ok(0)
+        }
     }
 
     fn uninstall(&self, _repo_root: &Path) -> AgentResult<()> {
@@ -565,7 +592,7 @@ impl AgentHook for OpenCodeHook {
     }
 
     fn is_installed(&self, _repo_root: &Path) -> bool {
-        false // Managed by atomic-opencode package
+        Self::is_plugin_installed()
     }
 
     fn supported_hooks(&self) -> Vec<HookType> {
@@ -580,8 +607,9 @@ impl AgentHook for OpenCodeHook {
     }
 
     fn detect_presence(&self, repo_root: &Path) -> bool {
-        // OpenCode is present if the .opencode directory exists
-        repo_root.join(OPENCODE_DIR).is_dir()
+        // OpenCode is present if the repo has a .opencode directory OR if
+        // the atomic-opencode plugin is installed globally.
+        repo_root.join(OPENCODE_DIR).is_dir() || Self::is_plugin_installed()
     }
 
     fn hook_verbs(&self) -> Vec<&str> {
@@ -914,7 +942,12 @@ mod tests {
     fn test_detect_presence_without_opencode_dir() {
         let tmp = TempDir::new().unwrap();
         let hook = make_hook();
-        assert!(!hook.detect_presence(tmp.path()));
+        // Without a repo-level .opencode dir, detection depends on the
+        // global plugin.  We only assert "no detection" when the plugin
+        // is also absent globally.
+        if !OpenCodeHook::is_plugin_installed() {
+            assert!(!hook.detect_presence(tmp.path()));
+        }
     }
 
     #[test]
@@ -922,15 +955,23 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         std::fs::write(tmp.path().join(".opencode"), "not a dir").unwrap();
         let hook = make_hook();
-        assert!(!hook.detect_presence(tmp.path()));
+        // A regular file named .opencode is not a directory, so repo-local
+        // detection fails.  Overall result depends on global plugin state.
+        if !OpenCodeHook::is_plugin_installed() {
+            assert!(!hook.detect_presence(tmp.path()));
+        }
     }
 
     #[test]
-    fn test_install_is_noop() {
+    fn test_install_returns_count_based_on_plugin() {
         let tmp = TempDir::new().unwrap();
         let hook = make_hook();
         let count = hook.install(tmp.path()).unwrap();
-        assert_eq!(count, 0);
+        if OpenCodeHook::is_plugin_installed() {
+            assert_eq!(count, 1);
+        } else {
+            assert_eq!(count, 0);
+        }
     }
 
     #[test]
@@ -941,10 +982,13 @@ mod tests {
     }
 
     #[test]
-    fn test_is_installed_returns_false() {
+    fn test_is_installed_matches_plugin_state() {
         let tmp = TempDir::new().unwrap();
         let hook = make_hook();
-        assert!(!hook.is_installed(tmp.path()));
+        assert_eq!(
+            hook.is_installed(tmp.path()),
+            OpenCodeHook::is_plugin_installed()
+        );
     }
 
     // uuid_short tests

--- a/atomic-agent/src/record/mod.rs
+++ b/atomic-agent/src/record/mod.rs
@@ -210,7 +210,7 @@ pub fn record_turn(
     // Keep the write handle on the same view for post-add status and record.
     // First turns may target a view that record/apply will create; other failures
     // mean we cannot trust the detection/apply alignment.
-    match repo.set_current_view(&options.session.view_name) {
+    match repo.align_to_view(&options.session.view_name) {
         Ok(()) => {}
         Err(atomic_repository::RepositoryError::ViewNotFound { .. }) => {
             log::debug!(

--- a/atomic-agent/src/turn/orchestrator/session_start.rs
+++ b/atomic-agent/src/turn/orchestrator/session_start.rs
@@ -208,14 +208,14 @@ impl TurnOrchestrator {
                     // while current_view points to the agent view. This ensures
                     // status/add/record see the right view. session-end will
                     // switch back to the user's view.
-                    if let Err(e) = repo.set_current_view(&session.view_name) {
+                    if let Err(e) = repo.align_to_view(&session.view_name) {
                         log::warn!(
-                            "Could not switch to agent view '{}': {} (non-fatal)",
+                            "Could not align to agent view '{}': {} (non-fatal)",
                             session.view_name,
                             e,
                         );
                     } else {
-                        log::info!("Switched to agent view '{}'", session.view_name,);
+                        log::info!("Aligned to agent view '{}'", session.view_name,);
                     }
                 }
                 Err(e) => {
@@ -334,9 +334,9 @@ impl TurnOrchestrator {
 
                         // Switch to the agent view so status/add/record
                         // target the right view.
-                        if let Err(e) = repo.set_current_view(&session.view_name) {
+                        if let Err(e) = repo.align_to_view(&session.view_name) {
                             log::warn!(
-                                "Fallback session {} could not switch to '{}': {} (non-fatal)",
+                                "Fallback session {} could not align to '{}': {} (non-fatal)",
                                 session_id,
                                 session.view_name,
                                 e,

--- a/atomic-agent/src/turn/orchestrator/tests.rs
+++ b/atomic-agent/src/turn/orchestrator/tests.rs
@@ -484,7 +484,8 @@ async fn test_session_attestation_covers_only_agent_recorded_changes() {
         let agent_view_history = repo
             .log(
                 atomic_repository::history::HistoryOptions::default()
-                    .view(&session_after_turn.view_name),
+                    .view(&session_after_turn.view_name)
+                    .include_inherited(true),
             )
             .unwrap();
         let inherited_hashes: Vec<_> = agent_view_history.iter().map(|e| e.hash).collect();

--- a/atomic-cli/src/commands/git/import.rs
+++ b/atomic-cli/src/commands/git/import.rs
@@ -468,8 +468,8 @@ impl Command for Import {
                         .map_err(|e| CliError::Internal(e.into()))?;
                 }
 
-                // Switch to the view
-                repo.set_current_view(&branch_name)
+                // Align to the view (materialize happens after all branches imported)
+                repo.align_to_view(&branch_name)
                     .map_err(|e| CliError::Internal(e.into()))?;
 
                 // Import the branch
@@ -531,8 +531,8 @@ impl Command for Import {
                     .map_err(|e| CliError::Internal(e.into()))?;
             }
 
-            // Switch to the view
-            repo.set_current_view(&branch_name)
+            // Align to the view (materialize/reindex follows)
+            repo.align_to_view(&branch_name)
                 .map_err(|e| CliError::Internal(e.into()))?;
 
             // Import

--- a/atomic-cli/src/commands/init.rs
+++ b/atomic-cli/src/commands/init.rs
@@ -522,7 +522,7 @@ impl Command for Init {
         // Create the initial view if it's different from the default
         if self.view != atomic_repository::DEFAULT_VIEW {
             repo.create_view(&self.view).map_err(CliError::Repository)?;
-            repo.set_current_view(&self.view)
+            repo.align_to_view(&self.view)
                 .map_err(CliError::Repository)?;
         }
 

--- a/atomic-cli/src/commands/log/command.rs
+++ b/atomic-cli/src/commands/log/command.rs
@@ -206,6 +206,10 @@ impl Log {
             options = options.from_sequence(from);
         }
 
+        if self.all {
+            options = options.include_inherited(true);
+        }
+
         options
     }
 
@@ -525,14 +529,9 @@ impl Command for Log {
             );
         }
 
-        // Show all entries in VIEW_CHANGES for this view.
-        //
-        // Previous draft-view filtering used `parent_change_count` which
-        // reads the parent's *live* change_count.  That counter moves as
-        // the parent gains more changes, shifting the filter threshold
-        // and hiding entries that should be visible — including the
-        // draft view's own local changes.  Until a stable fork-point
-        // snapshot is stored at view-creation time, show everything.
+        // Draft views now filter inherited changes by default (the
+        // repository layer compares against ancestor VIEW_CHANGES).
+        // Use `--all` to see the full log including inherited entries.
         self.print_entries(&entries);
 
         Ok(())

--- a/atomic-cli/src/commands/split.rs
+++ b/atomic-cli/src/commands/split.rs
@@ -214,9 +214,12 @@ impl Command for Split {
 
         // Optionally switch to the new view
         if self.switch {
-            repo.set_current_view(&self.name)
-                .map_err(CliError::Repository)?;
-            print_success(&format!("Switched to view: {}", style_view(&self.name)));
+            let result = repo.switch_view(&self.name).map_err(CliError::Repository)?;
+            print_success(&format!(
+                "Switched to view: {} ({} files updated)",
+                style_view(&self.name),
+                result.files_written,
+            ));
         } else {
             print_hint(&format!(
                 "Use 'atomic view switch {}' to switch to the new view",

--- a/atomic-cli/src/commands/view/list.rs
+++ b/atomic-cli/src/commands/view/list.rs
@@ -316,7 +316,7 @@ mod tests {
         {
             let mut repo = Repository::init(repo_path).unwrap();
             repo.create_view("feature").unwrap();
-            repo.set_current_view("feature").unwrap();
+            repo.align_to_view("feature").unwrap();
         }
 
         // Change to the repo directory

--- a/atomic-cli/src/commands/view/new.rs
+++ b/atomic-cli/src/commands/view/new.rs
@@ -298,8 +298,12 @@ impl New {
     /// Optionally switch to the new view and print hint.
     fn maybe_switch(&self, name: &str, repo: &mut Repository) -> CliResult<()> {
         if self.switch {
-            repo.set_current_view(name).map_err(CliError::Repository)?;
-            print_success(&format!("Switched to view: {}", style_view(name)));
+            let result = repo.switch_view(name).map_err(CliError::Repository)?;
+            print_success(&format!(
+                "Switched to view: {} ({} files updated)",
+                style_view(name),
+                result.files_written,
+            ));
         } else {
             print_hint(&format!(
                 "Use 'atomic view switch {}' to switch to the new view",

--- a/atomic-repository/src/history/iter.rs
+++ b/atomic-repository/src/history/iter.rs
@@ -194,6 +194,7 @@ pub fn reverse_log<T: ViewTxnT>(
         load_headers: options.load_headers,
         view: options.view.clone(),
         tagged_only: options.tagged_only,
+        include_inherited: options.include_inherited,
     };
 
     let iter = log(txn, view, &forward_options)?;

--- a/atomic-repository/src/history/types.rs
+++ b/atomic-repository/src/history/types.rs
@@ -229,6 +229,14 @@ pub struct HistoryOptions {
 
     /// Only include tagged changes.
     pub tagged_only: bool,
+
+    /// Include inherited changes on draft views.
+    ///
+    /// By default (`false`), `log()` on a draft view only shows changes
+    /// that are new to that view — changes inherited from parent views
+    /// are filtered out.  Set to `true` to see the full change log
+    /// including inherited entries (equivalent to `--all` on the CLI).
+    pub include_inherited: bool,
 }
 
 impl HistoryOptions {
@@ -288,6 +296,15 @@ impl HistoryOptions {
     /// * `n` - Number of recent changes to retrieve
     pub fn last(n: usize) -> Self {
         Self::default().limit(n)
+    }
+
+    /// Include inherited changes on draft views.
+    ///
+    /// By default, draft views only show their own changes.
+    /// Call this to see the full log including parent changes.
+    pub fn include_inherited(mut self, include: bool) -> Self {
+        self.include_inherited = include;
+        self
     }
 
     /// Create options with headers loaded.

--- a/atomic-repository/src/repository/history.rs
+++ b/atomic-repository/src/repository/history.rs
@@ -1,9 +1,16 @@
+use std::collections::HashSet;
+
 use super::*;
 
 impl Repository {
     // History Methods
 
     /// Get a forward history log for the current view.
+    ///
+    /// For **draft** views, only changes that are "new" on this view are
+    /// returned — inherited changes from ancestor views are filtered out.
+    /// Pass `--all` (via [`HistoryOptions::include_inherited`]) to see
+    /// the full change log including inherited entries.
     ///
     /// Returns an iterator over history entries starting from the given
     /// sequence number and proceeding forward (oldest to newest).
@@ -41,6 +48,17 @@ impl Repository {
                 name: view_name.to_string(),
             })?;
 
+        // For draft views, build a set of ancestor change NodeIds so we
+        // can filter out inherited entries.  This makes `atomic log` on a
+        // draft view show only "what's new" rather than the full history
+        // of every ancestor view.
+        let ancestor_ids: Option<HashSet<NodeId>> =
+            if view.kind.is_draft() && !options.include_inherited {
+                Some(Self::collect_ancestor_change_ids(&txn, &view)?)
+            } else {
+                None
+            };
+
         let iter = crate::history::log(&txn, &view, &options)
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
@@ -48,6 +66,13 @@ impl Repository {
         let mut entries = Vec::new();
         for result in iter {
             let mut entry = result.map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+            // Skip inherited entries on draft views
+            if let Some(ref ids) = ancestor_ids {
+                if ids.contains(&entry.node_id) {
+                    continue;
+                }
+            }
 
             // Load header if requested
             if options.load_headers {
@@ -91,6 +116,12 @@ impl Repository {
         let mut entries = crate::history::reverse_log(&txn, &view, &options)
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
+        // For draft views, filter out inherited entries
+        if view.kind.is_draft() && !options.include_inherited {
+            let ancestor_ids = Self::collect_ancestor_change_ids(&txn, &view)?;
+            entries.retain(|e| !ancestor_ids.contains(&e.node_id));
+        }
+
         // Load headers if requested
         if options.load_headers {
             for entry in &mut entries {
@@ -101,6 +132,33 @@ impl Repository {
         }
 
         Ok(entries)
+    }
+
+    /// Collect all change NodeIds from ancestor views' VIEW_CHANGES.
+    ///
+    /// Walks the parent chain and gathers each ancestor view's own
+    /// change entries.  The result is used by `log()` / `reverse_log()`
+    /// to filter out inherited entries on draft views.
+    fn collect_ancestor_change_ids<T: ViewTxnT>(
+        txn: &T,
+        view: &atomic_core::pristine::ViewState,
+    ) -> Result<HashSet<NodeId>, RepositoryError> {
+        let mut ids = HashSet::new();
+        let mut cursor = view.parent;
+        while let Some(pid) = cursor {
+            let parent = txn
+                .get_view_by_id(pid)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+            match parent {
+                Some(p) => {
+                    let parent_ids = super::filter::collect_view_change_ids(txn, &p)?;
+                    ids.extend(parent_ids);
+                    cursor = p.parent;
+                }
+                None => break,
+            }
+        }
+        Ok(ids)
     }
 
     /// Get a summary of the current view's history.

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -645,7 +645,7 @@ default = "{}"
     /// Use this only when the caller will immediately populate the working
     /// copy itself (e.g. the agent record hook, which creates files and
     /// then records them).  For interactive view switches, use
-    /// [`switch_view`] instead — it materializes the working copy and
+    /// [`Repository::switch_view`] instead — it materializes the working copy and
     /// prevents desync between the pointer and disk state.
     ///
     /// `status()` handles the desynchronised state gracefully: files that

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -593,20 +593,25 @@ default = "{}"
 
     /// Set the current view (internal, does not update working copy).
     ///
+    /// Update the view pointer on disk without materializing.
+    ///
     /// This updates both the in-memory state and persists the change to disk,
-    /// but does NOT update the working copy. Use `switch_view` instead for
-    /// the full switch operation that also updates the working copy.
+    /// but does **NOT** update the working copy.  The working copy may be
+    /// left inconsistent with the view pointer — `status()` handles this
+    /// gracefully (files tracked on other views show as `Added` rather than
+    /// `Untracked`), but callers should prefer `switch_view()` for any
+    /// user-facing view change.
     ///
-    /// # Arguments
-    ///
-    /// * `view` - The name of the view to switch to
+    /// This is `pub(crate)` to prevent external code from accidentally
+    /// desynchronising the view pointer and working copy.  Internal uses
+    /// (init, git import, agent record alignment) know they will
+    /// materialise or record immediately afterward.
     ///
     /// # Errors
     ///
-    /// Returns an error if:
-    /// - The view does not exist in the pristine database
-    /// - The view file cannot be written
-    pub fn set_current_view(&mut self, view: &str) -> Result<(), RepositoryError> {
+    /// Returns an error if the view does not exist or the pointer file
+    /// cannot be written.
+    pub(crate) fn set_current_view(&mut self, view: &str) -> Result<(), RepositoryError> {
         // Verify the view exists in the pristine database
         {
             let txn = self
@@ -628,6 +633,33 @@ default = "{}"
         self.current_view = view.to_string();
         self.write_current_view(view)?;
         Ok(())
+    }
+
+    /// Align the view pointer without materializing the working copy.
+    ///
+    /// This persists the new view name to `.atomic/current_view` so that
+    /// subsequent `status()`, `add()`, and `record()` calls target the
+    /// correct view, but it does **not** add, remove, or update any files
+    /// on disk.
+    ///
+    /// Use this only when the caller will immediately populate the working
+    /// copy itself (e.g. the agent record hook, which creates files and
+    /// then records them).  For interactive view switches, use
+    /// [`switch_view`] instead — it materializes the working copy and
+    /// prevents desync between the pointer and disk state.
+    ///
+    /// `status()` handles the desynchronised state gracefully: files that
+    /// are tracked globally (in TREE) but whose introducing change belongs
+    /// to another view appear as `Added` (not `Untracked`), so there is
+    /// no contradictory "Untracked + already tracked" state even if the
+    /// caller forgets to materialise.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the view does not exist or the pointer file
+    /// cannot be written.
+    pub fn align_to_view(&mut self, view: &str) -> Result<(), RepositoryError> {
+        self.set_current_view(view)
     }
 
     /// Set the current view on this handle only.

--- a/atomic-repository/src/repository/status.rs
+++ b/atomic-repository/src/repository/status.rs
@@ -80,6 +80,12 @@ impl Repository {
         let mut directory_inodes: HashSet<atomic_core::types::Inode> = HashSet::new();
         // Cache inode → has_graph_content so we don't call inode_position twice
         let mut has_graph_content_cache: HashMap<PathBuf, bool> = HashMap::new();
+        // Files tracked globally (in TREE) but whose introducing change
+        // belongs to another view.  These must stay in `tracked_paths` so
+        // they don't surface as "Untracked" in the filesystem walk, but if
+        // they are absent from disk they must be silently skipped (not
+        // reported as "Deleted" — they were never on this view).
+        let mut foreign_paths: HashSet<PathBuf> = HashSet::new();
 
         let tree_iter = txn
             .iter_tree()
@@ -88,25 +94,39 @@ impl Repository {
         for result in tree_iter {
             let (path, inode) = result.map_err(|e| RepositoryError::Database(e.to_string()))?;
 
-            // View filter: skip files whose creating change is not on
-            // the current view.  Files in TREE without a graph position
-            // must be classified as Added, not Clean.  Files whose
-            // creating change is not in the current view's filter are
-            // skipped entirely — they belong to other views and must not
-            // appear in this view's status.
+            // Normalize path once (before view filter so foreign_paths
+            // uses the same key as tracked_paths).
+            let normalized = normalize_tracked_path(&path, &self.root);
+
+            // View filter: decide whether this file's graph content is
+            // visible on the current view.
+            //
+            // Files in TREE without a graph position → Added (not yet
+            // recorded).  Files whose creating change IS in the current
+            // view's filter → tracked normally.  Files whose creating
+            // change is NOT in the filter → "foreign": they belong to
+            // another view.  We keep them in tracked_paths (so the
+            // filesystem walk doesn't mark them Untracked) but flag them
+            // so that if they're absent from disk we skip them silently
+            // instead of reporting Deleted.
             let has_graph = if let Ok(Some(position)) = txn.inode_position(inode) {
                 if let Some(ref ids) = current_view_change_ids {
                     if !position.change.is_root() && !ids.contains(&position.change) {
-                        continue;
+                        // Foreign file — tracked globally, not on this view.
+                        // Include in tracked_paths with has_graph=false so
+                        // it shows as Added if on disk, and track it as
+                        // foreign so we skip it when not on disk.
+                        foreign_paths.insert(normalized.clone());
+                        false
+                    } else {
+                        true
                     }
+                } else {
+                    true
                 }
-                true
             } else {
                 false
             };
-
-            // Normalize path once
-            let normalized = normalize_tracked_path(&path, &self.root);
 
             // Apply path filter if specified
             if !options.path_filters.is_empty() {
@@ -208,6 +228,17 @@ impl Repository {
             let metadata = match std::fs::metadata(&abs_path) {
                 Ok(m) if m.is_file() => m,
                 _ => {
+                    // Foreign file not on disk — skip silently.
+                    // This file is tracked globally (in TREE) but its
+                    // graph content belongs to another view and it does
+                    // not exist on disk for THIS view.  Reporting it as
+                    // "Deleted" would be wrong (it was never present on
+                    // this view).
+                    if foreign_paths.contains(path) {
+                        found_on_disk.insert(path.clone());
+                        continue;
+                    }
+
                     // File missing from disk.  Check whether the deletion
                     // has already been recorded in the graph.
                     //

--- a/atomic-repository/src/repository/tests/status_tests.rs
+++ b/atomic-repository/src/repository/tests/status_tests.rs
@@ -375,6 +375,190 @@ fn test_repo_status_ignores_node_modules_no_trailing_newline() {
 }
 
 #[test]
+fn test_status_no_untracked_for_files_tracked_on_other_view() {
+    // Reproduces the customer bug report:
+    //   "I run atomic status and it shows me tons of things that aren't
+    //    tracked, then I run atomic add and it says there's nothing to add."
+    //
+    // Root cause: status() filters TREE entries by the view's change filter
+    // (view-aware), excluding files whose introducing change isn't visible.
+    // Those files then appear as "Untracked" during the filesystem walk.
+    // But is_tracked() (used by add) checks the global TREE table without
+    // any view filter — so those same files are "already tracked."
+    //
+    // Scenario: agent hook creates a draft view, adds+records files on it,
+    // then the user checks status on the parent (dev) view while the files
+    // still exist on disk.
+    use crate::record::RecordOptions;
+    use crate::status::FileStatus;
+    use atomic_core::pristine::{MutTxnT, ViewScope, ViewTxnT};
+
+    let (temp_dir, mut repo) = create_temp_repo();
+
+    // Step 1: Record a base file on dev so the view isn't empty
+    std::fs::write(temp_dir.path().join("base.txt"), b"base content").unwrap();
+    repo.add("base.txt", TrackingOptions::default()).unwrap();
+    let header = ChangeHeader::new("Add base.txt");
+    repo.record(header, RecordOptions::new().with_all(true))
+        .expect("base record failed");
+
+    // Step 2: Create a draft child view (simulates agent session)
+    {
+        let mut txn = repo.pristine.write_txn().unwrap();
+        let dev = txn.get_view("dev").unwrap().unwrap();
+        txn.create_view("agent-draft", ViewScope::Draft, Some(dev.id))
+            .unwrap();
+        txn.commit().unwrap();
+    }
+
+    // Step 3: Switch to draft, add+record files, switch back
+    repo.set_current_view("agent-draft").unwrap();
+
+    std::fs::write(temp_dir.path().join("agent_file.txt"), b"created by agent").unwrap();
+    std::fs::create_dir_all(temp_dir.path().join("src")).unwrap();
+    std::fs::write(temp_dir.path().join("src/module.rs"), b"pub fn agent() {}").unwrap();
+
+    repo.add("agent_file.txt", TrackingOptions::default())
+        .unwrap();
+    repo.add("src/module.rs", TrackingOptions::default())
+        .unwrap();
+
+    let header = ChangeHeader::new("Agent adds files");
+    repo.record(header, RecordOptions::new().with_all(true))
+        .expect("agent record failed");
+
+    // Step 4: Switch back to dev (but leave files on disk — simulates
+    // agent creating files in the working copy without cleaning up)
+    repo.set_current_view("dev").unwrap();
+
+    // Files still exist on disk (agent created them, switch_view wasn't
+    // called so no materialization cleanup happened)
+    assert!(temp_dir.path().join("agent_file.txt").exists());
+    assert!(temp_dir.path().join("src/module.rs").exists());
+
+    // Step 5: Check status on dev — THE BUG
+    let status = repo
+        .status(StatusOptions::default())
+        .expect("status failed");
+
+    // These files should NOT appear as Untracked
+    let untracked_paths: Vec<String> = status
+        .entries()
+        .iter()
+        .filter(|e| e.status() == FileStatus::Untracked)
+        .map(|e| e.path().to_string_lossy().to_string())
+        .collect();
+
+    assert!(
+        !untracked_paths.iter().any(|p| p == "agent_file.txt"),
+        "agent_file.txt must NOT appear as Untracked on dev. \
+         It is in TREE (from draft view) and should be Added or hidden. \
+         Untracked entries: {:?}",
+        untracked_paths
+    );
+    assert!(
+        !untracked_paths.iter().any(|p| p == "src/module.rs"),
+        "src/module.rs must NOT appear as Untracked on dev. \
+         Untracked entries: {:?}",
+        untracked_paths
+    );
+
+    // Step 6: Verify the contradictory state doesn't exist
+    // is_tracked should return true (file is in global TREE)
+    assert!(
+        repo.is_tracked("agent_file.txt").unwrap(),
+        "agent_file.txt should be tracked (in global TREE)"
+    );
+
+    // If status says Untracked AND is_tracked says true, that's the bug
+    let is_untracked_in_status = untracked_paths.iter().any(|p| p == "agent_file.txt");
+    let is_tracked_globally = repo.is_tracked("agent_file.txt").unwrap();
+    assert!(
+        !(is_untracked_in_status && is_tracked_globally),
+        "CONTRADICTION: status says Untracked but is_tracked says true. \
+         This is the exact bug the customer reported."
+    );
+
+    // Step 7: The correct behavior — these files should show as Added
+    // (tracked in TREE, but not yet recorded on THIS view)
+    let added_paths: Vec<String> = status
+        .entries()
+        .iter()
+        .filter(|e| e.status() == FileStatus::Added)
+        .map(|e| e.path().to_string_lossy().to_string())
+        .collect();
+
+    assert!(
+        added_paths.iter().any(|p| p == "agent_file.txt"),
+        "agent_file.txt should appear as Added on dev (tracked but not \
+         recorded on this view). Added entries: {:?}, All entries: {:?}",
+        added_paths,
+        status
+            .entries()
+            .iter()
+            .map(|e| (e.path().to_string_lossy().to_string(), e.status()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_status_foreign_file_not_on_disk_is_invisible() {
+    // Complement to the test above: when a file is tracked on another view
+    // but does NOT exist on disk, it should not appear in status at all.
+    // It should not be Deleted (it was never on this view) or Untracked.
+    use crate::record::RecordOptions;
+    use crate::status::FileStatus;
+    use atomic_core::pristine::{MutTxnT, ViewScope, ViewTxnT};
+
+    let (temp_dir, mut repo) = create_temp_repo();
+
+    // Record base on dev
+    std::fs::write(temp_dir.path().join("base.txt"), b"base").unwrap();
+    repo.add("base.txt", TrackingOptions::default()).unwrap();
+    let header = ChangeHeader::new("Base commit");
+    repo.record(header, RecordOptions::new().with_all(true))
+        .unwrap();
+
+    // Create draft, record a file on it
+    {
+        let mut txn = repo.pristine.write_txn().unwrap();
+        let dev = txn.get_view("dev").unwrap().unwrap();
+        txn.create_view("draft", ViewScope::Draft, Some(dev.id))
+            .unwrap();
+        txn.commit().unwrap();
+    }
+    repo.set_current_view("draft").unwrap();
+
+    std::fs::write(temp_dir.path().join("draft_only.txt"), b"draft content").unwrap();
+    repo.add("draft_only.txt", TrackingOptions::default())
+        .unwrap();
+    let header = ChangeHeader::new("Draft file");
+    repo.record(header, RecordOptions::new().with_all(true))
+        .unwrap();
+
+    // Switch back to dev AND remove the file from disk
+    repo.set_current_view("dev").unwrap();
+    std::fs::remove_file(temp_dir.path().join("draft_only.txt")).unwrap();
+
+    // Status on dev should NOT mention draft_only.txt at all
+    let status = repo
+        .status(StatusOptions::default())
+        .expect("status failed");
+    let all_paths: Vec<(String, FileStatus)> = status
+        .entries()
+        .iter()
+        .map(|e| (e.path().to_string_lossy().to_string(), e.status()))
+        .collect();
+
+    assert!(
+        !all_paths.iter().any(|(p, _)| p == "draft_only.txt"),
+        "draft_only.txt should not appear in status on dev at all \
+         (not on disk, belongs to another view). Entries: {:?}",
+        all_paths
+    );
+}
+
+#[test]
 fn test_status_detects_modification_when_file_index_missing() {
     // Repro for the silent-data-loss bug: when a tracked file has no
     // FILE_INDEX entry (e.g. after `atomic insert` / `atomic clone` /

--- a/tests/harness/21_status_add_asymmetry.sh
+++ b/tests/harness/21_status_add_asymmetry.sh
@@ -1,0 +1,396 @@
+#!/usr/bin/env bash
+# 21_status_add_asymmetry.sh — Status/Add view-filter asymmetry bug.
+#
+# Reproduces the bug report:
+#   "I run atomic status and it shows me tons of things that aren't tracked,
+#    then I run atomic add and it says there's nothing to add."
+#
+# Root cause: `status` uses the view's change filter to decide which TREE
+# entries are "tracked" (view-aware), while `add` / `is_tracked` checks the
+# global TREE table (view-unaware).  Files recorded on a child/sibling view
+# are in TREE but their introducing change isn't visible on the current
+# view.  Result:
+#   - status: file in TREE but filtered out → filesystem walk finds it → "Untracked"
+#   - add: file in TREE → is_tracked() = true → "already tracked" → skip
+#
+# Scenarios tested:
+#   1. File recorded on child draft view, parent view shows it as untracked
+#   2. File recorded on sibling view, other sibling shows it as untracked
+#   3. Agent workflow: auto-created draft view records files, parent is confused
+#   4. After fix: no file should be simultaneously "Untracked" AND "already tracked"
+
+HARNESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$HARNESS_DIR/helpers.sh"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Status/Add Asymmetry: Child draft view leaks into parent"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Workflow (simulates the agent hook creating files on a draft view):
+#   1. Init repo on dev (shared)
+#   2. Record a base file on dev
+#   3. Create a draft child view (like the agent would)
+#   4. Switch to draft, create+add+record a new file
+#   5. Switch back to dev
+#   6. BUG: status shows the file as Untracked (it's on disk from the
+#           draft view's record, but the change isn't in dev's filter)
+#   7. BUG: atomic add says "already tracked" (it's in the global TREE)
+#
+# Expected after fix:
+#   - The file should NOT appear as Untracked on dev
+#   - atomic add should not produce a contradictory state
+
+make_temp_repo "status-add-child-draft"
+init_repo
+
+# Step 1: Record a base file on dev so the view isn't empty
+create_file "base.txt" "base content"
+assert_success "add base.txt on dev" atomic add base.txt
+record_change "Add base.txt on dev" >/dev/null 2>&1 || true
+assert_clean "dev is clean after recording base.txt"
+
+# Step 2: Create a draft child view (simulates agent session)
+out="$(atomic view create agent-session --draft --parent dev 2>&1)" || true
+if echo "$out" | grep -qiE "created|view"; then
+    _pass "create draft view agent-session"
+else
+    _fail "create draft view agent-session" "output: $out"
+fi
+
+# Step 3: Switch to the draft view and create+add+record a file
+switch_view "agent-session" >/dev/null 2>&1 || true
+assert_current_view "on agent-session" "agent-session"
+
+create_file "agent_file.txt" "created by agent"
+assert_success "add agent_file.txt on agent-session" atomic add agent_file.txt
+record_change "Agent creates agent_file.txt" >/dev/null 2>&1 || true
+
+# Verify it's clean on the draft view
+out="$(get_status_short)"
+if echo "$out" | grep -qE "^[MADU?].*agent_file\.txt"; then
+    _fail "agent_file.txt is clean on agent-session" "still dirty: $out"
+else
+    _pass "agent_file.txt is clean on agent-session after record"
+fi
+
+# Step 4: Switch back to dev
+switch_view "dev" >/dev/null 2>&1 || true
+assert_current_view "back on dev" "dev"
+
+# Step 5: THE BUG — status should NOT show agent_file.txt as Untracked
+out="$(get_status_short)"
+if echo "$out" | grep -qE "^\?.*agent_file\.txt"; then
+    _fail "agent_file.txt NOT shown as Untracked on dev" \
+        "BUG: status shows '?' for a file that is in TREE (from draft view). Status: $out"
+else
+    _pass "agent_file.txt NOT shown as Untracked on dev"
+fi
+
+# Step 6: THE BUG — add should not claim "already tracked" for an "Untracked" file
+# If the file shows as Untracked, trying to add it should succeed.
+# If the file doesn't show at all (correct behavior), add should say "already tracked".
+# The BROKEN state is: status=Untracked + add=already-tracked (contradictory).
+add_out="$(atomic add agent_file.txt 2>&1)" || true
+status_out="$(get_status_short)"
+has_untracked=$(echo "$status_out" | grep -cE "^\?.*agent_file\.txt" || true)
+has_already_tracked=$(echo "$add_out" | grep -ci "already tracked" || true)
+
+if [[ "$has_untracked" -gt 0 && "$has_already_tracked" -gt 0 ]]; then
+    _fail "no contradictory status+add state" \
+        "BUG: status says Untracked but add says 'already tracked'. Status: $status_out | Add: $add_out"
+else
+    _pass "no contradictory status+add state"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Status/Add Asymmetry: Sibling views don't leak"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Workflow:
+#   1. On dev, record a base file
+#   2. Create two sibling views: feature-a, feature-b (both children of dev)
+#   3. Record a file on feature-a
+#   4. Switch to feature-b
+#   5. The feature-a file should not show as Untracked on feature-b
+#   6. add on feature-b should not be contradictory
+
+make_temp_repo "status-add-sibling"
+init_repo
+
+# Record base on dev
+create_file "base.txt" "base"
+assert_success "add base.txt" atomic add base.txt
+record_change "Add base" >/dev/null 2>&1 || true
+
+# Create two sibling draft views
+atomic view create feature-a --draft --parent dev >/dev/null 2>&1 || true
+atomic view create feature-b --draft --parent dev >/dev/null 2>&1 || true
+
+# Record on feature-a
+switch_view "feature-a" >/dev/null 2>&1 || true
+create_file "only_on_a.txt" "feature-a content"
+assert_success "add only_on_a.txt on feature-a" atomic add only_on_a.txt
+record_change "Add only_on_a.txt on feature-a" >/dev/null 2>&1 || true
+
+# Switch to feature-b
+switch_view "feature-b" >/dev/null 2>&1 || true
+assert_current_view "on feature-b" "feature-b"
+
+# File from feature-a should NOT appear as Untracked on feature-b
+out="$(get_status_short)"
+if echo "$out" | grep -qE "^\?.*only_on_a\.txt"; then
+    _fail "only_on_a.txt NOT shown as Untracked on feature-b" \
+        "BUG: sibling view file leaks as Untracked. Status: $out"
+else
+    _pass "only_on_a.txt NOT shown as Untracked on feature-b"
+fi
+
+# No contradictory state
+add_out="$(atomic add only_on_a.txt 2>&1)" || true
+status_out="$(get_status_short)"
+has_untracked=$(echo "$status_out" | grep -cE "^\?.*only_on_a\.txt" || true)
+has_already_tracked=$(echo "$add_out" | grep -ci "already tracked" || true)
+
+if [[ "$has_untracked" -gt 0 && "$has_already_tracked" -gt 0 ]]; then
+    _fail "no contradictory state on feature-b" \
+        "BUG: status=Untracked + add='already tracked'. Status: $status_out | Add: $add_out"
+else
+    _pass "no contradictory state on feature-b"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Status/Add Asymmetry: Agent batch-add workflow"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Simulates the exact agent workflow that triggers the bug:
+#   1. Agent hook creates a draft view
+#   2. Agent creates multiple files, calls add_batch + record
+#   3. Parent view should not see any of those files as Untracked
+#   4. atomic add --all on parent should not find contradictory files
+
+make_temp_repo "status-add-agent-batch"
+init_repo
+
+# Base content on dev
+create_file "README.md" "# Project"
+assert_success "add README.md" atomic add README.md
+record_change "Initial commit" >/dev/null 2>&1 || true
+
+# Agent creates a draft view and records multiple files
+atomic view create agent-turn-1 --draft --parent dev >/dev/null 2>&1 || true
+switch_view "agent-turn-1" >/dev/null 2>&1 || true
+
+create_file "src/main.rs" "fn main() {}"
+create_file "src/lib.rs" "pub mod util;"
+create_file "src/util.rs" "pub fn helper() {}"
+create_file "Cargo.toml" "[package]\nname = \"test\""
+
+assert_success "add src/main.rs" atomic add src/main.rs
+assert_success "add src/lib.rs" atomic add src/lib.rs
+assert_success "add src/util.rs" atomic add src/util.rs
+assert_success "add Cargo.toml" atomic add Cargo.toml
+record_change "Agent adds project structure" >/dev/null 2>&1 || true
+
+# Switch back to dev
+switch_view "dev" >/dev/null 2>&1 || true
+assert_current_view "on dev after agent work" "dev"
+
+# NO agent files should appear as Untracked on dev
+out="$(get_status_short)"
+agent_untracked=0
+for f in "src/main.rs" "src/lib.rs" "src/util.rs" "Cargo.toml"; do
+    if echo "$out" | grep -qE "^\?.*$(echo "$f" | sed 's/[\/\.]/\\&/g')"; then
+        agent_untracked=$((agent_untracked + 1))
+    fi
+done
+
+if [[ "$agent_untracked" -gt 0 ]]; then
+    _fail "no agent files shown as Untracked on dev (found $agent_untracked)" \
+        "BUG: $agent_untracked agent files leak as Untracked on parent. Status: $out"
+else
+    _pass "no agent files shown as Untracked on dev"
+fi
+
+# atomic add --all should not find contradictory files
+add_all_out="$(atomic add --all 2>&1)" || true
+if echo "$add_all_out" | grep -qiE "already tracked"; then
+    # Check if any of those "already tracked" files were shown as Untracked
+    status_out="$(get_status_short)"
+    has_contradiction=false
+    for f in "src/main.rs" "src/lib.rs" "src/util.rs" "Cargo.toml"; do
+        escaped_f="$(echo "$f" | sed 's/[\/\.]/\\&/g')"
+        is_untracked=$(echo "$status_out" | grep -cE "^\?.*$escaped_f" || true)
+        if [[ "$is_untracked" -gt 0 ]]; then
+            has_contradiction=true
+            break
+        fi
+    done
+    if $has_contradiction; then
+        _fail "add --all not contradictory with status" \
+            "BUG: files shown as Untracked but add says 'already tracked'"
+    else
+        _pass "add --all not contradictory with status"
+    fi
+else
+    _pass "add --all not contradictory with status"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Status/Add Asymmetry: No-switch agent workflow (THE BUG)"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# This is the EXACT scenario from the customer report and the wordl project.
+# The agent creates files on disk WITHOUT switching views. The agent hook
+# then creates a draft view and records on it. The user never leaves dev.
+#
+# Workflow:
+#   1. User is on dev, has a base file recorded
+#   2. Agent creates files on disk (user's working copy)
+#   3. Agent hook creates a draft view (child of dev)
+#   4. Agent hook does: switch to draft → add files → record → switch back to dev
+#   5. User runs `atomic status` on dev
+#   6. BUG: agent's files show as Untracked (they're on disk, in TREE,
+#           but the change is on the draft view, not dev)
+#   7. User runs `atomic add` — says "already tracked"
+#
+# The critical difference from the switch tests above: the FILES REMAIN
+# ON DISK because the agent created them in the working copy. The switch
+# back to dev removes them via materialization, but then they're recreated
+# by the fact that the working copy still has pending content.
+#
+# Actually, the most common trigger is simpler: the agent hook adds files
+# to TREE and records on the draft view, but the user stays on dev the
+# whole time (or the switch back leaves files on disk).
+
+make_temp_repo "status-add-no-switch"
+init_repo
+
+# Base content on dev
+create_file "base.txt" "base"
+assert_success "add base.txt" atomic add base.txt
+record_change "Initial commit" >/dev/null 2>&1 || true
+assert_clean "dev is clean"
+
+# --- Simulate agent hook: create draft, add+record, switch back ---
+# Step 1: Agent creates files on disk while user is on dev
+create_file "agent_created.txt" "agent was here"
+create_file "src/agent_module.rs" "pub fn agent_fn() {}"
+
+# Step 2: Agent hook creates draft view
+atomic view create agent-draft --draft --parent dev >/dev/null 2>&1 || true
+
+# Step 3: Agent hook switches to draft, adds, records, switches back
+switch_view "agent-draft" >/dev/null 2>&1 || true
+assert_success "add agent_created.txt on draft" atomic add agent_created.txt
+assert_success "add src/agent_module.rs on draft" atomic add "src/agent_module.rs"
+record_change "Agent turn: add files" >/dev/null 2>&1 || true
+
+# Step 4: Switch back to dev (this is what the hook does after recording)
+switch_view "dev" >/dev/null 2>&1 || true
+assert_current_view "back on dev after agent hook" "dev"
+
+# Step 5: User manually re-creates files (or they leaked from switch)
+# In the real scenario, the agent might still be writing to disk,
+# or the files persist because the agent didn't clean up.
+# Simulate this by re-creating the files:
+create_file "agent_created.txt" "agent was here"
+create_file "src/agent_module.rs" "pub fn agent_fn() {}"
+
+# THE BUG: These files are in TREE (agent added them), the change is on
+# the draft view. On dev:
+#   - status: change not in dev's filter → skip from tracked → Untracked
+#   - add: is_tracked() checks global TREE → already tracked → skip
+
+out="$(get_status_short)"
+echo "  DEBUG status output: $out" >&2
+
+# Test 1: Files should NOT be shown as Untracked
+if echo "$out" | grep -qE "^\?.*agent_created\.txt"; then
+    _fail "agent_created.txt NOT Untracked on dev" \
+        "BUG: file in TREE from draft view shows as Untracked. Status: $out"
+else
+    _pass "agent_created.txt NOT Untracked on dev"
+fi
+
+if echo "$out" | grep -qE "^\?.*agent_module\.rs"; then
+    _fail "agent_module.rs NOT Untracked on dev" \
+        "BUG: file in TREE from draft view shows as Untracked. Status: $out"
+else
+    _pass "agent_module.rs NOT Untracked on dev"
+fi
+
+# Test 2: The contradictory state must not exist
+add_out="$(atomic add agent_created.txt 2>&1)" || true
+status_out="$(get_status_short)"
+has_untracked=$(echo "$status_out" | grep -cE "^\?.*agent_created\.txt" || true)
+has_already_tracked=$(echo "$add_out" | grep -ci "already tracked" || true)
+
+if [[ "$has_untracked" -gt 0 && "$has_already_tracked" -gt 0 ]]; then
+    _fail "no status+add contradiction for agent_created.txt" \
+        "BUG: status=Untracked + add='already tracked'. Status: $status_out | Add: $add_out"
+else
+    _pass "no status+add contradiction for agent_created.txt"
+fi
+
+# Test 3: If on disk + in TREE, the correct status should be Added
+# (tracked but not recorded on THIS view)
+if echo "$out" | grep -qE "^A.*agent_created\.txt"; then
+    _pass "agent_created.txt shown as Added (correct: tracked, needs record on dev)"
+else
+    # Also acceptable: not shown at all (file shouldn't be on disk)
+    if echo "$out" | grep -q "agent_created\.txt"; then
+        _fail "agent_created.txt shown as Added" \
+            "File shown with wrong status. Status: $out"
+    else
+        _pass "agent_created.txt shown as Added (or correctly hidden)"
+    fi
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Status/Add Asymmetry: File on disk from other view shows as Added"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# If a file IS on disk and IS in TREE (from another view), the correct
+# status should be "Added" (tracked, needs recording on this view) — NOT
+# "Untracked" (which implies it's unknown to the system).
+#
+# This test verifies that the file shows as Added when it's on disk but
+# its graph content belongs to another view.
+
+make_temp_repo "status-add-shows-added"
+init_repo
+
+# Record base on dev
+create_file "base.txt" "base"
+assert_success "add base.txt" atomic add base.txt
+record_change "Base commit" >/dev/null 2>&1 || true
+
+# Create draft, record a file on it
+atomic view create feature --draft --parent dev >/dev/null 2>&1 || true
+switch_view "feature" >/dev/null 2>&1 || true
+create_file "feature.txt" "feature content"
+assert_success "add feature.txt" atomic add feature.txt
+record_change "Feature file" >/dev/null 2>&1 || true
+
+# Switch to dev — file should be removed from disk by materialization
+switch_view "dev" >/dev/null 2>&1 || true
+
+# If the file was properly removed by switch_view, it should not appear at all
+# If it still exists on disk (materialization bug), it should show as Added, NOT Untracked
+if [[ -f "feature.txt" ]]; then
+    # File leaked onto disk — at minimum it should be Added, not Untracked
+    out="$(get_status_short)"
+    if echo "$out" | grep -qE "^\?.*feature\.txt"; then
+        _fail "leaked file shows as Added not Untracked" \
+            "BUG: file on disk from another view shows as '?' instead of 'A'. Status: $out"
+    elif echo "$out" | grep -qE "^A.*feature\.txt"; then
+        _pass "leaked file shows as Added not Untracked"
+    else
+        _pass "leaked file handled correctly (not shown or shown with other status)"
+    fi
+else
+    _pass "leaked file shows as Added not Untracked (file correctly removed by switch)"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+print_summary


### PR DESCRIPTION
This pull request introduces several important enhancements and documentation updates to the project. The main focus is on improved OpenCode plugin detection logic in the `atomic-agent`, as well as expanded project documentation for the vault, code intelligence, and system prompt. Additionally, two new intent files are scaffolded for future work.

### OpenCode Plugin Management Improvements

- **Global Plugin Detection and Installation Reporting**
  - Added `global_config_dir()` and `is_plugin_installed()` methods to `OpenCodeHook` for robust detection of the global OpenCode plugin (`atomic-hooks.ts`) in the user's config directory, following XDG conventions.
  - Updated `install` and `is_installed` methods to accurately report plugin status based on global installation, ensuring correct feedback for users and integration with `enable`.
  - Enhanced `detect_presence` to consider both the presence of a local `.opencode` directory and the global plugin, making detection more reliable across environments.

### Documentation and Project Knowledge

- **System Prompt and Skills Documentation**
  - Added a comprehensive system prompt for the AI coding agent, detailing tool usage, workflow, and knowledge graph commands.
  - Added and updated skills documentation for using the Atomic vault and leveraging code intelligence via the knowledge graph, including concrete examples and workflow guidance. [[1]](diffhunk://#diff-8dab7eff0175336137fe819945f9df7cdbcc109aec105fc36c26f7ef78fda5cbR1-R193) [[2]](diffhunk://#diff-7218ae8b6991d6dffa3e00c9a1cf83fea58c0aaf9cb21eaa4885d33b699c0c8eR1-R144)
  - Introduced a project memory index file to centralize shared knowledge references.

### Intent Scaffolding

- **New Intents for Future Work**
  - Scaffolded two intent files: one for understanding B-tree graph building (`ATOM-1`), and one for explaining identity mapping to change records (`ATOM-2`), each with acceptance criteria and scope for future planning. [[1]](diffhunk://#diff-4046d08a0e7d0aee67a67194b9186622b6589970d74d9c259e65f18268fc0296R1-R66) [[2]](diffhunk://#diff-2dae6756669892612207be0526e3289b5d1153a2ede34590e70a9705a2fc161dR1-R55)