### PR TITLE
Enhance vault intent management and CLI features

### DIFF
--- a/.vault/intents/gentle-waterfall-143b/019eeff2-a885-7370-b599-a5b3b3e5c58a/1/intent.md
+++ b/.vault/intents/gentle-waterfall-143b/019eeff2-a885-7370-b599-a5b3b3e5c58a/1/intent.md
@@ -1,0 +1,55 @@
+---
+created_by: continuouslee <lee@atomic.dev>
+goals: []
+id: ATOM-2
+priority: medium
+status: done
+title: Explain identity mapping to change records
+view: gentle-waterfall-143b
+entry_type: intent
+content_hash: QO36VLRYWKOIWLGTMNXOCTV3RBLZQGCDOWNYCSGH23M5UFPBM7JQ
+created_at: 2026-06-22T15:30:21.541422+00:00
+updated_at: 2026-06-22T15:30:21.541422+00:00
+---
+# Explain identity mapping to change records
+
+**ID:** ATOM-2 · **Priority:** medium · **Status:** backlog
+**Created by:** continuouslee <lee@atomic.dev> · **Created:** 2026-06-22T15:28:57.094530+00:00
+
+---
+
+## Problem
+
+REPLACE with what is broken or missing, and why it matters. Not a solution description.
+
+## Acceptance Criteria
+
+- [ ] REPLACE with first testable criterion
+- [ ] REPLACE with second testable criterion
+
+## Scope
+
+**In:**
+- REPLACE with specific crate, module, or component
+
+**Out:**
+- REPLACE with what is explicitly excluded
+
+## Constraints
+
+- REPLACE with technical limits, compatibility requirements, or design decisions
+
+## Dependencies
+
+None
+
+## TODOs
+
+- [ ] `ATOM-2/1` REPLACE with first independently executable task
+  **Files:** REPLACE with specific file paths from codebase search
+  **Criteria:** REPLACE with how to verify this TODO is done
+
+- [ ] `ATOM-2/2` REPLACE with second task
+  **Files:** REPLACE with specific file paths
+  **Criteria:** REPLACE with verification criteria
+  **Depends:** `ATOM-2/1` (if dependent, otherwise omit this line)

--- a/.vault/intents/tight-storm-0847/019eef64-2859-7ed1-8b32-dc3e837f6611/1/intent.md
+++ b/.vault/intents/tight-storm-0847/019eef64-2859-7ed1-8b32-dc3e837f6611/1/intent.md
@@ -1,0 +1,66 @@
+---
+created_by: continuouslee <lee@atomic.dev>
+goals: []
+id: ATOM-1
+priority: medium
+status: done
+title: Understand B-tree graph building
+view: tight-storm-0847
+entry_type: intent
+content_hash: 7TC3V3WDMX6ZFKXHX7PLECD223TEXS2TAW4KXTNJPAUQXM3GKFBA
+created_at: 2026-06-22T13:15:22.910549+00:00
+updated_at: 2026-06-22T13:15:22.910549+00:00
+---
+# Understand B-tree graph building
+
+**ID:** ATOM-1 · **Priority:** medium · **Status:** backlog
+**Created by:** continuouslee <lee@atomic.dev> · **Created:** 2026-06-22T12:53:50.551571+00:00
+
+---
+
+## Problem
+
+Explain how Atomic's persistent B-tree storage records are assembled into the
+runtime graph model developers see when reading files, diffing, or traversing
+history. The answer needs to connect the storage tables, graph node/edge keys,
+inode indexing, view filters, and traversal rules clearly enough to be useful
+for future implementation work.
+
+## Acceptance Criteria
+
+- [x] Identify the B-tree tables involved in graph construction.
+- [x] Explain how vertices and edges are encoded and resolved during traversal.
+- [x] Describe how views filter the ambient graph.
+- [x] Call out the key ambiguity around positions versus vertices.
+
+## Scope
+
+**In:**
+- `atomic-core` pristine storage and graph traversal concepts.
+- `atomic-repository` read/diff-facing interpretation where relevant.
+
+**Out:**
+- Code changes or behavior modifications.
+- A full CRDT semantic-layer implementation walkthrough.
+
+## Constraints
+
+- Use Atomic CLI and vault context only for repository operations.
+- Keep the explanation grounded in the project documentation and KG-discovered
+  code structure.
+
+## Dependencies
+
+None
+
+## TODOs
+
+- [x] `ATOM-1/1` Inspect graph storage and traversal symbols
+  **Files:** `atomic-core/src/pristine/**`, `atomic-core/src/types/**`
+  **Criteria:** Relevant graph entities and tables are identified.
+
+- [x] `ATOM-1/2` Provide concise conceptual explanation
+  **Files:** No code changes.
+  **Criteria:** User receives a clear answer connecting B-tree layout to graph
+  construction and traversal.
+  **Depends:** `ATOM-1/1`

--- a/.vault/memory/MEMORY.md
+++ b/.vault/memory/MEMORY.md
@@ -1,0 +1,13 @@
+---
+name: MEMORY
+type: index
+entry_type: memory
+content_hash: BYRJSIU5XUJKBSZNM6PJ2MBLIRVJP27P27PG24BPQGUAGDUJAL3Q
+created_at: 2026-06-16T22:21:17.849281+00:00
+updated_at: 2026-06-16T22:21:17.849281+00:00
+---
+# Project Memory
+
+This file indexes shared project knowledge. Each entry links to a detailed file.
+
+<!-- Add entries as: - [Title](filename.md) — description -->

--- a/.vault/prompts/system_prompt.md
+++ b/.vault/prompts/system_prompt.md
@@ -1,0 +1,146 @@
+---
+description: Default system prompt for the AI coding agent
+name: System Prompt
+entry_type: skill
+content_hash: HEKIL47UDSCUO6TJ43ZNESO6KFZXZ3WR6PPOIUJDDBONQGFHSH6A
+created_at: 2026-06-16T22:21:17.840228+00:00
+updated_at: 2026-06-16T22:21:17.840228+00:00
+---
+You are Pi, a CLI coding agent. Use your tools to help the user with software engineering tasks.
+
+# Tools
+
+You have: `grep`, `read`, `find`, `edit`, `write`, `bash`, and `atomic`.
+
+- `atomic` interacts with the Atomic VCS, project vault, and knowledge graph. **Use this first for code exploration.** The KG has indexed every function, struct, trait, and module in the project with their signatures, callers, and change history.
+- `grep` searches file contents (powered by ripgrep). Use this for literal text search when the KG doesn't have what you need, or to find specific strings/patterns.
+- `read` reads a file — but ONLY files discovered by a prior `grep` call. `.vault/` files are exempt from this restriction.
+- `find` locates files by name/glob pattern (powered by fd).
+- `edit` makes exact text replacements. `oldText` must match exactly including whitespace.
+- `write` creates new files.
+- `bash` runs shell commands. Only use for git, tests, builds — not for searching or reading files.
+
+Call multiple tools in parallel when there are no dependencies between them.
+
+# Workflow
+
+Every task follows this pattern:
+
+1. **KG first — search the knowledge graph.** The KG knows every function, struct, and module in the project. Start here:
+   ```
+   atomic vault query search "worker_threads Builder"
+   ```
+   This returns entity nodes with signatures, file locations, and metadata — often enough to plan your edit without reading any files.
+
+2. **Explore structure with neighbors.** When the KG search finds a relevant entity, explore its connections:
+   ```
+   atomic vault query neighbors entity:src/runtime/builder.rs:worker_threads:42
+   ```
+   This shows: who calls it, what changes modified it, what files define it, and what intents link to it.
+
+3. **grep only when needed.** Use grep for:
+   - Literal strings the KG doesn't index (error messages, config values, magic numbers)
+   - Pattern matching (regex)
+   - Finding all call sites of a function (when KG CALLS edges are incomplete)
+
+4. **Read only what you must.** After KG + grep narrow the scope, read only the specific functions you need to understand or edit. Don't read entire files.
+
+5. **Edit last.** Combine all changes to the same file in one edit call.
+
+**Do NOT default to grep → read → edit.** The KG is faster, cheaper, and gives you structural context that grep cannot. A KG `neighbors` query on one entity tells you more than reading 500 lines of source.
+
+# Knowledge Graph
+
+The project's knowledge graph indexes:
+- **Entities**: every function, struct, trait, enum, impl, const extracted by tree-sitter
+- **Files**: every tracked file
+- **Changes**: every recorded change with author and message
+- **Views**: branch-like perspectives on the graph
+- **Goals**: development sessions
+- **Intents**: JIRA-style work items
+
+## KG Commands
+
+| Command | Use when |
+|---------|----------|
+| `atomic vault query search "text"` | Finding functions, types, files by keyword |
+| `atomic vault query neighbors entity:file:name:line` | Understanding a function's callers, changes, relationships |
+| `atomic vault query neighbors change:HASH` | Seeing what a change modified |
+| `atomic vault query neighbors file:path` | Seeing what entities a file defines |
+| `atomic vault query ask "question"` | Complex questions (RAG — needs API key) |
+
+## Node ID Format
+
+- `entity:src/runtime/builder.rs:Builder:50` — struct at line 50
+- `entity:src/runtime/builder.rs:worker_threads:142` — function at line 142
+- `file:src/runtime/builder.rs` — a tracked file
+- `change:ABCD1234` — a recorded change (12-char hash prefix)
+- `view:master` — a view
+- `intent:TOKI-1` — a work item
+- `goal:swift-meadow-a3f2` — a development session
+
+# Goals and Intents
+
+When asked to work on a task, follow this exact sequence:
+
+1. **Check existing intents first** — do NOT create duplicates:
+   ```
+   atomic vault intent list
+   ```
+
+2. **Create exactly ONE intent** (never retry on error — check the list instead):
+   ```
+   command: "vault intent create", args: {"title": "Clear description", "priority": "high"}
+   ```
+
+3. **Explore the code using the KG** to build a plan:
+   ```
+   command: "vault query search", args: {"query": "worker_threads Builder runtime"}
+   command: "vault query neighbors entity:src/runtime/builder.rs:worker_threads:142"
+   ```
+
+4. **Write your plan INTO the intent file.** This is required — do NOT just describe the plan in chat. Use `edit` to fill in `.vault/intents/<id>/intent.md` with:
+   - **Description**: What's the problem?
+   - **Acceptance Criteria**: Concrete checkboxes.
+   - **Files to Modify**: Table of files and changes from your KG exploration.
+   - **Approach**: Step-by-step plan referencing specific functions.
+   - **Test Strategy**: How to verify.
+   - **Notes**: Findings from code exploration.
+
+   **The intent file IS the deliverable of your planning phase.**
+
+5. **Start a goal** linked to the intent, then create a draft view for isolated work:
+   ```
+   command: "vault goal start", args: {"intent": "TOKI-1"}
+   command: "view create my-goal --draft"
+   command: "view switch my-goal"
+   ```
+
+6. When done, record and promote:
+   ```
+   command: "record", args: {"message": "Add max_worker_threads option to Builder"}
+   command: "vault goal stop my-goal", args: {"promote": true}
+   ```
+
+# Code Changes
+
+- Read before editing. Match existing style, naming, indentation
+- Minimal changes only — don't refactor, add comments, or improve code beyond what was asked
+- Don't add error handling, abstractions, or features that weren't requested
+- Don't create files unless necessary. Prefer editing existing files
+- After editing, record your changes with `atomic record`
+
+# Safety
+
+- Confirm with user before destructive/irreversible actions (delete, force-push, rm -rf)
+- Never expose secrets or API keys in code or output
+
+# Output
+
+Be concise. Lead with action, not reasoning. No preamble or filler. If you can say it in one sentence, do. Reference code as `file_path:line_number`. No emojis unless asked.
+
+# Context Management
+
+Old tool results are automatically cleared from context to free up space. The 2 most recent tool results are always kept in full. Older results are replaced with one-line summaries.
+
+When working with tool results, write down important information in your response text (file paths, function signatures, key findings). Only your written notes survive context compaction.

--- a/.vault/skills/atomic-vault.md
+++ b/.vault/skills/atomic-vault.md
@@ -1,0 +1,193 @@
+---
+description: How to use the project vault for goals, intents, and shared memory
+name: Atomic Vault
+entry_type: skill
+content_hash: KFV3MJULZHJMKSTY3HNCDNZSFDALMYTAFMHEWGLR4JQNNMZ5WYYQ
+created_at: 2026-06-16T22:21:17.843890+00:00
+updated_at: 2026-06-16T22:21:17.843890+00:00
+---
+---
+name: Atomic Vault
+description: How to use the project vault for goals, intents, and shared memory
+---
+
+# Atomic Vault
+
+This project has an Atomic vault — a shared knowledge store at `.vault/`.
+Use the `atomic` tool to interact with it.
+
+## Goals (Development Sessions)
+
+Goals track your work sessions. Start one when you begin working, stop when done.
+
+```
+# Start a goal (generates a name like "swift-meadow-a3f2")
+atomic vault goal start --developer "your name"
+
+# Start with a linked intent
+atomic vault goal start --intent PIMO-1
+
+# Stop and promote (marks as completed for the team)
+atomic vault goal stop --promote
+
+# Stop and suspend (can resume later)
+atomic vault goal stop
+
+# Resume a previous goal
+atomic vault goal resume swift-meadow-a3f2
+
+# List goals
+atomic vault goal list --status active
+atomic vault goal list --status all
+```
+
+## Intents (JIRA-style Tasks)
+
+Intents are units of work with auto-generated IDs (e.g., PIMO-1, PIMO-2).
+
+**IMPORTANT: Create ONE intent per task. Check existing intents first.**
+
+### Creating an Intent
+
+1. **Check if the intent already exists:**
+   ```
+   atomic vault intent list
+   ```
+
+2. **Create exactly ONE intent** (do NOT retry if the CLI errors — check the list):
+   ```
+   atomic vault intent create --title "Fix authentication" --priority high
+   ```
+   This returns an ID like PROJ-1 and creates a scaffold file at `.vault/intents/proj-1/intent.md`.
+
+3. **Write your plan into the intent file.** The scaffold has sections to fill in:
+   ```
+   edit .vault/intents/proj-1/intent.md using the .vault/templates/intent.md template
+   ```
+   Replace the HTML comment placeholders in each section:
+   - **Description**: What's the problem? Link to the GitHub issue.
+   - **Preconditions**: What must be true before starting?
+   - **Acceptance Criteria**: Concrete checkboxes — what does "done" look like?
+   - **Files to Modify**: Table of files, what changes, and why.
+   - **Approach**: Step-by-step plan referencing specific functions from the KG.
+   - **Test Strategy**: How will you verify each criterion?
+   - **Notes**: Findings from code exploration, trade-offs, open questions.
+
+   The intent file IS the deliverable — a reviewer reads it to understand the full plan.
+
+4. **Update status as you work:**
+   ```
+   atomic vault intent update PROJ-1 --status in-progress
+   atomic vault intent update PROJ-1 --status review
+   atomic vault intent update PROJ-1 --status done
+   ```
+
+### Intent Workflow Example
+
+```
+# Check existing intents first
+atomic vault intent list
+
+# Create ONE intent
+atomic vault intent create --title "Add max_worker_threads option" --priority high
+# → returns TOKI-1
+
+# Explore the code to build the plan
+atomic vault query search "worker_threads Builder"
+atomic vault query neighbors "entity:src/runtime/builder.rs:worker_threads:42"
+
+# Write the plan into the intent file — fill in every section
+edit .vault/intents/toki-1/intent.md
+# Fill in: Description, Preconditions, Acceptance Criteria,
+# Files to Modify (table), Approach (steps), Test Strategy, Notes
+
+# Link a goal and start working
+atomic vault goal start --intent TOKI-1
+```
+
+Intent statuses: backlog → planned → in-progress → review → done
+
+## Memory (Shared Knowledge)
+
+Memory files persist project knowledge across sessions and developers.
+
+```
+# List memory files
+atomic vault memory list
+
+# Read a memory file
+atomic vault memory show architecture
+```
+
+To save new knowledge, write a markdown file to `.vault/memory/` and
+then run `atomic vault sync` to persist it to the database.
+
+## Version Control
+
+The vault is tracked by the same Atomic VCS as the code:
+
+```
+# Check repo status
+atomic status
+
+# View change history
+atomic log
+
+# Show working copy diff
+atomic diff
+```
+
+## Workflow
+
+1. **Check existing intents**: Don't create duplicates.
+   ```
+   atomic vault intent list
+   ```
+
+2. **Create ONE intent** with a clear title. Then explore the code and write a plan into the intent file:
+   ```
+   atomic vault intent create --title "Fix issue #42: description"
+   # Explore with grep + KG queries
+   # Edit .vault/intents/proj-N/intent.md with your plan
+   ```
+
+3. **Start a goal** linked to the intent:
+   ```
+   atomic vault goal start --intent PROJ-1
+   ```
+
+4. **Create a draft view** for isolated work:
+   ```
+   atomic view create <goal-name> --draft
+   atomic view switch <goal-name>
+   ```
+
+5. **Search and explore** using grep + knowledge graph together:
+   ```
+   grep "worker_threads" --type rs
+   atomic vault query search "worker_threads Builder"
+   atomic vault query neighbors "entity:src/builder.rs:worker_threads:42"
+   ```
+
+6. **Make changes** using read, edit, write tools
+
+7. **Record** your changes:
+   ```
+   atomic record -m "Add max_worker_threads option to Builder"
+   ```
+
+8. **Stop the goal** when done:
+   ```
+   atomic vault goal stop --promote
+   ```
+
+9. **Review**: The draft view stays alive for review.
+   ```
+   atomic view switch <goal-name>
+   atomic diff
+   ```
+
+10. **Merge** when approved:
+    ```
+    atomic insert from-view <goal-name> --to-view dev
+    ```

--- a/.vault/skills/code-intelligence.md
+++ b/.vault/skills/code-intelligence.md
@@ -1,0 +1,144 @@
+---
+description: Use the knowledge graph to understand code structure, not just text matches
+name: Code Intelligence
+entry_type: skill
+content_hash: K6OX4CAVWSXYE4KDD6YRWZMJBCVJ7NOIV7PK2J6UZ5QWXYBOFIKQ
+created_at: 2026-06-16T22:21:17.846222+00:00
+updated_at: 2026-06-16T22:21:17.846222+00:00
+---
+---
+name: Code Intelligence
+description: Use the knowledge graph to understand code structure before reading files
+---
+
+# Code Intelligence
+
+The project has a knowledge graph (KG) with every function, struct, trait, enum,
+and module indexed by tree-sitter. **Search the KG first, not grep.**
+
+## The Pattern: KG search → neighbors → targeted read
+
+### Step 1: Search the KG with SIMPLE terms
+
+Use one or two keywords, not long phrases. Simpler queries return better results:
+
+✅ Good: `atomic vault query search "worker_threads"`
+✅ Good: `atomic vault query search "Builder"`
+❌ Bad:  `atomic vault query search "Builder multithread worker_threads tokio::main"`
+
+Run multiple simple searches in parallel instead of one complex query.
+
+### Step 2: Read the `id` field from the results — this is the ONLY source of truth
+
+```
+CRITICAL RULE: You MUST copy the "id" field VERBATIM from search results.
+NEVER construct, guess, or modify an entity ID. If the search didn't
+return it, the ID does not exist.
+```
+
+Example: search returns this result:
+```json
+{"id": "entity:tokio/src/runtime/builder.rs:worker_threads:509", ...}
+```
+
+✅ CORRECT — copy the id exactly as returned:
+```
+atomic vault query neighbors entity:tokio/src/runtime/builder.rs:worker_threads:509
+```
+
+❌ WRONG — you guessed the line number:
+```
+atomic vault query neighbors entity:tokio/src/runtime/builder.rs:worker_threads:356
+```
+
+❌ WRONG — you guessed the path:
+```
+atomic vault query neighbors entity:src/runtime/builder.rs:worker_threads
+```
+
+❌ WRONG — the search didn't return this ID:
+```
+atomic vault query neighbors entity:tokio/src/runtime/builder.rs:Builder:44
+```
+
+If you need an entity that didn't appear in search results, do another search
+with different terms — do NOT guess the ID.
+
+### Step 3: Use neighbors on IDs you found
+
+The neighbors query returns:
+- **DEFINES edges**: which file defines this entity
+- **MODIFIES edges**: which changes touched it (who, when, commit message)
+- **Connected entities**: other functions in the same file
+
+### Step 4: Explore the file's entities
+
+To see ALL functions/structs in a file, query neighbors on the file node:
+
+```
+atomic vault query neighbors file:tokio/src/runtime/builder.rs
+```
+
+This returns every entity the file defines — all functions, structs, traits,
+impls, constants. Much faster than reading the file.
+
+### Step 5: Read only what you must
+
+After KG search + neighbors narrow the scope, read only the specific function
+body you need to understand or edit. Don't read entire files.
+
+## When to use KG vs grep vs read
+
+| I need to... | Use |
+|---|---|
+| Find functions/types by name | `atomic vault query search "name"` |
+| See a function's signature and location | KG search (summary field has the signature) |
+| See what file defines a function | `atomic vault query neighbors entity:...` → DEFINES edge |
+| See what changes modified a function | `atomic vault query neighbors entity:...` → MODIFIES edge |
+| See all functions in a file | `atomic vault query neighbors file:path` |
+| See what a change touched | `atomic vault query neighbors change:HASH` |
+| Find a literal string or error message | `grep "exact string"` |
+| Find regex patterns | `grep "pattern"` |
+| Read function implementation details | `read file` (only after KG narrows the scope) |
+
+## Searching tips
+
+- **Search broadly first**: `atomic vault query search "worker_threads"` finds entities, files, AND changes
+- **Use file: prefix to explore a file**: `atomic vault query neighbors file:src/runtime/builder.rs`
+- **Chain searches**: search → get IDs → neighbors on those IDs → find connected IDs → neighbors again
+- **The search returns at most 10 results** — use specific terms to narrow down
+
+## Entity ID Format
+
+Entity IDs are structured as `entity:{file_path}:{name}:{line_number}`:
+
+```
+entity:tokio/src/runtime/builder.rs:worker_threads:509    — function at line 509
+entity:tokio/src/runtime/builder.rs:Builder:50             — struct at line 50
+entity:tokio-macros/src/entry.rs:set_worker_threads:126    — method at line 126
+```
+
+The line number comes from the AST extraction and is stable for the current
+version of the code. **Always get IDs from search results, never construct them.**
+
+## Planning an Intent with KG
+
+When creating an intent, use the KG to build a concrete plan:
+
+1. Search for the relevant concept:
+   ```
+   atomic vault query search "worker_threads Builder multithread"
+   ```
+
+2. For each relevant entity in the results, explore its neighbors:
+   ```
+   atomic vault query neighbors entity:tokio/src/runtime/builder.rs:worker_threads:509
+   atomic vault query neighbors file:tokio/src/runtime/builder.rs
+   atomic vault query neighbors file:tokio-macros/src/entry.rs
+   ```
+
+3. Now you know the exact files, functions, and signatures involved.
+   Write this into the intent's **Files to Modify** table and **Approach** section.
+
+4. Only `read` the function bodies you need to understand the implementation
+   details for your plan.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,16 +280,20 @@ dependencies = [
  "atomic-semantic",
  "chrono",
  "dirs",
+ "flate2",
  "ignore",
  "log",
  "postcard",
  "rand 0.8.5",
  "rayon",
  "redb",
+ "reflink-copy",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "syntext",
+ "tar",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -845,6 +849,16 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -2132,6 +2146,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "reflink-copy"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13362233b147e57674c37b802d216b7c5e3dcccbed8967c84f0d8d223868ae27"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rustix",
+ "windows",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2680,6 +2706,17 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -3375,6 +3412,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3385,6 +3443,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3414,6 +3483,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -3535,6 +3614,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3777,6 +3865,16 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-agent"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "atomic-core",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "atomic-agent",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-config"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-identity"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "atomic-config",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-remote"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-repository"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "atomic-config",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-semantic"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-teams"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "atomic-remote",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-agent"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "atomic-core",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "atomic-agent",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-config"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-identity"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "atomic-config",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-remote"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-repository"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "atomic-config",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-semantic"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "atomic-teams"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "atomic-remote",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 authors = ["Atomic Contributors"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 authors = ["Atomic Contributors"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # Atomic
 
-A mathematically sound distributed version control system — built for the age of AI.
+A Semantic Change Graph (SCG) to track memory, intent, provenance, and change as a single unit of work.  This is the evolution of source code management in the era of agents and agentic coding.
 
 ## Why Atomic?
 
 Git was designed for humans writing code in text editors. It tracks lines in files. That worked for 20 years.
 
 Now AI agents write most of the code. They work in sessions and turns, use multiple models, cost money per token, and produce changes that need to be audited, attributed, and explained. Git doesn't know about any of this — you're bolting on external tools to answer basic questions like "which model wrote this?" or "how much did this session cost?"
-
-Atomic is version control that understands AI-assisted development from the ground up.
 
 ## Atomic vs Git for Agentic Workflows
 
@@ -483,4 +481,4 @@ Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for the f
 
 ## Acknowledgments
 
-Atomic builds on decades of research in patch theory, drawing inspiration from academic work on categorical semantics of version control and practical implementations that explored these ideas.
+Atomic builds on decades of research in patch theory, drawing inspiration from academic work on categorical semantics of version control and practical implementations that explored these ideas.  Thanks to the team at https://pijul.org for originating that work.

--- a/README.md
+++ b/README.md
@@ -406,6 +406,57 @@ atomic/
 | **atomic-remote-client** | `atomic-enterprise/atomic-remote` | HTTP client library for push/pull/clone |
 | **atomic-docs** | `atomic-docs/` | Documentation site ([docs.atomic.dev](https://docs.atomic.dev/)) |
 
+## Atomic + smolvm: Concurrent Agent Sandboxes
+
+When several agents work a repository at once, each needs an isolated build
+surface (no `node_modules` / `target` collisions) while still sharing one
+history. Atomic does this with **copy-on-write working trees over a single
+canonical graph** — no per-agent forks, no virtualized I/O.
+
+- **The working tree is cloned; the graph is not.** A sandbox is a reflink
+  (copy-on-write) clone of the working tree — APFS `clonefile`, Btrfs/XFS
+  `FICLONE`, ReFS block-clone — done in-process via the `reflink-copy` crate.
+  Five agents off a 200 MB base cost a few MB and run at bare-metal filesystem
+  speed. There is exactly **one** pristine; a sandbox carries a small
+  `.atomic-sandbox` pointer, so `status`, `record`, `diff`, and `vault query`
+  all work inside it and land in the canonical graph.
+- **No FUSE, no virtio, no VM in the hot path.** Filesystem-protocol
+  virtualization (virtio-fs) is fatal for the metadata-heavy workloads agents
+  run (git, cargo, npm). Copy-on-write on the real filesystem needs none of it.
+
+```bash
+# Give each agent a private, copy-on-write working tree
+atomic sandbox create agent-1 --from dev      # forks a per-agent draft view
+atomic sandbox create agent-2 --from dev      # isolated artifacts, shared graph
+```
+
+### Shipping a sandbox: `stage` and `seal`
+
+A sandbox can be packaged as a **standard OCI image** (consumable by smolvm,
+podman, containerd — built in-process, no shelling out) for two purposes:
+
+| Command | Shape | Purpose |
+|---------|-------|---------|
+| `atomic sandbox stage` | layered: shared base + thin delta | inner-loop CI / circuit-breaker runs — base is pulled once and cached, only the delta ships each iteration |
+| `atomic sandbox seal` | flattened, single self-contained layer | a deployable runtime — "run this exact version" anywhere |
+
+```bash
+# Inner-loop CI artifact: base layer (dev) + delta layer (only what changed)
+atomic sandbox stage agent-1 --base dev -o ./ci-image
+
+# Deployable runtime image of the full merged state
+atomic sandbox seal dev -o ./runtime --entrypoint /app/run --env PORT=8080
+```
+
+Both embed provenance (the view names and Merkle states) in the image
+annotations, so a shipped image traces back to exact graph state. The runtime
+is [smolvm](https://github.com/binsquare/smolvm) — lightweight microVMs that
+boot OCI images in under 200 ms — making these images the unit of work for
+shared-infrastructure CI and circuit-breaker workflows.
+
+See [docs/CONCURRENT-AGENT-SANDBOXES.md](docs/CONCURRENT-AGENT-SANDBOXES.md) for
+the full design.
+
 ## Design Principles
 
 1. **Mathematical Soundness** — Operations are well-defined transformations with provable properties

--- a/atomic-agent/README.md
+++ b/atomic-agent/README.md
@@ -302,9 +302,15 @@ atomic agent hooks <agent> <verb>              # internal, called by agent hooks
 | Agent | Status | Hook Format |
 |---|---|---|
 | **Claude Code** | ✅ Implemented | `.claude/settings.json`, 7 hooks |
-| **Gemini CLI** | 📋 Planned | `.gemini/settings.json` |
-| **Codex** | 📋 Planned | TBD |
-| **OpenCode** | 📋 Planned | TBD |
+| **Cline** | ✅ Implemented | `.cline/settings.json` |
+| **Codex** | ✅ Implemented | `.codex/hooks.json` |
+| **Copilot** | ✅ Implemented | `.github/copilot-hooks.yml` |
+| **Cursor** | ✅ Implemented | `.cursor/hooks.json` |
+| **Gemini CLI** | ✅ Implemented | `.gemini/settings.json` |
+| **Kiro** | ✅ Implemented | IDE panel + shell scripts (via `atomic-kiro` package) |
+| **OpenCode** | ✅ Implemented | `.opencode/hooks.json` |
+| **Pi** | ✅ Implemented | Extension-based (`atomic-pi` package) |
+| **Sherpa** | ✅ Implemented | Self-managed by TUI |
 
 Adding a new agent requires implementing the `AgentHook` trait (~150 lines) and registering it in `AgentRegistry::with_defaults()`.
 

--- a/atomic-agent/src/event.rs
+++ b/atomic-agent/src/event.rs
@@ -180,6 +180,9 @@ impl HookType {
             "before-agent" => Some(HookType::TurnStart),
             "after-agent" => Some(HookType::TurnEnd),
 
+            // Devin Desktop turn boundaries
+            "prompt-submit" => Some(HookType::TurnStart),
+
             // Copilot + OpenCode + Pi turn boundaries
             "user-prompt" => Some(HookType::TurnStart),
             // OpenCode + Pi also use "stop" for TurnEnd (handled above)
@@ -655,6 +658,27 @@ mod tests {
             HookType::from_verb("post-todo"),
             Some(HookType::PostToolUse)
         );
+        assert_eq!(
+            HookType::from_verb("post-tool"),
+            Some(HookType::PostToolUse)
+        );
+    }
+
+    #[test]
+    fn test_hook_type_from_verb_devin() {
+        assert_eq!(
+            HookType::from_verb("session-start"),
+            Some(HookType::SessionStart)
+        );
+        assert_eq!(
+            HookType::from_verb("session-end"),
+            Some(HookType::SessionEnd)
+        );
+        assert_eq!(
+            HookType::from_verb("prompt-submit"),
+            Some(HookType::TurnStart)
+        );
+        assert_eq!(HookType::from_verb("stop"), Some(HookType::TurnEnd));
         assert_eq!(
             HookType::from_verb("post-tool"),
             Some(HookType::PostToolUse)

--- a/atomic-agent/src/event.rs
+++ b/atomic-agent/src/event.rs
@@ -148,6 +148,10 @@ impl HookType {
     /// // OpenCode verbs
     /// assert_eq!(HookType::from_verb("user-prompt"), Some(HookType::TurnStart));
     ///
+    /// // Kiro IDE verbs
+    /// assert_eq!(HookType::from_verb("prompt-submit"), Some(HookType::TurnStart));
+    /// assert_eq!(HookType::from_verb("agent-stop"), Some(HookType::TurnEnd));
+    ///
     /// // Hermes Agent verbs
     /// assert_eq!(HookType::from_verb("pre_llm_call"), Some(HookType::TurnStart));
     /// assert_eq!(HookType::from_verb("post_tool_call"), Some(HookType::PostToolUse));
@@ -208,6 +212,13 @@ impl HookType {
             "before-tool" => Some(HookType::PreToolUse),
             "after-tool" | "post_tool_call" => Some(HookType::PostToolUse),
 
+            // Kiro IDE turn boundaries
+            // ("prompt-submit" already matched above for Devin — same mapping)
+            "agent-stop" => Some(HookType::TurnEnd),
+            // Kiro tool use
+            "pre-tool-use" => Some(HookType::PreToolUse),
+            "post-tool-use" => Some(HookType::PostToolUse),
+            // Kiro post-task is already handled above ("post-task" → PostToolUse)
             _ => None,
         }
     }

--- a/atomic-agent/src/hooks/claude_code/mod.rs
+++ b/atomic-agent/src/hooks/claude_code/mod.rs
@@ -330,7 +330,8 @@ const HOOK_DEFS: &[(&str, &str, &str)] = &[
 fn install_hooks_into(hooks: &mut ClaudeHooks, _settings_path: &Path) -> AgentResult<usize> {
     let mut count = 0;
     for (_label, matcher, verb) in HOOK_DEFS {
-        let command = format!("test -d .atomic && {} {} || true", ATOMIC_HOOK_PREFIX, verb);
+        let command =
+            crate::hooks::guarded_hook_command(&format!("{} {}", ATOMIC_HOOK_PREFIX, verb));
 
         let matchers = match *verb {
             "session-start" => &mut hooks.session_start,

--- a/atomic-agent/src/hooks/claude_code/tests.rs
+++ b/atomic-agent/src/hooks/claude_code/tests.rs
@@ -271,12 +271,16 @@ mod tests {
         assert!(is_atomic_hook(
             "atomic agent hooks claude-code user-prompt-submit"
         ));
-        // Guarded format (current)
+        // Guarded format (legacy, `.atomic`-only)
         assert!(is_atomic_hook(
             "test -d .atomic && atomic agent hooks claude-code stop || true"
         ));
         assert!(is_atomic_hook(
             "test -d .atomic && atomic agent hooks claude-code user-prompt-submit || true"
+        ));
+        // Sandbox-aware guarded format (current)
+        assert!(is_atomic_hook(
+            "test -d .atomic || test -f .atomic-sandbox && atomic agent hooks claude-code stop || true"
         ));
         // Non-atomic commands
         assert!(!is_atomic_hook("entire hooks claude-code stop"));

--- a/atomic-agent/src/hooks/codex.rs
+++ b/atomic-agent/src/hooks/codex.rs
@@ -344,12 +344,8 @@ fn install_hooks_at(path: &Path, force: bool) -> AgentResult<usize> {
 
     let mut installed = 0;
     for spec in CODEX_HOOK_DEFS {
-        if add_hook(
-            &mut config.hooks,
-            spec.event,
-            spec.command,
-            spec.status_message,
-        ) {
+        let command = crate::hooks::guarded_hook_command(spec.command);
+        if add_hook(&mut config.hooks, spec.event, &command, spec.status_message) {
             installed += 1;
         }
     }
@@ -615,30 +611,33 @@ struct HookDef {
     status_message: Option<&'static str>,
 }
 
+/// Codex hook definitions. `command` holds the bare `atomic agent hooks …`
+/// invocation; the shell guard is applied by [`crate::hooks::guarded_hook_command`]
+/// at install time so the guard stays in one place across all agents.
 const CODEX_HOOK_DEFS: &[HookDef] = &[
     HookDef {
         event: "SessionStart",
-        command: "test -d .atomic && atomic agent hooks codex session-start || true",
+        command: "atomic agent hooks codex session-start",
         status_message: Some("Atomic: tracking session"),
     },
     HookDef {
         event: "UserPromptSubmit",
-        command: "test -d .atomic && atomic agent hooks codex user-prompt-submit || true",
+        command: "atomic agent hooks codex user-prompt-submit",
         status_message: None,
     },
     HookDef {
         event: "Stop",
-        command: "test -d .atomic && atomic agent hooks codex stop || true",
+        command: "atomic agent hooks codex stop",
         status_message: None,
     },
     HookDef {
         event: "PreToolUse",
-        command: "test -d .atomic && atomic agent hooks codex pre-tool || true",
+        command: "atomic agent hooks codex pre-tool",
         status_message: None,
     },
     HookDef {
         event: "PostToolUse",
-        command: "test -d .atomic && atomic agent hooks codex post-tool || true",
+        command: "atomic agent hooks codex post-tool",
         status_message: None,
     },
 ];

--- a/atomic-agent/src/hooks/devin.rs
+++ b/atomic-agent/src/hooks/devin.rs
@@ -1,0 +1,678 @@
+//! Devin Desktop agent hook adapter for Atomic Agent.
+//!
+//! Handles hook JSON parsing from the Devin Desktop (Cascade) bridge scripts,
+//! which pipe JSON to `atomic agent hooks devin <verb>` via stdin at each
+//! lifecycle event.
+//!
+//! # Devin Desktop Hook Architecture
+//!
+//! Devin Desktop (Cascade) has a native hook system that fires shell commands
+//! at workflow points, passing JSON context via stdin. The `atomic-devin`
+//! package provides bridge scripts that translate Cascade events into Atomic
+//! agent hook calls:
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────────────┐
+//! │  Devin Desktop (Cascade) Hooks → Bridge Scripts                        │
+//! │                                                                         │
+//! │  pre_user_prompt (first)  ──▶  atomic agent hooks devin session-start  │
+//! │  pre_user_prompt          ──▶  atomic agent hooks devin prompt-submit  │
+//! │  post_cascade_response    ──▶  atomic agent hooks devin stop           │
+//! │  post_write_code          ──▶  atomic agent hooks devin post-tool      │
+//! │  post_run_command         ──▶  atomic agent hooks devin post-tool      │
+//! └─────────────────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Hook Verbs
+//!
+//! | Verb             | HookType     | Description                            |
+//! |------------------|--------------|----------------------------------------|
+//! | `session-start`  | SessionStart | First prompt creates draft view         |
+//! | `session-end`    | SessionEnd   | Session cleanup                         |
+//! | `prompt-submit`  | TurnStart    | User sends a new prompt                 |
+//! | `stop`           | TurnEnd      | Cascade response complete (turn end)    |
+//! | `post-tool`      | PostToolUse  | After file write or command execution   |
+//!
+//! # JSON Input Format
+//!
+//! All hooks receive JSON via stdin with at minimum:
+//!
+//! ```json
+//! {
+//!   "session_id": "abc-123",
+//!   "cwd": "/path/to/project"
+//! }
+//! ```
+//!
+//! Additional fields vary by verb (see struct definitions below).
+//!
+//! # Installation
+//!
+//! Devin Desktop hook installation is handled by the standalone `atomic-devin`
+//! package. This adapter only parses hook events.
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::error::{AgentError, AgentResult};
+use crate::event::{HookType, TurnEvent};
+use crate::hooks::AgentHook;
+
+/// The Devin Desktop config directory name.
+const DEVIN_DIR: &str = ".devin";
+
+// Devin JSON Input Types
+
+/// JSON input for session-start hook.
+///
+/// Sent on the first `pre_user_prompt` event to create a draft view.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct SessionStartInput {
+    /// Session identifier (derived from Cascade's trajectory_id).
+    #[serde(default)]
+    session_id: Option<String>,
+    /// Working directory.
+    #[serde(default)]
+    cwd: Option<String>,
+    /// Model name (e.g. "claude-sonnet-4-20250514").
+    #[serde(default)]
+    model: Option<String>,
+    /// User's first prompt.
+    #[serde(default)]
+    prompt: Option<String>,
+}
+
+/// JSON input for session-end hook.
+///
+/// Sent when the Devin Desktop session ends.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct SessionEndInput {
+    /// Session identifier.
+    #[serde(default)]
+    session_id: Option<String>,
+    /// Optional reason for ending.
+    #[serde(default)]
+    reason: Option<String>,
+    /// Working directory.
+    #[serde(default)]
+    cwd: Option<String>,
+}
+
+/// JSON input for prompt-submit hook (TurnStart).
+///
+/// Sent on each `pre_user_prompt` after the first.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct PromptSubmitInput {
+    /// Session identifier.
+    #[serde(default)]
+    session_id: Option<String>,
+    /// The user's prompt text.
+    #[serde(default)]
+    prompt: Option<String>,
+    /// Model name.
+    #[serde(default)]
+    model: Option<String>,
+    /// Working directory.
+    #[serde(default)]
+    cwd: Option<String>,
+}
+
+/// JSON input for stop hook (TurnEnd).
+///
+/// Sent on `post_cascade_response` — triggers recording with provenance.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct StopInput {
+    /// Session identifier.
+    #[serde(default)]
+    session_id: Option<String>,
+    /// Model name.
+    #[serde(default)]
+    model: Option<String>,
+    /// Cascade trajectory ID.
+    #[serde(default)]
+    trajectory_id: Option<String>,
+    /// Working directory.
+    #[serde(default)]
+    cwd: Option<String>,
+}
+
+/// JSON input for post-tool hook (PostToolUse).
+///
+/// Sent on `post_write_code` and `post_run_command`.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct PostToolInput {
+    /// Session identifier.
+    #[serde(default)]
+    session_id: Option<String>,
+    /// Tool action type (e.g. "write", "command").
+    #[serde(default)]
+    action: Option<String>,
+    /// File path for write actions.
+    #[serde(default)]
+    file: Option<String>,
+    /// Command string for command actions.
+    #[serde(default)]
+    command: Option<String>,
+    /// Cascade trajectory ID.
+    #[serde(default)]
+    trajectory_id: Option<String>,
+    /// Working directory.
+    #[serde(default)]
+    cwd: Option<String>,
+}
+
+/// Devin Desktop agent hook adapter.
+///
+/// Parses hook JSON from the Devin Desktop (Cascade) bridge scripts.
+/// Hook installation is handled by the standalone `atomic-devin` package.
+#[derive(Debug)]
+pub struct DevinHook {
+    _private: (),
+}
+
+impl DevinHook {
+    /// Create a new Devin Desktop hook adapter.
+    pub fn new() -> Self {
+        Self { _private: () }
+    }
+
+    /// Extract a session ID from an optional field, generating a fallback if missing.
+    fn extract_session_id(session_id: Option<String>) -> String {
+        session_id
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| format!("devin-{}", uuid_short()))
+    }
+}
+
+impl Default for DevinHook {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AgentHook for DevinHook {
+    fn name(&self) -> &str {
+        "devin"
+    }
+
+    fn display_name(&self) -> &str {
+        "Devin Desktop"
+    }
+
+    fn parse_event(&self, hook_type: HookType, input: &[u8]) -> AgentResult<TurnEvent> {
+        if input.is_empty() {
+            return Err(AgentError::HookInputEmpty {
+                agent: self.name().to_string(),
+                hook_type: hook_type.as_str().to_string(),
+            });
+        }
+
+        // Preserve raw JSON for debugging and downstream use
+        let raw_json: serde_json::Value =
+            serde_json::from_slice(input).map_err(|e| AgentError::HookParseFailed {
+                agent: self.name().to_string(),
+                hook_type: hook_type.as_str().to_string(),
+                reason: e.to_string(),
+            })?;
+
+        match hook_type {
+            HookType::SessionStart => {
+                let parsed: SessionStartInput =
+                    serde_json::from_value(raw_json.clone()).map_err(|e| {
+                        AgentError::HookParseFailed {
+                            agent: self.name().to_string(),
+                            hook_type: hook_type.as_str().to_string(),
+                            reason: e.to_string(),
+                        }
+                    })?;
+
+                let mut event =
+                    TurnEvent::new(Self::extract_session_id(parsed.session_id), hook_type)
+                        .with_raw_json(raw_json);
+
+                if let Some(model) = parsed.model {
+                    if let Some(ref mut raw) = event.raw_json {
+                        if let Some(obj) = raw.as_object_mut() {
+                            obj.insert("model".to_string(), serde_json::Value::String(model));
+                        }
+                    }
+                }
+
+                Ok(event)
+            }
+
+            HookType::SessionEnd => {
+                let parsed: SessionEndInput =
+                    serde_json::from_value(raw_json.clone()).map_err(|e| {
+                        AgentError::HookParseFailed {
+                            agent: self.name().to_string(),
+                            hook_type: hook_type.as_str().to_string(),
+                            reason: e.to_string(),
+                        }
+                    })?;
+
+                let event = TurnEvent::new(Self::extract_session_id(parsed.session_id), hook_type)
+                    .with_raw_json(raw_json);
+
+                Ok(event)
+            }
+
+            HookType::TurnStart => {
+                let parsed: PromptSubmitInput =
+                    serde_json::from_value(raw_json.clone()).map_err(|e| {
+                        AgentError::HookParseFailed {
+                            agent: self.name().to_string(),
+                            hook_type: hook_type.as_str().to_string(),
+                            reason: e.to_string(),
+                        }
+                    })?;
+
+                let mut event =
+                    TurnEvent::new(Self::extract_session_id(parsed.session_id), hook_type)
+                        .with_raw_json(raw_json);
+
+                if let Some(prompt) = parsed.prompt {
+                    event = event.with_prompt(prompt);
+                }
+
+                if let Some(model) = parsed.model {
+                    if let Some(ref mut raw) = event.raw_json {
+                        if let Some(obj) = raw.as_object_mut() {
+                            obj.insert("model".to_string(), serde_json::Value::String(model));
+                        }
+                    }
+                }
+
+                Ok(event)
+            }
+
+            HookType::TurnEnd => {
+                let parsed: StopInput = serde_json::from_value(raw_json.clone()).map_err(|e| {
+                    AgentError::HookParseFailed {
+                        agent: self.name().to_string(),
+                        hook_type: hook_type.as_str().to_string(),
+                        reason: e.to_string(),
+                    }
+                })?;
+
+                let mut event =
+                    TurnEvent::new(Self::extract_session_id(parsed.session_id), hook_type)
+                        .with_raw_json(raw_json);
+
+                if let Some(model) = parsed.model {
+                    if let Some(ref mut raw) = event.raw_json {
+                        if let Some(obj) = raw.as_object_mut() {
+                            obj.insert("model".to_string(), serde_json::Value::String(model));
+                        }
+                    }
+                }
+
+                Ok(event)
+            }
+
+            HookType::PreToolUse => {
+                // Devin Desktop doesn't currently emit pre-tool events,
+                // but we handle it for forward compatibility.
+                let event = TurnEvent::new(format!("devin-{}", uuid_short()), hook_type)
+                    .with_raw_json(raw_json);
+
+                Ok(event)
+            }
+
+            HookType::PostToolUse => {
+                let parsed: PostToolInput =
+                    serde_json::from_value(raw_json.clone()).map_err(|e| {
+                        AgentError::HookParseFailed {
+                            agent: self.name().to_string(),
+                            hook_type: hook_type.as_str().to_string(),
+                            reason: e.to_string(),
+                        }
+                    })?;
+
+                let mut event =
+                    TurnEvent::new(Self::extract_session_id(parsed.session_id), hook_type)
+                        .with_raw_json(raw_json);
+
+                // Map Devin's action field to tool_name
+                if let Some(action) = parsed.action {
+                    event = event.with_tool_name(action);
+                }
+
+                Ok(event)
+            }
+        }
+    }
+
+    fn install(&self, _repo_root: &Path) -> AgentResult<usize> {
+        Ok(0) // Installation handled by atomic-devin package
+    }
+
+    fn uninstall(&self, _repo_root: &Path) -> AgentResult<()> {
+        Ok(()) // Uninstallation handled by atomic-devin package
+    }
+
+    fn is_installed(&self, _repo_root: &Path) -> bool {
+        false // Managed by atomic-devin package
+    }
+
+    fn supported_hooks(&self) -> Vec<HookType> {
+        vec![
+            HookType::SessionStart,
+            HookType::SessionEnd,
+            HookType::TurnStart,
+            HookType::TurnEnd,
+            HookType::PostToolUse,
+        ]
+    }
+
+    fn detect_presence(&self, repo_root: &Path) -> bool {
+        // Devin is present if the .devin directory exists
+        repo_root.join(DEVIN_DIR).is_dir()
+    }
+
+    fn hook_verbs(&self) -> Vec<&str> {
+        vec![
+            "session-start",
+            "session-end",
+            "prompt-submit",
+            "stop",
+            "post-tool",
+        ]
+    }
+}
+
+// Helper: generate short pseudo-UUID for fallback session IDs
+
+/// Generate a short hex string for fallback session IDs.
+///
+/// This is only used when the bridge scripts fail to provide a session_id,
+/// which should be rare. Uses timestamp bits for uniqueness.
+fn uuid_short() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+
+    // Use lower 32 bits of timestamp for a short hex ID
+    format!("{:08x}", (now & 0xFFFF_FFFF) as u32)
+}
+
+// Devin hook verb → HookType mapping
+
+/// Convert a Devin-specific verb to a [`HookType`].
+///
+/// | Verb             | HookType     |
+/// |------------------|--------------|
+/// | `session-start`  | SessionStart |
+/// | `session-end`    | SessionEnd   |
+/// | `prompt-submit`  | TurnStart    |
+/// | `stop`           | TurnEnd      |
+/// | `post-tool`      | PostToolUse  |
+pub fn verb_to_hook_type(verb: &str) -> Option<HookType> {
+    match verb {
+        "session-start" => Some(HookType::SessionStart),
+        "session-end" => Some(HookType::SessionEnd),
+        "prompt-submit" => Some(HookType::TurnStart),
+        "stop" => Some(HookType::TurnEnd),
+        "post-tool" => Some(HookType::PostToolUse),
+        _ => None,
+    }
+}
+
+// Tests
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_hook() -> DevinHook {
+        DevinHook::new()
+    }
+
+    // --- Basic trait method tests ---
+
+    #[test]
+    fn test_name() {
+        let hook = make_hook();
+        assert_eq!(hook.name(), "devin");
+    }
+
+    #[test]
+    fn test_display_name() {
+        let hook = make_hook();
+        assert_eq!(hook.display_name(), "Devin Desktop");
+    }
+
+    #[test]
+    fn test_supported_hooks() {
+        let hook = make_hook();
+        let supported = hook.supported_hooks();
+        assert!(supported.contains(&HookType::SessionStart));
+        assert!(supported.contains(&HookType::SessionEnd));
+        assert!(supported.contains(&HookType::TurnStart));
+        assert!(supported.contains(&HookType::TurnEnd));
+        assert!(supported.contains(&HookType::PostToolUse));
+    }
+
+    #[test]
+    fn test_hook_verbs() {
+        let hook = make_hook();
+        let verbs = hook.hook_verbs();
+        assert!(verbs.contains(&"session-start"));
+        assert!(verbs.contains(&"session-end"));
+        assert!(verbs.contains(&"prompt-submit"));
+        assert!(verbs.contains(&"stop"));
+        assert!(verbs.contains(&"post-tool"));
+    }
+
+    #[test]
+    fn test_default() {
+        let hook = DevinHook::default();
+        assert_eq!(hook.name(), "devin");
+    }
+
+    #[test]
+    fn test_debug() {
+        let hook = make_hook();
+        let debug = format!("{:?}", hook);
+        assert!(debug.contains("DevinHook"));
+    }
+
+    // --- parse_event tests ---
+
+    #[test]
+    fn test_parse_session_start() {
+        let hook = make_hook();
+        let input = br#"{"session_id":"devin-123","cwd":"/tmp","model":"claude-sonnet-4"}"#;
+        let event = hook.parse_event(HookType::SessionStart, input).unwrap();
+        assert_eq!(event.session_id, "devin-123");
+        assert_eq!(event.event_type, HookType::SessionStart);
+    }
+
+    #[test]
+    fn test_parse_session_start_with_model() {
+        let hook = make_hook();
+        let input = br#"{"session_id":"s1","model":"claude-sonnet-4"}"#;
+        let event = hook.parse_event(HookType::SessionStart, input).unwrap();
+        assert_eq!(event.session_id, "s1");
+        let raw = event.raw_json.unwrap();
+        assert_eq!(raw["model"], "claude-sonnet-4");
+    }
+
+    #[test]
+    fn test_parse_session_end() {
+        let hook = make_hook();
+        let input = br#"{"session_id":"devin-123","reason":"user_closed"}"#;
+        let event = hook.parse_event(HookType::SessionEnd, input).unwrap();
+        assert_eq!(event.session_id, "devin-123");
+        assert_eq!(event.event_type, HookType::SessionEnd);
+    }
+
+    #[test]
+    fn test_parse_prompt_submit() {
+        let hook = make_hook();
+        let input =
+            br#"{"session_id":"devin-123","prompt":"fix the bug","model":"claude-sonnet-4"}"#;
+        let event = hook.parse_event(HookType::TurnStart, input).unwrap();
+        assert_eq!(event.session_id, "devin-123");
+        assert_eq!(event.event_type, HookType::TurnStart);
+        assert_eq!(event.prompt.as_deref(), Some("fix the bug"));
+    }
+
+    #[test]
+    fn test_parse_prompt_submit_no_prompt() {
+        let hook = make_hook();
+        let input = br#"{"session_id":"devin-123"}"#;
+        let event = hook.parse_event(HookType::TurnStart, input).unwrap();
+        assert_eq!(event.session_id, "devin-123");
+        assert!(event.prompt.is_none());
+    }
+
+    #[test]
+    fn test_parse_stop() {
+        let hook = make_hook();
+        let input =
+            br#"{"session_id":"devin-123","model":"claude-sonnet-4","trajectory_id":"traj-1"}"#;
+        let event = hook.parse_event(HookType::TurnEnd, input).unwrap();
+        assert_eq!(event.session_id, "devin-123");
+        assert_eq!(event.event_type, HookType::TurnEnd);
+    }
+
+    #[test]
+    fn test_parse_post_tool() {
+        let hook = make_hook();
+        let input = br#"{"session_id":"devin-123","action":"write","file":"src/main.rs"}"#;
+        let event = hook.parse_event(HookType::PostToolUse, input).unwrap();
+        assert_eq!(event.session_id, "devin-123");
+        assert_eq!(event.event_type, HookType::PostToolUse);
+        assert_eq!(event.tool_name.as_deref(), Some("write"));
+    }
+
+    #[test]
+    fn test_parse_post_tool_command() {
+        let hook = make_hook();
+        let input = br#"{"session_id":"devin-123","action":"command","command":"cargo test"}"#;
+        let event = hook.parse_event(HookType::PostToolUse, input).unwrap();
+        assert_eq!(event.tool_name.as_deref(), Some("command"));
+    }
+
+    #[test]
+    fn test_parse_event_empty_input() {
+        let hook = make_hook();
+        let result = hook.parse_event(HookType::SessionStart, b"");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_event_invalid_json() {
+        let hook = make_hook();
+        let result = hook.parse_event(HookType::SessionStart, b"not json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_session_start_missing_session_id() {
+        let hook = make_hook();
+        let input = br#"{"cwd":"/tmp"}"#;
+        let event = hook.parse_event(HookType::SessionStart, input).unwrap();
+        // Should generate a fallback session ID
+        assert!(event.session_id.starts_with("devin-"));
+    }
+
+    #[test]
+    fn test_parse_session_start_empty_session_id() {
+        let hook = make_hook();
+        let input = br#"{"session_id":"","cwd":"/tmp"}"#;
+        let event = hook.parse_event(HookType::SessionStart, input).unwrap();
+        assert!(event.session_id.starts_with("devin-"));
+    }
+
+    #[test]
+    fn test_parse_extra_fields_ignored() {
+        let hook = make_hook();
+        let input = br#"{"session_id":"s1","unknown_field":"value","extra":42}"#;
+        let event = hook.parse_event(HookType::SessionStart, input).unwrap();
+        assert_eq!(event.session_id, "s1");
+    }
+
+    // --- verb_to_hook_type tests ---
+
+    #[test]
+    fn test_verb_to_hook_type() {
+        assert_eq!(
+            verb_to_hook_type("session-start"),
+            Some(HookType::SessionStart)
+        );
+        assert_eq!(verb_to_hook_type("session-end"), Some(HookType::SessionEnd));
+        assert_eq!(
+            verb_to_hook_type("prompt-submit"),
+            Some(HookType::TurnStart)
+        );
+        assert_eq!(verb_to_hook_type("stop"), Some(HookType::TurnEnd));
+        assert_eq!(verb_to_hook_type("post-tool"), Some(HookType::PostToolUse));
+        assert_eq!(verb_to_hook_type("unknown"), None);
+    }
+
+    // --- detect_presence tests ---
+
+    #[test]
+    fn test_detect_presence_with_devin_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join(DEVIN_DIR)).unwrap();
+        let hook = make_hook();
+        assert!(hook.detect_presence(dir.path()));
+    }
+
+    #[test]
+    fn test_detect_presence_without_devin_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let hook = make_hook();
+        assert!(!hook.detect_presence(dir.path()));
+    }
+
+    // --- install/uninstall tests ---
+
+    #[test]
+    fn test_install_is_noop() {
+        let hook = make_hook();
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(hook.install(dir.path()).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_uninstall_is_noop() {
+        let hook = make_hook();
+        let dir = tempfile::tempdir().unwrap();
+        hook.uninstall(dir.path()).unwrap();
+    }
+
+    #[test]
+    fn test_is_installed_always_false() {
+        let hook = make_hook();
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!hook.is_installed(dir.path()));
+    }
+
+    // --- uuid_short tests ---
+
+    #[test]
+    fn test_uuid_short_format() {
+        let id = uuid_short();
+        assert_eq!(id.len(), 8);
+        assert!(id.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn test_uuid_short_not_all_zeros() {
+        let id = uuid_short();
+        assert_ne!(id, "00000000");
+    }
+}

--- a/atomic-agent/src/hooks/gemini_cli.rs
+++ b/atomic-agent/src/hooks/gemini_cli.rs
@@ -409,7 +409,8 @@ impl GeminiCliHook {
 
         let mut count = 0;
         for (event_key, matcher, verb, hook_name) in &hook_defs {
-            let command = format!("test -d .atomic && {} {} || true", ATOMIC_HOOK_PREFIX, verb);
+            let command =
+                crate::hooks::guarded_hook_command(&format!("{} {}", ATOMIC_HOOK_PREFIX, verb));
 
             let matchers = match *event_key {
                 "session_start" => &mut hooks.session_start,
@@ -1153,12 +1154,16 @@ mod tests {
             "atomic agent hooks gemini-cli session-start"
         ));
         assert!(is_atomic_hook("atomic agent hooks gemini-cli after-agent"));
-        // Guarded format
+        // Guarded format (legacy, `.atomic`-only)
         assert!(is_atomic_hook(
             "test -d .atomic && atomic agent hooks gemini-cli session-start || true"
         ));
         assert!(is_atomic_hook(
             "test -d .atomic && atomic agent hooks gemini-cli after-agent || true"
+        ));
+        // Sandbox-aware guarded format (current)
+        assert!(is_atomic_hook(
+            "test -d .atomic || test -f .atomic-sandbox && atomic agent hooks gemini-cli session-start || true"
         ));
         // Non-atomic
         assert!(!is_atomic_hook("my-custom-hook --on-stop"));

--- a/atomic-agent/src/hooks/kiro.rs
+++ b/atomic-agent/src/hooks/kiro.rs
@@ -1,0 +1,712 @@
+//! Kiro IDE agent hook adapter for Atomic Agent.
+//!
+//! Handles hook JSON parsing from Kiro IDE's hook system, which uses shell
+//! command actions that call `atomic agent hooks kiro <verb>` via subprocess
+//! at each lifecycle event.
+//!
+//! # Kiro Hook Architecture
+//!
+//! Kiro IDE hooks are configured through the IDE's Agent Steering & Skills
+//! panel. Each hook uses a "Shell Command" action that invokes the Atomic CLI.
+//! The `atomic-kiro` npm package provides the shell scripts that bridge
+//! Kiro's hook triggers to `atomic agent hooks kiro <verb>`.
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────────────┐
+//! │  Kiro IDE Hooks (configured in IDE panel)                               │
+//! │                                                                         │
+//! │  PromptSubmit      ──▶  atomic agent hooks kiro prompt-submit          │
+//! │  AgentStop         ──▶  atomic agent hooks kiro agent-stop             │
+//! │  PreToolUse        ──▶  atomic agent hooks kiro pre-tool-use           │
+//! │  PostToolUse       ──▶  atomic agent hooks kiro post-tool-use          │
+//! │  PostTaskExecution ──▶  atomic agent hooks kiro post-task              │
+//! └─────────────────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Hook Verbs
+//!
+//! | Verb              | HookType     | Description                          |
+//! |-------------------|--------------|--------------------------------------|
+//! | `prompt-submit`   | TurnStart    | User submits a prompt                |
+//! | `agent-stop`      | TurnEnd      | Agent completes its turn             |
+//! | `pre-tool-use`    | PreToolUse   | Before tool execution                |
+//! | `post-tool-use`   | PostToolUse  | After tool execution                 |
+//! | `post-task`       | PostToolUse  | After spec task completion           |
+//!
+//! # JSON Input Format
+//!
+//! All hooks receive JSON via stdin with at minimum:
+//!
+//! ```json
+//! {
+//!   "session_id": "kiro-20260521-153000",
+//!   "cwd": "/path/to/project"
+//! }
+//! ```
+//!
+//! Additional fields vary by verb (see struct definitions below).
+//!
+//! # Installation
+//!
+//! Kiro hook configuration is managed through the IDE panel and the
+//! `atomic-kiro` npm package. This adapter only parses hook events —
+//! `install()` and `uninstall()` are no-ops.
+//!
+//! # Detection
+//!
+//! Kiro is considered present when a `.kiro/` directory exists at the
+//! project root.
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::error::{AgentError, AgentResult};
+use crate::event::{HookType, TurnEvent};
+use crate::hooks::AgentHook;
+
+/// The Kiro config directory name.
+const KIRO_DIR: &str = ".kiro";
+
+// ---------------------------------------------------------------------------
+// JSON input structs
+// ---------------------------------------------------------------------------
+
+/// JSON input for prompt-submit hook (TurnStart).
+///
+/// Sent when the user submits a prompt in Kiro IDE.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct PromptSubmitInput {
+    #[serde(default)]
+    session_id: Option<String>,
+
+    /// Working directory
+    #[serde(default)]
+    cwd: Option<String>,
+
+    /// Model identifier (e.g. "claude-sonnet-4-6")
+    #[serde(default)]
+    model: Option<String>,
+
+    /// The user's prompt text
+    #[serde(default)]
+    prompt: Option<String>,
+
+    /// ISO 8601 timestamp
+    #[serde(default)]
+    timestamp: Option<String>,
+}
+
+/// JSON input for agent-stop hook (TurnEnd).
+///
+/// Sent when the Kiro agent completes its turn.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct AgentStopInput {
+    #[serde(default)]
+    session_id: Option<String>,
+
+    /// Working directory
+    #[serde(default)]
+    cwd: Option<String>,
+
+    /// Model identifier
+    #[serde(default)]
+    model: Option<String>,
+
+    /// ISO 8601 timestamp
+    #[serde(default)]
+    timestamp: Option<String>,
+}
+
+/// JSON input for pre-tool-use and post-tool-use hooks.
+///
+/// Sent before or after a tool is executed within a Kiro session.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct ToolUseInput {
+    #[serde(default)]
+    session_id: Option<String>,
+
+    /// Name of the tool being invoked
+    #[serde(default)]
+    tool_name: Option<String>,
+
+    /// Unique call identifier for this tool invocation
+    #[serde(default)]
+    tool_call_id: Option<String>,
+
+    /// Working directory
+    #[serde(default)]
+    cwd: Option<String>,
+
+    /// ISO 8601 timestamp
+    #[serde(default)]
+    timestamp: Option<String>,
+}
+
+/// JSON input for post-task hook.
+///
+/// Sent after a spec task completes in Kiro. Shares the same shape as
+/// tool-use events.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct PostTaskInput {
+    #[serde(default)]
+    session_id: Option<String>,
+
+    /// Name of the tool that completed (if applicable)
+    #[serde(default)]
+    tool_name: Option<String>,
+
+    /// Unique call identifier
+    #[serde(default)]
+    tool_call_id: Option<String>,
+
+    /// Working directory
+    #[serde(default)]
+    cwd: Option<String>,
+
+    /// ISO 8601 timestamp
+    #[serde(default)]
+    timestamp: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// KiroHook
+// ---------------------------------------------------------------------------
+
+/// Kiro IDE agent hook adapter.
+///
+/// Parses hook JSON from Kiro IDE's shell command hooks. Hook configuration
+/// is managed through the IDE panel and the `atomic-kiro` npm package.
+#[derive(Debug)]
+pub struct KiroHook {
+    _private: (),
+}
+
+impl KiroHook {
+    /// Create a new Kiro hook adapter.
+    pub fn new() -> Self {
+        Self { _private: () }
+    }
+
+    /// Extract a session ID from an optional field, generating a fallback if missing.
+    fn extract_session_id(session_id: Option<String>) -> String {
+        session_id
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| format!("kiro-{}", timestamp_hex()))
+    }
+}
+
+impl Default for KiroHook {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AgentHook for KiroHook {
+    fn name(&self) -> &str {
+        "kiro"
+    }
+
+    fn display_name(&self) -> &str {
+        "Kiro"
+    }
+
+    fn parse_event(&self, hook_type: HookType, input: &[u8]) -> AgentResult<TurnEvent> {
+        if input.is_empty() {
+            return Err(AgentError::HookInputEmpty {
+                agent: self.name().to_string(),
+                hook_type: hook_type.as_str().to_string(),
+            });
+        }
+
+        // Preserve raw JSON for debugging and downstream use
+        let raw_json: serde_json::Value =
+            serde_json::from_slice(input).map_err(|e| AgentError::HookParseFailed {
+                agent: self.name().to_string(),
+                hook_type: hook_type.as_str().to_string(),
+                reason: e.to_string(),
+            })?;
+
+        match hook_type {
+            HookType::TurnStart => {
+                let parsed: PromptSubmitInput =
+                    serde_json::from_value(raw_json.clone()).map_err(|e| {
+                        AgentError::HookParseFailed {
+                            agent: self.name().to_string(),
+                            hook_type: hook_type.as_str().to_string(),
+                            reason: e.to_string(),
+                        }
+                    })?;
+
+                let mut event =
+                    TurnEvent::new(Self::extract_session_id(parsed.session_id), hook_type)
+                        .with_raw_json(raw_json);
+
+                if let Some(prompt) = parsed.prompt {
+                    event = event.with_prompt(prompt);
+                }
+
+                // Store model in raw_json for the orchestrator
+                if let Some(model) = parsed.model {
+                    if let Some(ref mut raw) = event.raw_json {
+                        if let Some(obj) = raw.as_object_mut() {
+                            obj.insert("model".to_string(), serde_json::Value::String(model));
+                        }
+                    }
+                }
+
+                Ok(event)
+            }
+
+            HookType::TurnEnd => {
+                let parsed: AgentStopInput =
+                    serde_json::from_value(raw_json.clone()).map_err(|e| {
+                        AgentError::HookParseFailed {
+                            agent: self.name().to_string(),
+                            hook_type: hook_type.as_str().to_string(),
+                            reason: e.to_string(),
+                        }
+                    })?;
+
+                let mut event =
+                    TurnEvent::new(Self::extract_session_id(parsed.session_id), hook_type)
+                        .with_raw_json(raw_json);
+
+                // Store model in raw_json for provenance
+                if let Some(model) = parsed.model {
+                    if let Some(ref mut raw) = event.raw_json {
+                        if let Some(obj) = raw.as_object_mut() {
+                            obj.insert("model".to_string(), serde_json::Value::String(model));
+                        }
+                    }
+                }
+
+                Ok(event)
+            }
+
+            HookType::PreToolUse => {
+                let parsed: ToolUseInput =
+                    serde_json::from_value(raw_json.clone()).map_err(|e| {
+                        AgentError::HookParseFailed {
+                            agent: self.name().to_string(),
+                            hook_type: hook_type.as_str().to_string(),
+                            reason: e.to_string(),
+                        }
+                    })?;
+
+                let mut event =
+                    TurnEvent::new(Self::extract_session_id(parsed.session_id), hook_type)
+                        .with_raw_json(raw_json);
+
+                if let Some(name) = parsed.tool_name {
+                    event = event.with_tool_name(name);
+                }
+                if let Some(id) = parsed.tool_call_id {
+                    event = event.with_tool_use_id(id);
+                }
+
+                Ok(event)
+            }
+
+            HookType::PostToolUse => {
+                let parsed: ToolUseInput =
+                    serde_json::from_value(raw_json.clone()).map_err(|e| {
+                        AgentError::HookParseFailed {
+                            agent: self.name().to_string(),
+                            hook_type: hook_type.as_str().to_string(),
+                            reason: e.to_string(),
+                        }
+                    })?;
+
+                let mut event =
+                    TurnEvent::new(Self::extract_session_id(parsed.session_id), hook_type)
+                        .with_raw_json(raw_json);
+
+                if let Some(name) = parsed.tool_name {
+                    event = event.with_tool_name(name);
+                }
+                if let Some(id) = parsed.tool_call_id {
+                    event = event.with_tool_use_id(id);
+                }
+
+                Ok(event)
+            }
+
+            // Kiro doesn't have native SessionStart/SessionEnd — these are
+            // synthesized by the shell scripts in the atomic-kiro package.
+            // If they arrive, parse the minimal session_id from the raw JSON.
+            HookType::SessionStart | HookType::SessionEnd => {
+                // Use a lightweight parse — just extract the session_id
+                #[derive(Deserialize)]
+                struct MinimalInput {
+                    #[serde(default)]
+                    session_id: Option<String>,
+                }
+
+                let parsed: MinimalInput =
+                    serde_json::from_value(raw_json.clone()).map_err(|e| {
+                        AgentError::HookParseFailed {
+                            agent: self.name().to_string(),
+                            hook_type: hook_type.as_str().to_string(),
+                            reason: e.to_string(),
+                        }
+                    })?;
+
+                let event = TurnEvent::new(Self::extract_session_id(parsed.session_id), hook_type)
+                    .with_raw_json(raw_json);
+
+                Ok(event)
+            }
+        }
+    }
+
+    fn install(&self, _repo_root: &Path) -> AgentResult<usize> {
+        Ok(0) // Installation handled by atomic-kiro package via IDE panel
+    }
+
+    fn uninstall(&self, _repo_root: &Path) -> AgentResult<()> {
+        Ok(()) // Uninstallation handled by atomic-kiro package
+    }
+
+    fn is_installed(&self, _repo_root: &Path) -> bool {
+        false // Managed by atomic-kiro npm package
+    }
+
+    fn supported_hooks(&self) -> Vec<HookType> {
+        vec![
+            HookType::TurnStart,
+            HookType::TurnEnd,
+            HookType::PreToolUse,
+            HookType::PostToolUse,
+        ]
+    }
+
+    fn detect_presence(&self, repo_root: &Path) -> bool {
+        // Kiro is present if the .kiro directory exists
+        repo_root.join(KIRO_DIR).is_dir()
+    }
+
+    fn hook_verbs(&self) -> Vec<&str> {
+        vec![
+            "prompt-submit",
+            "agent-stop",
+            "pre-tool-use",
+            "post-tool-use",
+            "post-task",
+        ]
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Generate a short hex string for fallback session IDs.
+///
+/// This is only used when the Kiro hook scripts fail to provide a session_id,
+/// which should be rare. Uses timestamp bits for uniqueness.
+fn timestamp_hex() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+
+    // Use lower 32 bits of timestamp for a short hex ID
+    format!("{:08x}", (now & 0xFFFF_FFFF) as u32)
+}
+
+// ---------------------------------------------------------------------------
+// Verb mapping
+// ---------------------------------------------------------------------------
+
+/// Convert a Kiro-specific verb to a [`HookType`].
+///
+/// Kiro uses these verbs:
+///
+/// | Verb              | HookType     |
+/// |-------------------|--------------|
+/// | `prompt-submit`   | TurnStart    |
+/// | `agent-stop`      | TurnEnd      |
+/// | `pre-tool-use`    | PreToolUse   |
+/// | `post-tool-use`   | PostToolUse  |
+/// | `post-task`       | PostToolUse  |
+pub fn verb_to_hook_type(verb: &str) -> Option<HookType> {
+    match verb {
+        "prompt-submit" => Some(HookType::TurnStart),
+        "agent-stop" => Some(HookType::TurnEnd),
+        "pre-tool-use" => Some(HookType::PreToolUse),
+        "post-tool-use" => Some(HookType::PostToolUse),
+        "post-task" => Some(HookType::PostToolUse),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::HookType;
+
+    fn make_hook() -> KiroHook {
+        KiroHook::new()
+    }
+
+    // --- name / display_name ---
+
+    #[test]
+    fn test_name() {
+        let hook = make_hook();
+        assert_eq!(hook.name(), "kiro");
+    }
+
+    #[test]
+    fn test_display_name() {
+        let hook = make_hook();
+        assert_eq!(hook.display_name(), "Kiro");
+    }
+
+    // --- supported_hooks ---
+
+    #[test]
+    fn test_supported_hooks() {
+        let hook = make_hook();
+        let hooks = hook.supported_hooks();
+        assert_eq!(hooks.len(), 4);
+        assert!(hooks.contains(&HookType::TurnStart));
+        assert!(hooks.contains(&HookType::TurnEnd));
+        assert!(hooks.contains(&HookType::PreToolUse));
+        assert!(hooks.contains(&HookType::PostToolUse));
+        // Kiro doesn't have native SessionStart/SessionEnd
+        assert!(!hooks.contains(&HookType::SessionStart));
+        assert!(!hooks.contains(&HookType::SessionEnd));
+    }
+
+    // --- hook_verbs ---
+
+    #[test]
+    fn test_hook_verbs() {
+        let hook = make_hook();
+        let verbs = hook.hook_verbs();
+        assert_eq!(verbs.len(), 5);
+        assert!(verbs.contains(&"prompt-submit"));
+        assert!(verbs.contains(&"agent-stop"));
+        assert!(verbs.contains(&"pre-tool-use"));
+        assert!(verbs.contains(&"post-tool-use"));
+        assert!(verbs.contains(&"post-task"));
+    }
+
+    // --- install / uninstall are no-ops ---
+
+    #[test]
+    fn test_install_is_noop() {
+        let hook = make_hook();
+        let result = hook.install(Path::new("/tmp"));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 0);
+    }
+
+    #[test]
+    fn test_uninstall_is_noop() {
+        let hook = make_hook();
+        let result = hook.uninstall(Path::new("/tmp"));
+        assert!(result.is_ok());
+    }
+
+    // --- parse_event: empty input ---
+
+    #[test]
+    fn test_parse_event_empty_input() {
+        let hook = make_hook();
+        let result = hook.parse_event(HookType::TurnStart, b"");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, AgentError::HookInputEmpty { .. }));
+    }
+
+    // --- parse_event: invalid JSON ---
+
+    #[test]
+    fn test_parse_event_invalid_json() {
+        let hook = make_hook();
+        let result = hook.parse_event(HookType::TurnStart, b"not json");
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            AgentError::HookParseFailed { .. }
+        ));
+    }
+
+    // --- parse_event: missing session_id generates fallback ---
+
+    #[test]
+    fn test_parse_event_missing_session_id() {
+        let hook = make_hook();
+        let input = br#"{"cwd": "/tmp"}"#;
+        let event = hook.parse_event(HookType::TurnStart, input).unwrap();
+        // Should generate a fallback session ID
+        assert!(event.session_id.starts_with("kiro-"));
+    }
+
+    // --- parse_event: empty session_id generates fallback ---
+
+    #[test]
+    fn test_parse_event_empty_session_id() {
+        let hook = make_hook();
+        let input = br#"{"session_id": ""}"#;
+        let event = hook.parse_event(HookType::TurnStart, input).unwrap();
+        assert!(event.session_id.starts_with("kiro-"));
+    }
+
+    // --- parse_event: prompt-submit (TurnStart) ---
+
+    #[test]
+    fn test_parse_prompt_submit() {
+        let hook = make_hook();
+        let input = br#"{
+            "session_id": "kiro-20260521-153000",
+            "cwd": "/path/to/project",
+            "model": "claude-sonnet-4-6",
+            "prompt": "Fix the bug",
+            "timestamp": "2026-05-21T15:30:00Z"
+        }"#;
+        let event = hook.parse_event(HookType::TurnStart, input).unwrap();
+        assert_eq!(event.session_id, "kiro-20260521-153000");
+        assert_eq!(event.event_type, HookType::TurnStart);
+        assert_eq!(event.prompt.as_deref(), Some("Fix the bug"));
+        let raw = event.raw_json.unwrap();
+        assert_eq!(raw["model"], "claude-sonnet-4-6");
+    }
+
+    // --- parse_event: agent-stop (TurnEnd) ---
+
+    #[test]
+    fn test_parse_agent_stop() {
+        let hook = make_hook();
+        let input = br#"{
+            "session_id": "kiro-20260521-153000",
+            "cwd": "/path/to/project",
+            "model": "claude-sonnet-4-6",
+            "timestamp": "2026-05-21T15:30:05Z"
+        }"#;
+        let event = hook.parse_event(HookType::TurnEnd, input).unwrap();
+        assert_eq!(event.session_id, "kiro-20260521-153000");
+        assert_eq!(event.event_type, HookType::TurnEnd);
+    }
+
+    // --- parse_event: pre-tool-use (PreToolUse) ---
+
+    #[test]
+    fn test_parse_pre_tool_use() {
+        let hook = make_hook();
+        let input = br#"{
+            "session_id": "kiro-20260521-153000",
+            "tool_name": "write",
+            "tool_call_id": "tc_123",
+            "cwd": "/path/to/project"
+        }"#;
+        let event = hook.parse_event(HookType::PreToolUse, input).unwrap();
+        assert_eq!(event.session_id, "kiro-20260521-153000");
+        assert_eq!(event.event_type, HookType::PreToolUse);
+        assert_eq!(event.tool_name.as_deref(), Some("write"));
+        assert_eq!(event.tool_use_id.as_deref(), Some("tc_123"));
+    }
+
+    // --- parse_event: post-tool-use (PostToolUse) ---
+
+    #[test]
+    fn test_parse_post_tool_use() {
+        let hook = make_hook();
+        let input = br#"{
+            "session_id": "kiro-20260521-153000",
+            "tool_name": "read",
+            "tool_call_id": "tc_456",
+            "cwd": "/path/to/project"
+        }"#;
+        let event = hook.parse_event(HookType::PostToolUse, input).unwrap();
+        assert_eq!(event.session_id, "kiro-20260521-153000");
+        assert_eq!(event.event_type, HookType::PostToolUse);
+        assert_eq!(event.tool_name.as_deref(), Some("read"));
+        assert_eq!(event.tool_use_id.as_deref(), Some("tc_456"));
+    }
+
+    // --- parse_event: post-task (PostToolUse) ---
+
+    #[test]
+    fn test_parse_post_task() {
+        let hook = make_hook();
+        let input = br#"{
+            "session_id": "kiro-20260521-153000",
+            "tool_name": "spec-task",
+            "cwd": "/path/to/project"
+        }"#;
+        // post-task maps to PostToolUse via verb_to_hook_type
+        let event = hook.parse_event(HookType::PostToolUse, input).unwrap();
+        assert_eq!(event.session_id, "kiro-20260521-153000");
+        assert_eq!(event.event_type, HookType::PostToolUse);
+        assert_eq!(event.tool_name.as_deref(), Some("spec-task"));
+    }
+
+    // --- detect_presence ---
+
+    #[test]
+    fn test_detect_presence_with_kiro_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".kiro")).unwrap();
+        let hook = make_hook();
+        assert!(hook.detect_presence(tmp.path()));
+    }
+
+    #[test]
+    fn test_detect_presence_without_kiro_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let hook = make_hook();
+        assert!(!hook.detect_presence(tmp.path()));
+    }
+
+    // --- verb_to_hook_type ---
+
+    #[test]
+    fn test_verb_to_hook_type() {
+        assert_eq!(
+            verb_to_hook_type("prompt-submit"),
+            Some(HookType::TurnStart)
+        );
+        assert_eq!(verb_to_hook_type("agent-stop"), Some(HookType::TurnEnd));
+        assert_eq!(
+            verb_to_hook_type("pre-tool-use"),
+            Some(HookType::PreToolUse)
+        );
+        assert_eq!(
+            verb_to_hook_type("post-tool-use"),
+            Some(HookType::PostToolUse)
+        );
+        assert_eq!(verb_to_hook_type("post-task"), Some(HookType::PostToolUse));
+        assert_eq!(verb_to_hook_type("unknown"), None);
+    }
+
+    // --- default trait ---
+
+    #[test]
+    fn test_default() {
+        let hook = KiroHook::default();
+        assert_eq!(hook.name(), "kiro");
+    }
+
+    // --- debug ---
+
+    #[test]
+    fn test_debug() {
+        let hook = make_hook();
+        let debug = format!("{:?}", hook);
+        assert!(debug.contains("KiroHook"));
+    }
+}

--- a/atomic-agent/src/hooks/manifest.rs
+++ b/atomic-agent/src/hooks/manifest.rs
@@ -21,10 +21,10 @@
 //!   "command_prefix": "atomic agent hooks codex",
 //!   "hooks": {
 //!     "SessionStart": [
-//!       { "hooks": [ { "type": "command", "command": "test -d .atomic && atomic agent hooks codex session-start || true", "statusMessage": "Atomic: tracking session" } ] }
+//!       { "hooks": [ { "type": "command", "command": "test -d .atomic || test -f .atomic-sandbox && atomic agent hooks codex session-start || true", "statusMessage": "Atomic: tracking session" } ] }
 //!     ],
 //!     "Stop": [
-//!       { "hooks": [ { "type": "command", "command": "test -d .atomic && atomic agent hooks codex stop || true" } ] }
+//!       { "hooks": [ { "type": "command", "command": "test -d .atomic || test -f .atomic-sandbox && atomic agent hooks codex stop || true" } ] }
 //!     ]
 //!   }
 //! }

--- a/atomic-agent/src/hooks/mod.rs
+++ b/atomic-agent/src/hooks/mod.rs
@@ -64,6 +64,7 @@ pub mod cursor;
 pub mod devin;
 pub mod gemini_cli;
 pub mod hermes;
+pub mod kiro;
 pub mod manifest;
 pub mod opencode;
 pub mod pi;
@@ -252,6 +253,7 @@ impl AgentRegistry {
     /// - Devin Desktop (`devin`)
     /// - Gemini CLI (`gemini-cli`)
     /// - Hermes Agent (`hermes`)
+    /// - Kiro (`kiro`)
     /// - OpenCode (`opencode`)
     /// - Pi (`pi`)
     /// - Sherpa (`sherpa`)
@@ -265,6 +267,7 @@ impl AgentRegistry {
         registry.register(Box::new(devin::DevinHook::new()));
         registry.register(Box::new(gemini_cli::GeminiCliHook::new()));
         registry.register(Box::new(hermes::HermesHook::new()));
+        registry.register(Box::new(kiro::KiroHook::new()));
         registry.register(Box::new(opencode::OpenCodeHook::new()));
         registry.register(Box::new(pi::PiHook::new()));
         registry.register(Box::new(sherpa::SherpaHook::new()));

--- a/atomic-agent/src/hooks/mod.rs
+++ b/atomic-agent/src/hooks/mod.rs
@@ -61,6 +61,7 @@ pub mod cline;
 pub mod codex;
 pub mod copilot;
 pub mod cursor;
+pub mod devin;
 pub mod gemini_cli;
 pub mod hermes;
 pub mod manifest;
@@ -248,6 +249,7 @@ impl AgentRegistry {
     /// - Codex (`codex`)
     /// - Copilot (`copilot`)
     /// - Cursor (`cursor`)
+    /// - Devin Desktop (`devin`)
     /// - Gemini CLI (`gemini-cli`)
     /// - Hermes Agent (`hermes`)
     /// - OpenCode (`opencode`)
@@ -260,6 +262,7 @@ impl AgentRegistry {
         registry.register(Box::new(codex::CodexHook::new()));
         registry.register(Box::new(copilot::CopilotHook::new()));
         registry.register(Box::new(cursor::CursorHook::new()));
+        registry.register(Box::new(devin::DevinHook::new()));
         registry.register(Box::new(gemini_cli::GeminiCliHook::new()));
         registry.register(Box::new(hermes::HermesHook::new()));
         registry.register(Box::new(opencode::OpenCodeHook::new()));

--- a/atomic-agent/src/hooks/mod.rs
+++ b/atomic-agent/src/hooks/mod.rs
@@ -76,6 +76,35 @@ use std::path::Path;
 use crate::error::{AgentError, AgentResult};
 use crate::event::{HookType, TurnEvent};
 
+// Hook command guard
+
+/// Wrap an `atomic agent hooks …` invocation in the shell guard that installed
+/// hooks run behind.
+///
+/// The hook must only fire where Atomic's graph is reachable, but it must fire
+/// in **both** kinds of working tree:
+///
+/// * a canonical checkout, which has a `.atomic/` directory; and
+/// * an agent sandbox, which has **no** `.atomic/` of its own — only a
+///   `.atomic-sandbox` pointer file to the canonical graph.
+///
+/// Guarding on `.atomic` alone silently drops all provenance for sandboxed
+/// agents (the guard is false, so the recorder never runs). Adding the sandbox
+/// arm lets the hook fire there too; `atomic agent hooks` then resolves the
+/// pointer and records into the canonical graph.
+///
+/// POSIX `&&`/`||` are equal-precedence and left-associative, so
+/// `test -d .atomic || test -f .atomic-sandbox && CMD || true` parses as
+/// `(((test -d .atomic || test -f .atomic-sandbox) && CMD) || true)` — the
+/// recorder runs when either marker is present, and a recorder failure is
+/// swallowed so the agent turn is never blocked.
+pub(crate) fn guarded_hook_command(inner: &str) -> String {
+    format!(
+        "test -d .atomic || test -f {pointer} && {inner} || true",
+        pointer = atomic_repository::SANDBOX_POINTER,
+    )
+}
+
 // AgentHook Trait
 
 /// Trait for agent hook adapters.

--- a/atomic-agent/src/hooks/opencode.rs
+++ b/atomic-agent/src/hooks/opencode.rs
@@ -354,6 +354,26 @@ impl OpenCodeHook {
             .filter(|s| !s.is_empty())
             .unwrap_or_else(|| format!("opencode-{}", uuid_short()))
     }
+
+    /// Path to the global OpenCode config directory (`~/.config/opencode/`).
+    ///
+    /// OpenCode uses the XDG-style `~/.config/opencode/` path on all
+    /// platforms (including macOS, where `dirs::config_dir()` returns
+    /// `~/Library/Application Support/`), so we construct it from the
+    /// home directory.
+    fn global_config_dir() -> Option<std::path::PathBuf> {
+        dirs::home_dir().map(|h| h.join(".config").join("opencode"))
+    }
+
+    /// Check whether the `atomic-opencode` plugin is installed globally.
+    ///
+    /// Returns `true` if `~/.config/opencode/plugins/atomic-hooks.ts` exists
+    /// (as a file or valid symlink).
+    fn is_plugin_installed() -> bool {
+        Self::global_config_dir()
+            .map(|d| d.join("plugins").join("atomic-hooks.ts").exists())
+            .unwrap_or(false)
+    }
 }
 
 impl Default for OpenCodeHook {
@@ -557,7 +577,14 @@ impl AgentHook for OpenCodeHook {
     }
 
     fn install(&self, _repo_root: &Path) -> AgentResult<usize> {
-        Ok(0) // Installation handled by atomic-opencode package
+        // OpenCode hooks are managed by the atomic-opencode package, not
+        // by writing files into the repo.  Report 1 if the plugin is
+        // already present so that `enable` shows a success message.
+        if Self::is_plugin_installed() {
+            Ok(1)
+        } else {
+            Ok(0)
+        }
     }
 
     fn uninstall(&self, _repo_root: &Path) -> AgentResult<()> {
@@ -565,7 +592,7 @@ impl AgentHook for OpenCodeHook {
     }
 
     fn is_installed(&self, _repo_root: &Path) -> bool {
-        false // Managed by atomic-opencode package
+        Self::is_plugin_installed()
     }
 
     fn supported_hooks(&self) -> Vec<HookType> {
@@ -580,8 +607,9 @@ impl AgentHook for OpenCodeHook {
     }
 
     fn detect_presence(&self, repo_root: &Path) -> bool {
-        // OpenCode is present if the .opencode directory exists
-        repo_root.join(OPENCODE_DIR).is_dir()
+        // OpenCode is present if the repo has a .opencode directory OR if
+        // the atomic-opencode plugin is installed globally.
+        repo_root.join(OPENCODE_DIR).is_dir() || Self::is_plugin_installed()
     }
 
     fn hook_verbs(&self) -> Vec<&str> {
@@ -914,7 +942,12 @@ mod tests {
     fn test_detect_presence_without_opencode_dir() {
         let tmp = TempDir::new().unwrap();
         let hook = make_hook();
-        assert!(!hook.detect_presence(tmp.path()));
+        // Without a repo-level .opencode dir, detection depends on the
+        // global plugin.  We only assert "no detection" when the plugin
+        // is also absent globally.
+        if !OpenCodeHook::is_plugin_installed() {
+            assert!(!hook.detect_presence(tmp.path()));
+        }
     }
 
     #[test]
@@ -922,15 +955,23 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         std::fs::write(tmp.path().join(".opencode"), "not a dir").unwrap();
         let hook = make_hook();
-        assert!(!hook.detect_presence(tmp.path()));
+        // A regular file named .opencode is not a directory, so repo-local
+        // detection fails.  Overall result depends on global plugin state.
+        if !OpenCodeHook::is_plugin_installed() {
+            assert!(!hook.detect_presence(tmp.path()));
+        }
     }
 
     #[test]
-    fn test_install_is_noop() {
+    fn test_install_returns_count_based_on_plugin() {
         let tmp = TempDir::new().unwrap();
         let hook = make_hook();
         let count = hook.install(tmp.path()).unwrap();
-        assert_eq!(count, 0);
+        if OpenCodeHook::is_plugin_installed() {
+            assert_eq!(count, 1);
+        } else {
+            assert_eq!(count, 0);
+        }
     }
 
     #[test]
@@ -941,10 +982,13 @@ mod tests {
     }
 
     #[test]
-    fn test_is_installed_returns_false() {
+    fn test_is_installed_matches_plugin_state() {
         let tmp = TempDir::new().unwrap();
         let hook = make_hook();
-        assert!(!hook.is_installed(tmp.path()));
+        assert_eq!(
+            hook.is_installed(tmp.path()),
+            OpenCodeHook::is_plugin_installed()
+        );
     }
 
     // uuid_short tests

--- a/atomic-agent/src/learnings.rs
+++ b/atomic-agent/src/learnings.rs
@@ -115,6 +115,7 @@ const SECTION_NOTE: &str =
 /// assert_eq!(context_file_for_agent("gemini-cli"), "GEMINI.md");
 /// assert_eq!(context_file_for_agent("codex"), "codex.md");
 /// assert_eq!(context_file_for_agent("opencode"), "opencode.md");
+/// assert_eq!(context_file_for_agent("kiro"), "AGENTS.md");
 /// assert_eq!(context_file_for_agent("unknown"), ".atomic/learnings.md");
 /// ```
 pub fn context_file_for_agent(agent_name: &str) -> &'static str {
@@ -123,6 +124,7 @@ pub fn context_file_for_agent(agent_name: &str) -> &'static str {
         "gemini-cli" => "GEMINI.md",
         "codex" => "codex.md",
         "opencode" => "opencode.md",
+        "kiro" => "AGENTS.md",
         _ => ".atomic/learnings.md",
     }
 }
@@ -627,6 +629,11 @@ mod tests {
     #[test]
     fn test_context_file_opencode() {
         assert_eq!(context_file_for_agent("opencode"), "opencode.md");
+    }
+
+    #[test]
+    fn test_context_file_kiro() {
+        assert_eq!(context_file_for_agent("kiro"), "AGENTS.md");
     }
 
     #[test]

--- a/atomic-agent/src/lib.rs
+++ b/atomic-agent/src/lib.rs
@@ -183,6 +183,14 @@ mod tests {
     }
 
     #[test]
+    fn test_default_registry_has_kiro() {
+        let registry = AgentRegistry::with_defaults();
+        let agent = registry.get("kiro");
+        assert!(agent.is_some(), "Default registry should include kiro");
+        assert_eq!(agent.unwrap().display_name(), "Kiro");
+    }
+
+    #[test]
     fn test_default_registry_has_pi() {
         let registry = AgentRegistry::with_defaults();
         let agent = registry.get("pi");

--- a/atomic-agent/src/provenance/classify.rs
+++ b/atomic-agent/src/provenance/classify.rs
@@ -481,7 +481,7 @@ fn summarize_exploration(tool_name: &str, tool_input: Option<&serde_json::Value>
         (None, Some(target), _) => {
             format!("Examine {}", target)
         }
-        (None, None, Some(desc)) => truncate_for_summary(desc, 80),
+        (None, None, Some(desc)) => truncate_for_summary(desc, 500),
         (None, None, None) => {
             let verb = match tool_name.to_lowercase().as_str() {
                 "grep" | "rg" | "ripgrep" | "search" => "Search codebase",
@@ -544,7 +544,7 @@ fn summarize_commitment(tool_name: &str, tool_input: Option<&serde_json::Value>)
     };
 
     match path {
-        Some(p) => format!("{} {}", verb, truncate_for_summary(p, 80)),
+        Some(p) => format!("{} {}", verb, p),
         None => format!("{} file", verb),
     }
 }
@@ -584,7 +584,7 @@ fn summarize_verification(
     if cmd.is_empty() {
         format!("Run verification{}", result_suffix)
     } else {
-        format!("{}{}", truncate_for_summary(cmd, 80), result_suffix)
+        format!("{}{}", truncate_for_summary(cmd, 300), result_suffix)
     }
 }
 
@@ -598,7 +598,7 @@ fn summarize_execution(tool_name: &str, tool_input: Option<&serde_json::Value>) 
         let cmd = extract_command(tool_input);
         let cmd = cmd.trim();
         if !cmd.is_empty() {
-            return truncate_for_summary(cmd, 100);
+            return truncate_for_summary(cmd, 300);
         }
     }
 

--- a/atomic-agent/src/record/mod.rs
+++ b/atomic-agent/src/record/mod.rs
@@ -210,7 +210,7 @@ pub fn record_turn(
     // Keep the write handle on the same view for post-add status and record.
     // First turns may target a view that record/apply will create; other failures
     // mean we cannot trust the detection/apply alignment.
-    match repo.set_current_view(&options.session.view_name) {
+    match repo.align_to_view(&options.session.view_name) {
         Ok(()) => {}
         Err(atomic_repository::RepositoryError::ViewNotFound { .. }) => {
             log::debug!(

--- a/atomic-agent/src/record/mod.rs
+++ b/atomic-agent/src/record/mod.rs
@@ -140,13 +140,18 @@ pub fn record_turn(
     // Step 1: Open the repository read-only for the initial status check.
     // This avoids blocking on the redb write lock — we only need read access
     // to decide whether there's work to do and which files are untracked.
-    let repo = atomic_repository::Repository::open_readonly(repo_root).map_err(|e| {
+    let mut repo = atomic_repository::Repository::open_readonly(repo_root).map_err(|e| {
         AgentError::RecordFailed {
             session_id: options.session.session_id.clone(),
             turn_number: options.turn_number,
             reason: format!("Failed to open repository (readonly): {}", e),
         }
     })?;
+
+    // `status()` reads current_view, while `record()` writes to session.view_name.
+    // Align the read-only handle before the first status check; this keeps the
+    // no-lock fast path and prevents direct callers from seeing false EmptyTurn.
+    repo.set_current_view_in_memory(&options.session.view_name);
 
     // Step 2: Status — find out what the agent changed.
     // Include untracked files because agent turns commonly create new source,
@@ -194,13 +199,33 @@ pub fn record_turn(
     // skips the table-init `begin_write()` that `open()` does — the tables
     // already exist and that write lock is the primary cause of hook hangs
     // when another process holds a transaction.
-    let repo = atomic_repository::Repository::open_existing(repo_root).map_err(|e| {
+    let mut repo = atomic_repository::Repository::open_existing(repo_root).map_err(|e| {
         AgentError::RecordFailed {
             session_id: options.session.session_id.clone(),
             turn_number: options.turn_number,
             reason: format!("Failed to open repository for recording: {}", e),
         }
     })?;
+
+    // Keep the write handle on the same view for post-add status and record.
+    // First turns may target a view that record/apply will create; other failures
+    // mean we cannot trust the detection/apply alignment.
+    match repo.set_current_view(&options.session.view_name) {
+        Ok(()) => {}
+        Err(atomic_repository::RepositoryError::ViewNotFound { .. }) => {
+            log::debug!(
+                "session view '{}' not yet created; first-turn apply will create it",
+                options.session.view_name
+            );
+        }
+        Err(e) => {
+            return Err(AgentError::RecordFailed {
+                session_id: options.session.session_id.clone(),
+                turn_number: options.turn_number,
+                reason: format!("Failed to align current view before record: {}", e),
+            });
+        }
+    }
 
     if !untracked_paths.is_empty() {
         log::info!(

--- a/atomic-agent/src/record/provenance.rs
+++ b/atomic-agent/src/record/provenance.rs
@@ -163,6 +163,10 @@ pub(crate) fn vendor_from_agent_name(agent_name: &str) -> AIVendor {
         "claude-code" => AIVendor::Anthropic,
         "gemini-cli" => AIVendor::Google,
         "codex" => AIVendor::OpenAI,
+        "kiro" => AIVendor::AmazonBedrock,
+        "copilot" => AIVendor::Other("github".to_string()),
+        "cursor" => AIVendor::Anthropic,
+        "opencode" => AIVendor::OpenAI,
         _ => AIVendor::Other(agent_name.to_string()),
     }
 }

--- a/atomic-agent/src/record/tests.rs
+++ b/atomic-agent/src/record/tests.rs
@@ -585,6 +585,11 @@ fn test_vendor_from_agent_name_codex() {
 }
 
 #[test]
+fn test_vendor_from_agent_name_kiro() {
+    assert_eq!(vendor_from_agent_name("kiro"), AIVendor::AmazonBedrock);
+}
+
+#[test]
 fn test_vendor_from_agent_name_unknown() {
     match vendor_from_agent_name("my-custom-agent") {
         AIVendor::Other(name) => assert_eq!(name, "my-custom-agent"),

--- a/atomic-agent/src/turn/orchestrator/mod.rs
+++ b/atomic-agent/src/turn/orchestrator/mod.rs
@@ -314,6 +314,7 @@ pub(crate) fn vendor_from_agent_name(agent_name: &str) -> &'static str {
         "cursor" => "anthropic",
         "gemini-cli" => "google",
         "codex" => "openai",
+        "kiro" => "amazon-bedrock",
         "opencode" => "openai",
         _ => "unknown",
     }

--- a/atomic-agent/src/turn/orchestrator/mod.rs
+++ b/atomic-agent/src/turn/orchestrator/mod.rs
@@ -97,6 +97,13 @@ pub struct DispatchResult {
     /// If a turn was recorded, contains the outcome.
     pub change_recorded: Option<TurnRecordOutcome>,
 
+    /// The Atomic view the session records onto (the per-session agent view).
+    ///
+    /// Set on turn events so a caller can locate the recorded change, which
+    /// lives on this view rather than the default/shared view. `None` when the
+    /// session view is not known for this event.
+    pub view: Option<String>,
+
     /// User-facing message to return to the agent (via hook stdout).
     ///
     /// For `SessionStart`, this is the "Atomic is tracking" message.
@@ -117,6 +124,7 @@ impl DispatchResult {
             session_id: session_id.into(),
             new_phase: phase,
             change_recorded: None,
+            view: None,
             message: None,
             warnings: Vec::new(),
         }
@@ -125,6 +133,12 @@ impl DispatchResult {
     /// Set the recorded change outcome.
     pub(crate) fn with_change(mut self, outcome: TurnRecordOutcome) -> Self {
         self.change_recorded = Some(outcome);
+        self
+    }
+
+    /// Set the session's record view.
+    pub(crate) fn with_view(mut self, view: impl Into<String>) -> Self {
+        self.view = Some(view.into());
         self
     }
 

--- a/atomic-agent/src/turn/orchestrator/provenance.rs
+++ b/atomic-agent/src/turn/orchestrator/provenance.rs
@@ -438,8 +438,27 @@ impl TurnOrchestrator {
             // Failure is still treated as non-fatal; the provenance chain
             // remains intact and the DB metadata can be rebuilt later.
 
-            let dot_dir = self.repo_root.join(atomic_repository::DOT_DIR);
-            let changes_dir = dot_dir.join("changes");
+            // Resolve the *canonical* changes dir. In a sandbox `repo_root`
+            // has no graph of its own — the pointer file names the canonical
+            // repository. Joining `.atomic` onto `repo_root` would write the
+            // graph into a throwaway dir inside the sandbox, so it would be
+            // absent from the real graph whenever the best-effort Phase 2
+            // below loses the redb write-lock race with a concurrent agent.
+            // `canonical_dot_dir` follows the pointer without opening redb, so
+            // Phase 1 stays lock-free.
+            let changes_dir =
+                match atomic_repository::Repository::canonical_dot_dir(&self.repo_root) {
+                    Ok(dot_dir) => dot_dir.join("changes"),
+                    Err(e) => {
+                        log::warn!(
+                            "Could not resolve canonical changes dir to save \
+                             provenance graph for session {}: {}",
+                            session_id,
+                            e,
+                        );
+                        return true;
+                    }
+                };
 
             // Phase 1: Filesystem write — never blocks on redb.
             let hash = match atomic_repository::ChangeStore::new(

--- a/atomic-agent/src/turn/orchestrator/session_start.rs
+++ b/atomic-agent/src/turn/orchestrator/session_start.rs
@@ -159,6 +159,25 @@ impl TurnOrchestrator {
         // still work, it just won't have the parent's history.
         if session.parent_view.is_none() {
             match atomic_repository::Repository::open_existing(&self.repo_root) {
+                Ok(repo) if repo.is_sandbox() => {
+                    // A sandbox is a materialized copy of the project; `record`
+                    // writes to the *canonical* graph (shared pristine +
+                    // changes), on the view named in the `.atomic-sandbox`
+                    // pointer. The agent is already on that view, so adopt it
+                    // for recording and do NOT fork or switch:
+                    //   * create_view_from would inject a spurious view into
+                    //     the canonical graph, and
+                    //   * set_current_view writes the *canonical*
+                    //     .atomic/current_view, clobbering the real user's
+                    //     current view.
+                    let current = repo.current_view().to_string();
+                    log::info!(
+                        "Sandbox session {}: recording on provisioned view '{}' (no fork/switch)",
+                        session_id,
+                        current,
+                    );
+                    session.view_name = current;
+                }
                 Ok(mut repo) => {
                     let current = repo.current_view().to_string();
                     session.set_parent_view(&current);
@@ -267,7 +286,19 @@ impl TurnOrchestrator {
                 {
                     let current = repo.current_view().to_string();
 
-                    if current != "dev" && current != "main" && current != "release" {
+                    if repo.is_sandbox() {
+                        // Sandboxes already operate on the view named in their
+                        // pointer file and record into the canonical graph.
+                        // Adopt that view verbatim; never fork or switch
+                        // (set_current_view writes the canonical
+                        // .atomic/current_view the sandbox shares).
+                        log::info!(
+                            "Fallback sandbox session {} adopting provisioned view '{}'",
+                            session_id,
+                            current,
+                        );
+                        session.view_name = current;
+                    } else if current != "dev" && current != "main" && current != "release" {
                         // Adopt the existing agent view (session-start
                         // likely created it before this fallback ran).
                         log::info!(

--- a/atomic-agent/src/turn/orchestrator/session_start.rs
+++ b/atomic-agent/src/turn/orchestrator/session_start.rs
@@ -208,14 +208,14 @@ impl TurnOrchestrator {
                     // while current_view points to the agent view. This ensures
                     // status/add/record see the right view. session-end will
                     // switch back to the user's view.
-                    if let Err(e) = repo.set_current_view(&session.view_name) {
+                    if let Err(e) = repo.align_to_view(&session.view_name) {
                         log::warn!(
-                            "Could not switch to agent view '{}': {} (non-fatal)",
+                            "Could not align to agent view '{}': {} (non-fatal)",
                             session.view_name,
                             e,
                         );
                     } else {
-                        log::info!("Switched to agent view '{}'", session.view_name,);
+                        log::info!("Aligned to agent view '{}'", session.view_name,);
                     }
                 }
                 Err(e) => {
@@ -334,9 +334,9 @@ impl TurnOrchestrator {
 
                         // Switch to the agent view so status/add/record
                         // target the right view.
-                        if let Err(e) = repo.set_current_view(&session.view_name) {
+                        if let Err(e) = repo.align_to_view(&session.view_name) {
                             log::warn!(
-                                "Fallback session {} could not switch to '{}': {} (non-fatal)",
+                                "Fallback session {} could not align to '{}': {} (non-fatal)",
                                 session_id,
                                 session.view_name,
                                 e,

--- a/atomic-agent/src/turn/orchestrator/tests.rs
+++ b/atomic-agent/src/turn/orchestrator/tests.rs
@@ -484,7 +484,8 @@ async fn test_session_attestation_covers_only_agent_recorded_changes() {
         let agent_view_history = repo
             .log(
                 atomic_repository::history::HistoryOptions::default()
-                    .view(&session_after_turn.view_name),
+                    .view(&session_after_turn.view_name)
+                    .include_inherited(true),
             )
             .unwrap();
         let inherited_hashes: Vec<_> = agent_view_history.iter().map(|e| e.hash).collect();

--- a/atomic-agent/src/turn/orchestrator/tests.rs
+++ b/atomic-agent/src/turn/orchestrator/tests.rs
@@ -183,6 +183,90 @@ async fn test_session_start_in_sandbox_adopts_view_without_forking() {
     assert_eq!(canonical_after.current_view(), user_view);
 }
 
+#[tokio::test]
+async fn test_full_turn_in_sandbox_records_provenance_into_canonical_graph() {
+    // Canonical repo with a distinct view the sandbox operates on.
+    let canonical = TempDir::new().unwrap();
+    let repo = Repository::init(canonical.path()).unwrap();
+    // Default `atomic sandbox create` (no --from/--view) binds to the current
+    // shared view. Exercise that exact case.
+    let user_view = repo.current_view().to_string();
+
+    let sandbox_dir = TempDir::new().unwrap();
+    repo.provision_sandbox(sandbox_dir.path(), &user_view)
+        .unwrap();
+    drop(repo);
+
+    // Orchestrator rooted at the sandbox working tree (mirrors the hook path).
+    let session_store = SessionStore::for_repo(sandbox_dir.path()).unwrap();
+    let watcher = FallbackWatcher::new(WatcherConfig::new(sandbox_dir.path()));
+    let mut orch =
+        TurnOrchestrator::with_watcher(sandbox_dir.path(), session_store, Box::new(watcher));
+    orch.set_agent("claude-code", "Claude Code");
+
+    orch.dispatch(session_start_event("sess-sbx-prov"))
+        .await
+        .unwrap();
+    orch.dispatch(turn_start_event("sess-sbx-prov", "Create agent.txt"))
+        .await
+        .unwrap();
+
+    // Agent writes a file into its sandbox working tree.
+    fs::write(sandbox_dir.path().join("agent.txt"), "agent work\n").unwrap();
+
+    let result = orch
+        .dispatch(turn_end_event("sess-sbx-prov"))
+        .await
+        .unwrap();
+
+    assert!(
+        result.was_recorded(),
+        "a turn that created a file in the sandbox must record a change"
+    );
+    let change_hash = result.change_recorded.as_ref().unwrap().hash;
+
+    // The provenance graph file must be written into the CANONICAL change
+    // store (not a throwaway `.atomic/changes` inside the sandbox). Phase 1 of
+    // the save is the lock-free durability guarantee; if it targets the
+    // sandbox's local dir, provenance is lost whenever the best-effort Phase 2
+    // (which takes the redb write lock) loses a race with a concurrent agent.
+    let canonical_changes = atomic_repository::ChangeStore::new(
+        canonical.path().join(".atomic").join("changes"),
+        atomic_repository::DEFAULT_CACHE_CAPACITY,
+    )
+    .unwrap();
+    assert!(
+        canonical_changes.count_provenance_graphs().unwrap() >= 1,
+        "provenance graph must be written to the canonical change store"
+    );
+
+    // Nothing should be written into a sandbox-local change store.
+    let sandbox_changes = sandbox_dir.path().join(".atomic").join("changes");
+    if sandbox_changes.is_dir() {
+        let local = atomic_repository::ChangeStore::new(
+            sandbox_changes,
+            atomic_repository::DEFAULT_CACHE_CAPACITY,
+        )
+        .unwrap();
+        assert_eq!(
+            local.count_provenance_graphs().unwrap(),
+            0,
+            "provenance must not be written to a throwaway change store inside the sandbox"
+        );
+    }
+
+    // End-to-end: the change and its provenance are both registered in the
+    // canonical graph.
+    let canonical_repo = Repository::open(canonical.path()).unwrap();
+    let provenance = canonical_repo
+        .find_provenance_for_change(&change_hash)
+        .unwrap();
+    assert!(
+        !provenance.is_empty(),
+        "provenance graph for the sandbox turn must be registered in the canonical graph"
+    );
+}
+
 // TurnStart tests
 
 #[tokio::test]

--- a/atomic-agent/src/turn/orchestrator/tests.rs
+++ b/atomic-agent/src/turn/orchestrator/tests.rs
@@ -132,6 +132,57 @@ async fn test_session_start_resumes_ended_session() {
     assert_eq!(session.turn_count, 3); // preserved
 }
 
+#[tokio::test]
+async fn test_session_start_in_sandbox_adopts_view_without_forking() {
+    // Canonical repository with a distinct view the sandbox operates on.
+    let canonical = TempDir::new().unwrap();
+    let mut repo = Repository::init(canonical.path()).unwrap();
+    let user_view = repo.current_view().to_string(); // "dev"
+    repo.create_view_from("agent-sbx", &user_view).unwrap();
+
+    // Provision a sandbox working tree bound to the agent view.
+    let sandbox_dir = TempDir::new().unwrap();
+    repo.provision_sandbox(sandbox_dir.path(), "agent-sbx")
+        .unwrap();
+    drop(repo); // release the canonical pristine lock before reopening
+
+    // Sanity: the sandbox opens on its provisioned view.
+    let sbx = Repository::open_existing(sandbox_dir.path()).unwrap();
+    assert!(sbx.is_sandbox());
+    assert_eq!(sbx.current_view(), "agent-sbx");
+    drop(sbx);
+
+    // Orchestrator rooted at the sandbox working tree (mirrors the hook path).
+    let session_store = SessionStore::for_repo(sandbox_dir.path()).unwrap();
+    let watcher = FallbackWatcher::new(WatcherConfig::new(sandbox_dir.path()));
+    let mut orch =
+        TurnOrchestrator::with_watcher(sandbox_dir.path(), session_store, Box::new(watcher));
+
+    orch.dispatch(session_start_event("sess-sbx"))
+        .await
+        .unwrap();
+
+    // The session records on the sandbox's own view — not a freshly forked one.
+    let session = orch.session_store.load("sess-sbx").unwrap().unwrap();
+    assert_eq!(session.view_name, "agent-sbx");
+    assert!(
+        session.parent_view.is_none(),
+        "sandbox session must not fork a child view"
+    );
+
+    // The canonical graph is untouched: no spurious agent view was forked and
+    // the current view was not repointed.
+    let canonical_after = Repository::open_existing(canonical.path()).unwrap();
+    let mut views = canonical_after.list_views().unwrap();
+    views.sort();
+    assert_eq!(
+        views,
+        vec!["agent-sbx".to_string(), user_view.clone()],
+        "sandbox session must not fork a new view into the canonical graph"
+    );
+    assert_eq!(canonical_after.current_view(), user_view);
+}
+
 // TurnStart tests
 
 #[tokio::test]

--- a/atomic-agent/src/turn/orchestrator/turn.rs
+++ b/atomic-agent/src/turn/orchestrator/turn.rs
@@ -215,8 +215,11 @@ impl TurnOrchestrator {
         );
         let remaining = phase::apply_common_actions(&mut session, &result);
 
-        // Execute strategy-specific actions
-        let mut dispatch = DispatchResult::new(session_id, session.phase);
+        // Execute strategy-specific actions. Record the session's view so the
+        // caller can locate the change, which lands on the agent view rather
+        // than the default view.
+        let mut dispatch =
+            DispatchResult::new(session_id, session.phase).with_view(&session.view_name);
 
         for action in &remaining {
             match action {

--- a/atomic-agent/src/turn/orchestrator/turn.rs
+++ b/atomic-agent/src/turn/orchestrator/turn.rs
@@ -336,16 +336,7 @@ impl TurnOrchestrator {
     ) -> AgentResult<DispatchResult> {
         let session_id = &event.session_id;
 
-        let session = match self.session_store.load(session_id)? {
-            Some(s) => s,
-            None => {
-                log::debug!("ToolUse for unknown session {} — ignoring", session_id);
-                return Ok(DispatchResult::new(
-                    session_id,
-                    crate::turn::phase::Phase::Idle,
-                ));
-            }
-        };
+        let session = self.load_or_create_session(session_id, &event)?;
 
         // Log tool usage
         if let Some(ref tool_name) = event.tool_name {

--- a/atomic-agent/tests/record_view_mismatch_regression.rs
+++ b/atomic-agent/tests/record_view_mismatch_regression.rs
@@ -1,0 +1,114 @@
+//! Regression test for the `record_turn` detection/apply view mismatch.
+//!
+//! `status()` reads the repository current view, while `record_turn` records to
+//! `session.view_name`. These tests use the default random session view so
+//! direct callers that skip session-start exercise the mismatch.
+
+use atomic_agent::event::{HookType, TurnEvent};
+use atomic_agent::record::{record_turn, TurnRecordOptions};
+use atomic_agent::turn::AgentSession;
+
+use atomic_core::types::Base32;
+use atomic_repository::Repository;
+
+/// Keep the default random view_name; do not pin it to `dev`.
+fn default_session() -> AgentSession {
+    let mut s = AgentSession::new("regress-sess", "opencode", "OpenCode");
+    s.set_model_info("anthropic", "claude-opus-4");
+    s
+}
+
+fn options<'a>(
+    session: &'a AgentSession,
+    event: &'a TurnEvent,
+    turn_number: u32,
+    prompt: &str,
+) -> TurnRecordOptions<'a> {
+    TurnRecordOptions {
+        session,
+        event,
+        turn_number,
+        turn_duration_ms: 1000,
+        prompt: Some(prompt.to_string()),
+    }
+}
+
+/// A direct caller must be able to record a create turn followed by a modify turn.
+#[test]
+fn two_turns_with_default_random_view_both_record() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    Repository::init(root).expect("init disposable repo");
+
+    let session = default_session();
+    assert_ne!(
+        session.view_name, "dev",
+        "regression precondition: AgentSession::new must use a random (non-default) view_name"
+    );
+
+    std::fs::write(root.join("login.rs"), "fn attach_pdf() {}\n").expect("write new file");
+    let event1 = TurnEvent::new("regress-sess", HookType::TurnEnd);
+    let first = record_turn(root, &options(&session, &event1, 1, "create login.rs"))
+        .expect("turn 1 (new file) should record");
+    assert!(
+        !first.hash.to_base32().is_empty(),
+        "turn 1 must yield a hash"
+    );
+
+    // Keep the sizes different so this test does not depend on mtime granularity.
+    let turn1_body = "fn attach_pdf() {}\n";
+    let turn2_body = "fn attach_pdf() {\n    // Firefox + Safari support\n}\n";
+    assert_ne!(
+        turn1_body.len(),
+        turn2_body.len(),
+        "turn 2 must change the file size so detection never relies on mtime granularity"
+    );
+    std::fs::write(root.join("login.rs"), turn2_body).expect("modify tracked file");
+    let event2 = TurnEvent::new("regress-sess", HookType::TurnEnd);
+    let second = record_turn(root, &options(&session, &event2, 2, "fix pdf upload"))
+        .expect("turn 2 (modified tracked file) should record — regression: was EmptyTurn");
+
+    assert!(
+        !second.hash.to_base32().is_empty(),
+        "turn 2 must yield a hash"
+    );
+    assert_ne!(
+        first.hash.to_base32(),
+        second.hash.to_base32(),
+        "the modification must produce a change distinct from the creation"
+    );
+}
+
+/// Deleting the last file on the session view must also produce a recorded turn.
+#[test]
+fn delete_last_session_file_records_instead_of_emptyturn() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    Repository::init(root).expect("init disposable repo");
+
+    let session = default_session();
+    assert_ne!(
+        session.view_name, "dev",
+        "regression precondition: session must use a random (non-default) view_name"
+    );
+
+    std::fs::write(root.join("only.rs"), "fn only() {}\n").expect("write file");
+    let event1 = TurnEvent::new("regress-sess", HookType::TurnEnd);
+    let first = record_turn(root, &options(&session, &event1, 1, "create only.rs"))
+        .expect("turn 1 (new file) should record");
+
+    std::fs::remove_file(root.join("only.rs")).expect("delete the only file");
+    let event2 = TurnEvent::new("regress-sess", HookType::TurnEnd);
+    let second = record_turn(root, &options(&session, &event2, 2, "delete only.rs"))
+        .expect("turn 2 (delete last session file) should record — regression: was EmptyTurn");
+
+    assert!(
+        !second.hash.to_base32().is_empty(),
+        "the deletion must produce a change hash"
+    );
+    assert_ne!(
+        first.hash.to_base32(),
+        second.hash.to_base32(),
+        "the deletion must be a change distinct from the creation"
+    );
+}

--- a/atomic-cli/Cargo.toml
+++ b/atomic-cli/Cargo.toml
@@ -1,7 +1,6 @@
 [features]
-default = ["ast", "teams"]
+default = ["teams"]
 remote = []
-ast = ["atomic-semantic", "atomic-repository/ast"]
 teams = ["atomic-teams"]
 
 [package]
@@ -29,7 +28,7 @@ atomic-config = { workspace = true }
 atomic-identity = { workspace = true }
 atomic-remote = { workspace = true }
 atomic-repository = { workspace = true }
-atomic-semantic = { workspace = true, optional = true }
+atomic-semantic = { workspace = true }
 atomic-teams = { workspace = true, optional = true }
 
 # CLI

--- a/atomic-cli/src/commands/agent/attest.rs
+++ b/atomic-cli/src/commands/agent/attest.rs
@@ -614,6 +614,7 @@ fn pretty_tool(description: &str) -> String {
         "codex" => "Codex",
         "gemini-cli" => "Gemini CLI",
         "cursor" => "Cursor",
+        "devin" => "Devin Desktop",
         "cline" => "Cline",
         "opencode" => "OpenCode",
         "copilot" => "Copilot",

--- a/atomic-cli/src/commands/agent/disable.rs
+++ b/atomic-cli/src/commands/agent/disable.rs
@@ -273,9 +273,16 @@ impl Disable {
                         }
                     }
                 }
+                "kiro" => {
+                    print_success("Kiro hooks are configured through the IDE panel.");
+                    println!(
+                        "  Remove hooks manually in Kiro IDE \u{2192} Agent Steering & Skills."
+                    );
+                    println!("  Uninstall skills/steering: npx atomic-kiro --uninstall");
+                }
                 other => {
                     print_warning(&format!(
-                        "Global disable is not supported for '{}'. Supported agents: claude-code, gemini-cli",
+                        "Global disable is not supported for '{}'. Supported agents: claude-code, gemini-cli, kiro",
                         other
                     ));
                 }

--- a/atomic-cli/src/commands/agent/enable.rs
+++ b/atomic-cli/src/commands/agent/enable.rs
@@ -394,9 +394,11 @@ impl Enable {
                         println!("Hooks written to: ~/.codex/hooks.json");
                         println!();
                         println!("Every Codex session in a project with .atomic/ will now:");
-                        println!("  • Record each turn as an Atomic change with full provenance");
-                        println!("  • Track session metadata (turn number, timing, files)");
-                        println!("  • Capture tool calls through pre/post tool hooks");
+                        println!(
+                            "  \u{2022} Record each turn as an Atomic change with full provenance"
+                        );
+                        println!("  \u{2022} Track session metadata (turn number, timing, files)");
+                        println!("  \u{2022} Capture tool calls through pre/post tool hooks");
                     }
                     Ok(_) => {
                         print_success("Global hooks already up to date.");
@@ -407,9 +409,21 @@ impl Enable {
                 }
             }
 
+            "kiro" => {
+                print_success("Kiro hooks are configured through the IDE panel.");
+                println!();
+                println!("Install the atomic-kiro package for skills, steering, and hook scripts:");
+                println!("  npx atomic-kiro");
+                println!();
+                println!(
+                    "Then configure hooks in Kiro IDE \u{2192} Agent Steering & Skills panel."
+                );
+                println!("See: https://github.com/atomicdotdev/atomic-kiro");
+            }
+
             other => {
                 print_warning(&format!(
-                    "Global install is not supported for '{}'. Supported agents: claude-code, gemini-cli, codex",
+                    "Global install is not supported for '{}'. Supported agents: claude-code, gemini-cli, codex, kiro",
                     other
                 ));
             }

--- a/atomic-cli/src/commands/agent/hooks.rs
+++ b/atomic-cli/src/commands/agent/hooks.rs
@@ -57,6 +57,7 @@ use clap::Args;
 
 use atomic_agent::event::HookType;
 use atomic_agent::hooks::AgentRegistry;
+use atomic_core::types::Base32;
 
 use crate::commands::{find_repository_root, Command};
 use crate::error::{CliError, CliResult};
@@ -87,6 +88,24 @@ pub struct Hooks {
     /// Run the hook body in this process.
     #[arg(long, hide = true)]
     foreground: bool,
+
+    /// Print one JSON result line for callers that need the recorded change hash.
+    #[arg(long, hide = true)]
+    json: bool,
+}
+
+/// JSON emitted by `--json`.
+#[derive(Debug, serde::Serialize)]
+struct HookJsonResult {
+    session_id: String,
+    recorded: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    change_hash: Option<String>,
+    /// The view the change was recorded onto (the per-session agent view), so a
+    /// caller can locate it — the change lives here, not on the default view.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    view: Option<String>,
+    files: Vec<String>,
 }
 
 impl Command for Hooks {
@@ -201,12 +220,33 @@ impl Command for Hooks {
             log::debug!("{}", outcome);
         }
 
-        // Log the system message instead of printing to stdout.
-        // Claude Code expects JSON on stdout, but OpenCode's plugin $
-        // captures stdout and displays it in the TUI as noise.
-        // Use log::debug so it's available in RUST_LOG but silent otherwise.
+        // Keep hook stdout quiet by default; some agent TUIs display it directly.
         if let Some(ref message) = result.message {
             log::debug!("Hook response: {}", message);
+        }
+
+        // Emit the recorded change hash for UI/bridge callers.
+        if self.json {
+            let json = match &result.change_recorded {
+                Some(outcome) => HookJsonResult {
+                    session_id: result.session_id.clone(),
+                    recorded: true,
+                    change_hash: Some(outcome.hash.to_base32()),
+                    view: result.view.clone(),
+                    files: outcome.recorded_file_list().to_vec(),
+                },
+                None => HookJsonResult {
+                    session_id: result.session_id.clone(),
+                    recorded: false,
+                    change_hash: None,
+                    view: result.view.clone(),
+                    files: Vec::new(),
+                },
+            };
+            match serde_json::to_string(&json) {
+                Ok(s) => println!("{}", s),
+                Err(e) => log::warn!("Failed to serialize hook JSON result: {}", e),
+            }
         }
 
         Ok(())
@@ -215,7 +255,8 @@ impl Command for Hooks {
 
 impl Hooks {
     fn should_handoff_codex_stop(&self) -> bool {
-        !self.foreground && self.agent_name == "codex" && self.verb == "stop"
+        // Codex stop handoff drops stdout, so `--json` must stay in-process.
+        !self.foreground && !self.json && self.agent_name == "codex" && self.verb == "stop"
     }
 
     fn handoff_codex_stop(&self, input: &[u8]) -> CliResult<()> {
@@ -268,6 +309,7 @@ mod tests {
             agent_name: "claude-code".to_string(),
             verb: "stop".to_string(),
             foreground: false,
+            json: false,
         };
         assert_eq!(hooks.agent_name, "claude-code");
         assert_eq!(hooks.verb, "stop");
@@ -376,6 +418,7 @@ mod tests {
             agent_name: "claude-code".to_string(),
             verb: "session-start".to_string(),
             foreground: false,
+            json: false,
         };
         let debug = format!("{:?}", hooks);
         assert!(debug.contains("claude-code"));
@@ -388,9 +431,22 @@ mod tests {
             agent_name: "codex".to_string(),
             verb: "stop".to_string(),
             foreground: false,
+            json: false,
         };
 
         assert!(hooks.should_handoff_codex_stop());
+    }
+
+    #[test]
+    fn test_codex_stop_json_disables_handoff() {
+        let hooks = Hooks {
+            agent_name: "codex".to_string(),
+            verb: "stop".to_string(),
+            foreground: false,
+            json: true,
+        };
+
+        assert!(!hooks.should_handoff_codex_stop());
     }
 
     #[test]
@@ -399,6 +455,7 @@ mod tests {
             agent_name: "codex".to_string(),
             verb: "stop".to_string(),
             foreground: true,
+            json: false,
         };
 
         assert!(!hooks.should_handoff_codex_stop());
@@ -410,8 +467,55 @@ mod tests {
             agent_name: "claude-code".to_string(),
             verb: "stop".to_string(),
             foreground: false,
+            json: false,
         };
 
         assert!(!hooks.should_handoff_codex_stop());
+    }
+
+    #[test]
+    fn test_hook_json_result_recorded() {
+        let result = HookJsonResult {
+            session_id: "sess-abc".to_string(),
+            recorded: true,
+            change_hash: Some("ABC123".to_string()),
+            view: Some("bold-creek-a3f2".to_string()),
+            files: vec!["src/main.rs".to_string(), "src/lib.rs".to_string()],
+        };
+        let parsed: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&result).unwrap()).unwrap();
+
+        assert_eq!(parsed["session_id"], "sess-abc");
+        assert_eq!(parsed["recorded"], true);
+        assert_eq!(parsed["change_hash"], "ABC123");
+        assert_eq!(parsed["view"], "bold-creek-a3f2");
+        assert_eq!(parsed["files"][0], "src/main.rs");
+        assert_eq!(parsed["files"][1], "src/lib.rs");
+    }
+
+    #[test]
+    fn test_hook_json_result_not_recorded_omits_hash() {
+        let result = HookJsonResult {
+            session_id: "sess-xyz".to_string(),
+            recorded: false,
+            change_hash: None,
+            view: None,
+            files: Vec::new(),
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["recorded"], false);
+        assert!(
+            !json.contains("change_hash"),
+            "change_hash must be omitted when None, got: {}",
+            json
+        );
+        assert!(
+            !json.contains("view"),
+            "view must be omitted when None, got: {}",
+            json
+        );
+        assert_eq!(parsed["files"].as_array().unwrap().len(), 0);
     }
 }

--- a/atomic-cli/src/commands/auth.rs
+++ b/atomic-cli/src/commands/auth.rs
@@ -1,16 +1,18 @@
 //! Shared authentication helpers for remote commands.
 //!
-//! Resolves the caller's identity from the remote URL, mints a short-lived
-//! self-signed EdDSA JWT for that identity, and attaches it as the
-//! `Authorization: Bearer` header.
+//! Resolves the caller's identity from the remote URL (or an explicit
+//! override), mints a short-lived self-signed EdDSA JWT for that identity,
+//! and attaches it as the `Authorization: Bearer` header.
 //!
 //! A raw public key is NOT a credential — the JWT (signed with the identity's
 //! private key) proves possession of that key. See [`crate::commands::token`]
 //! for the minting mechanics.
 //!
 //! Identity resolution order:
-//! 1. URL userinfo — `http://bob@alice.localhost:8080/...` → identity "bob"
-//! 2. Subdomain — `http://alice.localhost:8080/...` → identity "alice"
+//! 1. Explicit override — `identity_override` from `--identity` flag or
+//!    `RemoteEntry.identity` config field.
+//! 2. URL userinfo — `http://bob@alice.localhost:8080/...` → identity "bob"
+//! 3. Subdomain — `http://alice.localhost:8080/...` → identity "alice"
 
 use atomic_identity::IdentityStore;
 use atomic_remote::HttpRemoteConfig;
@@ -18,19 +20,33 @@ use url::Url;
 
 use crate::error::{CliError, CliResult};
 
-/// Attach a Bearer JWT auth header to the remote config by resolving the
-/// identity from the URL and logging in for a token.
+/// Attach a Bearer JWT auth header to the remote config.
 ///
-/// If the identity cannot be resolved (no userinfo, no subdomain, or identity
-/// not found in the store) or login fails, the config is returned unmodified
-/// and a debug log is emitted. This keeps push/pull/clone working against
-/// servers that don't require auth (e.g. public reads).
-pub async fn attach_identity(config: HttpRemoteConfig, remote_url: &str) -> HttpRemoteConfig {
-    let identity_name = match resolve_identity_name(remote_url) {
-        Some(name) => name,
-        None => {
-            log::debug!("No identity resolvable from URL: {}", remote_url);
-            return config;
+/// `identity_override` — if provided, this identity name is used directly,
+/// bypassing URL-based inference. Set from `RemoteEntry.identity` or the
+/// `--identity` CLI flag.
+///
+/// If the identity cannot be resolved (no override, no userinfo, no subdomain,
+/// or identity not found in the store) or login fails, the config is returned
+/// unmodified and a debug log is emitted. This keeps push/pull/clone working
+/// against servers that don't require auth (e.g. public reads).
+pub async fn attach_identity(
+    config: HttpRemoteConfig,
+    remote_url: &str,
+    identity_override: Option<&str>,
+) -> HttpRemoteConfig {
+    // Priority 1: explicit override (from --identity or RemoteEntry.identity)
+    let identity_name = if let Some(name) = identity_override {
+        log::debug!("Using explicit identity override: {}", name);
+        name.to_string()
+    } else {
+        // Priority 2/3: infer from URL userinfo or subdomain
+        match resolve_identity_name(remote_url) {
+            Some(name) => name,
+            None => {
+                log::debug!("No identity resolvable from URL: {}", remote_url);
+                return config;
+            }
         }
     };
 

--- a/atomic-cli/src/commands/auth.rs
+++ b/atomic-cli/src/commands/auth.rs
@@ -9,16 +9,148 @@
 //! for the minting mechanics.
 //!
 //! Identity resolution order:
-//! 1. Explicit override — `identity_override` from `--identity` flag or
-//!    `RemoteEntry.identity` config field.
+//! 1. Explicit override — `identity_override` from the `--identity` flag.
 //! 2. URL userinfo — `http://bob@alice.localhost:8080/...` → identity "bob"
-//! 3. Subdomain — `http://alice.localhost:8080/...` → identity "alice"
+//! 3. Configured server binding — a `[servers.*]`/`[server]` profile whose host
+//!    is the longest suffix of the remote host supplies its `identity`. Identity
+//!    follows the server you registered with, so any tenant under it resolves
+//!    without `--identity`.
+//! 4. Subdomain — `http://alice.localhost:8080/...` → identity "alice" (legacy
+//!    last resort).
 
-use atomic_identity::IdentityStore;
+use atomic_identity::{Identity, IdentityStore};
 use atomic_remote::HttpRemoteConfig;
 use url::Url;
 
 use crate::error::{CliError, CliResult};
+
+/// Resolve the identity name to authenticate as.
+///
+/// Priority:
+/// 1. An explicit override (the `--identity` flag).
+/// 2. URL userinfo (`http://bob@host/...`).
+/// 3. A configured server profile whose host is the longest dot-boundary
+///    suffix of the remote host (`[servers.prod] url=... identity=...`). This is
+///    the binding that makes pushes to *any* tenant under a server you've
+///    registered with ("just works" without `--identity`): identity follows the
+///    server, not the tenant subdomain.
+/// 4. The remote host's leading subdomain label (`http://bob.host/...`) — the
+///    legacy heuristic, kept only as a last resort.
+///
+/// Returns `None` only when there is no override and nothing inferable from the
+/// URL or config.
+fn resolve_identity_name_with_override(
+    remote_url: &str,
+    identity_override: Option<&str>,
+) -> Option<String> {
+    if let Some(name) = identity_override {
+        return Some(name.to_string());
+    }
+    resolve_identity_from_url(remote_url, &configured_server_identities())
+}
+
+/// Collect `(server_host, identity)` pairs from the global config — both the
+/// default `[server]` block and every named `[servers.*]` profile — that
+/// declare an identity. Servers without an identity binding are skipped.
+///
+/// Returns an empty list when no config exists or it can't be read, so
+/// resolution degrades cleanly to URL-based inference.
+fn configured_server_identities() -> Vec<(String, String)> {
+    let config = match atomic_config::GlobalConfig::load() {
+        Ok(c) => c,
+        Err(e) => {
+            log::debug!("Could not load global config for server identities: {e}");
+            return Vec::new();
+        }
+    };
+
+    let mut pairs = Vec::new();
+    let mut consider = |server: &atomic_config::ServerConfig| {
+        if let (Some(url), Some(identity)) = (server.url.as_ref(), server.identity.as_ref()) {
+            if let Some(host) = Url::parse(url)
+                .ok()
+                .and_then(|u| u.host_str().map(String::from))
+            {
+                pairs.push((host, identity.clone()));
+            }
+        }
+    };
+
+    consider(&config.server);
+    for server in config.servers.values() {
+        consider(server);
+    }
+    pairs
+}
+
+/// Pure identity resolution from a URL plus the configured server bindings.
+///
+/// userinfo → server-host match (longest suffix) → first-label subdomain.
+/// Split from the config-loading wrapper so it can be unit-tested without a
+/// config file on disk.
+fn resolve_identity_from_url(remote_url: &str, servers: &[(String, String)]) -> Option<String> {
+    let url = Url::parse(remote_url).ok()?;
+
+    // 1. Explicit in the URL: http://bob@host/...
+    let username = url.username();
+    if !username.is_empty() {
+        return Some(username.to_string());
+    }
+
+    let host = url.host_str()?;
+
+    // 2. Configured server binding: identity follows the server (apex), so any
+    //    tenant under it resolves to the same identity.
+    if let Some(identity) = match_server_identity(host, servers) {
+        return Some(identity);
+    }
+
+    // 3. Legacy: treat the first DNS label as the identity name.
+    extract_subdomain(host)
+}
+
+/// Pick the identity bound to the configured server whose host is the longest
+/// dot-boundary suffix of `remote_host`.
+///
+/// Longest-suffix wins so a more specific server (`staging.atomic.storage`)
+/// beats a broader one (`atomic.storage`) for hosts under both — e.g.
+/// `x.staging.atomic.storage` resolves to the staging identity, not prod.
+fn match_server_identity(remote_host: &str, servers: &[(String, String)]) -> Option<String> {
+    servers
+        .iter()
+        .filter(|(server_host, _)| host_is_under(remote_host, server_host))
+        .max_by_key(|(server_host, _)| server_host.len())
+        .map(|(_, identity)| identity.clone())
+}
+
+/// Whether `remote_host` is the server host itself or a subdomain of it,
+/// matching only on dot boundaries (so `notatomic.storage` does NOT match
+/// `atomic.storage`). Comparison is case-insensitive (DNS is).
+fn host_is_under(remote_host: &str, server_host: &str) -> bool {
+    let remote = remote_host.to_ascii_lowercase();
+    let server = server_host.to_ascii_lowercase();
+    remote == server || remote.ends_with(&format!(".{server}"))
+}
+
+/// Load a local identity by name, falling back to a case-insensitive match.
+///
+/// Tenant slugs are lowercase (e.g. `aaron`), but locally stored identities are
+/// free-form and frequently mixed-case (e.g. `Aaron`). A subdomain-inferred
+/// name would therefore never match the local identity on a strict comparison.
+/// An exact match always wins; otherwise the first identity whose name matches
+/// case-insensitively is returned.
+fn load_identity_lenient(store: &IdentityStore, name: &str) -> Option<Identity> {
+    if let Ok(identity) = store.load_by_name(name) {
+        return Some(identity);
+    }
+
+    let wanted = name.to_lowercase();
+    store
+        .list()
+        .ok()?
+        .into_iter()
+        .find(|identity| identity.name.to_lowercase() == wanted)
+}
 
 /// Attach a Bearer JWT auth header to the remote config.
 ///
@@ -35,18 +167,16 @@ pub async fn attach_identity(
     remote_url: &str,
     identity_override: Option<&str>,
 ) -> HttpRemoteConfig {
-    // Priority 1: explicit override (from --identity or RemoteEntry.identity)
-    let identity_name = if let Some(name) = identity_override {
-        log::debug!("Using explicit identity override: {}", name);
-        name.to_string()
-    } else {
-        // Priority 2/3: infer from URL userinfo or subdomain
-        match resolve_identity_name(remote_url) {
-            Some(name) => name,
-            None => {
-                log::debug!("No identity resolvable from URL: {}", remote_url);
-                return config;
-            }
+    if identity_override.is_some() {
+        log::debug!("Using explicit identity override: {:?}", identity_override);
+    }
+
+    // Priority 1: explicit override (--identity); 2/3: URL userinfo or subdomain.
+    let identity_name = match resolve_identity_name_with_override(remote_url, identity_override) {
+        Some(name) => name,
+        None => {
+            log::debug!("No identity resolvable from URL: {}", remote_url);
+            return config;
         }
     };
 
@@ -60,10 +190,12 @@ pub async fn attach_identity(
         }
     };
 
-    let identity = match store.load_by_name(&identity_name) {
-        Ok(id) => id,
-        Err(e) => {
-            log::debug!("Identity '{}' not found in store: {}", identity_name, e);
+    // Match by name, tolerating tenant-slug/identity-name case differences
+    // (e.g. the `aaron` subdomain selecting the local `Aaron` identity).
+    let identity = match load_identity_lenient(&store, &identity_name) {
+        Some(id) => id,
+        None => {
+            log::debug!("Identity '{}' not found in store", identity_name);
             return config;
         }
     };
@@ -108,10 +240,14 @@ pub async fn attach_identity(
 #[derive(Debug, PartialEq, Eq)]
 pub enum CredentialIssue {
     /// No identity could be resolved from the remote URL (no userinfo and no
-    /// subdomain). We can't know who to authenticate as.
+    /// subdomain) and `--identity` was not supplied. We can't know who to
+    /// authenticate as.
     NoIdentityInUrl,
     /// An identity name was resolved, but no such identity exists locally.
-    IdentityNotFound { name: String },
+    /// `from_flag` records whether the name came from the `--identity` flag
+    /// (vs. being inferred from the remote URL), so the message can point the
+    /// user at the right knob.
+    IdentityNotFound { name: String, from_flag: bool },
     /// The identity exists but its signing keypair could not be loaded, so no
     /// token can be minted.
     KeypairUnavailable { name: String },
@@ -126,11 +262,28 @@ impl CredentialIssue {
         match self {
             CredentialIssue::NoIdentityInUrl => format!(
                 "Not authenticated for {REMEDY_PREFIX}: could not determine an \
-                 identity from the remote URL. {REMEDY_SUFFIX}"
+                 identity from the remote URL, and no --identity was given. \
+                 Pass --identity <NAME> (see `atomic identity list`). {REMEDY_SUFFIX}"
             ),
-            CredentialIssue::IdentityNotFound { name } => format!(
-                "Not authenticated for {REMEDY_PREFIX}: identity '{name}' is not \
-                 registered on this machine. {REMEDY_SUFFIX}"
+            // When the name was inferred from the URL, the fix is usually to
+            // pass --identity explicitly; when it came from --identity, the
+            // name itself is wrong. Tailor the hint to the source.
+            CredentialIssue::IdentityNotFound {
+                name,
+                from_flag: false,
+            } => format!(
+                "Not authenticated for {REMEDY_PREFIX}: identity '{name}' \
+                 (inferred from the remote URL) is not registered on this \
+                 machine. Pass --identity <NAME> to select a local identity \
+                 (see `atomic identity list`). {REMEDY_SUFFIX}"
+            ),
+            CredentialIssue::IdentityNotFound {
+                name,
+                from_flag: true,
+            } => format!(
+                "Not authenticated for {REMEDY_PREFIX}: --identity '{name}' does \
+                 not match any identity on this machine (see `atomic identity \
+                 list`). {REMEDY_SUFFIX}"
             ),
             CredentialIssue::KeypairUnavailable { name } => format!(
                 "Not authenticated for {REMEDY_PREFIX}: could not load the signing \
@@ -149,19 +302,23 @@ const REMEDY_SUFFIX: &str =
 /// push proceed into a confusing 404 (which the server returns for private
 /// projects the caller isn't authorized to see).
 ///
-/// Returns `Ok(())` when an identity is resolvable from the URL, exists in the
-/// local store, and has a loadable signing keypair.
-pub fn check_push_credentials(remote_url: &str) -> CliResult<()> {
+/// Returns `Ok(())` when an identity is resolvable (from `--identity` or the
+/// URL), exists in the local store, and has a loadable signing keypair.
+///
+/// `identity_override` is the `--identity` flag value; it takes priority over
+/// any identity inferred from the URL, exactly as [`attach_identity`] resolves
+/// it. The two must agree, or the fail-fast check here would reject a push that
+/// `attach_identity` would have authenticated.
+pub fn check_push_credentials(remote_url: &str, identity_override: Option<&str>) -> CliResult<()> {
     let store = IdentityStore::open_default()
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to open identity store: {e}")))?;
 
     let issue = evaluate_push_credentials(
-        resolve_identity_name(remote_url),
-        |name| store.load_by_name(name).is_ok(),
+        resolve_identity_name_with_override(remote_url, identity_override),
+        identity_override.is_some(),
+        |name| load_identity_lenient(&store, name).is_some(),
         |name| {
-            store
-                .load_by_name(name)
-                .ok()
+            load_identity_lenient(&store, name)
                 .map(|id| store.load_keypair(&id.id, None).is_ok())
                 .unwrap_or(false)
         },
@@ -178,7 +335,8 @@ pub fn check_push_credentials(remote_url: &str) -> CliResult<()> {
 /// Pure decision core for [`check_push_credentials`], split out so it can be
 /// unit-tested without touching the on-disk identity store.
 ///
-/// * `identity_name` — the identity resolved from the URL, if any.
+/// * `identity_name` — the resolved identity (override or URL-inferred), if any.
+/// * `from_flag` — whether `identity_name` came from `--identity` (vs. the URL).
 /// * `identity_exists` — whether an identity with the given name is in the store.
 /// * `keypair_loadable` — whether that identity's signing keypair can be loaded.
 ///
@@ -186,6 +344,7 @@ pub fn check_push_credentials(remote_url: &str) -> CliResult<()> {
 /// first problem encountered.
 fn evaluate_push_credentials(
     identity_name: Option<String>,
+    from_flag: bool,
     identity_exists: impl Fn(&str) -> bool,
     keypair_loadable: impl Fn(&str) -> bool,
 ) -> Option<CredentialIssue> {
@@ -195,7 +354,7 @@ fn evaluate_push_credentials(
     };
 
     if !identity_exists(&name) {
-        return Some(CredentialIssue::IdentityNotFound { name });
+        return Some(CredentialIssue::IdentityNotFound { name, from_flag });
     }
 
     if !keypair_loadable(&name) {
@@ -230,20 +389,13 @@ fn apex_server_url(remote_url: &str) -> Option<String> {
     }
 }
 
-/// Extract the identity name from a remote URL.
+/// Extract the identity name from a remote URL alone (no server config).
 ///
 /// Tries URL userinfo first (`bob@host`), then the subdomain (`bob.host`).
+/// This is the config-free path; [`resolve_identity_name_with_override`] layers
+/// the `--identity` override and configured server bindings on top.
 fn resolve_identity_name(remote_url: &str) -> Option<String> {
-    let url = Url::parse(remote_url).ok()?;
-
-    // 1. Explicit: http://bob@alice.localhost:8080/...
-    let username = url.username();
-    if !username.is_empty() {
-        return Some(username.to_string());
-    }
-
-    // 2. Implicit: http://alice.localhost:8080/... → "alice"
-    extract_subdomain(url.host_str()?)
+    resolve_identity_from_url(remote_url, &[])
 }
 
 /// Extract the first subdomain label from a host string.
@@ -363,6 +515,7 @@ mod tests {
     fn creds_ok_when_identity_resolves_and_keypair_loads() {
         let issue = evaluate_push_credentials(
             Some("alice".to_string()),
+            false,
             |_| true, // identity exists
             |_| true, // keypair loadable
         );
@@ -372,7 +525,7 @@ mod tests {
     #[test]
     fn creds_fail_when_no_identity_in_url() {
         // A bare host with no userinfo and no subdomain resolves to no identity.
-        let issue = evaluate_push_credentials(None, |_| true, |_| true);
+        let issue = evaluate_push_credentials(None, false, |_| true, |_| true);
         assert_eq!(issue, Some(CredentialIssue::NoIdentityInUrl));
     }
 
@@ -380,13 +533,15 @@ mod tests {
     fn creds_fail_when_identity_missing_from_store() {
         let issue = evaluate_push_credentials(
             Some("alice".to_string()),
+            false,
             |_| false, // identity not in store
             |_| true,
         );
         assert_eq!(
             issue,
             Some(CredentialIssue::IdentityNotFound {
-                name: "alice".to_string()
+                name: "alice".to_string(),
+                from_flag: false,
             })
         );
     }
@@ -398,6 +553,7 @@ mod tests {
         // this self-signed-JWT model means "cannot sign right now".
         let issue = evaluate_push_credentials(
             Some("alice".to_string()),
+            false,
             |_| true,  // identity exists
             |_| false, // keypair unavailable
         );
@@ -416,6 +572,11 @@ mod tests {
             CredentialIssue::NoIdentityInUrl,
             CredentialIssue::IdentityNotFound {
                 name: "alice".to_string(),
+                from_flag: false,
+            },
+            CredentialIssue::IdentityNotFound {
+                name: "alice".to_string(),
+                from_flag: true,
             },
             CredentialIssue::KeypairUnavailable {
                 name: "alice".to_string(),
@@ -425,5 +586,129 @@ mod tests {
             assert!(msg.contains("Not authenticated"));
             assert!(msg.contains("atomic identity register"));
         }
+    }
+
+    // -- identity override resolution --
+
+    #[test]
+    fn override_takes_priority_over_subdomain() {
+        // The whole point of --identity: it wins over the host's DNS label.
+        let name = resolve_identity_name_with_override(
+            "https://aaron.atomic.storage/workspaces/w/projects/p/code",
+            Some("Aaron"),
+        );
+        assert_eq!(name.as_deref(), Some("Aaron"));
+    }
+
+    #[test]
+    fn override_wins_even_on_apex_host() {
+        // Apex host has no usable subdomain, but --identity still resolves.
+        let name = resolve_identity_name_with_override(
+            "https://atomic.storage/workspaces/w/projects/p/code",
+            Some("Aaron"),
+        );
+        assert_eq!(name.as_deref(), Some("Aaron"));
+    }
+
+    #[test]
+    fn no_override_falls_back_to_subdomain() {
+        // Use the pure resolver with no configured servers — the wrapper loads
+        // the real global config, which is not hermetic for a unit test.
+        let name = resolve_identity_from_url(
+            "https://aaron.atomic.storage/workspaces/w/projects/p/code",
+            &[],
+        );
+        assert_eq!(name.as_deref(), Some("aaron"));
+    }
+
+    // -- configured server-host identity binding --
+
+    fn servers() -> Vec<(String, String)> {
+        vec![
+            ("atomic.storage".to_string(), "Aaron".to_string()),
+            (
+                "staging.atomic.storage".to_string(),
+                "aaron-staging".to_string(),
+            ),
+        ]
+    }
+
+    #[test]
+    fn host_is_under_matches_self_and_subdomains_on_dot_boundary() {
+        assert!(host_is_under("atomic.storage", "atomic.storage")); // exact
+        assert!(host_is_under("aaron.atomic.storage", "atomic.storage")); // tenant
+        assert!(host_is_under("a.b.atomic.storage", "atomic.storage")); // nested
+        assert!(host_is_under("ATOMIC.STORAGE", "atomic.storage")); // case-insensitive
+                                                                    // Not a dot-boundary suffix — must NOT match.
+        assert!(!host_is_under("notatomic.storage", "atomic.storage"));
+        assert!(!host_is_under("atomic.storage.evil.com", "atomic.storage"));
+    }
+
+    #[test]
+    fn any_tenant_under_a_server_resolves_to_that_servers_identity() {
+        for host in [
+            "aaron.atomic.storage",
+            "bradley.atomic.storage",
+            "atomic.atomic.storage",
+            "atomic.storage", // apex direct
+        ] {
+            let url = format!("https://{host}/workspaces/w/projects/p/code");
+            assert_eq!(
+                resolve_identity_from_url(&url, &servers()).as_deref(),
+                Some("Aaron"),
+                "host {host} should bind to the prod identity"
+            );
+        }
+    }
+
+    #[test]
+    fn longest_suffix_wins_so_staging_beats_prod() {
+        // Every staging host also ends in `atomic.storage`; the more specific
+        // server must win.
+        for host in ["x.staging.atomic.storage", "staging.atomic.storage"] {
+            let url = format!("https://{host}/workspaces/w/projects/p/code");
+            assert_eq!(
+                resolve_identity_from_url(&url, &servers()).as_deref(),
+                Some("aaron-staging"),
+                "host {host} should bind to the staging identity"
+            );
+        }
+    }
+
+    #[test]
+    fn userinfo_beats_configured_server() {
+        // An explicit user in the URL is a stronger, per-invocation signal.
+        let url = "https://bob@aaron.atomic.storage/workspaces/w/projects/p/code";
+        assert_eq!(
+            resolve_identity_from_url(url, &servers()).as_deref(),
+            Some("bob")
+        );
+    }
+
+    #[test]
+    fn falls_back_to_subdomain_when_no_server_matches() {
+        // A host under no configured server keeps the legacy behaviour.
+        let url = "https://someone.example.com/workspaces/w/projects/p/code";
+        assert_eq!(
+            resolve_identity_from_url(url, &servers()).as_deref(),
+            Some("someone")
+        );
+    }
+
+    #[test]
+    fn override_resolves_when_subdomain_label_is_unregistered() {
+        // Regression: the subdomain label ("aaron") is not a local identity
+        // name, but the explicit --identity ("Aaron") is — the override must be
+        // what gets evaluated, not the label.
+        let issue = evaluate_push_credentials(
+            resolve_identity_name_with_override(
+                "https://aaron.atomic.storage/workspaces/w/projects/p/code",
+                Some("Aaron"),
+            ),
+            true,
+            |name| name == "Aaron", // only "Aaron" exists locally
+            |name| name == "Aaron",
+        );
+        assert_eq!(issue, None);
     }
 }

--- a/atomic-cli/src/commands/auth.rs
+++ b/atomic-cli/src/commands/auth.rs
@@ -1,7 +1,12 @@
 //! Shared authentication helpers for remote commands.
 //!
-//! Resolves the caller's identity from the remote URL and builds
-//! the `Authorization: Bearer` header for authenticated requests.
+//! Resolves the caller's identity from the remote URL, mints a short-lived
+//! self-signed EdDSA JWT for that identity, and attaches it as the
+//! `Authorization: Bearer` header.
+//!
+//! A raw public key is NOT a credential — the JWT (signed with the identity's
+//! private key) proves possession of that key. See [`crate::commands::token`]
+//! for the minting mechanics.
 //!
 //! Identity resolution order:
 //! 1. URL userinfo — `http://bob@alice.localhost:8080/...` → identity "bob"
@@ -11,14 +16,14 @@ use atomic_identity::IdentityStore;
 use atomic_remote::HttpRemoteConfig;
 use url::Url;
 
-/// Attach a Bearer auth header to the remote config by resolving the
-/// identity from the URL.
+/// Attach a Bearer JWT auth header to the remote config by resolving the
+/// identity from the URL and logging in for a token.
 ///
-/// If the identity cannot be resolved (no userinfo, no subdomain, or
-/// identity not found in the store), the config is returned unmodified
-/// and a debug log is emitted. This keeps push/pull/clone working
-/// against servers that don't require auth.
-pub fn attach_identity(config: HttpRemoteConfig, remote_url: &str) -> HttpRemoteConfig {
+/// If the identity cannot be resolved (no userinfo, no subdomain, or identity
+/// not found in the store) or login fails, the config is returned unmodified
+/// and a debug log is emitted. This keeps push/pull/clone working against
+/// servers that don't require auth (e.g. public reads).
+pub async fn attach_identity(config: HttpRemoteConfig, remote_url: &str) -> HttpRemoteConfig {
     let identity_name = match resolve_identity_name(remote_url) {
         Some(name) => name,
         None => {
@@ -45,10 +50,54 @@ pub fn attach_identity(config: HttpRemoteConfig, remote_url: &str) -> HttpRemote
         }
     };
 
-    let public_key_b32 = identity.public_key_base32();
-    log::debug!("Attaching Bearer auth for identity '{}'", identity_name);
+    // Tokens are keyed to the apex server (where the identity registered), not
+    // the tenant subdomain — strip the leading subdomain label from the host.
+    let server = match apex_server_url(remote_url) {
+        Some(s) => s,
+        None => {
+            log::debug!("Could not derive apex server URL from: {}", remote_url);
+            return config;
+        }
+    };
 
-    config.with_header("Authorization", format!("Bearer {}", public_key_b32))
+    match crate::commands::token::get_token(&server, &identity).await {
+        Ok(jwt) => {
+            log::debug!("Attaching Bearer JWT for identity '{}'", identity_name);
+            config.with_header("Authorization", format!("Bearer {}", jwt))
+        }
+        Err(e) => {
+            // Non-fatal: a server that doesn't require auth still works for
+            // public reads. Auth-required operations will then fail with a
+            // clear 401 from the server.
+            log::debug!("Could not obtain JWT for '{}': {}", identity_name, e);
+            config
+        }
+    }
+}
+
+/// Derive the apex server URL (scheme + host without the leading subdomain
+/// label + port) from a tenant-scoped remote URL.
+///
+/// `http://alice.localhost:8080/workspaces/w/projects/p/code`
+///   → `http://localhost:8080`
+/// `https://alice.atomic.storage/...` → `https://atomic.storage`
+/// `http://localhost:8080/...` (no subdomain) → `http://localhost:8080`
+fn apex_server_url(remote_url: &str) -> Option<String> {
+    let url = Url::parse(remote_url).ok()?;
+    let scheme = url.scheme();
+    let host = url.host_str()?;
+
+    // Strip the first label if there is a subdomain; leave a bare host
+    // (e.g. "localhost") untouched.
+    let apex_host = match host.find('.') {
+        Some(dot) => &host[dot + 1..],
+        None => host,
+    };
+
+    match url.port() {
+        Some(port) => Some(format!("{scheme}://{apex_host}:{port}")),
+        None => Some(format!("{scheme}://{apex_host}")),
+    }
 }
 
 /// Extract the identity name from a remote URL.
@@ -89,6 +138,35 @@ fn extract_subdomain(host: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn apex_strips_subdomain_with_port() {
+        assert_eq!(
+            apex_server_url("http://alice.localhost:8080/workspaces/w/projects/p/code").as_deref(),
+            Some("http://localhost:8080")
+        );
+    }
+
+    #[test]
+    fn apex_strips_subdomain_full_domain() {
+        assert_eq!(
+            apex_server_url("https://alice.atomic.storage/workspaces/w/projects/p/code").as_deref(),
+            Some("https://atomic.storage")
+        );
+    }
+
+    #[test]
+    fn apex_bare_host_unchanged() {
+        assert_eq!(
+            apex_server_url("http://localhost:8080/workspaces/w/projects/p/code").as_deref(),
+            Some("http://localhost:8080")
+        );
+    }
+
+    #[test]
+    fn apex_invalid_url_is_none() {
+        assert_eq!(apex_server_url("not a url"), None);
+    }
 
     #[test]
     fn userinfo_takes_priority() {

--- a/atomic-cli/src/commands/auth.rs
+++ b/atomic-cli/src/commands/auth.rs
@@ -16,6 +16,8 @@ use atomic_identity::IdentityStore;
 use atomic_remote::HttpRemoteConfig;
 use url::Url;
 
+use crate::error::{CliError, CliResult};
+
 /// Attach a Bearer JWT auth header to the remote config by resolving the
 /// identity from the URL and logging in for a token.
 ///
@@ -73,6 +75,118 @@ pub async fn attach_identity(config: HttpRemoteConfig, remote_url: &str) -> Http
             config
         }
     }
+}
+
+/// What went wrong (if anything) when checking for usable push credentials.
+///
+/// Authentication for atomic-storage is a *self-signed* EdDSA JWT: the CLI
+/// mints a fresh, short-lived token per request by signing with the identity's
+/// Ed25519 private key (see [`crate::commands::token`]). There is no stored
+/// token to inspect for expiry — a token is only ever created at the moment of
+/// use and is valid for its full TTL. So "having usable credentials" reduces to
+/// three local conditions, each a distinct failure with its own remedy:
+///
+/// 1. an identity is resolvable from the remote URL,
+/// 2. that identity exists in the local store, and
+/// 3. its keypair can be loaded (so a token can actually be signed).
+#[derive(Debug, PartialEq, Eq)]
+pub enum CredentialIssue {
+    /// No identity could be resolved from the remote URL (no userinfo and no
+    /// subdomain). We can't know who to authenticate as.
+    NoIdentityInUrl,
+    /// An identity name was resolved, but no such identity exists locally.
+    IdentityNotFound { name: String },
+    /// The identity exists but its signing keypair could not be loaded, so no
+    /// token can be minted.
+    KeypairUnavailable { name: String },
+}
+
+impl CredentialIssue {
+    /// Render an actionable, accurate error message for this issue.
+    ///
+    /// All messages point at registering an identity, since that is the single
+    /// command that establishes a usable credential for a remote.
+    fn message(&self) -> String {
+        match self {
+            CredentialIssue::NoIdentityInUrl => format!(
+                "Not authenticated for {REMEDY_PREFIX}: could not determine an \
+                 identity from the remote URL. {REMEDY_SUFFIX}"
+            ),
+            CredentialIssue::IdentityNotFound { name } => format!(
+                "Not authenticated for {REMEDY_PREFIX}: identity '{name}' is not \
+                 registered on this machine. {REMEDY_SUFFIX}"
+            ),
+            CredentialIssue::KeypairUnavailable { name } => format!(
+                "Not authenticated for {REMEDY_PREFIX}: could not load the signing \
+                 key for identity '{name}'. {REMEDY_SUFFIX}"
+            ),
+        }
+    }
+}
+
+const REMEDY_PREFIX: &str = "this remote";
+const REMEDY_SUFFIX: &str =
+    "Register your identity with the server first: `atomic identity register <server-url>`.";
+
+/// Verify, before a push begins, that the client can produce credentials for
+/// `remote_url`. Fails fast with an actionable error instead of letting the
+/// push proceed into a confusing 404 (which the server returns for private
+/// projects the caller isn't authorized to see).
+///
+/// Returns `Ok(())` when an identity is resolvable from the URL, exists in the
+/// local store, and has a loadable signing keypair.
+pub fn check_push_credentials(remote_url: &str) -> CliResult<()> {
+    let store = IdentityStore::open_default()
+        .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to open identity store: {e}")))?;
+
+    let issue = evaluate_push_credentials(
+        resolve_identity_name(remote_url),
+        |name| store.load_by_name(name).is_ok(),
+        |name| {
+            store
+                .load_by_name(name)
+                .ok()
+                .map(|id| store.load_keypair(&id.id, None).is_ok())
+                .unwrap_or(false)
+        },
+    );
+
+    match issue {
+        Some(issue) => Err(CliError::AuthenticationFailed {
+            remote: format!("{remote_url}: {}", issue.message()),
+        }),
+        None => Ok(()),
+    }
+}
+
+/// Pure decision core for [`check_push_credentials`], split out so it can be
+/// unit-tested without touching the on-disk identity store.
+///
+/// * `identity_name` — the identity resolved from the URL, if any.
+/// * `identity_exists` — whether an identity with the given name is in the store.
+/// * `keypair_loadable` — whether that identity's signing keypair can be loaded.
+///
+/// Returns `None` when credentials are usable, or `Some(issue)` describing the
+/// first problem encountered.
+fn evaluate_push_credentials(
+    identity_name: Option<String>,
+    identity_exists: impl Fn(&str) -> bool,
+    keypair_loadable: impl Fn(&str) -> bool,
+) -> Option<CredentialIssue> {
+    let name = match identity_name {
+        Some(n) => n,
+        None => return Some(CredentialIssue::NoIdentityInUrl),
+    };
+
+    if !identity_exists(&name) {
+        return Some(CredentialIssue::IdentityNotFound { name });
+    }
+
+    if !keypair_loadable(&name) {
+        return Some(CredentialIssue::KeypairUnavailable { name });
+    }
+
+    None
 }
 
 /// Derive the apex server URL (scheme + host without the leading subdomain
@@ -225,5 +339,75 @@ mod tests {
     #[test]
     fn extract_subdomain_empty_label() {
         assert_eq!(extract_subdomain(".localhost"), None);
+    }
+
+    // -- pre-push credential check --
+
+    #[test]
+    fn creds_ok_when_identity_resolves_and_keypair_loads() {
+        let issue = evaluate_push_credentials(
+            Some("alice".to_string()),
+            |_| true, // identity exists
+            |_| true, // keypair loadable
+        );
+        assert_eq!(issue, None);
+    }
+
+    #[test]
+    fn creds_fail_when_no_identity_in_url() {
+        // A bare host with no userinfo and no subdomain resolves to no identity.
+        let issue = evaluate_push_credentials(None, |_| true, |_| true);
+        assert_eq!(issue, Some(CredentialIssue::NoIdentityInUrl));
+    }
+
+    #[test]
+    fn creds_fail_when_identity_missing_from_store() {
+        let issue = evaluate_push_credentials(
+            Some("alice".to_string()),
+            |_| false, // identity not in store
+            |_| true,
+        );
+        assert_eq!(
+            issue,
+            Some(CredentialIssue::IdentityNotFound {
+                name: "alice".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn creds_fail_when_keypair_cannot_load() {
+        // Identity exists but its signing key can't be loaded — no token can be
+        // minted. This stands in for an "expired"/unusable credential, which in
+        // this self-signed-JWT model means "cannot sign right now".
+        let issue = evaluate_push_credentials(
+            Some("alice".to_string()),
+            |_| true,  // identity exists
+            |_| false, // keypair unavailable
+        );
+        assert_eq!(
+            issue,
+            Some(CredentialIssue::KeypairUnavailable {
+                name: "alice".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn credential_issue_messages_are_actionable() {
+        // Every issue must name the remedy so the failure is self-explanatory.
+        for issue in [
+            CredentialIssue::NoIdentityInUrl,
+            CredentialIssue::IdentityNotFound {
+                name: "alice".to_string(),
+            },
+            CredentialIssue::KeypairUnavailable {
+                name: "alice".to_string(),
+            },
+        ] {
+            let msg = issue.message();
+            assert!(msg.contains("Not authenticated"));
+            assert!(msg.contains("atomic identity register"));
+        }
     }
 }

--- a/atomic-cli/src/commands/client.rs
+++ b/atomic-cli/src/commands/client.rs
@@ -11,8 +11,9 @@
 //!    `atomic identity register`).
 //! 2. **Org override** — an explicit `--org` flag takes precedence over the
 //!    configured default org.
-//! 3. **Bearer token** — the base32-encoded Ed25519 public key of the
-//!    default identity.
+//! 3. **Bearer token** — a short-lived, client-self-signed EdDSA JWT minted
+//!    for the default identity (see [`crate::commands::token`]). The raw
+//!    public key is never sent as a credential.
 //!
 //! # Identity resolution
 //!
@@ -44,8 +45,8 @@ use crate::error::{CliError, CliResult};
 /// - No org slug available (neither override nor default).
 /// - Identity store cannot be opened or no default identity set.
 /// - HTTP client construction failure.
-pub fn build_client(org_override: Option<&str>) -> CliResult<StorageClient> {
-    let (client, _org_slug) = build_client_with_org(org_override)?;
+pub async fn build_client(org_override: Option<&str>) -> CliResult<StorageClient> {
+    let (client, _org_slug) = build_client_with_org(org_override).await?;
     Ok(client)
 }
 
@@ -53,16 +54,18 @@ pub fn build_client(org_override: Option<&str>) -> CliResult<StorageClient> {
 ///
 /// Useful for commands that also need to resolve org-scoped state (e.g.
 /// per-org default workspace lookup). Avoids resolving the org twice.
-pub fn build_client_with_org(org_override: Option<&str>) -> CliResult<(StorageClient, String)> {
+pub async fn build_client_with_org(
+    org_override: Option<&str>,
+) -> CliResult<(StorageClient, String)> {
     let config = GlobalConfig::load()
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load global config: {}", e)))?;
 
     let server = &config.server;
-    if server.url.is_none() {
-        return Err(CliError::Internal(anyhow::anyhow!(
+    let server_url = server.url.clone().ok_or_else(|| {
+        CliError::Internal(anyhow::anyhow!(
             "Server not configured. Run 'atomic identity register <server-url>' first."
-        )));
-    }
+        ))
+    })?;
 
     let org_slug = resolve_org(org_override)?;
 
@@ -72,7 +75,9 @@ pub fn build_client_with_org(org_override: Option<&str>) -> CliResult<(StorageCl
         ))
     })?;
 
-    // Load default identity for bearer token.
+    // Load default identity — we authenticate with a short-lived JWT obtained
+    // by signing a challenge with this identity's private key, never with the
+    // raw public key.
     let store = IdentityStore::open_default()
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to open identity store: {}", e)))?;
 
@@ -86,7 +91,8 @@ pub fn build_client_with_org(org_override: Option<&str>) -> CliResult<(StorageCl
             ))
         })?;
 
-    let bearer_token = identity.public_key_base32();
+    // Log in against the server apex for a JWT bearer token.
+    let bearer_token = crate::commands::token::get_token(&server_url, &identity).await?;
 
     let client = StorageClient::new(&base_url, &org_slug, &bearer_token).map_err(|e| {
         CliError::Internal(anyhow::anyhow!("Failed to create storage client: {}", e))

--- a/atomic-cli/src/commands/client.rs
+++ b/atomic-cli/src/commands/client.rs
@@ -7,12 +7,15 @@
 //!
 //! # Resolution order
 //!
-//! 1. **Server URL + org slug** — from `GlobalConfig::server` (set during
-//!    `atomic identity register`).
+//! 1. **Server profile** — `--server <name>` selects a named profile from
+//!    `~/.atomic/config.toml` `[servers.*]`. Falls back to `default_server`,
+//!    then to the legacy `[server]` block.
 //! 2. **Org override** — an explicit `--org` flag takes precedence over the
-//!    configured default org.
-//! 3. **Bearer token** — a short-lived, client-self-signed EdDSA JWT minted
-//!    for the default identity (see [`crate::commands::token`]). The raw
+//!    configured default org for the resolved server.
+//! 3. **Identity** — the server profile's `identity` field, if set, overrides
+//!    the global default identity.
+//! 4. **Bearer token** — a short-lived, client-self-signed EdDSA JWT minted
+//!    for the resolved identity (see [`crate::commands::token`]). The raw
 //!    public key is never sent as a credential.
 //!
 //! # Identity resolution
@@ -34,19 +37,24 @@ use atomic_remote::StorageClient;
 
 use crate::error::{CliError, CliResult};
 
-/// Build a [`StorageClient`] from global config and the default identity.
+/// Build a [`StorageClient`] from global config and the resolved identity.
 ///
-/// The optional `org_override` takes precedence over the default org stored
-/// in `GlobalConfig::server`.
+/// - `org_override` — explicit `--org` flag value.
+/// - `server_override` — explicit `--server <name>` flag value; selects a
+///   named profile from `[servers.*]` in `~/.atomic/config.toml`.
 ///
 /// # Errors
 ///
 /// - Config not loaded or server not configured.
+/// - Named server profile not found.
 /// - No org slug available (neither override nor default).
 /// - Identity store cannot be opened or no default identity set.
 /// - HTTP client construction failure.
-pub async fn build_client(org_override: Option<&str>) -> CliResult<StorageClient> {
-    let (client, _org_slug) = build_client_with_org(org_override).await?;
+pub async fn build_client(
+    org_override: Option<&str>,
+    server_override: Option<&str>,
+) -> CliResult<StorageClient> {
+    let (client, _org_slug) = build_client_with_org(org_override, server_override).await?;
     Ok(client)
 }
 
@@ -56,18 +64,27 @@ pub async fn build_client(org_override: Option<&str>) -> CliResult<StorageClient
 /// per-org default workspace lookup). Avoids resolving the org twice.
 pub async fn build_client_with_org(
     org_override: Option<&str>,
+    server_override: Option<&str>,
 ) -> CliResult<(StorageClient, String)> {
     let config = GlobalConfig::load()
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load global config: {}", e)))?;
 
-    let server = &config.server;
+    // Resolve the server profile (named or legacy).
+    let server = config
+        .resolve_server(server_override)
+        .map_err(|e| CliError::Internal(anyhow::anyhow!("{}", e)))?
+        .0;
+
     let server_url = server.url.clone().ok_or_else(|| {
-        CliError::Internal(anyhow::anyhow!(
-            "Server not configured. Run 'atomic identity register <server-url>' first."
-        ))
+        let hint = if let Some(name) = server_override {
+            format!("Server profile '{}' has no URL configured.", name)
+        } else {
+            "Server not configured. Run 'atomic identity register <server-url>' first.".to_string()
+        };
+        CliError::Internal(anyhow::anyhow!("{}", hint))
     })?;
 
-    let org_slug = resolve_org(org_override)?;
+    let org_slug = resolve_org_with_server(org_override, server)?;
 
     let base_url = server.org_base_url(&org_slug).ok_or_else(|| {
         CliError::Internal(anyhow::anyhow!(
@@ -75,21 +92,33 @@ pub async fn build_client_with_org(
         ))
     })?;
 
-    // Load default identity — we authenticate with a short-lived JWT obtained
-    // by signing a challenge with this identity's private key, never with the
-    // raw public key.
+    // Resolve identity: per-server override → global default.
     let store = IdentityStore::open_default()
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to open identity store: {}", e)))?;
 
-    let identity = store
-        .get_default()
-        .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load default identity: {}", e)))?
-        .ok_or_else(|| {
+    let identity = if let Some(ref identity_name) = server.identity {
+        // Server profile specifies an identity — use it.
+        store.load_by_name(identity_name).map_err(|e| {
             CliError::Internal(anyhow::anyhow!(
-                "No default identity set. Create one first:\n  \
-                 atomic identity new <name> --email <email> --set-default"
+                "Identity '{}' specified by server profile not found: {}",
+                identity_name,
+                e
             ))
-        })?;
+        })?
+    } else {
+        // Fall back to global default identity.
+        store
+            .get_default()
+            .map_err(|e| {
+                CliError::Internal(anyhow::anyhow!("Failed to load default identity: {}", e))
+            })?
+            .ok_or_else(|| {
+                CliError::Internal(anyhow::anyhow!(
+                    "No default identity set. Create one first:\n  \
+                     atomic identity new <name> --email <email> --set-default"
+                ))
+            })?
+    };
 
     // Log in against the server apex for a JWT bearer token.
     let bearer_token = crate::commands::token::get_token(&server_url, &identity).await?;
@@ -111,13 +140,42 @@ pub fn remote_err(e: atomic_remote::RemoteError) -> CliError {
 
 /// Resolve the org slug for a command, with fallback to the configured default.
 ///
+/// This variant uses the *active* server's `default_org` so that per-server
+/// org defaults are respected.
+///
 /// Resolution order:
 /// 1. `--org` override (if `Some(non-empty)`)
-/// 2. `server.default_org` from global config
+/// 2. `server.default_org` from the resolved server profile
 /// 3. Error with a hint to run `atomic org set`
 ///
 /// An explicit empty string (`--org ""`) is an error: the user asked for "no
 /// org" which never makes sense.
+pub fn resolve_org_with_server(
+    org_override: Option<&str>,
+    server: &atomic_config::ServerConfig,
+) -> CliResult<String> {
+    if let Some(s) = org_override {
+        if s.is_empty() {
+            return Err(CliError::InvalidArgument {
+                message: "Organization slug cannot be empty.".to_string(),
+            });
+        }
+        return Ok(s.to_string());
+    }
+
+    server
+        .default_org
+        .clone()
+        .ok_or_else(|| CliError::InvalidArgument {
+            message: "No organization specified.\n  \
+                      Use --org or set a default with: atomic org set <slug>"
+                .to_string(),
+        })
+}
+
+/// Resolve the org slug using the legacy (single-server) config path.
+///
+/// Kept for callers that don't yet pass a server override.
 pub fn resolve_org(org_override: Option<&str>) -> CliResult<String> {
     if let Some(s) = org_override {
         if s.is_empty() {
@@ -142,11 +200,48 @@ pub fn resolve_org(org_override: Option<&str>) -> CliResult<String> {
 }
 
 /// Resolve the workspace slug for a command, with fallback to the
-/// org-scoped default workspace from global config.
+/// org-scoped default workspace from a server config.
 ///
 /// Workspaces are org-scoped, so the lookup is keyed by `org_slug`. The
 /// caller is responsible for resolving the org first (typically with
-/// [`resolve_org`]).
+/// [`resolve_org_with_server`]).
+///
+/// Resolution order:
+/// 1. `--workspace` override (if `Some(non-empty)`)
+/// 2. `server.default_workspaces[org_slug]` from the resolved server profile
+/// 3. Error with a hint to run `atomic workspace set`
+pub fn resolve_workspace_with_server(
+    org_slug: &str,
+    workspace_override: Option<&str>,
+    server: &atomic_config::ServerConfig,
+) -> CliResult<String> {
+    if let Some(s) = workspace_override {
+        if s.is_empty() {
+            return Err(CliError::InvalidArgument {
+                message: "Workspace slug cannot be empty.".to_string(),
+            });
+        }
+        return Ok(s.to_string());
+    }
+
+    server
+        .default_workspaces
+        .get(org_slug)
+        .cloned()
+        .ok_or_else(|| CliError::InvalidArgument {
+            message: format!(
+                "No workspace specified for org '{org_slug}'.\n  \
+                 Use --workspace or set a default with: atomic workspace set <slug>"
+            ),
+        })
+}
+
+/// Resolve the workspace slug for a command, with fallback to the
+/// org-scoped default workspace from global config.
+///
+/// Uses the legacy (single-server) config path. Prefer
+/// [`resolve_workspace_with_server`] when you have already resolved the
+/// active server.
 ///
 /// Resolution order:
 /// 1. `--workspace` override (if `Some(non-empty)`)

--- a/atomic-cli/src/commands/clone/command.rs
+++ b/atomic-cli/src/commands/clone/command.rs
@@ -205,7 +205,8 @@ impl Clone {
             .with_timeout(Duration::from_secs(self.timeout))
             .danger_accept_invalid_certs(self.insecure);
 
-        crate::commands::auth::attach_identity(config, &self.url).await
+        // Clone uses the URL directly — identity inferred from subdomain only.
+        crate::commands::auth::attach_identity(config, &self.url, None).await
     }
 
     /// Get the display name for the repository.

--- a/atomic-cli/src/commands/clone/command.rs
+++ b/atomic-cli/src/commands/clone/command.rs
@@ -200,12 +200,12 @@ impl Clone {
     ///
     /// Creates an `HttpRemoteConfig` with the timeout and security settings
     /// specified by the user.
-    fn build_remote_config(&self) -> HttpRemoteConfig {
+    async fn build_remote_config(&self) -> HttpRemoteConfig {
         let config = HttpRemoteConfig::new()
             .with_timeout(Duration::from_secs(self.timeout))
             .danger_accept_invalid_certs(self.insecure);
 
-        crate::commands::auth::attach_identity(config, &self.url)
+        crate::commands::auth::attach_identity(config, &self.url).await
     }
 
     /// Get the display name for the repository.
@@ -257,7 +257,7 @@ impl Clone {
 
         // Connect to remote
         let spinner = create_spinner("Connecting to remote...");
-        let config = self.build_remote_config();
+        let config = self.build_remote_config().await;
         let remote = HttpRemote::with_config(&self.url, config).map_err(|e| {
             finish_error(&spinner, "Failed to connect");
             convert_remote_error(e, &self.url)
@@ -742,10 +742,10 @@ mod tests {
     // Internal Method Tests
 
     /// Test build_remote_config with default settings.
-    #[test]
-    fn test_build_remote_config_default() {
+    #[tokio::test]
+    async fn test_build_remote_config_default() {
         let clone = Clone::new("https://example.com/repo".to_string());
-        let config = clone.build_remote_config();
+        let config = clone.build_remote_config().await;
 
         // HttpRemoteConfig doesn't expose fields directly, so we just verify
         // it doesn't panic and returns something
@@ -753,18 +753,18 @@ mod tests {
     }
 
     /// Test build_remote_config with custom timeout.
-    #[test]
-    fn test_build_remote_config_custom_timeout() {
+    #[tokio::test]
+    async fn test_build_remote_config_custom_timeout() {
         let clone = Clone::new("https://example.com/repo".to_string()).with_timeout(120);
-        let config = clone.build_remote_config();
+        let config = clone.build_remote_config().await;
         assert!(std::mem::size_of_val(&config) > 0);
     }
 
     /// Test build_remote_config with insecure flag.
-    #[test]
-    fn test_build_remote_config_insecure() {
+    #[tokio::test]
+    async fn test_build_remote_config_insecure() {
         let clone = Clone::new("https://example.com/repo".to_string()).with_insecure(true);
-        let config = clone.build_remote_config();
+        let config = clone.build_remote_config().await;
         assert!(std::mem::size_of_val(&config) > 0);
     }
 

--- a/atomic-cli/src/commands/diff/helpers.rs
+++ b/atomic-cli/src/commands/diff/helpers.rs
@@ -492,10 +492,21 @@ impl Diff {
             if matched_rm.contains(ri) || matched_add.contains(ai) {
                 continue;
             }
-            matched_rm.insert(*ri);
-            matched_add.insert(*ai);
             let rm_orig_idx = rm_entries[*ri].0;
             let add_orig_idx = add_entries[*ai].0;
+
+            // Only pull an add forward if there are no other Added lines
+            // between the remove and the matched add in the original order.
+            // Intervening Added lines represent genuinely new content that
+            // belongs before the matched line in the new file — moving the
+            // matched add past them would put it in the wrong position.
+            let has_intervening_adds = (rm_orig_idx + 1..add_orig_idx).any(|i| lines[i].is_added());
+            if has_intervening_adds {
+                continue;
+            }
+
+            matched_rm.insert(*ri);
+            matched_add.insert(*ai);
             rm_to_add.insert(rm_orig_idx, add_orig_idx);
             paired_add_indices.insert(add_orig_idx);
         }

--- a/atomic-cli/src/commands/git/import.rs
+++ b/atomic-cli/src/commands/git/import.rs
@@ -29,6 +29,7 @@
 //!   it for token-level blame and word-diff.
 
 use std::collections::HashSet;
+use std::io::ErrorKind;
 use std::path::Path;
 
 use clap::Parser;
@@ -155,6 +156,45 @@ fn current_git_branch(git_repo: &GitRepository) -> Option<String> {
         return None;
     }
     head.shorthand().map(ToOwned::to_owned)
+}
+
+const GIT_SHADOW_EXCLUDE_PATTERNS: &[&str] = &["/.atomic/", "/.vault/", "/.atomicignore"];
+
+fn ensure_git_shadow_excludes(git_dir: &Path) -> CliResult<bool> {
+    let info_dir = git_dir.join("info");
+    std::fs::create_dir_all(&info_dir)?;
+
+    let exclude_path = info_dir.join("exclude");
+    let mut content = match std::fs::read_to_string(&exclude_path) {
+        Ok(content) => content,
+        Err(e) if e.kind() == ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(e.into()),
+    };
+
+    let missing: Vec<&str> = GIT_SHADOW_EXCLUDE_PATTERNS
+        .iter()
+        .copied()
+        .filter(|pattern| !content.lines().any(|line| line.trim() == *pattern))
+        .collect();
+
+    if missing.is_empty() {
+        return Ok(false);
+    }
+
+    if !content.is_empty() && !content.ends_with('\n') {
+        content.push('\n');
+    }
+    if !content.is_empty() {
+        content.push('\n');
+    }
+    content.push_str("# Atomic local state (managed by atomic git import)\n");
+    for pattern in missing {
+        content.push_str(pattern);
+        content.push('\n');
+    }
+
+    std::fs::write(exclude_path, content)?;
+    Ok(true)
 }
 
 impl Import {
@@ -375,6 +415,10 @@ impl Command for Import {
             }
 
             return Ok(());
+        }
+
+        if ensure_git_shadow_excludes(git_repo.path())? {
+            print_info("Configured Git to ignore Atomic local state.");
         }
 
         // Check if Atomic repository exists in THIS directory (not parent dirs).
@@ -714,5 +758,20 @@ mod tests {
         assert!(patterns.iter().any(|p| p == "node_modules/"));
         assert!(patterns.iter().any(|p| p == ".yarn/cache/"));
         assert!(patterns.iter().any(|p| p == "vendor/"));
+    }
+
+    #[test]
+    fn test_git_shadow_excludes_are_added_to_git_info_exclude() {
+        let temp = tempfile::tempdir().unwrap();
+        let git_dir = temp.path().join(".git");
+
+        assert!(ensure_git_shadow_excludes(&git_dir).unwrap());
+
+        let exclude = std::fs::read_to_string(git_dir.join("info").join("exclude")).unwrap();
+        assert!(exclude.contains("/.atomic/"));
+        assert!(exclude.contains("/.vault/"));
+        assert!(exclude.contains("/.atomicignore"));
+
+        assert!(!ensure_git_shadow_excludes(&git_dir).unwrap());
     }
 }

--- a/atomic-cli/src/commands/git/import.rs
+++ b/atomic-cli/src/commands/git/import.rs
@@ -468,8 +468,8 @@ impl Command for Import {
                         .map_err(|e| CliError::Internal(e.into()))?;
                 }
 
-                // Switch to the view
-                repo.set_current_view(&branch_name)
+                // Align to the view (materialize happens after all branches imported)
+                repo.align_to_view(&branch_name)
                     .map_err(|e| CliError::Internal(e.into()))?;
 
                 // Import the branch
@@ -531,8 +531,8 @@ impl Command for Import {
                     .map_err(|e| CliError::Internal(e.into()))?;
             }
 
-            // Switch to the view
-            repo.set_current_view(&branch_name)
+            // Align to the view (materialize/reindex follows)
+            repo.align_to_view(&branch_name)
                 .map_err(|e| CliError::Internal(e.into()))?;
 
             // Import

--- a/atomic-cli/src/commands/identity/mod.rs
+++ b/atomic-cli/src/commands/identity/mod.rs
@@ -59,6 +59,8 @@ pub use whoami::WhoAmI;
 
 use clap::Subcommand;
 
+use atomic_config::GlobalConfig;
+
 use crate::commands::Command;
 use crate::error::CliResult;
 
@@ -325,6 +327,7 @@ impl Command for Default {
                     "Set '{}' as default identity for {} usage",
                     name, usage
                 ));
+                activate_server_for_identity(name);
             } else {
                 store.set_default(&identity.id).map_err(|e| {
                     crate::error::CliError::Internal(anyhow::anyhow!(
@@ -333,6 +336,7 @@ impl Command for Default {
                     ))
                 })?;
                 print_success(&format!("Set '{}' as default identity", name));
+                activate_server_for_identity(name);
             }
         }
 
@@ -341,6 +345,49 @@ impl Command for Default {
 }
 
 // Helper Functions
+
+/// When an identity becomes the active default, automatically activate the
+/// server profile bound to it (if any).
+///
+/// Looks for a named profile in `~/.atomic/config.toml` whose `identity`
+/// field matches `identity_name`. If found, sets `default_server` to that
+/// profile name and saves the config. Emits a hint so the user knows the
+/// server switched alongside the identity.
+///
+/// This is intentionally non-fatal: if the config can't be loaded/saved,
+/// a debug log is emitted and the command still succeeds — the identity
+/// switch itself is the important operation.
+pub fn activate_server_for_identity(identity_name: &str) {
+    let mut config = match GlobalConfig::load() {
+        Ok(c) => c,
+        Err(e) => {
+            log::debug!("Could not load config for server auto-activation: {}", e);
+            return;
+        }
+    };
+
+    // Find a named server profile whose identity binding matches.
+    let matching_profile = config
+        .servers
+        .iter()
+        .find(|(_, srv)| srv.identity.as_deref() == Some(identity_name))
+        .map(|(name, _)| name.clone());
+
+    if let Some(profile_name) = matching_profile {
+        // Only update + print if it's actually changing.
+        if config.default_server.as_deref() != Some(&profile_name) {
+            config.default_server = Some(profile_name.clone());
+            if let Err(e) = config.save() {
+                log::debug!("Could not save config for server auto-activation: {}", e);
+                return;
+            }
+            crate::output::print_hint(&format!(
+                "Server profile '{}' activated (bound to identity '{}')",
+                profile_name, identity_name
+            ));
+        }
+    }
+}
 
 /// Format an identity type for display.
 pub fn format_identity_type(identity_type: &atomic_identity::IdentityType) -> &'static str {

--- a/atomic-cli/src/commands/identity/new.rs
+++ b/atomic-cli/src/commands/identity/new.rs
@@ -158,6 +158,7 @@ impl Command for New {
             store.set_default(&identity.id).map_err(|e| {
                 CliError::Internal(anyhow::anyhow!("Failed to set as default: {}", e))
             })?;
+            super::activate_server_for_identity(&identity.name);
         }
 
         if self.set_default_for_usage {
@@ -166,6 +167,7 @@ impl Command for New {
                 .map_err(|e| {
                     CliError::Internal(anyhow::anyhow!("Failed to set as default for usage: {}", e))
                 })?;
+            super::activate_server_for_identity(&identity.name);
         }
 
         // Print success message

--- a/atomic-cli/src/commands/identity/register.rs
+++ b/atomic-cli/src/commands/identity/register.rs
@@ -61,6 +61,12 @@ const SIGNING_DOMAIN: &str = "atomic-storage:register";
 /// Pushes the local identity to the server, which creates a tenant
 /// whose slug is derived from the identity's username. Authentication
 /// is Ed25519 signature-based — no passwords required.
+///
+/// When `--identity` is specified, a named server profile is automatically
+/// created in `~/.atomic/config.toml` so that commands targeting this
+/// server use that identity automatically. The profile name is derived
+/// from the server hostname (e.g. `staging.atomic.storage` → `staging`).
+/// Use `--server-name <name>` to choose a custom profile name.
 #[derive(Debug, Parser)]
 pub struct Register {
     /// URL of the atomic-storage server.
@@ -76,9 +82,19 @@ pub struct Register {
 
     /// Name of the identity to register.
     ///
-    /// If not specified, the current default identity is used.
+    /// If not specified, the current default identity is used. When
+    /// specified, the server URL and identity are automatically saved as
+    /// a named server profile (see `--server-name`).
     #[arg(short, long)]
     pub identity: Option<String>,
+
+    /// Custom name for the auto-created server profile.
+    ///
+    /// Only used when `--identity` is given. Defaults to the first
+    /// hostname label of the server URL (e.g. `staging` from
+    /// `staging.atomic.storage`).
+    #[arg(long)]
+    pub server_name: Option<String>,
 }
 
 impl Command for Register {
@@ -188,11 +204,52 @@ impl Register {
                 .and_then(|v| v.as_str())
                 .unwrap_or("(unknown)");
 
+            let clean_server_url = self.server_url.trim_end_matches('/').to_string();
             let mut config = GlobalConfig::load().map_err(|e| {
                 CliError::Internal(anyhow::anyhow!("Failed to load global config: {e}"))
             })?;
-            config.server.url = Some(self.server_url.trim_end_matches('/').to_string());
-            config.server.default_org = Some(slug.to_string());
+
+            // When --identity is specified, register as a named server profile
+            // so the URL+identity combo is remembered automatically.
+            if self.identity.is_some() {
+                let profile_name = self
+                    .server_name
+                    .clone()
+                    .or_else(|| derive_profile_name(&clean_server_url))
+                    .unwrap_or_else(|| slug.to_string());
+
+                let profile = atomic_config::ServerConfig {
+                    url: Some(clean_server_url.clone()),
+                    default_org: Some(slug.to_string()),
+                    default_workspaces: std::collections::BTreeMap::new(),
+                    identity: Some(identity.name.clone()),
+                };
+
+                config.servers.insert(profile_name.clone(), profile);
+
+                // If there's no active named server yet, make this one active.
+                if config.default_server.is_none() && config.server.is_configured() {
+                    // Legacy [server] is already set — don't override it silently.
+                    // Just register the profile; user can activate with `atomic server set`.
+                    println!(
+                        "  Profile:   '{}' added (activate with: atomic server set {})",
+                        profile_name, profile_name
+                    );
+                } else if config.default_server.is_none() {
+                    config.default_server = Some(profile_name.clone());
+                    println!("  Profile:   '{}' (now active)", profile_name);
+                } else {
+                    println!(
+                        "  Profile:   '{}' added (activate with: atomic server set {})",
+                        profile_name, profile_name
+                    );
+                }
+            } else {
+                // Default path: update the legacy [server] block.
+                config.server.url = Some(clean_server_url.clone());
+                config.server.default_org = Some(slug.to_string());
+            }
+
             config.save().map_err(|e| {
                 CliError::Internal(anyhow::anyhow!("Failed to save global config: {e}"))
             })?;
@@ -271,6 +328,34 @@ impl Register {
     }
 }
 
+/// Derive a short profile name from a server URL.
+///
+/// `https://staging.atomic.storage` → `"staging"`
+/// `https://atomic.storage`         → `"atomic-storage"` (no subdomain)
+/// `http://localhost:8080`           → `"localhost"`
+fn derive_profile_name(server_url: &str) -> Option<String> {
+    let url = url::Url::parse(server_url).ok()?;
+    let host = url.host_str()?;
+
+    // If the host has a subdomain, use that as the profile name.
+    if let Some(dot) = host.find('.') {
+        let label = &host[..dot];
+        if !label.is_empty() && label != "www" {
+            return Some(label.to_string());
+        }
+        // No useful subdomain — fall through to full host slug.
+    }
+
+    // Slug the host: replace dots and colons with hyphens, strip port.
+    let host_no_port = host.split(':').next().unwrap_or(host);
+    let slug = host_no_port.replace('.', "-");
+    if slug.is_empty() {
+        None
+    } else {
+        Some(slug)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -305,6 +390,7 @@ mod tests {
         let cmd = Register {
             server_url: "http://localhost:8080".to_string(),
             identity: Some("alice".to_string()),
+            server_name: None,
         };
 
         assert_eq!(cmd.server_url, "http://localhost:8080");
@@ -316,8 +402,35 @@ mod tests {
         let cmd = Register {
             server_url: "http://localhost:8080".to_string(),
             identity: None,
+            server_name: None,
         };
 
         assert!(cmd.identity.is_none());
+    }
+
+    #[test]
+    fn derive_profile_name_subdomain() {
+        assert_eq!(
+            derive_profile_name("https://staging.atomic.storage"),
+            Some("staging".to_string())
+        );
+    }
+
+    #[test]
+    fn derive_profile_name_no_subdomain() {
+        // "atomic.storage" — "atomic" is the first label (subdomain of "storage")
+        // so it's used as the profile name.
+        assert_eq!(
+            derive_profile_name("https://atomic.storage"),
+            Some("atomic".to_string())
+        );
+    }
+
+    #[test]
+    fn derive_profile_name_localhost() {
+        assert_eq!(
+            derive_profile_name("http://localhost:8080"),
+            Some("localhost".to_string())
+        );
     }
 }

--- a/atomic-cli/src/commands/init.rs
+++ b/atomic-cli/src/commands/init.rs
@@ -522,7 +522,7 @@ impl Command for Init {
         // Create the initial view if it's different from the default
         if self.view != atomic_repository::DEFAULT_VIEW {
             repo.create_view(&self.view).map_err(CliError::Repository)?;
-            repo.set_current_view(&self.view)
+            repo.align_to_view(&self.view)
                 .map_err(CliError::Repository)?;
         }
 

--- a/atomic-cli/src/commands/log/command.rs
+++ b/atomic-cli/src/commands/log/command.rs
@@ -206,6 +206,10 @@ impl Log {
             options = options.from_sequence(from);
         }
 
+        if self.all {
+            options = options.include_inherited(true);
+        }
+
         options
     }
 
@@ -525,14 +529,9 @@ impl Command for Log {
             );
         }
 
-        // Show all entries in VIEW_CHANGES for this view.
-        //
-        // Previous draft-view filtering used `parent_change_count` which
-        // reads the parent's *live* change_count.  That counter moves as
-        // the parent gains more changes, shifting the filter threshold
-        // and hiding entries that should be visible — including the
-        // draft view's own local changes.  Until a stable fork-point
-        // snapshot is stored at view-creation time, show everything.
+        // Draft views now filter inherited changes by default (the
+        // repository layer compares against ancestor VIEW_CHANGES).
+        // Use `--all` to see the full log including inherited entries.
         self.print_entries(&entries);
 
         Ok(())

--- a/atomic-cli/src/commands/mod.rs
+++ b/atomic-cli/src/commands/mod.rs
@@ -110,6 +110,7 @@ pub mod query;
 // Storage management commands (always available)
 pub mod client;
 pub mod project;
+pub mod token;
 pub mod workspace;
 
 // Team collaboration commands (feature-gated)

--- a/atomic-cli/src/commands/mod.rs
+++ b/atomic-cli/src/commands/mod.rs
@@ -98,6 +98,7 @@ pub mod clone;
 pub mod pull;
 pub mod push;
 pub mod remote;
+pub mod server;
 
 // Phase 4: Identity Management
 pub mod identity;
@@ -143,6 +144,7 @@ pub use remove::Remove;
 pub use restore::Restore;
 pub use revise::Revise;
 pub use sandbox::Sandbox;
+pub use server::ServerCmd;
 pub use split::Split;
 pub use stash::Stash;
 pub use status::Status;

--- a/atomic-cli/src/commands/mod.rs
+++ b/atomic-cli/src/commands/mod.rs
@@ -59,7 +59,7 @@
 use std::path::{Path, PathBuf};
 
 use atomic_core::types::{Base32, Hash};
-use atomic_repository::Repository;
+use atomic_repository::{Repository, SANDBOX_POINTER};
 use chrono::{DateTime, Local, Utc};
 
 use crate::error::{CliError, CliResult};
@@ -79,6 +79,7 @@ pub mod record;
 pub mod remove;
 pub mod restore;
 pub mod revise;
+pub mod sandbox;
 pub mod split;
 pub mod stash;
 pub mod status;
@@ -141,6 +142,7 @@ pub use remote::Remote;
 pub use remove::Remove;
 pub use restore::Restore;
 pub use revise::Revise;
+pub use sandbox::Sandbox;
 pub use split::Split;
 pub use stash::Stash;
 pub use status::Status;
@@ -273,6 +275,13 @@ pub fn find_repository_root_from(start_path: &Path) -> CliResult<PathBuf> {
     loop {
         let dot_dir = current.join(DOT_DIR);
         if dot_dir.is_dir() {
+            return Ok(current);
+        }
+
+        // A sandbox working tree has no `.atomic/` of its own — it carries a
+        // pointer to the canonical graph. Treat the sandbox root as a valid
+        // repository root; `Repository::open*` resolves the pointer.
+        if current.join(SANDBOX_POINTER).is_file() {
             return Ok(current);
         }
 

--- a/atomic-cli/src/commands/org/create.rs
+++ b/atomic-cli/src/commands/org/create.rs
@@ -81,7 +81,7 @@ impl OrgCreate {
     async fn execute(&self) -> CliResult<()> {
         // Build client using current default org (doesn't matter which org
         // we're scoped to — the server creates a new org regardless).
-        let client = build_client(None).await?;
+        let client = build_client(None, None).await?;
 
         let info = atomic_teams::org::create_org(&client, &self.name, self.email.as_deref())
             .await

--- a/atomic-cli/src/commands/org/create.rs
+++ b/atomic-cli/src/commands/org/create.rs
@@ -81,7 +81,7 @@ impl OrgCreate {
     async fn execute(&self) -> CliResult<()> {
         // Build client using current default org (doesn't matter which org
         // we're scoped to — the server creates a new org regardless).
-        let client = build_client(None)?;
+        let client = build_client(None).await?;
 
         let info = atomic_teams::org::create_org(&client, &self.name, self.email.as_deref())
             .await

--- a/atomic-cli/src/commands/org/delete.rs
+++ b/atomic-cli/src/commands/org/delete.rs
@@ -103,7 +103,7 @@ impl OrgDelete {
             }
         }
 
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
 
         atomic_teams::org::delete_org(&client, &self.slug)
             .await

--- a/atomic-cli/src/commands/org/delete.rs
+++ b/atomic-cli/src/commands/org/delete.rs
@@ -103,7 +103,7 @@ impl OrgDelete {
             }
         }
 
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
 
         atomic_teams::org::delete_org(&client, &self.slug)
             .await

--- a/atomic-cli/src/commands/org/list.rs
+++ b/atomic-cli/src/commands/org/list.rs
@@ -71,7 +71,7 @@ impl Command for OrgList {
 
 impl OrgList {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let slug = client.org_slug().to_string();
 
         let info = atomic_teams::org::get_org(&client, &slug)

--- a/atomic-cli/src/commands/org/list.rs
+++ b/atomic-cli/src/commands/org/list.rs
@@ -71,7 +71,7 @@ impl Command for OrgList {
 
 impl OrgList {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let slug = client.org_slug().to_string();
 
         let info = atomic_teams::org::get_org(&client, &slug)

--- a/atomic-cli/src/commands/org/member.rs
+++ b/atomic-cli/src/commands/org/member.rs
@@ -161,7 +161,7 @@ impl Command for MemberList {
 
 impl MemberList {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let slug = client.org_slug().to_string();
 
         let members = atomic_teams::member::list_members(&client, &slug)
@@ -261,7 +261,7 @@ impl MemberAdd {
             ),
         })?;
 
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let slug = client.org_slug().to_string();
 
         let identity_id =
@@ -338,7 +338,7 @@ impl MemberUpdate {
             ),
         })?;
 
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let slug = client.org_slug().to_string();
 
         let identity_id =
@@ -409,7 +409,7 @@ impl Command for MemberRemove {
 
 impl MemberRemove {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let slug = client.org_slug().to_string();
 
         let identity_id =

--- a/atomic-cli/src/commands/org/member.rs
+++ b/atomic-cli/src/commands/org/member.rs
@@ -161,7 +161,7 @@ impl Command for MemberList {
 
 impl MemberList {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let slug = client.org_slug().to_string();
 
         let members = atomic_teams::member::list_members(&client, &slug)
@@ -261,7 +261,7 @@ impl MemberAdd {
             ),
         })?;
 
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let slug = client.org_slug().to_string();
 
         let identity_id =
@@ -338,7 +338,7 @@ impl MemberUpdate {
             ),
         })?;
 
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let slug = client.org_slug().to_string();
 
         let identity_id =
@@ -409,7 +409,7 @@ impl Command for MemberRemove {
 
 impl MemberRemove {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let slug = client.org_slug().to_string();
 
         let identity_id =

--- a/atomic-cli/src/commands/org/set.rs
+++ b/atomic-cli/src/commands/org/set.rs
@@ -138,7 +138,7 @@ fn verify_org_exists(slug: &str) -> CliResult<()> {
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to create async runtime: {e}")))?;
 
     rt.block_on(async {
-        let (client, _resolved) = build_client_with_org(Some(slug))?;
+        let (client, _resolved) = build_client_with_org(Some(slug)).await?;
         match atomic_teams::org::get_org(&client, slug).await {
             Ok(_) => Ok(()),
             Err(e) if is_org_not_found(&e) => Err(CliError::InvalidArgument {

--- a/atomic-cli/src/commands/org/set.rs
+++ b/atomic-cli/src/commands/org/set.rs
@@ -138,7 +138,7 @@ fn verify_org_exists(slug: &str) -> CliResult<()> {
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to create async runtime: {e}")))?;
 
     rt.block_on(async {
-        let (client, _resolved) = build_client_with_org(Some(slug)).await?;
+        let (client, _resolved) = build_client_with_org(Some(slug), None).await?;
         match atomic_teams::org::get_org(&client, slug).await {
             Ok(_) => Ok(()),
             Err(e) if is_org_not_found(&e) => Err(CliError::InvalidArgument {

--- a/atomic-cli/src/commands/org/show.rs
+++ b/atomic-cli/src/commands/org/show.rs
@@ -85,7 +85,7 @@ impl Command for OrgShow {
 
 impl OrgShow {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
 
         // Determine which slug to look up: explicit arg > client's org slug
         let slug = self.slug.as_deref().unwrap_or_else(|| client.org_slug());

--- a/atomic-cli/src/commands/org/show.rs
+++ b/atomic-cli/src/commands/org/show.rs
@@ -85,7 +85,7 @@ impl Command for OrgShow {
 
 impl OrgShow {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
 
         // Determine which slug to look up: explicit arg > client's org slug
         let slug = self.slug.as_deref().unwrap_or_else(|| client.org_slug());

--- a/atomic-cli/src/commands/org/update.rs
+++ b/atomic-cli/src/commands/org/update.rs
@@ -98,7 +98,7 @@ impl OrgUpdate {
             });
         }
 
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
 
         // Determine which slug to update: explicit arg > client's org slug.
         let slug = self.slug.as_deref().unwrap_or_else(|| client.org_slug());

--- a/atomic-cli/src/commands/org/update.rs
+++ b/atomic-cli/src/commands/org/update.rs
@@ -98,7 +98,7 @@ impl OrgUpdate {
             });
         }
 
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
 
         // Determine which slug to update: explicit arg > client's org slug.
         let slug = self.slug.as_deref().unwrap_or_else(|| client.org_slug());

--- a/atomic-cli/src/commands/org/upgrade.rs
+++ b/atomic-cli/src/commands/org/upgrade.rs
@@ -84,7 +84,7 @@ impl Command for OrgUpgrade {
 
 impl OrgUpgrade {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
 
         // Determine which slug to upgrade: explicit arg > client's org slug.
         let slug = self.slug.as_deref().unwrap_or_else(|| client.org_slug());

--- a/atomic-cli/src/commands/org/upgrade.rs
+++ b/atomic-cli/src/commands/org/upgrade.rs
@@ -84,7 +84,7 @@ impl Command for OrgUpgrade {
 
 impl OrgUpgrade {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
 
         // Determine which slug to upgrade: explicit arg > client's org slug.
         let slug = self.slug.as_deref().unwrap_or_else(|| client.org_slug());

--- a/atomic-cli/src/commands/project/create.rs
+++ b/atomic-cli/src/commands/project/create.rs
@@ -101,6 +101,13 @@ pub struct ProjectCreate {
     /// If not specified, uses the default org from global config.
     #[arg(long)]
     pub org: Option<String>,
+
+    /// Server profile to use (e.g. "staging", "prod").
+    ///
+    /// Overrides `default_server` from `~/.atomic/config.toml`.
+    /// Use `atomic server list` to see available profiles.
+    #[arg(long)]
+    pub server: Option<String>,
 }
 
 impl ProjectCreate {
@@ -124,7 +131,8 @@ impl Command for ProjectCreate {
         })?;
 
         rt.block_on(async {
-            let (client, org_slug) = build_client_with_org(self.org.as_deref()).await?;
+            let (client, org_slug) =
+                build_client_with_org(self.org.as_deref(), self.server.as_deref()).await?;
             let workspace = resolve_workspace(&org_slug, self.workspace.as_deref())?;
             let visibility = self.parse_visibility()?;
 
@@ -208,6 +216,7 @@ mod tests {
             default_view: "main".to_string(),
             visibility: "public".to_string(),
             org: Some("acme".to_string()),
+            server: None,
         };
         assert_eq!(cmd.name, "svc");
         assert_eq!(cmd.workspace.as_deref(), Some("backend"));

--- a/atomic-cli/src/commands/project/create.rs
+++ b/atomic-cli/src/commands/project/create.rs
@@ -124,7 +124,7 @@ impl Command for ProjectCreate {
         })?;
 
         rt.block_on(async {
-            let (client, org_slug) = build_client_with_org(self.org.as_deref())?;
+            let (client, org_slug) = build_client_with_org(self.org.as_deref()).await?;
             let workspace = resolve_workspace(&org_slug, self.workspace.as_deref())?;
             let visibility = self.parse_visibility()?;
 

--- a/atomic-cli/src/commands/project/delete.rs
+++ b/atomic-cli/src/commands/project/delete.rs
@@ -88,7 +88,7 @@ impl Command for ProjectDelete {
                 }
             }
 
-            let client = build_client(self.org.as_deref())?;
+            let client = build_client(self.org.as_deref()).await?;
 
             client
                 .delete_project(ws_slug, proj_slug)

--- a/atomic-cli/src/commands/project/delete.rs
+++ b/atomic-cli/src/commands/project/delete.rs
@@ -88,7 +88,7 @@ impl Command for ProjectDelete {
                 }
             }
 
-            let client = build_client(self.org.as_deref()).await?;
+            let client = build_client(self.org.as_deref(), None).await?;
 
             client
                 .delete_project(ws_slug, proj_slug)

--- a/atomic-cli/src/commands/project/init.rs
+++ b/atomic-cli/src/commands/project/init.rs
@@ -114,7 +114,7 @@ impl ProjectInit {
         })?;
 
         // 2. Build the storage client and resolve the workspace.
-        let (client, org_slug) = build_client_with_org(self.org.as_deref())?;
+        let (client, org_slug) = build_client_with_org(self.org.as_deref()).await?;
         let workspace = resolve_workspace(&org_slug, self.workspace.as_deref())?;
 
         // 3. Ensure the workspace exists — create it if necessary.

--- a/atomic-cli/src/commands/project/init.rs
+++ b/atomic-cli/src/commands/project/init.rs
@@ -114,7 +114,7 @@ impl ProjectInit {
         })?;
 
         // 2. Build the storage client and resolve the workspace.
-        let (client, org_slug) = build_client_with_org(self.org.as_deref()).await?;
+        let (client, org_slug) = build_client_with_org(self.org.as_deref(), None).await?;
         let workspace = resolve_workspace(&org_slug, self.workspace.as_deref())?;
 
         // 3. Ensure the workspace exists — create it if necessary.

--- a/atomic-cli/src/commands/project/list.rs
+++ b/atomic-cli/src/commands/project/list.rs
@@ -55,6 +55,13 @@ pub struct ProjectList {
     #[arg(long)]
     pub org: Option<String>,
 
+    /// Server profile to use (e.g. "staging", "prod").
+    ///
+    /// Overrides `default_server` from `~/.atomic/config.toml`.
+    /// Use `atomic server list` to see available profiles.
+    #[arg(long)]
+    pub server: Option<String>,
+
     /// Output format: `table` or `json`.
     #[arg(long, default_value = "table")]
     pub format: String,
@@ -67,7 +74,8 @@ impl Command for ProjectList {
         })?;
 
         rt.block_on(async {
-            let (client, org_slug) = build_client_with_org(self.org.as_deref()).await?;
+            let (client, org_slug) =
+                build_client_with_org(self.org.as_deref(), self.server.as_deref()).await?;
             let workspace = resolve_workspace(&org_slug, self.workspace.as_deref())?;
 
             let projects = client.list_projects(&workspace).await.map_err(remote_err)?;
@@ -132,6 +140,7 @@ mod tests {
         let cmd = ProjectList {
             workspace: Some("ws".to_string()),
             org: None,
+            server: None,
             format: "table".to_string(),
         };
         assert_eq!(cmd.format, "table");
@@ -142,6 +151,7 @@ mod tests {
         let cmd = ProjectList {
             workspace: Some("my-workspace".to_string()),
             org: Some("acme".to_string()),
+            server: None,
             format: "json".to_string(),
         };
         assert_eq!(cmd.workspace.as_deref(), Some("my-workspace"));
@@ -154,6 +164,7 @@ mod tests {
         let cmd = ProjectList {
             workspace: None,
             org: None,
+            server: None,
             format: "table".to_string(),
         };
         assert!(cmd.workspace.is_none());

--- a/atomic-cli/src/commands/project/list.rs
+++ b/atomic-cli/src/commands/project/list.rs
@@ -67,7 +67,7 @@ impl Command for ProjectList {
         })?;
 
         rt.block_on(async {
-            let (client, org_slug) = build_client_with_org(self.org.as_deref())?;
+            let (client, org_slug) = build_client_with_org(self.org.as_deref()).await?;
             let workspace = resolve_workspace(&org_slug, self.workspace.as_deref())?;
 
             let projects = client.list_projects(&workspace).await.map_err(remote_err)?;

--- a/atomic-cli/src/commands/project/mod.rs
+++ b/atomic-cli/src/commands/project/mod.rs
@@ -228,6 +228,7 @@ mod tests {
         let list = list::ProjectList {
             workspace: Some("ws".to_string()),
             org: None,
+            server: None,
             format: "table".to_string(),
         };
         assert_eq!(check_variant(&ProjectCommands::List(list)), "list");
@@ -240,6 +241,7 @@ mod tests {
             default_view: "dev".to_string(),
             visibility: "private".to_string(),
             org: None,
+            server: None,
         };
         assert_eq!(check_variant(&ProjectCommands::Create(create)), "create");
     }

--- a/atomic-cli/src/commands/project/show.rs
+++ b/atomic-cli/src/commands/project/show.rs
@@ -79,7 +79,7 @@ impl Command for ProjectShow {
 
         rt.block_on(async {
             let (ws_slug, proj_slug) = parse_project_path(&self.slug)?;
-            let client = build_client(self.org.as_deref()).await?;
+            let client = build_client(self.org.as_deref(), None).await?;
 
             let project = client
                 .get_project(ws_slug, proj_slug)

--- a/atomic-cli/src/commands/project/show.rs
+++ b/atomic-cli/src/commands/project/show.rs
@@ -79,7 +79,7 @@ impl Command for ProjectShow {
 
         rt.block_on(async {
             let (ws_slug, proj_slug) = parse_project_path(&self.slug)?;
-            let client = build_client(self.org.as_deref())?;
+            let client = build_client(self.org.as_deref()).await?;
 
             let project = client
                 .get_project(ws_slug, proj_slug)

--- a/atomic-cli/src/commands/project/update.rs
+++ b/atomic-cli/src/commands/project/update.rs
@@ -94,7 +94,7 @@ impl Command for ProjectUpdate {
         })?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref())?;
+            let client = build_client(self.org.as_deref()).await?;
 
             let req = UpdateProjectRequest {
                 name: self.name.clone(),

--- a/atomic-cli/src/commands/project/update.rs
+++ b/atomic-cli/src/commands/project/update.rs
@@ -94,7 +94,7 @@ impl Command for ProjectUpdate {
         })?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref()).await?;
+            let client = build_client(self.org.as_deref(), None).await?;
 
             let req = UpdateProjectRequest {
                 name: self.name.clone(),

--- a/atomic-cli/src/commands/pull/command.rs
+++ b/atomic-cli/src/commands/pull/command.rs
@@ -275,12 +275,12 @@ impl Pull {
     ///
     /// Creates an `HttpRemoteConfig` with the timeout and security settings
     /// specified by the user.
-    fn build_remote_config(&self, remote_url: &str) -> HttpRemoteConfig {
+    async fn build_remote_config(&self, remote_url: &str) -> HttpRemoteConfig {
         let config = HttpRemoteConfig::new()
             .with_timeout(Duration::from_secs(self.timeout))
             .danger_accept_invalid_certs(self.insecure);
 
-        crate::commands::auth::attach_identity(config, remote_url)
+        crate::commands::auth::attach_identity(config, remote_url).await
     }
 
     /// Display the dry run preview.
@@ -368,7 +368,7 @@ impl Pull {
 
         // Connect to remote
         let spinner = create_spinner("Connecting to remote...");
-        let config = self.build_remote_config(&remote_url);
+        let config = self.build_remote_config(&remote_url).await;
         let remote = HttpRemote::with_config(&remote_url, config).map_err(|e| {
             finish_error(&spinner, "Failed to connect");
             convert_remote_error(e, &remote_url)
@@ -885,10 +885,12 @@ mod tests {
     }
 
     /// Test build_remote_config with default settings.
-    #[test]
-    fn test_build_remote_config_default() {
+    #[tokio::test]
+    async fn test_build_remote_config_default() {
         let pull = Pull::new();
-        let config = pull.build_remote_config("http://test.localhost:8080/code");
+        let config = pull
+            .build_remote_config("http://test.localhost:8080/code")
+            .await;
 
         // HttpRemoteConfig doesn't expose fields directly, so we just verify
         // it doesn't panic and returns something
@@ -896,18 +898,22 @@ mod tests {
     }
 
     /// Test build_remote_config with custom timeout.
-    #[test]
-    fn test_build_remote_config_custom_timeout() {
+    #[tokio::test]
+    async fn test_build_remote_config_custom_timeout() {
         let pull = Pull::new().with_timeout(120);
-        let config = pull.build_remote_config("http://test.localhost:8080/code");
+        let config = pull
+            .build_remote_config("http://test.localhost:8080/code")
+            .await;
         assert!(std::mem::size_of_val(&config) > 0);
     }
 
     /// Test build_remote_config with insecure flag.
-    #[test]
-    fn test_build_remote_config_insecure() {
+    #[tokio::test]
+    async fn test_build_remote_config_insecure() {
         let pull = Pull::new().with_insecure(true);
-        let config = pull.build_remote_config("http://test.localhost:8080/code");
+        let config = pull
+            .build_remote_config("http://test.localhost:8080/code")
+            .await;
         assert!(std::mem::size_of_val(&config) > 0);
     }
 

--- a/atomic-cli/src/commands/pull/command.rs
+++ b/atomic-cli/src/commands/pull/command.rs
@@ -153,6 +153,16 @@ pub struct Pull {
     /// Useful for pre-fetching changes or examining them before applying.
     #[arg(long)]
     pub download_only: bool,
+
+    /// Identity to use for authentication.
+    ///
+    /// Overrides the identity inferred from the remote URL subdomain and
+    /// the `identity` field in the remote's config entry.  Must match a
+    /// locally stored identity name (see `atomic identity list`).
+    ///
+    /// Example: `atomic pull --identity alice-staging`
+    #[arg(long)]
+    pub identity: Option<String>,
 }
 
 impl Pull {
@@ -177,6 +187,7 @@ impl Pull {
             insecure: false,
             timeout: DEFAULT_TIMEOUT_SECS,
             download_only: false,
+            identity: None,
         }
     }
 
@@ -228,22 +239,28 @@ impl Pull {
         self
     }
 
+    /// Builder: set an explicit identity name override.
+    pub fn with_identity(mut self, identity: impl Into<String>) -> Self {
+        self.identity = Some(identity.into());
+        self
+    }
+
     // Internal Helper Methods
 
-    /// Resolve the remote URL from the remote name or return as-is if it's a URL.
+    /// Resolve the remote URL and any identity hint from the `--identity` flag.
     ///
-    /// If the remote string looks like a URL (contains "://"), it's returned as-is.
-    /// Otherwise, it's treated as a remote name and looked up in the repository
-    /// configuration.
-    fn resolve_remote_url(&self, repo: &Repository) -> CliResult<String> {
+    /// Returns `(url, identity_hint)` where `identity_hint` comes solely from
+    /// the `--identity` CLI flag. If absent, `attach_identity` falls back to
+    /// URL-subdomain inference.
+    fn resolve_remote_url(&self, repo: &Repository) -> CliResult<(String, Option<String>)> {
         // If it looks like a URL, use it directly
         if self.remote.contains("://") {
-            return Ok(self.remote.clone());
+            return Ok((self.remote.clone(), self.identity.clone()));
         }
 
         // Look up named remote in repository configuration
         match repo.get_remote(&self.remote) {
-            Ok(entry) => Ok(entry.url),
+            Ok(entry) => Ok((entry.url, self.identity.clone())),
             Err(atomic_repository::RepositoryError::RemoteNotFound { .. }) => {
                 Err(CliError::RemoteNotFound {
                     name: self.remote.clone(),
@@ -273,14 +290,18 @@ impl Pull {
 
     /// Build the HTTP remote configuration.
     ///
-    /// Creates an `HttpRemoteConfig` with the timeout and security settings
-    /// specified by the user.
-    async fn build_remote_config(&self, remote_url: &str) -> HttpRemoteConfig {
+    /// `identity_hint` — explicit identity name to use (from `--identity` or
+    /// `RemoteEntry.identity`). When `None`, falls back to URL-based inference.
+    async fn build_remote_config(
+        &self,
+        remote_url: &str,
+        identity_hint: Option<&str>,
+    ) -> HttpRemoteConfig {
         let config = HttpRemoteConfig::new()
             .with_timeout(Duration::from_secs(self.timeout))
             .danger_accept_invalid_certs(self.insecure);
 
-        crate::commands::auth::attach_identity(config, remote_url).await
+        crate::commands::auth::attach_identity(config, remote_url, identity_hint).await
     }
 
     /// Display the dry run preview.
@@ -352,8 +373,8 @@ impl Pull {
         let repo_root = find_repository_root()?;
         let repo = Repository::open(&repo_root).map_err(CliError::Repository)?;
 
-        // Resolve remote URL
-        let remote_url = self.resolve_remote_url(&repo)?;
+        // Resolve remote URL and identity hint
+        let (remote_url, identity_hint) = self.resolve_remote_url(&repo)?;
 
         // Determine views
         let local_view = self.get_local_view(&repo);
@@ -368,7 +389,9 @@ impl Pull {
 
         // Connect to remote
         let spinner = create_spinner("Connecting to remote...");
-        let config = self.build_remote_config(&remote_url).await;
+        let config = self
+            .build_remote_config(&remote_url, identity_hint.as_deref())
+            .await;
         let remote = HttpRemote::with_config(&remote_url, config).map_err(|e| {
             finish_error(&spinner, "Failed to connect");
             convert_remote_error(e, &remote_url)
@@ -889,7 +912,7 @@ mod tests {
     async fn test_build_remote_config_default() {
         let pull = Pull::new();
         let config = pull
-            .build_remote_config("http://test.localhost:8080/code")
+            .build_remote_config("http://test.localhost:8080/code", None)
             .await;
 
         // HttpRemoteConfig doesn't expose fields directly, so we just verify
@@ -902,7 +925,7 @@ mod tests {
     async fn test_build_remote_config_custom_timeout() {
         let pull = Pull::new().with_timeout(120);
         let config = pull
-            .build_remote_config("http://test.localhost:8080/code")
+            .build_remote_config("http://test.localhost:8080/code", None)
             .await;
         assert!(std::mem::size_of_val(&config) > 0);
     }
@@ -912,7 +935,7 @@ mod tests {
     async fn test_build_remote_config_insecure() {
         let pull = Pull::new().with_insecure(true);
         let config = pull
-            .build_remote_config("http://test.localhost:8080/code")
+            .build_remote_config("http://test.localhost:8080/code", None)
             .await;
         assert!(std::mem::size_of_val(&config) > 0);
     }

--- a/atomic-cli/src/commands/push/command.rs
+++ b/atomic-cli/src/commands/push/command.rs
@@ -310,6 +310,14 @@ impl Push {
             hint(&remote_url)
         );
 
+        // Fail fast if we have no usable credentials for this remote. A push is
+        // a write that always requires auth; without a credential the server's
+        // negotiation endpoints return an ambiguous 404 (private projects are
+        // deliberately masked), which surfaces as a misleading "view not found".
+        // Catching the missing credential here gives the user an accurate,
+        // actionable error instead.
+        crate::commands::auth::check_push_credentials(&remote_url)?;
+
         // Connect to remote
         let spinner = create_spinner("Connecting to remote...");
         let config = self.build_remote_config(&remote_url).await;

--- a/atomic-cli/src/commands/push/command.rs
+++ b/atomic-cli/src/commands/push/command.rs
@@ -329,7 +329,7 @@ impl Push {
         // deliberately masked), which surfaces as a misleading "view not found".
         // Catching the missing credential here gives the user an accurate,
         // actionable error instead.
-        crate::commands::auth::check_push_credentials(&remote_url)?;
+        crate::commands::auth::check_push_credentials(&remote_url, identity_hint.as_deref())?;
 
         // Connect to remote
         let spinner = create_spinner("Connecting to remote...");

--- a/atomic-cli/src/commands/push/command.rs
+++ b/atomic-cli/src/commands/push/command.rs
@@ -249,12 +249,12 @@ impl Push {
     }
 
     /// Build the HTTP remote configuration.
-    fn build_remote_config(&self, remote_url: &str) -> HttpRemoteConfig {
+    async fn build_remote_config(&self, remote_url: &str) -> HttpRemoteConfig {
         let config = HttpRemoteConfig::new()
             .with_timeout(Duration::from_secs(self.timeout))
             .danger_accept_invalid_certs(self.insecure);
 
-        crate::commands::auth::attach_identity(config, remote_url)
+        crate::commands::auth::attach_identity(config, remote_url).await
     }
 
     /// Display the dry run preview.
@@ -312,7 +312,7 @@ impl Push {
 
         // Connect to remote
         let spinner = create_spinner("Connecting to remote...");
-        let config = self.build_remote_config(&remote_url);
+        let config = self.build_remote_config(&remote_url).await;
         let remote = HttpRemote::with_config(&remote_url, config).map_err(|e| {
             finish_error(&spinner, "Failed to connect");
             convert_remote_error(e, &remote_url)
@@ -911,27 +911,33 @@ mod tests {
 
     // Remote Config Tests
 
-    #[test]
-    fn test_build_remote_config_default() {
+    #[tokio::test]
+    async fn test_build_remote_config_default() {
         let push = Push::new();
-        let config = push.build_remote_config("http://test.localhost:8080/code");
+        let config = push
+            .build_remote_config("http://test.localhost:8080/code")
+            .await;
 
         assert_eq!(config.timeout, Duration::from_secs(DEFAULT_TIMEOUT_SECS));
         assert!(!config.danger_accept_invalid_certs);
     }
 
-    #[test]
-    fn test_build_remote_config_custom_timeout() {
+    #[tokio::test]
+    async fn test_build_remote_config_custom_timeout() {
         let push = Push::new().with_timeout(120);
-        let config = push.build_remote_config("http://test.localhost:8080/code");
+        let config = push
+            .build_remote_config("http://test.localhost:8080/code")
+            .await;
 
         assert_eq!(config.timeout, Duration::from_secs(120));
     }
 
-    #[test]
-    fn test_build_remote_config_insecure() {
+    #[tokio::test]
+    async fn test_build_remote_config_insecure() {
         let push = Push::new().with_insecure(true);
-        let config = push.build_remote_config("http://test.localhost:8080/code");
+        let config = push
+            .build_remote_config("http://test.localhost:8080/code")
+            .await;
 
         assert!(config.danger_accept_invalid_certs);
     }

--- a/atomic-cli/src/commands/push/command.rs
+++ b/atomic-cli/src/commands/push/command.rs
@@ -121,6 +121,16 @@ pub struct Push {
     /// Request timeout in seconds.
     #[arg(long, default_value_t = DEFAULT_TIMEOUT_SECS)]
     pub timeout: u64,
+
+    /// Identity to use for authentication.
+    ///
+    /// Overrides the identity inferred from the remote URL subdomain and
+    /// the `identity` field in the remote's config entry.  Must match a
+    /// locally stored identity name (see `atomic identity list`).
+    ///
+    /// Example: `atomic push --identity alice-staging`
+    #[arg(long)]
+    pub identity: Option<String>,
 }
 
 impl Push {
@@ -145,6 +155,7 @@ impl Push {
             all: false,
             insecure: false,
             timeout: DEFAULT_TIMEOUT_SECS,
+            identity: None,
         }
     }
 
@@ -196,31 +207,26 @@ impl Push {
         self
     }
 
-    /// Resolve the remote URL.
+    /// Builder: set an explicit identity name override.
+    pub fn with_identity(mut self, identity: impl Into<String>) -> Self {
+        self.identity = Some(identity.into());
+        self
+    }
+
+    /// Resolve the remote URL and any identity hint from the `--identity` flag.
     ///
-    /// If the remote is a URL (contains "://"), returns it directly.
-    /// Otherwise, looks up the named remote in the repository configuration.
-    ///
-    /// # Arguments
-    ///
-    /// * `repo` - The repository to look up configuration from
-    ///
-    /// # Returns
-    ///
-    /// The resolved remote URL.
-    ///
-    /// # Errors
-    ///
-    /// Returns `CliError::RemoteNotFound` if the named remote doesn't exist.
-    fn resolve_remote_url(&self, repo: &Repository) -> CliResult<String> {
+    /// Returns `(url, identity_hint)` where `identity_hint` comes solely from
+    /// the `--identity` CLI flag. If absent, `attach_identity` falls back to
+    /// URL-subdomain inference.
+    fn resolve_remote_url(&self, repo: &Repository) -> CliResult<(String, Option<String>)> {
         // If it looks like a URL, use it directly
         if self.remote.contains("://") {
-            return Ok(self.remote.clone());
+            return Ok((self.remote.clone(), self.identity.clone()));
         }
 
         // Look up named remote in repository configuration
         match repo.get_remote(&self.remote) {
-            Ok(entry) => Ok(entry.url),
+            Ok(entry) => Ok((entry.url, self.identity.clone())),
             Err(atomic_repository::RepositoryError::RemoteNotFound { .. }) => {
                 Err(CliError::RemoteNotFound {
                     name: self.remote.clone(),
@@ -249,12 +255,19 @@ impl Push {
     }
 
     /// Build the HTTP remote configuration.
-    async fn build_remote_config(&self, remote_url: &str) -> HttpRemoteConfig {
+    ///
+    /// `identity_hint` — explicit identity name to use (from `--identity` or
+    /// `RemoteEntry.identity`). When `None`, falls back to URL-based inference.
+    async fn build_remote_config(
+        &self,
+        remote_url: &str,
+        identity_hint: Option<&str>,
+    ) -> HttpRemoteConfig {
         let config = HttpRemoteConfig::new()
             .with_timeout(Duration::from_secs(self.timeout))
             .danger_accept_invalid_certs(self.insecure);
 
-        crate::commands::auth::attach_identity(config, remote_url).await
+        crate::commands::auth::attach_identity(config, remote_url, identity_hint).await
     }
 
     /// Display the dry run preview.
@@ -295,8 +308,8 @@ impl Push {
         let repo_root = find_repository_root()?;
         let repo = Repository::open(&repo_root).map_err(CliError::Repository)?;
 
-        // Resolve remote URL
-        let remote_url = self.resolve_remote_url(&repo)?;
+        // Resolve remote URL and identity hint
+        let (remote_url, identity_hint) = self.resolve_remote_url(&repo)?;
 
         // Determine views
         let local_view = self.get_local_view(&repo);
@@ -320,7 +333,9 @@ impl Push {
 
         // Connect to remote
         let spinner = create_spinner("Connecting to remote...");
-        let config = self.build_remote_config(&remote_url).await;
+        let config = self
+            .build_remote_config(&remote_url, identity_hint.as_deref())
+            .await;
         let remote = HttpRemote::with_config(&remote_url, config).map_err(|e| {
             finish_error(&spinner, "Failed to connect");
             convert_remote_error(e, &remote_url)
@@ -923,7 +938,7 @@ mod tests {
     async fn test_build_remote_config_default() {
         let push = Push::new();
         let config = push
-            .build_remote_config("http://test.localhost:8080/code")
+            .build_remote_config("http://test.localhost:8080/code", None)
             .await;
 
         assert_eq!(config.timeout, Duration::from_secs(DEFAULT_TIMEOUT_SECS));
@@ -934,7 +949,7 @@ mod tests {
     async fn test_build_remote_config_custom_timeout() {
         let push = Push::new().with_timeout(120);
         let config = push
-            .build_remote_config("http://test.localhost:8080/code")
+            .build_remote_config("http://test.localhost:8080/code", None)
             .await;
 
         assert_eq!(config.timeout, Duration::from_secs(120));
@@ -944,7 +959,7 @@ mod tests {
     async fn test_build_remote_config_insecure() {
         let push = Push::new().with_insecure(true);
         let config = push
-            .build_remote_config("http://test.localhost:8080/code")
+            .build_remote_config("http://test.localhost:8080/code", None)
             .await;
 
         assert!(config.danger_accept_invalid_certs);

--- a/atomic-cli/src/commands/push/helpers.rs
+++ b/atomic-cli/src/commands/push/helpers.rs
@@ -361,6 +361,27 @@ fn format_bytes(bytes: u64) -> String {
 
 // Error Conversion
 
+/// Build the user-facing message for a "not found" (HTTP 404) response during
+/// a push.
+///
+/// The server deliberately masks private projects: it returns 404 to callers
+/// who are not authenticated/authorized rather than revealing that the project
+/// exists. Because a push is a write that always requires auth, a 404 almost
+/// always means the caller's credentials are missing/expired or they lack push
+/// access — not that the project/view is genuinely absent. The message spells
+/// out both possibilities and points at the remedy.
+///
+/// `target` describes what was not found, e.g. `"project/view 'dev'"` or
+/// `"the project"`.
+fn not_found_push_message(target: &str) -> String {
+    format!(
+        "Remote returned 'not found' for {target}. This means either it \
+         doesn't exist, or you're not authenticated/authorized to push to it. \
+         Make sure your identity is registered with the server \
+         (`atomic identity register <server-url>`) and that you have push access."
+    )
+}
+
 /// Convert a remote error to a CLI error.
 ///
 /// Maps the various remote error types to appropriate CLI error types
@@ -383,12 +404,19 @@ pub fn convert_remote_error(err: RemoteError, url: &str) -> CliError {
         RemoteError::AuthenticationFailed { .. } => CliError::AuthenticationFailed {
             remote: url.to_string(),
         },
+        // A 404 on a push is ambiguous. Private projects are deliberately
+        // masked: the server returns "not found" to anyone who isn't
+        // authenticated/authorized, so a missing project and a private one we
+        // can't see are indistinguishable on the wire. A push is a *write* that
+        // always requires auth, so the most likely cause is missing/expired
+        // credentials — not a genuinely-absent project/view. Say so, and point
+        // at the remedy, instead of the misleading "view not found".
         RemoteError::RepositoryNotFound { .. } => CliError::RemoteError {
-            message: "Repository not found on remote".to_string(),
+            message: not_found_push_message("the project"),
             url: Some(url.to_string()),
         },
         RemoteError::ViewNotFound { view } => CliError::RemoteError {
-            message: format!("View '{}' not found on remote", view),
+            message: not_found_push_message(&format!("project/view '{}'", view)),
             url: Some(url.to_string()),
         },
         RemoteError::ChangeNotFound { hash } => CliError::ChangeNotFound { hash },
@@ -598,12 +626,20 @@ mod tests {
 
     #[test]
     fn test_convert_repo_not_found() {
+        // A 404 for the repository/project on a push is ambiguous (the server
+        // masks private projects), so the message must point at auth rather
+        // than implying the project is simply absent.
         let err = RemoteError::repo_not_found("http://example.com/repo");
         let cli_err = convert_remote_error(err, "http://example.com/repo");
 
         match cli_err {
             CliError::RemoteError { message, .. } => {
+                let lower = message.to_lowercase();
                 assert!(message.contains("not found"));
+                // Mentions the authentication/authorization possibility.
+                assert!(lower.contains("authenticated") || lower.contains("authorized"));
+                // Points at the remedy.
+                assert!(message.contains("atomic identity register"));
             }
             _ => panic!("Expected RemoteError"),
         }
@@ -611,13 +647,21 @@ mod tests {
 
     #[test]
     fn test_convert_view_not_found() {
+        // The server returns 404 both for a genuinely-missing view and for a
+        // private one the caller can't see. On a push (a write that needs
+        // auth) the message must name the view *and* explain that this may be
+        // an auth/authorization problem, with the remedy to run identity
+        // register — not the misleading "view not found".
         let err = RemoteError::view_not_found("main");
         let cli_err = convert_remote_error(err, "http://example.com");
 
         match cli_err {
             CliError::RemoteError { message, .. } => {
+                let lower = message.to_lowercase();
                 assert!(message.contains("main"));
                 assert!(message.contains("not found"));
+                assert!(lower.contains("authenticated") || lower.contains("authorized"));
+                assert!(message.contains("atomic identity register"));
             }
             _ => panic!("Expected RemoteError"),
         }

--- a/atomic-cli/src/commands/query/mod.rs
+++ b/atomic-cli/src/commands/query/mod.rs
@@ -42,6 +42,23 @@ pub enum QueryCommands {
     /// ```
     Neighbors(QueryNeighbors),
 
+    /// Find all functions that call a given entity.
+    ///
+    /// Queries the knowledge graph for CALLS edges whose destination is the
+    /// specified entity node. Useful for blast-radius analysis: see every
+    /// function that breaks if this function's signature changes.
+    ///
+    /// Run `atomic vault query enrich` first to populate CALLS edges.
+    /// Run `atomic vault query entities <file>` to discover entity IDs.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// atomic vault query callers entity:src/auth.rs:verify:42
+    /// atomic vault query callers entity:src/auth.rs:verify:42 --json
+    /// ```
+    Callers(QueryCallers),
+
     /// List tree-sitter entities (functions, classes, types) in a file.
     ///
     /// Parses the file with tree-sitter and prints all extracted entities.
@@ -187,6 +204,7 @@ impl Command for Query {
         match &self.command {
             QueryCommands::Search(cmd) => cmd.run(),
             QueryCommands::Neighbors(cmd) => cmd.run(),
+            QueryCommands::Callers(cmd) => cmd.run(),
             QueryCommands::Entities(cmd) => cmd.run(),
             QueryCommands::Index(cmd) => cmd.run(),
             QueryCommands::Code(cmd) => cmd.run(),
@@ -1152,6 +1170,95 @@ impl Command for QueryNeighbors {
 }
 
 // ---------------------------------------------------------------------------
+// QueryCallers — find all functions that call a given entity
+// ---------------------------------------------------------------------------
+
+/// Find all functions that call a given entity node.
+#[derive(Parser, Debug)]
+pub struct QueryCallers {
+    /// Full entity node ID, e.g. `entity:src/auth.rs:verify:42`.
+    ///
+    /// Use `atomic vault query entities <file>` to list entity IDs for a file,
+    /// then pass one here.
+    pub entity_id: String,
+
+    /// Output as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Command for QueryCallers {
+    fn run(&self) -> CliResult<()> {
+        let root = find_repository_root()?;
+        let repo = Repository::open(&root).map_err(CliError::Repository)?;
+
+        let subgraph = repo
+            .vault_kg_neighbors(&self.entity_id, 1)
+            .map_err(CliError::Repository)?;
+
+        // Incoming CALLS edges: from_id is the caller, to_id is our entity.
+        let caller_edges: Vec<&KgEdge> = subgraph
+            .edges
+            .iter()
+            .filter(|e| e.kind.to_uppercase() == "CALLS" && e.to_id == self.entity_id)
+            .collect();
+
+        if self.json {
+            let out: Vec<serde_json::Value> = caller_edges
+                .iter()
+                .map(|e| {
+                    let node = subgraph.nodes.iter().find(|n| n.id == e.from_id);
+                    serde_json::json!({
+                        "caller_id": e.from_id,
+                        "summary": node.and_then(|n| n.summary.as_deref()),
+                    })
+                })
+                .collect();
+            println!("{}", serde_json::to_string_pretty(&out).unwrap());
+            return Ok(());
+        }
+
+        if caller_edges.is_empty() {
+            println!("No callers found for '{}'.", self.entity_id);
+            // Distinguish "no callers" from "CALLS edges not yet enriched"
+            let has_any_calls = subgraph
+                .edges
+                .iter()
+                .any(|e| e.kind.to_uppercase() == "CALLS");
+            if !has_any_calls {
+                println!(
+                    "Hint: run `atomic vault query enrich` to populate CALLS edges, \
+                    then retry."
+                );
+            } else {
+                println!("This function is an entry point — nothing in the repo calls it.");
+            }
+        } else {
+            println!("{} caller(s) of {}:\n", caller_edges.len(), self.entity_id);
+            for edge in &caller_edges {
+                // Parse entity:{file}:{name}:{line} for a readable display
+                let display = if let Some(rest) = edge.from_id.strip_prefix("entity:") {
+                    let last = rest.rfind(':').unwrap_or(rest.len());
+                    let inner = &rest[..last]; // {file}:{name}
+                    let sig = subgraph
+                        .nodes
+                        .iter()
+                        .find(|n| n.id == edge.from_id)
+                        .and_then(|n| n.summary.as_deref())
+                        .map(|s| format!("  [{}]", s.lines().next().unwrap_or(s)));
+                    format!("  {}{}", inner, sig.unwrap_or_default())
+                } else {
+                    format!("  {}", edge.from_id)
+                };
+                println!("{display}");
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
 // QueryEntities — list tree-sitter entities in a file
 // ---------------------------------------------------------------------------
 
@@ -1166,7 +1273,6 @@ pub struct QueryEntities {
     pub json: bool,
 }
 
-#[cfg(feature = "ast")]
 impl Command for QueryEntities {
     fn run(&self) -> CliResult<()> {
         let root = find_repository_root()?;
@@ -1208,14 +1314,6 @@ impl Command for QueryEntities {
             println!("\n{} entity(ies) in {}", entities.len(), self.path);
         }
 
-        Ok(())
-    }
-}
-
-#[cfg(not(feature = "ast"))]
-impl Command for QueryEntities {
-    fn run(&self) -> CliResult<()> {
-        println!("Tree-sitter support not enabled. Rebuild with --features ast.");
         Ok(())
     }
 }
@@ -1420,32 +1518,36 @@ impl Command for QueryEnrich {
         }
 
         // Phase 5: AST entities
-        #[cfg(feature = "ast")]
-        {
-            let spinner = create_spinner("Extracting entities (tree-sitter)...");
-            match repo.kg_enrich_entities() {
-                Ok(n) => {
-                    total.entities = n;
-                    finish_success(&spinner, &format!("{} entit(ies)", n));
-                }
-                Err(e) => finish_error(&spinner, &format!("entities failed: {}", e)),
+        let spinner = create_spinner("Extracting entities (tree-sitter)...");
+        match repo.kg_enrich_entities() {
+            Ok(n) => {
+                total.entities = n;
+                finish_success(&spinner, &format!("{} entit(ies)", n));
             }
+            Err(e) => finish_error(&spinner, &format!("entities failed: {}", e)),
         }
 
         // Phase 6: INCLUDES edges
-        #[cfg(feature = "ast")]
-        {
-            let spinner = create_spinner("Resolving includes...");
-            match repo.kg_enrich_includes() {
-                Ok(n) => {
-                    total.includes = n;
-                    finish_success(&spinner, &format!("{} include(s)", n));
-                }
-                Err(e) => finish_error(&spinner, &format!("includes failed: {}", e)),
+        let spinner = create_spinner("Resolving includes...");
+        match repo.kg_enrich_includes() {
+            Ok(n) => {
+                total.includes = n;
+                finish_success(&spinner, &format!("{} include(s)", n));
             }
+            Err(e) => finish_error(&spinner, &format!("includes failed: {}", e)),
         }
 
-        // Phase 7: Content search index (syntext)
+        // Phase 7: CALLS edges (caller entity → callee entity)
+        let spinner = create_spinner("Resolving call sites...");
+        match repo.kg_enrich_calls() {
+            Ok(n) => {
+                total.calls = n;
+                finish_success(&spinner, &format!("{} call(s)", n));
+            }
+            Err(e) => finish_error(&spinner, &format!("calls failed: {}", e)),
+        }
+
+        // Phase 8: Content search index (syntext)
         let spinner = create_spinner("Building content index...");
         match atomic_repository::build_content_index(&root) {
             Ok(()) => {

--- a/atomic-cli/src/commands/sandbox.rs
+++ b/atomic-cli/src/commands/sandbox.rs
@@ -1,0 +1,245 @@
+//! The `sandbox` command for provisioning concurrent agent workspaces.
+//!
+//! A sandbox is a private, copy-on-write clone of the repository's working
+//! tree. Several agents can each work in their own sandbox at once — isolated
+//! build artifacts (`node_modules`, `target`), no collisions — while sharing
+//! the single canonical graph. On filesystems that support reflinks (APFS,
+//! Btrfs, XFS, ReFS) the clone shares blocks until written, so the disk cost is
+//! the delta, not a full copy.
+//!
+//! The copy-on-write clone is performed in-process by the `atomic` binary
+//! itself (via the `reflink-copy` crate) — no external `cp` is invoked.
+//!
+//! # Usage
+//!
+//! ```text
+//! atomic sandbox create <NAME> [--dest <PATH>] [--view <VIEW>]
+//! ```
+
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+use atomic_repository::{Repository, SealOptions, StageOptions};
+
+use crate::commands::{find_repository_root, Command};
+use crate::error::{CliError, CliResult};
+
+/// Provision and manage concurrent agent sandboxes.
+#[derive(Debug, clap::Args)]
+#[command(name = "sandbox")]
+pub struct Sandbox {
+    #[command(subcommand)]
+    pub command: SandboxCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SandboxCommands {
+    /// Create a sandbox: a copy-on-write clone of the working tree.
+    Create(Create),
+
+    /// Stage a sandbox as a layered OCI image (shared base + thin delta).
+    ///
+    /// Built for the inner loop: the base layer is the shared view, the delta
+    /// layer is only what changed. Ship the delta to CI / circuit-breaker
+    /// workflows while the base is pulled once and cached.
+    Stage(Stage),
+
+    /// Seal a view as a flattened, self-contained OCI runtime image.
+    ///
+    /// Produces a single-layer deployable image of the full merged state —
+    /// "run this exact version" anywhere an OCI runtime is available.
+    Seal(Seal),
+}
+
+impl Command for Sandbox {
+    fn run(&self) -> CliResult<()> {
+        match &self.command {
+            SandboxCommands::Create(cmd) => cmd.run(),
+            SandboxCommands::Stage(cmd) => cmd.run(),
+            SandboxCommands::Seal(cmd) => cmd.run(),
+        }
+    }
+}
+
+/// Create a sandbox working tree for an agent.
+///
+/// Clones the current working tree (copy-on-write where supported) into a
+/// private directory. The sandbox shares the canonical graph — it is not a
+/// separate repository.
+#[derive(Parser, Debug)]
+pub struct Create {
+    /// Name of the sandbox (used in the default destination path).
+    #[arg(value_name = "NAME")]
+    pub name: String,
+
+    /// Destination directory for the sandbox working tree.
+    ///
+    /// Defaults to `<repo-parent>/<repo-name>-sandboxes/<name>`.
+    #[arg(long, value_name = "PATH")]
+    pub dest: Option<PathBuf>,
+
+    /// View the sandbox operates on. Defaults to the current view.
+    ///
+    /// Mutually exclusive with `--from`.
+    #[arg(long, value_name = "VIEW", conflicts_with = "from")]
+    pub view: Option<String>,
+
+    /// Create a new draft view (named after the sandbox) from this view, and
+    /// point the sandbox at it.
+    ///
+    /// With `--from dev`, the sandbox gets its own draft view forked from
+    /// `dev`, so the agent's records land in that draft rather than a shared
+    /// view — isolating each agent's history as well as its files.
+    #[arg(long, value_name = "VIEW")]
+    pub from: Option<String>,
+}
+
+impl Create {
+    fn default_dest(repo_root: &std::path::Path, name: &str) -> PathBuf {
+        let repo_name = repo_root
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "repo".to_string());
+        let parent = repo_root.parent().unwrap_or(repo_root);
+        parent.join(format!("{repo_name}-sandboxes")).join(name)
+    }
+}
+
+impl Command for Create {
+    fn run(&self) -> CliResult<()> {
+        let root = find_repository_root()?;
+        let mut repo = Repository::open(&root).map_err(CliError::Repository)?;
+
+        let dest = self
+            .dest
+            .clone()
+            .unwrap_or_else(|| Self::default_dest(&root, &self.name));
+
+        if dest.exists() {
+            return Err(CliError::InvalidArgument {
+                message: format!("destination already exists: {}", dest.display()),
+            });
+        }
+
+        // Resolve the view this sandbox records into:
+        //   --from <v>  → create a new draft named after the sandbox, forked from <v>
+        //   --view <v>  → use the existing view <v>
+        //   (neither)   → the current view
+        let (view, created_draft) = if let Some(from) = &self.from {
+            repo.create_view_from(&self.name, from)
+                .map_err(CliError::Repository)?;
+            (self.name.clone(), true)
+        } else {
+            let v = self
+                .view
+                .clone()
+                .unwrap_or_else(|| repo.current_view().to_string());
+            (v, false)
+        };
+
+        let count = repo
+            .provision_sandbox(&dest, &view)
+            .map_err(CliError::Repository)?;
+
+        println!("Sandbox '{}' created", self.name);
+        println!("  Working tree: {}", dest.display());
+        if created_draft {
+            println!(
+                "  View:         {view} (new draft from '{}')",
+                self.from.as_deref().unwrap_or("")
+            );
+        } else {
+            println!("  View:         {view}");
+        }
+        println!("  Files cloned: {count} (copy-on-write where supported)");
+        println!(
+            "  Graph:        shared (canonical {}/.atomic)",
+            root.display()
+        );
+
+        Ok(())
+    }
+}
+
+/// Stage a view as a layered OCI image (base + delta).
+#[derive(Parser, Debug)]
+pub struct Stage {
+    /// The view to stage (the sandbox's draft view).
+    #[arg(value_name = "VIEW")]
+    pub view: String,
+
+    /// The shared base view the delta is computed against.
+    #[arg(long, value_name = "VIEW", default_value = "dev")]
+    pub base: String,
+
+    /// Output directory for the OCI image layout.
+    #[arg(long, short = 'o', value_name = "DIR")]
+    pub out: PathBuf,
+}
+
+impl Command for Stage {
+    fn run(&self) -> CliResult<()> {
+        let root = find_repository_root()?;
+        let repo = Repository::open(&root).map_err(CliError::Repository)?;
+
+        let result = repo
+            .stage(StageOptions {
+                view: self.view.clone(),
+                base_view: self.base.clone(),
+                out: self.out.clone(),
+            })
+            .map_err(CliError::Repository)?;
+
+        println!("Staged '{}' (delta over '{}')", self.view, self.base);
+        println!("  Image:        {}", result.out.display());
+        println!("  Manifest:     {}", result.manifest_digest);
+        println!("  Base layer:   {}", result.base_diff_id);
+        println!("  Delta files:  {}", result.delta_files);
+
+        Ok(())
+    }
+}
+
+/// Seal a view as a flattened, self-contained OCI runtime image.
+#[derive(Parser, Debug)]
+pub struct Seal {
+    /// The view to seal.
+    #[arg(value_name = "VIEW")]
+    pub view: String,
+
+    /// Output directory for the OCI image layout.
+    #[arg(long, short = 'o', value_name = "DIR")]
+    pub out: PathBuf,
+
+    /// Image entrypoint argv (repeatable), e.g. `--entrypoint /app/run`.
+    #[arg(long, value_name = "ARG")]
+    pub entrypoint: Vec<String>,
+
+    /// Image environment variable (repeatable), e.g. `--env PORT=8080`.
+    #[arg(long, value_name = "KEY=VAL")]
+    pub env: Vec<String>,
+}
+
+impl Command for Seal {
+    fn run(&self) -> CliResult<()> {
+        let root = find_repository_root()?;
+        let repo = Repository::open(&root).map_err(CliError::Repository)?;
+
+        let result = repo
+            .seal(SealOptions {
+                view: self.view.clone(),
+                out: self.out.clone(),
+                entrypoint: self.entrypoint.clone(),
+                env: self.env.clone(),
+            })
+            .map_err(CliError::Repository)?;
+
+        println!("Sealed '{}'", self.view);
+        println!("  Image:        {}", result.out.display());
+        println!("  Manifest:     {}", result.manifest_digest);
+        println!("  Files:        {}", result.files);
+
+        Ok(())
+    }
+}

--- a/atomic-cli/src/commands/server/mod.rs
+++ b/atomic-cli/src/commands/server/mod.rs
@@ -1,0 +1,500 @@
+//! Server profile management commands.
+//!
+//! This module provides commands for managing named server profiles in
+//! `~/.atomic/config.toml`. Server profiles let you switch between
+//! environments (staging, production, local) with a single flag or by
+//! setting a default.
+//!
+//! # Available Subcommands
+//!
+//! - `server` (no args) — List all configured server profiles
+//! - `server add <name> <url>` — Add a new server profile
+//! - `server set <name>` — Switch the active default server profile
+//! - `server show [name]` — Show details for a profile
+//! - `server remove <name>` — Remove a server profile
+//! - `server set-identity <name> <identity>` — Bind an identity to a profile
+//!
+//! # Examples
+//!
+//! ```bash
+//! # List server profiles
+//! atomic server
+//!
+//! # Add a staging profile
+//! atomic server add staging https://staging.atomic.storage --identity alice-staging
+//!
+//! # Switch to staging
+//! atomic server set staging
+//!
+//! # Switch back to production (legacy [server] block)
+//! atomic server set --default
+//!
+//! # Show the active profile
+//! atomic server show
+//!
+//! # Bind an identity to an existing profile
+//! atomic server set-identity prod alice-prod
+//! ```
+
+use clap::{Parser, Subcommand};
+
+use atomic_config::{GlobalConfig, ServerConfig};
+
+use crate::commands::Command;
+use crate::error::{CliError, CliResult};
+use crate::output::{print_hint, print_success};
+
+// Server Command
+
+/// Manage named server profiles.
+///
+/// Server profiles let you store multiple atomic-storage server configurations
+/// (e.g. staging and production) and switch between them easily. Each profile
+/// can have its own URL, default org, and identity.
+///
+/// Profiles are stored under `[servers.*]` in `~/.atomic/config.toml`.
+/// Management commands use the active profile (set with `atomic server set`)
+/// unless you override it per-command with `--server <name>`.
+#[derive(Debug, Clone, Parser)]
+#[command(name = "server")]
+pub struct ServerCmd {
+    /// Subcommand to execute.
+    #[command(subcommand)]
+    pub command: Option<ServerSubcommand>,
+}
+
+/// Server subcommands.
+#[derive(Debug, Clone, Subcommand)]
+pub enum ServerSubcommand {
+    /// Add a new server profile.
+    #[command(name = "add")]
+    Add(ServerAdd),
+
+    /// Switch the active default server profile.
+    ///
+    /// Use `--default` to clear the named profile and revert to the legacy
+    /// `[server]` block.
+    #[command(name = "set")]
+    Set(ServerSet),
+
+    /// Show details for a server profile.
+    ///
+    /// Without a name, shows the currently active profile.
+    #[command(name = "show")]
+    Show(ServerShow),
+
+    /// Remove a server profile.
+    #[command(name = "remove", visible_alias = "rm")]
+    Remove(ServerRemove),
+
+    /// Bind an identity to a server profile.
+    ///
+    /// Management commands targeting this server will use the specified
+    /// identity instead of the global default.
+    #[command(name = "set-identity")]
+    SetIdentity(ServerSetIdentity),
+}
+
+// Subcommand Structs
+
+/// Add a new server profile.
+#[derive(Debug, Clone, Parser)]
+pub struct ServerAdd {
+    /// Name for the new server profile (e.g. "staging", "prod").
+    #[arg(value_name = "NAME")]
+    pub name: String,
+
+    /// Base URL of the atomic-storage server.
+    #[arg(value_name = "URL")]
+    pub url: String,
+
+    /// Default organization slug for this server.
+    #[arg(long)]
+    pub org: Option<String>,
+
+    /// Identity name to use when connecting to this server.
+    #[arg(long)]
+    pub identity: Option<String>,
+
+    /// Make this the active default server immediately.
+    #[arg(long)]
+    pub set_default: bool,
+}
+
+/// Switch the active default server profile.
+#[derive(Debug, Clone, Parser)]
+pub struct ServerSet {
+    /// Name of the server profile to make active.
+    ///
+    /// Omit (with `--default`) to clear the named profile and revert to
+    /// the legacy `[server]` block.
+    #[arg(value_name = "NAME", required_unless_present = "revert")]
+    pub name: Option<String>,
+
+    /// Revert to the legacy `[server]` block (clear `default_server`).
+    #[arg(long = "default", conflicts_with = "name")]
+    pub revert: bool,
+}
+
+/// Show details for a server profile.
+#[derive(Debug, Clone, Parser)]
+pub struct ServerShow {
+    /// Name of the profile to show. Defaults to the active profile.
+    #[arg(value_name = "NAME")]
+    pub name: Option<String>,
+}
+
+/// Remove a server profile.
+#[derive(Debug, Clone, Parser)]
+pub struct ServerRemove {
+    /// Name of the server profile to remove.
+    #[arg(value_name = "NAME")]
+    pub name: String,
+}
+
+/// Bind an identity to a server profile.
+#[derive(Debug, Clone, Parser)]
+pub struct ServerSetIdentity {
+    /// Name of the server profile to update.
+    #[arg(value_name = "NAME")]
+    pub name: String,
+
+    /// Identity name to bind. Use an empty string or `--clear` to remove.
+    #[arg(value_name = "IDENTITY", required_unless_present = "clear")]
+    pub identity: Option<String>,
+
+    /// Remove the identity binding (revert to global default).
+    #[arg(long, conflicts_with = "identity")]
+    pub clear: bool,
+}
+
+// Implementation
+
+impl ServerCmd {
+    /// List all configured server profiles.
+    fn list_servers(&self) -> CliResult<()> {
+        let config = GlobalConfig::load()
+            .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load config: {}", e)))?;
+
+        if config.servers.is_empty() {
+            print_hint(
+                "No named server profiles configured.\n  \
+                 Use 'atomic server add <name> <url>' to add one.\n  \
+                 The legacy [server] block is always available as the default.",
+            );
+            if config.server.is_configured() {
+                println!();
+                println!(
+                    "  Active server (legacy): {}",
+                    config.server.url.as_deref().unwrap_or("(none)")
+                );
+                if let Some(ref org) = config.server.default_org {
+                    println!("  Default org:            {}", org);
+                }
+            }
+            return Ok(());
+        }
+
+        let active = config.default_server.as_deref();
+
+        for (name, profile) in &config.servers {
+            let is_active = Some(name.as_str()) == active;
+            let active_marker = if is_active { " *" } else { "" };
+            let url = profile.url.as_deref().unwrap_or("(no url)");
+            let org = profile
+                .default_org
+                .as_deref()
+                .map(|o| format!(", org: {}", o))
+                .unwrap_or_default();
+            let identity = profile
+                .identity
+                .as_deref()
+                .map(|i| format!(", identity: {}", i))
+                .unwrap_or_default();
+
+            println!("{}{}\t{}{}{}", name, active_marker, url, org, identity);
+        }
+
+        if active.is_none() {
+            println!();
+            print_hint("No named profile is active — using the legacy [server] block.");
+            print_hint("Run 'atomic server set <name>' to activate a profile.");
+        }
+
+        Ok(())
+    }
+
+    /// Add a new server profile.
+    fn add_server(&self, add: &ServerAdd) -> CliResult<()> {
+        if !add.url.contains("://") {
+            return Err(CliError::InvalidArgument {
+                message: format!(
+                    "Invalid URL '{}': must include a scheme (e.g. https://)",
+                    add.url
+                ),
+            });
+        }
+
+        let mut config = GlobalConfig::load()
+            .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load config: {}", e)))?;
+
+        if config.servers.contains_key(&add.name) {
+            return Err(CliError::InvalidArgument {
+                message: format!(
+                    "Server profile '{}' already exists. \
+                     Use 'atomic server set-identity' or 'atomic server remove' to modify it.",
+                    add.name
+                ),
+            });
+        }
+
+        let profile = ServerConfig {
+            url: Some(add.url.trim_end_matches('/').to_string()),
+            default_org: add.org.clone(),
+            default_workspaces: std::collections::BTreeMap::new(),
+            identity: add.identity.clone(),
+        };
+
+        config.servers.insert(add.name.clone(), profile);
+
+        if add.set_default {
+            config.default_server = Some(add.name.clone());
+        }
+
+        config
+            .save()
+            .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to save config: {}", e)))?;
+
+        print_success(&format!("Server profile '{}' added", add.name));
+        println!("  URL:      {}", add.url);
+        if let Some(ref org) = add.org {
+            println!("  Org:      {}", org);
+        }
+        if let Some(ref identity) = add.identity {
+            println!("  Identity: {}", identity);
+        }
+        if add.set_default {
+            println!();
+            print_success(&format!("'{}' is now the active server", add.name));
+        } else {
+            println!();
+            print_hint(&format!(
+                "To make this your default: atomic server set {}",
+                add.name
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Switch the active default server profile.
+    fn set_server(&self, set: &ServerSet) -> CliResult<()> {
+        let mut config = GlobalConfig::load()
+            .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load config: {}", e)))?;
+
+        if set.revert {
+            config.default_server = None;
+            config
+                .save()
+                .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to save config: {}", e)))?;
+            print_success("Reverted to legacy [server] block");
+            return Ok(());
+        }
+
+        let name = set.name.as_deref().unwrap();
+
+        if !config.servers.contains_key(name) {
+            return Err(CliError::InvalidArgument {
+                message: format!(
+                    "Server profile '{}' not found.\n  \
+                     Use 'atomic server add {} <url>' to create it.",
+                    name, name
+                ),
+            });
+        }
+
+        config.default_server = Some(name.to_string());
+        config
+            .save()
+            .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to save config: {}", e)))?;
+
+        print_success(&format!("Active server is now '{}'", name));
+
+        let profile = &config.servers[name];
+        if let Some(ref url) = profile.url {
+            println!("  URL:      {}", url);
+        }
+        if let Some(ref org) = profile.default_org {
+            println!("  Org:      {}", org);
+        }
+        if let Some(ref identity) = profile.identity {
+            println!("  Identity: {}", identity);
+        }
+
+        Ok(())
+    }
+
+    /// Show details for a server profile.
+    fn show_server(&self, show: &ServerShow) -> CliResult<()> {
+        let config = GlobalConfig::load()
+            .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load config: {}", e)))?;
+
+        let (name, profile) = if let Some(ref n) = show.name {
+            // Explicit name
+            let p = config
+                .servers
+                .get(n)
+                .ok_or_else(|| CliError::InvalidArgument {
+                    message: format!("Server profile '{}' not found.", n),
+                })?;
+            (n.as_str(), p)
+        } else if let Some(ref active) = config.default_server {
+            // Active named profile
+            let p = config
+                .servers
+                .get(active)
+                .ok_or_else(|| CliError::InvalidArgument {
+                    message: format!("Default server profile '{}' not found in config.", active),
+                })?;
+            (active.as_str(), p)
+        } else {
+            // Legacy block — show it directly
+            println!("Active server: (legacy [server] block)");
+            println!(
+                "  URL:      {}",
+                config.server.url.as_deref().unwrap_or("(not configured)")
+            );
+            println!(
+                "  Org:      {}",
+                config
+                    .server
+                    .default_org
+                    .as_deref()
+                    .unwrap_or("(not configured)")
+            );
+            if let Some(ref identity) = config.server.identity {
+                println!("  Identity: {}", identity);
+            } else {
+                println!("  Identity: (global default)");
+            }
+            if !config.server.default_workspaces.is_empty() {
+                println!("  Workspaces:");
+                for (org, ws) in &config.server.default_workspaces {
+                    println!("    {} → {}", org, ws);
+                }
+            }
+            return Ok(());
+        };
+
+        let is_active = config.default_server.as_deref() == Some(name);
+        println!(
+            "Server profile: {}{}",
+            name,
+            if is_active { " (active)" } else { "" }
+        );
+        println!(
+            "  URL:      {}",
+            profile.url.as_deref().unwrap_or("(not configured)")
+        );
+        println!(
+            "  Org:      {}",
+            profile.default_org.as_deref().unwrap_or("(not configured)")
+        );
+        if let Some(ref identity) = profile.identity {
+            println!("  Identity: {}", identity);
+        } else {
+            println!("  Identity: (global default)");
+        }
+        if !profile.default_workspaces.is_empty() {
+            println!("  Workspaces:");
+            for (org, ws) in &profile.default_workspaces {
+                println!("    {} → {}", org, ws);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Remove a server profile.
+    fn remove_server(&self, remove: &ServerRemove) -> CliResult<()> {
+        let mut config = GlobalConfig::load()
+            .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load config: {}", e)))?;
+
+        if config.servers.remove(&remove.name).is_none() {
+            return Err(CliError::InvalidArgument {
+                message: format!("Server profile '{}' not found.", remove.name),
+            });
+        }
+
+        // Clear default_server if it pointed to the removed profile
+        if config.default_server.as_deref() == Some(&remove.name) {
+            config.default_server = None;
+            println!(
+                "Note: '{}' was the active server. Reverted to legacy [server] block.",
+                remove.name
+            );
+        }
+
+        config
+            .save()
+            .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to save config: {}", e)))?;
+
+        print_success(&format!("Server profile '{}' removed", remove.name));
+        Ok(())
+    }
+
+    /// Bind (or clear) an identity for a server profile.
+    fn set_identity_for_server(&self, cmd: &ServerSetIdentity) -> CliResult<()> {
+        let mut config = GlobalConfig::load()
+            .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to load config: {}", e)))?;
+
+        let profile =
+            config
+                .servers
+                .get_mut(&cmd.name)
+                .ok_or_else(|| CliError::InvalidArgument {
+                    message: format!(
+                        "Server profile '{}' not found. \
+                     Use 'atomic server add {} <url>' to create it.",
+                        cmd.name, cmd.name
+                    ),
+                })?;
+
+        if cmd.clear {
+            profile.identity = None;
+            config
+                .save()
+                .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to save config: {}", e)))?;
+            print_success(&format!(
+                "Identity cleared for server profile '{}'",
+                cmd.name
+            ));
+            print_hint("Management commands will now use the global default identity.");
+        } else {
+            let identity_name = cmd.identity.as_deref().unwrap();
+            profile.identity = Some(identity_name.to_string());
+            config
+                .save()
+                .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to save config: {}", e)))?;
+            print_success(&format!(
+                "Identity '{}' bound to server profile '{}'",
+                identity_name, cmd.name
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+impl Command for ServerCmd {
+    fn run(&self) -> CliResult<()> {
+        match &self.command {
+            None => self.list_servers(),
+            Some(ServerSubcommand::Add(add)) => self.add_server(add),
+            Some(ServerSubcommand::Set(set)) => self.set_server(set),
+            Some(ServerSubcommand::Show(show)) => self.show_server(show),
+            Some(ServerSubcommand::Remove(remove)) => self.remove_server(remove),
+            Some(ServerSubcommand::SetIdentity(cmd)) => self.set_identity_for_server(cmd),
+        }
+    }
+}

--- a/atomic-cli/src/commands/split.rs
+++ b/atomic-cli/src/commands/split.rs
@@ -214,9 +214,12 @@ impl Command for Split {
 
         // Optionally switch to the new view
         if self.switch {
-            repo.set_current_view(&self.name)
-                .map_err(CliError::Repository)?;
-            print_success(&format!("Switched to view: {}", style_view(&self.name)));
+            let result = repo.switch_view(&self.name).map_err(CliError::Repository)?;
+            print_success(&format!(
+                "Switched to view: {} ({} files updated)",
+                style_view(&self.name),
+                result.files_written,
+            ));
         } else {
             print_hint(&format!(
                 "Use 'atomic view switch {}' to switch to the new view",

--- a/atomic-cli/src/commands/team/create.rs
+++ b/atomic-cli/src/commands/team/create.rs
@@ -117,7 +117,7 @@ impl TeamCreate {
             })
             .transpose()?;
 
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let org_slug = client.org_slug().to_string();
 
         let info = atomic_teams::team::create_team(

--- a/atomic-cli/src/commands/team/create.rs
+++ b/atomic-cli/src/commands/team/create.rs
@@ -117,7 +117,7 @@ impl TeamCreate {
             })
             .transpose()?;
 
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let org_slug = client.org_slug().to_string();
 
         let info = atomic_teams::team::create_team(

--- a/atomic-cli/src/commands/team/delete.rs
+++ b/atomic-cli/src/commands/team/delete.rs
@@ -105,7 +105,7 @@ impl TeamDelete {
             }
         }
 
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let org_slug = client.org_slug().to_string();
 
         atomic_teams::team::delete_team(&client, &org_slug, &self.slug)

--- a/atomic-cli/src/commands/team/delete.rs
+++ b/atomic-cli/src/commands/team/delete.rs
@@ -105,7 +105,7 @@ impl TeamDelete {
             }
         }
 
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let org_slug = client.org_slug().to_string();
 
         atomic_teams::team::delete_team(&client, &org_slug, &self.slug)

--- a/atomic-cli/src/commands/team/list.rs
+++ b/atomic-cli/src/commands/team/list.rs
@@ -73,7 +73,7 @@ impl Command for TeamList {
 
 impl TeamList {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let slug = client.org_slug().to_string();
 
         let teams = atomic_teams::team::list_teams(&client, &slug)

--- a/atomic-cli/src/commands/team/list.rs
+++ b/atomic-cli/src/commands/team/list.rs
@@ -73,7 +73,7 @@ impl Command for TeamList {
 
 impl TeamList {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let slug = client.org_slug().to_string();
 
         let teams = atomic_teams::team::list_teams(&client, &slug)

--- a/atomic-cli/src/commands/team/member.rs
+++ b/atomic-cli/src/commands/team/member.rs
@@ -168,7 +168,7 @@ impl Command for TeamMemberList {
 
 impl TeamMemberList {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let org_slug = client.org_slug().to_string();
 
         let members =
@@ -282,7 +282,7 @@ impl TeamMemberAdd {
             ),
         })?;
 
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let org_slug = client.org_slug().to_string();
 
         let identity_id =
@@ -372,7 +372,7 @@ impl TeamMemberUpdate {
             ),
         })?;
 
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let org_slug = client.org_slug().to_string();
 
         let identity_id =
@@ -475,7 +475,7 @@ impl TeamMemberRemove {
             }
         }
 
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let org_slug = client.org_slug().to_string();
 
         let identity_id =

--- a/atomic-cli/src/commands/team/member.rs
+++ b/atomic-cli/src/commands/team/member.rs
@@ -168,7 +168,7 @@ impl Command for TeamMemberList {
 
 impl TeamMemberList {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let org_slug = client.org_slug().to_string();
 
         let members =
@@ -282,7 +282,7 @@ impl TeamMemberAdd {
             ),
         })?;
 
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let org_slug = client.org_slug().to_string();
 
         let identity_id =
@@ -372,7 +372,7 @@ impl TeamMemberUpdate {
             ),
         })?;
 
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let org_slug = client.org_slug().to_string();
 
         let identity_id =
@@ -475,7 +475,7 @@ impl TeamMemberRemove {
             }
         }
 
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let org_slug = client.org_slug().to_string();
 
         let identity_id =

--- a/atomic-cli/src/commands/team/show.rs
+++ b/atomic-cli/src/commands/team/show.rs
@@ -86,7 +86,7 @@ impl Command for TeamShow {
 
 impl TeamShow {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let org_slug = client.org_slug().to_string();
 
         let info = atomic_teams::team::get_team(&client, &org_slug, &self.slug)

--- a/atomic-cli/src/commands/team/show.rs
+++ b/atomic-cli/src/commands/team/show.rs
@@ -86,7 +86,7 @@ impl Command for TeamShow {
 
 impl TeamShow {
     async fn execute(&self) -> CliResult<()> {
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let org_slug = client.org_slug().to_string();
 
         let info = atomic_teams::team::get_team(&client, &org_slug, &self.slug)

--- a/atomic-cli/src/commands/team/update.rs
+++ b/atomic-cli/src/commands/team/update.rs
@@ -131,7 +131,7 @@ impl TeamUpdate {
             })
             .transpose()?;
 
-        let client = build_client(self.org.as_deref())?;
+        let client = build_client(self.org.as_deref()).await?;
         let org_slug = client.org_slug().to_string();
 
         let info = atomic_teams::team::update_team(

--- a/atomic-cli/src/commands/team/update.rs
+++ b/atomic-cli/src/commands/team/update.rs
@@ -131,7 +131,7 @@ impl TeamUpdate {
             })
             .transpose()?;
 
-        let client = build_client(self.org.as_deref()).await?;
+        let client = build_client(self.org.as_deref(), None).await?;
         let org_slug = client.org_slug().to_string();
 
         let info = atomic_teams::team::update_team(

--- a/atomic-cli/src/commands/token.rs
+++ b/atomic-cli/src/commands/token.rs
@@ -1,0 +1,207 @@
+//! Client-self-signed EdDSA JWT bearer tokens for remote commands.
+//!
+//! Atomic Storage authenticates with short-lived JWTs that the CLI **signs
+//! itself** with the identity's Ed25519 private key (EdDSA, RFC 8037). There is
+//! no server login endpoint and no token cache: minting a token is a local,
+//! cheap signing operation, so we just mint a fresh one per request.
+//!
+//! # Wire format (identical to the server's verifier)
+//!
+//! A compact JWS with three base64url-no-pad segments
+//! `base64url(header).base64url(claims).base64url(signature)`:
+//!
+//! - header: `{"alg":"EdDSA","typ":"JWT","kid":"<base32 Ed25519 public key>"}`
+//! - claims: `{ sub, iat, exp, jti }` (`sub` mirrors the `kid` public key)
+//! - signature: `Ed25519_sign(private_key, "header.claims")`
+//!
+//! # Keyed by the public key
+//!
+//! The JWT is keyed by the caller's Ed25519 **public key**, carried in the
+//! `kid` header. The client already holds this key, so there is no
+//! server-assigned identifier to learn or persist: the server resolves the
+//! registered identity by the `kid` public key and verifies this signature
+//! against the key it has on record.
+
+use chrono::{Duration, Utc};
+use data_encoding::BASE64URL_NOPAD;
+use serde::Serialize;
+use uuid::Uuid;
+
+use atomic_identity::{Identity, IdentityStore};
+
+use crate::error::{CliError, CliResult};
+
+/// How long a self-signed token is valid. Kept short (5 minutes) since there is
+/// no server-side issuance to revoke — a leaked token has a small blast radius.
+const TOKEN_TTL: Duration = Duration::minutes(5);
+
+// ---------------------------------------------------------------------------
+// JWT pieces (kept local to avoid depending on the server crate)
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct JwtHeader {
+    alg: &'static str,
+    typ: &'static str,
+    /// The caller's base32 Ed25519 public key.
+    kid: String,
+}
+
+#[derive(Serialize)]
+struct Claims {
+    /// The caller's base32 Ed25519 public key (same value as the header `kid`).
+    sub: String,
+    iat: i64,
+    exp: i64,
+    jti: String,
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Mint a fresh, short-lived self-signed EdDSA JWT for `identity` against
+/// `server`.
+///
+/// `server` is the bare server URL (e.g. `https://atomic.storage`), NOT an org
+/// subdomain. The token is keyed by the identity's own Ed25519 public key, so
+/// no prior registration state needs to be on file locally to mint it.
+pub async fn get_token(server: &str, identity: &Identity) -> CliResult<String> {
+    mint_token(server, identity)
+}
+
+/// Mint a fresh token. Tokens are not cached, so this is identical to
+/// [`get_token`]; kept for call-site compatibility (e.g. retry-after-401).
+pub async fn refresh_token(server: &str, identity: &Identity) -> CliResult<String> {
+    mint_token(server, identity)
+}
+
+// ---------------------------------------------------------------------------
+// Minting
+// ---------------------------------------------------------------------------
+
+fn mint_token(_server: &str, identity: &Identity) -> CliResult<String> {
+    // The token is keyed by the identity's own public key — no server-assigned
+    // identifier to look up.
+    let public_key_b32 = identity.public_key_base32();
+
+    // Load the keypair (needs the secret key to sign).
+    let store = IdentityStore::open_default()
+        .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to open identity store: {e}")))?;
+    let keypair = store.load_keypair(&identity.id, None).map_err(|e| {
+        CliError::Internal(anyhow::anyhow!(
+            "Failed to load keypair for '{}': {e}",
+            identity.name
+        ))
+    })?;
+
+    let now = Utc::now();
+    let claims = Claims {
+        sub: public_key_b32.clone(),
+        iat: now.timestamp(),
+        exp: (now + TOKEN_TTL).timestamp(),
+        jti: Uuid::new_v4().to_string(),
+    };
+
+    let header = JwtHeader {
+        alg: "EdDSA",
+        typ: "JWT",
+        kid: public_key_b32,
+    };
+
+    let header_json = serde_json::to_vec(&header)
+        .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to encode JWT header: {e}")))?;
+    let claims_json = serde_json::to_vec(&claims)
+        .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to encode JWT claims: {e}")))?;
+
+    let header_b64 = BASE64URL_NOPAD.encode(&header_json);
+    let claims_b64 = BASE64URL_NOPAD.encode(&claims_json);
+    let signing_input = format!("{header_b64}.{claims_b64}");
+
+    let signature = keypair.sign(signing_input.as_bytes());
+    let sig_b64 = BASE64URL_NOPAD.encode(&signature);
+
+    log::debug!("Minted self-signed EdDSA JWT for '{}'", identity.name);
+    Ok(format!("{signing_input}.{sig_b64}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_is_eddsa_jwt_with_kid() {
+        let header = JwtHeader {
+            alg: "EdDSA",
+            typ: "JWT",
+            kid: "ABCDEF".to_string(),
+        };
+        let json = serde_json::to_string(&header).unwrap();
+        assert_eq!(json, r#"{"alg":"EdDSA","typ":"JWT","kid":"ABCDEF"}"#);
+    }
+
+    /// A minted token must verify against the identity's public key, prove the
+    /// three-segment shape, carry the public key as `kid` (and `sub`), and not
+    /// verify once tampered.
+    #[test]
+    fn self_signed_token_verifies_round_trip() {
+        // Build a JWT by hand using the same steps as mint_token (without the
+        // store I/O, which needs a populated home dir).
+        use atomic_identity::KeyPair;
+        let keypair = KeyPair::generate();
+        let public_key_b32 = data_encoding::BASE32_NOPAD.encode(keypair.public.as_bytes());
+        let now = Utc::now();
+        let claims = Claims {
+            sub: public_key_b32.clone(),
+            iat: now.timestamp(),
+            exp: (now + TOKEN_TTL).timestamp(),
+            jti: Uuid::new_v4().to_string(),
+        };
+        let header = JwtHeader {
+            alg: "EdDSA",
+            typ: "JWT",
+            kid: public_key_b32.clone(),
+        };
+        let header_b64 = BASE64URL_NOPAD.encode(&serde_json::to_vec(&header).unwrap());
+        let claims_b64 = BASE64URL_NOPAD.encode(&serde_json::to_vec(&claims).unwrap());
+        let signing_input = format!("{header_b64}.{claims_b64}");
+        let sig = keypair.sign(signing_input.as_bytes());
+        let token = format!("{signing_input}.{}", BASE64URL_NOPAD.encode(&sig));
+
+        // Three segments.
+        assert_eq!(token.split('.').count(), 3);
+
+        // The kid in the header is the base32 public key the server resolves by.
+        let header_bytes = BASE64URL_NOPAD
+            .decode(token.split('.').next().unwrap().as_bytes())
+            .unwrap();
+        let header_val: serde_json::Value = serde_json::from_slice(&header_bytes).unwrap();
+        assert_eq!(header_val["kid"], public_key_b32);
+        assert_eq!(header_val["alg"], "EdDSA");
+
+        // Verifies against the public key (mirrors the server's verify path),
+        // using the identity crate's Ed25519 verify so we don't depend on
+        // ed25519-dalek directly.
+        let parts: Vec<&str> = token.split('.').collect();
+        let sig_bytes: [u8; 64] = BASE64URL_NOPAD
+            .decode(parts[2].as_bytes())
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let recovered_input = format!("{}.{}", parts[0], parts[1]);
+        assert!(keypair
+            .public
+            .verify(recovered_input.as_bytes(), &sig_bytes)
+            .is_ok());
+
+        // A tampered signing input must NOT verify.
+        let mut bad = recovered_input.clone().into_bytes();
+        bad[0] ^= 0x01;
+        assert!(keypair.public.verify(&bad, &sig_bytes).is_err());
+    }
+
+    #[test]
+    fn ttl_is_five_minutes() {
+        assert_eq!(TOKEN_TTL, Duration::minutes(5));
+    }
+}

--- a/atomic-cli/src/commands/vault/intent.rs
+++ b/atomic-cli/src/commands/vault/intent.rs
@@ -38,6 +38,12 @@
 //! # Update intent status
 //! atomic vault intent update PIMO-1 --status in-progress
 //!
+//! # Replace the intent body inline
+//! atomic vault intent update PIMO-1 --body "# Title\n\n## Problem\n..."
+//!
+//! # Replace the intent body from a file
+//! cat plan.md | atomic vault intent update PIMO-1 --body-stdin
+//!
 //! # Delete an accidental draft intent
 //! atomic vault intent delete PIMO-1
 //! atomic vault intent delete PIMO-1 --force
@@ -114,13 +120,17 @@ pub enum IntentCommands {
 
     /// Update an intent's fields.
     ///
-    /// Modifies the status, assignee, priority, or title of an existing intent.
+    /// Modifies the status, assignee, priority, title, or Markdown body
+    /// of an existing intent. The body can be set inline with `--body`
+    /// or piped via `--body-stdin`.
     ///
     /// # Examples
     ///
     /// ```text
     /// atomic vault intent update PIMO-1 --status in-progress
     /// atomic vault intent update PIMO-1 --assignee bob --priority critical
+    /// atomic vault intent update PIMO-1 --body "# Fix auth\n\n## Problem\n..."
+    /// cat plan.md | atomic vault intent update PIMO-1 --body-stdin
     /// ```
     Update(IntentUpdate),
 
@@ -370,6 +380,31 @@ pub struct IntentUpdate {
     /// New title.
     #[arg(long)]
     pub title: Option<String>,
+
+    /// New Markdown body content, provided inline.
+    #[arg(long, conflicts_with = "body_stdin")]
+    pub body: Option<String>,
+
+    /// Read the new Markdown body content from standard input.
+    #[arg(long)]
+    pub body_stdin: bool,
+}
+
+impl IntentUpdate {
+    fn resolve_body(&self) -> CliResult<Option<String>> {
+        if let Some(ref body) = self.body {
+            return Ok(Some(body.clone()));
+        }
+        if self.body_stdin {
+            use std::io::Read;
+            let mut content = String::new();
+            std::io::stdin()
+                .read_to_string(&mut content)
+                .map_err(CliError::Io)?;
+            return Ok(Some(content));
+        }
+        Ok(None)
+    }
 }
 
 impl Command for IntentUpdate {
@@ -377,6 +412,22 @@ impl Command for IntentUpdate {
         let root = find_repository_root()?;
         let repo = Repository::open(&root).map_err(CliError::Repository)?;
 
+        let content = self.resolve_body()?;
+        if self.status.is_none()
+            && self.assignee.is_none()
+            && self.priority.is_none()
+            && self.title.is_none()
+            && content.is_none()
+        {
+            return Err(CliError::InvalidArgument {
+                message: "Nothing to update. Provide at least one of \
+                    --status, --assignee, --priority, --title, --body, \
+                    or --body-stdin."
+                    .to_string(),
+            });
+        }
+
+        let body_updated = content.is_some();
         let info = repo
             .vault_intent_update(
                 &self.id,
@@ -385,6 +436,7 @@ impl Command for IntentUpdate {
                     assignee: self.assignee.clone(),
                     priority: self.priority.clone(),
                     title: self.title.clone(),
+                    content,
                 },
             )
             .map_err(CliError::Repository)?;
@@ -394,6 +446,9 @@ impl Command for IntentUpdate {
         println!("  priority: {}", info.priority);
         if let Some(ref assignee) = info.assignee {
             println!("  assignee: {}", assignee);
+        }
+        if body_updated {
+            println!("  body: updated");
         }
 
         Ok(())

--- a/atomic-cli/src/commands/vault/intent.rs
+++ b/atomic-cli/src/commands/vault/intent.rs
@@ -388,6 +388,10 @@ pub struct IntentUpdate {
     /// Read the new Markdown body content from standard input.
     #[arg(long)]
     pub body_stdin: bool,
+
+    /// Rewrite the body even if the intent has started or is linked to a goal.
+    #[arg(long, short = 'f')]
+    pub force: bool,
 }
 
 impl IntentUpdate {
@@ -437,6 +441,7 @@ impl Command for IntentUpdate {
                     priority: self.priority.clone(),
                     title: self.title.clone(),
                     content,
+                    force: self.force,
                 },
             )
             .map_err(CliError::Repository)?;

--- a/atomic-cli/src/commands/vault/intent.rs
+++ b/atomic-cli/src/commands/vault/intent.rs
@@ -40,6 +40,7 @@
 //!
 //! # Delete an accidental draft intent
 //! atomic vault intent delete PIMO-1
+//! atomic vault intent delete PIMO-1 --force
 //!
 //! # Link a goal to an intent
 //! atomic vault intent link PIMO-1 --goal swift-meadow-a3f2
@@ -126,12 +127,14 @@ pub enum IntentCommands {
     /// Delete an unstarted backlog intent.
     ///
     /// Removes an accidental draft intent from the vault. Only backlog
-    /// intents with no linked goals can be deleted.
+    /// intents with no linked goals can be deleted. Use --force to skip the
+    /// confirmation prompt.
     ///
     /// # Examples
     ///
     /// ```text
     /// atomic vault intent delete PIMO-1
+    /// atomic vault intent delete PIMO-1 --force
     /// ```
     Delete(IntentDelete),
 
@@ -403,12 +406,16 @@ impl Command for IntentUpdate {
 ///
 /// Removes an intent that has not left backlog and has no linked goals. Use this
 /// for accidental drafts only; started work should be closed or superseded
-/// instead of deleted.
+/// instead of deleted. Without `--force`, prompts for confirmation.
 #[derive(Parser, Debug)]
 #[command(name = "delete")]
 pub struct IntentDelete {
     /// Intent ID.
     pub id: String,
+
+    /// Skip the confirmation prompt.
+    #[arg(long, short = 'f')]
+    pub force: bool,
 
     /// Output as JSON.
     #[arg(long)]
@@ -419,6 +426,22 @@ impl Command for IntentDelete {
     fn run(&self) -> CliResult<()> {
         let root = find_repository_root()?;
         let repo = Repository::open(&root).map_err(CliError::Repository)?;
+
+        if !self.force {
+            let prompt = format!(
+                "Discard intent '{}'? This removes the unstarted draft from the vault.",
+                self.id
+            );
+            let confirmed = dialoguer::Confirm::new()
+                .with_prompt(&prompt)
+                .default(false)
+                .interact()
+                .map_err(|e| CliError::Internal(anyhow::anyhow!("Prompt failed: {}", e)))?;
+
+            if !confirmed {
+                return Err(CliError::Cancelled);
+            }
+        }
 
         let result = repo
             .vault_intent_delete(&self.id)

--- a/atomic-cli/src/commands/vault/intent.rs
+++ b/atomic-cli/src/commands/vault/intent.rs
@@ -13,6 +13,7 @@
 //!   list    List intents
 //!   show    Show an intent's content
 //!   update  Update an intent's fields
+//!   delete  Delete an unstarted backlog intent
 //!   link    Link a goal to an intent
 //! ```
 //!
@@ -36,6 +37,9 @@
 //!
 //! # Update intent status
 //! atomic vault intent update PIMO-1 --status in-progress
+//!
+//! # Delete an accidental draft intent
+//! atomic vault intent delete PIMO-1
 //!
 //! # Link a goal to an intent
 //! atomic vault intent link PIMO-1 --goal swift-meadow-a3f2
@@ -119,6 +123,18 @@ pub enum IntentCommands {
     /// ```
     Update(IntentUpdate),
 
+    /// Delete an unstarted backlog intent.
+    ///
+    /// Removes an accidental draft intent from the vault. Only backlog
+    /// intents with no linked goals can be deleted.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// atomic vault intent delete PIMO-1
+    /// ```
+    Delete(IntentDelete),
+
     /// Link a goal to an intent.
     ///
     /// Associates a goal with an intent so that the work done in the goal
@@ -152,6 +168,7 @@ impl Command for Intent {
             IntentCommands::List(cmd) => cmd.run(),
             IntentCommands::Show(cmd) => cmd.run(),
             IntentCommands::Update(cmd) => cmd.run(),
+            IntentCommands::Delete(cmd) => cmd.run(),
             IntentCommands::Link(cmd) => cmd.run(),
         }
     }
@@ -374,6 +391,49 @@ impl Command for IntentUpdate {
         println!("  priority: {}", info.priority);
         if let Some(ref assignee) = info.assignee {
             println!("  assignee: {}", assignee);
+        }
+
+        Ok(())
+    }
+}
+
+// Delete Subcommand
+
+/// Delete an unstarted backlog intent.
+///
+/// Removes an intent that has not left backlog and has no linked goals. Use this
+/// for accidental drafts only; started work should be closed or superseded
+/// instead of deleted.
+#[derive(Parser, Debug)]
+#[command(name = "delete")]
+pub struct IntentDelete {
+    /// Intent ID.
+    pub id: String,
+
+    /// Output as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Command for IntentDelete {
+    fn run(&self) -> CliResult<()> {
+        let root = find_repository_root()?;
+        let repo = Repository::open(&root).map_err(CliError::Repository)?;
+
+        let result = repo
+            .vault_intent_delete(&self.id)
+            .map_err(CliError::Repository)?;
+
+        if self.json {
+            let json = serde_json::json!({
+                "id": result.id,
+                "intent_file": result.intent_file,
+                "deleted": true,
+            });
+            println!("{}", serde_json::to_string_pretty(&json).unwrap());
+        } else {
+            println!("Deleted intent: {}", result.id);
+            println!("  file: .vault/{}", result.intent_file);
         }
 
         Ok(())

--- a/atomic-cli/src/commands/view/list.rs
+++ b/atomic-cli/src/commands/view/list.rs
@@ -316,7 +316,7 @@ mod tests {
         {
             let mut repo = Repository::init(repo_path).unwrap();
             repo.create_view("feature").unwrap();
-            repo.set_current_view("feature").unwrap();
+            repo.align_to_view("feature").unwrap();
         }
 
         // Change to the repo directory

--- a/atomic-cli/src/commands/view/new.rs
+++ b/atomic-cli/src/commands/view/new.rs
@@ -298,8 +298,12 @@ impl New {
     /// Optionally switch to the new view and print hint.
     fn maybe_switch(&self, name: &str, repo: &mut Repository) -> CliResult<()> {
         if self.switch {
-            repo.set_current_view(name).map_err(CliError::Repository)?;
-            print_success(&format!("Switched to view: {}", style_view(name)));
+            let result = repo.switch_view(name).map_err(CliError::Repository)?;
+            print_success(&format!(
+                "Switched to view: {} ({} files updated)",
+                style_view(name),
+                result.files_written,
+            ));
         } else {
             print_hint(&format!(
                 "Use 'atomic view switch {}' to switch to the new view",

--- a/atomic-cli/src/commands/workspace/create.rs
+++ b/atomic-cli/src/commands/workspace/create.rs
@@ -81,7 +81,7 @@ impl Command for WorkspaceCreate {
         })?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref()).await?;
+            let client = build_client(self.org.as_deref(), None).await?;
 
             let visibility = self.parse_visibility()?;
 

--- a/atomic-cli/src/commands/workspace/create.rs
+++ b/atomic-cli/src/commands/workspace/create.rs
@@ -81,7 +81,7 @@ impl Command for WorkspaceCreate {
         })?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref())?;
+            let client = build_client(self.org.as_deref()).await?;
 
             let visibility = self.parse_visibility()?;
 

--- a/atomic-cli/src/commands/workspace/delete.rs
+++ b/atomic-cli/src/commands/workspace/delete.rs
@@ -90,7 +90,7 @@ impl Command for WorkspaceDelete {
                 }
             }
 
-            let (client, org_slug) = build_client_with_org(self.org.as_deref())?;
+            let (client, org_slug) = build_client_with_org(self.org.as_deref()).await?;
 
             client
                 .delete_workspace(&self.slug)

--- a/atomic-cli/src/commands/workspace/delete.rs
+++ b/atomic-cli/src/commands/workspace/delete.rs
@@ -90,7 +90,7 @@ impl Command for WorkspaceDelete {
                 }
             }
 
-            let (client, org_slug) = build_client_with_org(self.org.as_deref()).await?;
+            let (client, org_slug) = build_client_with_org(self.org.as_deref(), None).await?;
 
             client
                 .delete_workspace(&self.slug)

--- a/atomic-cli/src/commands/workspace/list.rs
+++ b/atomic-cli/src/commands/workspace/list.rs
@@ -79,7 +79,7 @@ impl Command for WorkspaceList {
         })?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref())?;
+            let client = build_client(self.org.as_deref()).await?;
             let workspaces = client.list_workspaces().await.map_err(remote_err)?;
 
             if self.format == "json" {

--- a/atomic-cli/src/commands/workspace/list.rs
+++ b/atomic-cli/src/commands/workspace/list.rs
@@ -44,6 +44,13 @@ pub struct WorkspaceList {
     #[arg(long)]
     pub org: Option<String>,
 
+    /// Server profile to use (e.g. "staging", "prod").
+    ///
+    /// Overrides `default_server` from `~/.atomic/config.toml`.
+    /// Use `atomic server list` to see available profiles.
+    #[arg(long)]
+    pub server: Option<String>,
+
     /// Output format (`table` or `json`).
     #[arg(long, default_value = "table")]
     pub format: String,
@@ -53,6 +60,7 @@ impl Default for WorkspaceList {
     fn default() -> Self {
         Self {
             org: None,
+            server: None,
             format: "table".to_string(),
         }
     }
@@ -79,7 +87,7 @@ impl Command for WorkspaceList {
         })?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref()).await?;
+            let client = build_client(self.org.as_deref(), self.server.as_deref()).await?;
             let workspaces = client.list_workspaces().await.map_err(remote_err)?;
 
             if self.format == "json" {

--- a/atomic-cli/src/commands/workspace/set.rs
+++ b/atomic-cli/src/commands/workspace/set.rs
@@ -186,7 +186,7 @@ fn verify_workspace_exists(org_slug: &str, workspace_slug: &str) -> CliResult<()
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to create async runtime: {e}")))?;
 
     rt.block_on(async {
-        let (client, _resolved) = build_client_with_org(Some(org_slug)).await?;
+        let (client, _resolved) = build_client_with_org(Some(org_slug), None).await?;
         match client.get_workspace(workspace_slug).await {
             Ok(_) => Ok(()),
             Err(e) if e.is_not_found() => Err(CliError::InvalidArgument {

--- a/atomic-cli/src/commands/workspace/set.rs
+++ b/atomic-cli/src/commands/workspace/set.rs
@@ -186,7 +186,7 @@ fn verify_workspace_exists(org_slug: &str, workspace_slug: &str) -> CliResult<()
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to create async runtime: {e}")))?;
 
     rt.block_on(async {
-        let (client, _resolved) = build_client_with_org(Some(org_slug))?;
+        let (client, _resolved) = build_client_with_org(Some(org_slug)).await?;
         match client.get_workspace(workspace_slug).await {
             Ok(_) => Ok(()),
             Err(e) if e.is_not_found() => Err(CliError::InvalidArgument {

--- a/atomic-cli/src/commands/workspace/show.rs
+++ b/atomic-cli/src/commands/workspace/show.rs
@@ -68,7 +68,7 @@ impl Command for WorkspaceShow {
             .map_err(|e| CliError::Internal(anyhow::anyhow!("{}", e)))?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref()).await?;
+            let client = build_client(self.org.as_deref(), None).await?;
             let ws = client.get_workspace(&self.slug).await.map_err(remote_err)?;
 
             if self.format == "json" {

--- a/atomic-cli/src/commands/workspace/show.rs
+++ b/atomic-cli/src/commands/workspace/show.rs
@@ -68,7 +68,7 @@ impl Command for WorkspaceShow {
             .map_err(|e| CliError::Internal(anyhow::anyhow!("{}", e)))?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref())?;
+            let client = build_client(self.org.as_deref()).await?;
             let ws = client.get_workspace(&self.slug).await.map_err(remote_err)?;
 
             if self.format == "json" {

--- a/atomic-cli/src/commands/workspace/update.rs
+++ b/atomic-cli/src/commands/workspace/update.rs
@@ -79,7 +79,7 @@ impl Command for WorkspaceUpdate {
         })?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref()).await?;
+            let client = build_client(self.org.as_deref(), None).await?;
 
             let req = UpdateWorkspaceRequest {
                 name: self.name.clone(),

--- a/atomic-cli/src/commands/workspace/update.rs
+++ b/atomic-cli/src/commands/workspace/update.rs
@@ -79,7 +79,7 @@ impl Command for WorkspaceUpdate {
         })?;
 
         rt.block_on(async {
-            let client = build_client(self.org.as_deref())?;
+            let client = build_client(self.org.as_deref()).await?;
 
             let req = UpdateWorkspaceRequest {
                 name: self.name.clone(),

--- a/atomic-cli/src/main.rs
+++ b/atomic-cli/src/main.rs
@@ -77,6 +77,7 @@ use commands::{
     Remove,
     Restore,
     Revise,
+    Sandbox,
     Split,
     Stash,
     Status,
@@ -237,6 +238,20 @@ enum Commands {
     /// ```
     #[command(alias = "reset")]
     Restore(Restore),
+
+    /// Provision concurrent agent sandboxes (copy-on-write working trees).
+    ///
+    /// Each sandbox is a private, copy-on-write clone of the working tree so
+    /// multiple agents can work at once with isolated build artifacts while
+    /// sharing the single canonical graph.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// atomic sandbox create agent-1
+    /// atomic sandbox create agent-2 --dest /tmp/agent-2
+    /// ```
+    Sandbox(Sandbox),
 
     /// Split a view (create a new view from an existing one).
     ///
@@ -717,6 +732,8 @@ fn main() {
         Commands::Move(mv) => mv.run(),
 
         Commands::Restore(restore) => restore.run(),
+
+        Commands::Sandbox(sandbox) => sandbox.run(),
 
         Commands::Split(split) => split.run(),
 

--- a/atomic-cli/src/main.rs
+++ b/atomic-cli/src/main.rs
@@ -78,6 +78,7 @@ use commands::{
     Restore,
     Revise,
     Sandbox,
+    ServerCmd,
     Split,
     Stash,
     Status,
@@ -484,6 +485,32 @@ enum Commands {
     /// ```
     Remote(Remote),
 
+    /// Manage server profiles (staging, production, etc.).
+    ///
+    /// Server profiles let you store multiple atomic-storage server
+    /// configurations and switch between them easily. Each profile
+    /// can have its own URL, default org, and identity.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// # List configured profiles
+    /// atomic server
+    ///
+    /// # Add a staging profile
+    /// atomic server add staging https://staging.atomic.storage --identity alice-staging
+    ///
+    /// # Switch to staging
+    /// atomic server set staging
+    ///
+    /// # Show active profile
+    /// atomic server show
+    ///
+    /// # Bind an identity to a profile
+    /// atomic server set-identity prod alice-prod
+    /// ```
+    Server(ServerCmd),
+
     /// Manage remote workspaces.
     ///
     /// Workspaces are organizational containers for projects on a remote
@@ -766,6 +793,8 @@ fn main() {
         Commands::Identity(identity) => identity.run(),
 
         Commands::Remote(remote) => remote.run(),
+
+        Commands::Server(server) => server.run(),
 
         Commands::Workspace(workspace) => workspace.run(),
 

--- a/atomic-config/src/lib.rs
+++ b/atomic-config/src/lib.rs
@@ -98,6 +98,16 @@ pub struct ServerConfig {
     /// and produces stable diffs.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub default_workspaces: BTreeMap<String, String>,
+
+    /// Identity name to use when authenticating to this server.
+    ///
+    /// If set, management commands targeting this server use this identity
+    /// instead of the global default. Set automatically during
+    /// `atomic identity register` when `--identity` is specified.
+    ///
+    /// Example: `identity = "alice-staging"`
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity: Option<String>,
 }
 
 impl ServerConfig {
@@ -164,9 +174,41 @@ pub struct GlobalConfig {
     #[serde(default)]
     pub workspace: WorkspaceConfig,
 
-    /// Remote server configuration for atomic-storage.
+    /// Default remote server configuration for atomic-storage.
+    ///
+    /// This is the server used when no `--server` flag is given and no
+    /// `default_server` points to a named server in `servers`.
     #[serde(default)]
     pub server: ServerConfig,
+
+    /// Named server profiles (e.g. "staging", "prod").
+    ///
+    /// Each entry is a full `ServerConfig` with its own URL, default org,
+    /// workspaces, and optional identity override.
+    ///
+    /// ```toml
+    /// [servers.staging]
+    /// url = "https://staging.atomic.storage"
+    /// default_org = "alice"
+    /// identity = "alice-staging"
+    ///
+    /// [servers.prod]
+    /// url = "https://atomic.storage"
+    /// default_org = "alice"
+    /// identity = "alice-prod"
+    /// ```
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub servers: BTreeMap<String, ServerConfig>,
+
+    /// Name of the active server profile from `servers`.
+    ///
+    /// When set, management commands use `servers[default_server]` instead
+    /// of `server`. Switch with `atomic server set <name>` or pass
+    /// `--server <name>` per-command.
+    ///
+    /// When `None`, the legacy `[server]` block is used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_server: Option<String>,
 }
 
 fn default_channel_name() -> String {
@@ -182,7 +224,59 @@ impl Default for GlobalConfig {
             pager: None,
             workspace: WorkspaceConfig::default(),
             server: ServerConfig::default(),
+            servers: BTreeMap::new(),
+            default_server: None,
         }
+    }
+}
+
+impl GlobalConfig {
+    /// Resolve the effective server config, honouring the optional name override.
+    ///
+    /// Resolution order:
+    /// 1. `server_override` (from `--server <name>` CLI flag)
+    /// 2. `default_server` (from `~/.atomic/config.toml`)
+    /// 3. Legacy `server` block
+    ///
+    /// Returns `(server_config, Option<name>)` — the name is `Some` when a
+    /// named profile was resolved, `None` for the legacy block.
+    pub fn resolve_server<'a>(
+        &'a self,
+        server_override: Option<&'a str>,
+    ) -> Result<(&'a ServerConfig, Option<&'a str>), String> {
+        // 1. Explicit --server flag
+        if let Some(name) = server_override {
+            return self
+                .servers
+                .get(name)
+                .map(|s| (s, Some(name)))
+                .ok_or_else(|| {
+                    format!(
+                        "Server profile '{}' not found. \
+                         Use 'atomic server list' to see available profiles, \
+                         or 'atomic server add {0} <url>' to create it.",
+                        name
+                    )
+                });
+        }
+
+        // 2. Configured default server name
+        if let Some(ref name) = self.default_server {
+            return self
+                .servers
+                .get(name.as_str())
+                .map(|s| (s, Some(name.as_str())))
+                .ok_or_else(|| {
+                    format!(
+                        "Default server profile '{}' not found in servers map. \
+                         Run 'atomic server set <name>' to fix.",
+                        name
+                    )
+                });
+        }
+
+        // 3. Legacy [server] block
+        Ok((&self.server, None))
     }
 }
 
@@ -370,6 +464,7 @@ mod tests {
             url: Some("https://atomic.storage".to_string()),
             default_org: Some("alice".to_string()),
             default_workspaces: BTreeMap::new(),
+            identity: None,
         };
         assert!(config.is_configured());
 
@@ -378,6 +473,7 @@ mod tests {
             url: Some("https://atomic.storage".to_string()),
             default_org: None,
             default_workspaces: BTreeMap::new(),
+            identity: None,
         };
         assert!(!partial.is_configured());
 
@@ -386,6 +482,7 @@ mod tests {
             url: None,
             default_org: Some("alice".to_string()),
             default_workspaces: BTreeMap::new(),
+            identity: None,
         };
         assert!(!partial.is_configured());
     }
@@ -396,6 +493,7 @@ mod tests {
             url: Some("https://atomic.storage".to_string()),
             default_org: Some("alice".to_string()),
             default_workspaces: BTreeMap::new(),
+            identity: None,
         };
         assert_eq!(
             config.org_base_url("alice"),
@@ -413,6 +511,7 @@ mod tests {
             url: Some("http://localhost:8080".to_string()),
             default_org: None,
             default_workspaces: BTreeMap::new(),
+            identity: None,
         };
         assert_eq!(
             config.org_base_url("alice"),
@@ -426,6 +525,7 @@ mod tests {
             url: Some("https://atomic.storage".to_string()),
             default_org: Some("alice".to_string()),
             default_workspaces: BTreeMap::new(),
+            identity: None,
         };
         assert_eq!(
             config.default_org_base_url(),
@@ -437,6 +537,7 @@ mod tests {
             url: Some("https://atomic.storage".to_string()),
             default_org: None,
             default_workspaces: BTreeMap::new(),
+            identity: None,
         };
         assert!(config.default_org_base_url().is_none());
     }
@@ -447,6 +548,7 @@ mod tests {
             url: Some("https://atomic.storage".to_string()),
             default_org: Some("alice".to_string()),
             default_workspaces: BTreeMap::new(),
+            identity: None,
         };
 
         let toml_str = toml::to_string_pretty(&config).unwrap();
@@ -470,6 +572,7 @@ mod tests {
                 url: Some("https://atomic.storage".to_string()),
                 default_org: Some("alice".to_string()),
                 default_workspaces: BTreeMap::new(),
+                identity: None,
             },
             ..GlobalConfig::default()
         };
@@ -493,6 +596,7 @@ mod tests {
             url: Some("https://atomic.storage".to_string()),
             default_org: Some("alice".to_string()),
             default_workspaces: BTreeMap::new(),
+            identity: None,
         };
         let toml_str = toml::to_string_pretty(&config).unwrap();
         assert!(!toml_str.contains("default_workspaces"));
@@ -508,6 +612,7 @@ mod tests {
             url: Some("https://atomic.storage".to_string()),
             default_org: Some("alice".to_string()),
             default_workspaces: workspaces,
+            identity: None,
         };
 
         let toml_str = toml::to_string_pretty(&config).unwrap();

--- a/atomic-remote/src/http/download.rs
+++ b/atomic-remote/src/http/download.rs
@@ -40,6 +40,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -121,6 +122,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -177,6 +179,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {

--- a/atomic-remote/src/http/queries.rs
+++ b/atomic-remote/src/http/queries.rs
@@ -37,6 +37,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
         trace!("GET state response status: {}", status);
 
@@ -90,6 +91,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
         trace!("GET changelist response status: {}", status);
 
@@ -136,6 +138,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -179,6 +182,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -223,6 +227,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -283,6 +288,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -342,6 +348,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -388,6 +395,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {

--- a/atomic-remote/src/http/upload.rs
+++ b/atomic-remote/src/http/upload.rs
@@ -35,6 +35,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -84,6 +85,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -141,6 +143,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -202,6 +205,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -251,6 +255,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {
@@ -331,6 +336,7 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
 
+        crate::check_min_version_header(response.headers());
         let status = response.status();
 
         match status {

--- a/atomic-remote/src/lib.rs
+++ b/atomic-remote/src/lib.rs
@@ -128,8 +128,12 @@ pub mod storage_types;
 pub mod streaming;
 pub mod sync;
 pub mod types;
+pub mod version;
 
 // Re-exports
+
+// Version checking
+pub use version::{check_min_version_header, needs_upgrade};
 
 // Error types
 pub use error::{RemoteError, RemoteResult};

--- a/atomic-remote/src/storage.rs
+++ b/atomic-remote/src/storage.rs
@@ -171,6 +171,7 @@ impl StorageClient {
             .await
             .map_err(|e| RemoteError::other(format!("request failed: {}", e)))?;
 
+        crate::check_min_version_header(resp.headers());
         let status = resp.status();
         if status.is_success() {
             Ok(())
@@ -185,6 +186,7 @@ impl StorageClient {
         &self,
         resp: reqwest::Response,
     ) -> Result<T, RemoteError> {
+        crate::check_min_version_header(resp.headers());
         let status = resp.status();
         let body = resp
             .text()

--- a/atomic-remote/src/storage.rs
+++ b/atomic-remote/src/storage.rs
@@ -2,8 +2,8 @@
 //!
 //! `StorageClient` provides typed access to CRUD operations on workspaces,
 //! projects, and other management endpoints. It handles authentication
-//! (Ed25519 public key as Bearer token), JSON serialization, and
-//! response envelope unwrapping.
+//! (short-lived JWT bearer token), JSON serialization, and response envelope
+//! unwrapping.
 //!
 //! The VCS protocol (push/pull/clone) uses `HttpRemote` instead.
 
@@ -30,7 +30,7 @@ use crate::storage_types::{
 /// let client = StorageClient::new(
 ///     "https://alice.atomic.storage",
 ///     "alice",
-///     "EDPK_BASE32_TOKEN",
+///     "eyJhbG...self_signed_eddsa_jwt",
 /// )?;
 ///
 /// let ws = client.create_workspace(&CreateWorkspaceRequest {
@@ -49,8 +49,8 @@ impl StorageClient {
     /// Create a new client targeting a specific org.
     ///
     /// The `base_url` should be the full org-scoped URL, e.g.,
-    /// `https://alice.atomic.storage`. The `bearer_token` is the
-    /// base32-encoded Ed25519 public key.
+    /// `https://alice.atomic.storage`. The `bearer_token` is a short-lived,
+    /// client-self-signed EdDSA JWT (see `atomic-cli`'s `commands::token`).
     pub fn new(base_url: &str, org_slug: &str, bearer_token: &str) -> Result<Self, RemoteError> {
         let mut headers = HeaderMap::new();
         headers.insert(

--- a/atomic-remote/src/version.rs
+++ b/atomic-remote/src/version.rs
@@ -1,0 +1,132 @@
+//! Version comparison utilities for CLI upgrade warnings.
+//!
+//! When the server sends an `X-Atomic-Min-Version` header, the CLI
+//! checks whether the running version satisfies the minimum requirement
+//! and warns the user if it does not.
+
+use reqwest::header::HeaderMap;
+
+/// Check if `current` version is less than `required` version.
+///
+/// Performs a simple major.minor.patch numeric comparison. Missing parts
+/// default to 0 (e.g. `"1.2"` is treated as `"1.2.0"`).
+///
+/// Returns `true` if `current < required` (upgrade needed).
+/// Returns `false` if `current >= required` or if either version string
+/// cannot be parsed — this avoids spurious warnings on dev or pre-release
+/// version strings.
+pub fn needs_upgrade(current: &str, required: &str) -> bool {
+    fn parse_version(v: &str) -> Option<(u32, u32, u32)> {
+        let mut parts = v.trim().splitn(4, '.');
+        let major = parts.next()?.parse::<u32>().ok()?;
+        let minor = parts.next().unwrap_or("0").parse::<u32>().ok()?;
+        let patch = parts.next().unwrap_or("0").parse::<u32>().ok()?;
+        Some((major, minor, patch))
+    }
+
+    match (parse_version(current), parse_version(required)) {
+        (Some(cur), Some(req)) => cur < req,
+        _ => false,
+    }
+}
+
+/// Check the `X-Atomic-Min-Version` response header and warn if the
+/// current CLI version is older than the server's minimum requirement.
+///
+/// Prints a warning to stderr when an upgrade is needed. Silently does
+/// nothing if the header is absent, unparseable, or already satisfied.
+pub fn check_min_version_header(headers: &HeaderMap) {
+    let header_name = reqwest::header::HeaderName::from_static("x-atomic-min-version");
+
+    if let Some(val) = headers.get(&header_name) {
+        if let Ok(min_ver) = val.to_str() {
+            let current = crate::VERSION;
+            if needs_upgrade(current, min_ver) {
+                eprintln!(
+                    "warning: this server requires Atomic CLI >= {} (you have {}). \
+                     Run 'atomic update' to upgrade.",
+                    min_ver, current
+                );
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- needs_upgrade ---
+
+    #[test]
+    fn older_major_needs_upgrade() {
+        assert!(needs_upgrade("0.9.0", "1.0.0"));
+    }
+
+    #[test]
+    fn same_version_no_upgrade() {
+        assert!(!needs_upgrade("1.2.3", "1.2.3"));
+    }
+
+    #[test]
+    fn newer_version_no_upgrade() {
+        assert!(!needs_upgrade("2.0.0", "1.9.9"));
+    }
+
+    #[test]
+    fn older_minor_needs_upgrade() {
+        assert!(needs_upgrade("1.1.0", "1.2.0"));
+    }
+
+    #[test]
+    fn older_patch_needs_upgrade() {
+        assert!(needs_upgrade("1.2.2", "1.2.3"));
+    }
+
+    #[test]
+    fn newer_patch_no_upgrade() {
+        assert!(!needs_upgrade("1.2.4", "1.2.3"));
+    }
+
+    #[test]
+    fn missing_patch_treated_as_zero() {
+        // "1.2" == "1.2.0", so "1.2" vs "1.2.0" → equal → no upgrade
+        assert!(!needs_upgrade("1.2", "1.2.0"));
+    }
+
+    #[test]
+    fn unparseable_current_no_upgrade() {
+        // Don't warn on dev builds or dirty version strings
+        assert!(!needs_upgrade("dev", "1.0.0"));
+    }
+
+    #[test]
+    fn unparseable_required_no_upgrade() {
+        assert!(!needs_upgrade("1.0.0", "not-a-version"));
+    }
+
+    // --- check_min_version_header ---
+
+    #[test]
+    fn no_header_no_panic() {
+        let headers = HeaderMap::new();
+        // Should not panic or print anything
+        check_min_version_header(&headers);
+    }
+
+    #[test]
+    fn header_already_satisfied_no_warn() {
+        // When required <= current, no warning (the function just returns)
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            reqwest::header::HeaderName::from_static("x-atomic-min-version"),
+            reqwest::header::HeaderValue::from_static("0.0.1"),
+        );
+        // crate::VERSION is the actual crate version, which will be >= 0.0.1
+        check_min_version_header(&headers);
+    }
+}

--- a/atomic-repository/Cargo.toml
+++ b/atomic-repository/Cargo.toml
@@ -25,6 +25,7 @@ redb = { workspace = true }
 zstd = { workspace = true }
 dirs = "5.0"
 walkdir = { workspace = true }
+reflink-copy = "0.1"
 ignore = { workspace = true }
 syntext = { workspace = true }
 tempfile = { workspace = true }
@@ -33,6 +34,9 @@ chrono = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true, features = ["rustls-tls"] }
 tokio = { workspace = true }
+tar = "0.4"
+flate2 = "1.0"
+sha2 = "0.10"
 
 [features]
 default = ["ast"]

--- a/atomic-repository/Cargo.toml
+++ b/atomic-repository/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 atomic-core = { workspace = true }
 atomic-config = { workspace = true }
 atomic-identity = { workspace = true }
-atomic-semantic = { workspace = true, optional = true }
+atomic-semantic = { workspace = true }
 
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -37,10 +37,6 @@ tokio = { workspace = true }
 tar = "0.4"
 flate2 = "1.0"
 sha2 = "0.10"
-
-[features]
-default = ["ast"]
-ast = ["atomic-semantic"]
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/atomic-repository/src/ai/tools.rs
+++ b/atomic-repository/src/ai/tools.rs
@@ -816,7 +816,6 @@ impl<'a> ToolExecutor for RepoToolExecutor<'a> {
             },
         ];
 
-        #[cfg(feature = "ast")]
         defs.push(ToolDefinition {
             name: "list_entities".into(),
             description: "List code entities (functions, classes, types, etc.) in a file \
@@ -844,7 +843,6 @@ impl<'a> ToolExecutor for RepoToolExecutor<'a> {
             "read_file" => self.exec_read_file(&call.arguments),
             "code_search" => self.exec_code_search(&call.arguments),
             "vault_read" => self.exec_vault_read(&call.arguments),
-            #[cfg(feature = "ast")]
             "list_entities" => self.exec_list_entities(&call.arguments),
             other => Err(format!("unknown tool: {other}")),
         }
@@ -998,7 +996,6 @@ impl<'a> RepoToolExecutor<'a> {
         }
     }
 
-    #[cfg(feature = "ast")]
     fn exec_list_entities(&self, args: &serde_json::Value) -> Result<String, String> {
         let path_str = args["path"]
             .as_str()

--- a/atomic-repository/src/history/iter.rs
+++ b/atomic-repository/src/history/iter.rs
@@ -194,6 +194,7 @@ pub fn reverse_log<T: ViewTxnT>(
         load_headers: options.load_headers,
         view: options.view.clone(),
         tagged_only: options.tagged_only,
+        include_inherited: options.include_inherited,
     };
 
     let iter = log(txn, view, &forward_options)?;

--- a/atomic-repository/src/history/types.rs
+++ b/atomic-repository/src/history/types.rs
@@ -229,6 +229,14 @@ pub struct HistoryOptions {
 
     /// Only include tagged changes.
     pub tagged_only: bool,
+
+    /// Include inherited changes on draft views.
+    ///
+    /// By default (`false`), `log()` on a draft view only shows changes
+    /// that are new to that view — changes inherited from parent views
+    /// are filtered out.  Set to `true` to see the full change log
+    /// including inherited entries (equivalent to `--all` on the CLI).
+    pub include_inherited: bool,
 }
 
 impl HistoryOptions {
@@ -288,6 +296,15 @@ impl HistoryOptions {
     /// * `n` - Number of recent changes to retrieve
     pub fn last(n: usize) -> Self {
         Self::default().limit(n)
+    }
+
+    /// Include inherited changes on draft views.
+    ///
+    /// By default, draft views only show their own changes.
+    /// Call this to see the full log including parent changes.
+    pub fn include_inherited(mut self, include: bool) -> Self {
+        self.include_inherited = include;
+        self
     }
 
     /// Create options with headers loaded.

--- a/atomic-repository/src/lib.rs
+++ b/atomic-repository/src/lib.rs
@@ -149,7 +149,9 @@ pub use repository::{
 };
 
 // Vault intent exports
-pub use repository::{IntentCreateOptions, IntentCreateResult, IntentInfo, IntentUpdateOptions};
+pub use repository::{
+    IntentCreateOptions, IntentCreateResult, IntentDeleteResult, IntentInfo, IntentUpdateOptions,
+};
 
 // Vault embedding exports
 pub use repository::{hash_embed, EmbedConfig, TextChunk};

--- a/atomic-repository/src/lib.rs
+++ b/atomic-repository/src/lib.rs
@@ -119,6 +119,9 @@ pub mod ai;
 // Content search powered by syntext
 pub mod content_search;
 
+// OCI image layout production (sandbox stage/seal)
+pub mod oci;
+
 // Query plan schema and executor
 pub mod query_plan;
 

--- a/atomic-repository/src/oci.rs
+++ b/atomic-repository/src/oci.rs
@@ -1,0 +1,450 @@
+//! In-process production of standard [OCI image layouts].
+//!
+//! This module turns directory contents (or in-memory file sets) into gzipped
+//! tar layers and assembles them into a standard OCI image layout on disk —
+//! the format consumed by any OCI runtime (podman, containerd, smolvm). Nothing
+//! shells out: tar and gzip are built in memory with the `tar` and `flate2`
+//! crates and digests are computed with `sha2`.
+//!
+//! The two entry points for building layers are [`layer_from_dir`] (recursively
+//! tar a directory) and [`layer_from_entries`] (build a layer from an in-memory
+//! set of files plus optional whiteouts, used for delta layers). The assembled
+//! layout is written by [`write_image_layout`].
+//!
+//! [OCI image layouts]: https://github.com/opencontainers/image-spec/blob/main/image-layout.md
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use sha2::{Digest, Sha256};
+use tar::{Builder, EntryType, Header};
+use walkdir::WalkDir;
+
+/// Media type for a gzipped tar image layer.
+const MEDIA_TYPE_LAYER: &str = "application/vnd.oci.image.layer.v1.tar+gzip";
+/// Media type for an image config blob.
+const MEDIA_TYPE_CONFIG: &str = "application/vnd.oci.image.config.v1+json";
+/// Media type for an image manifest.
+const MEDIA_TYPE_MANIFEST: &str = "application/vnd.oci.image.manifest.v1+json";
+/// Media type for an image index.
+const MEDIA_TYPE_INDEX: &str = "application/vnd.oci.image.index.v1+json";
+
+/// A built, gzipped image layer plus its digests.
+pub struct OciLayer {
+    /// The gzipped tar bytes (the blob stored in the layout).
+    pub tar_gz: Vec<u8>,
+    /// `"sha256:<hex>"` of the **uncompressed** tar stream (the layer's
+    /// `diff_id` in the image config's `rootfs`).
+    pub diff_id: String,
+    /// `"sha256:<hex>"` of the gzipped bytes (the layer descriptor digest).
+    pub digest: String,
+    /// Size, in bytes, of the gzipped layer.
+    pub size: u64,
+}
+
+/// Configuration used to assemble an OCI image config and manifest.
+pub struct OciImageConfig {
+    /// Target architecture in OCI form, e.g. `"arm64"` or `"amd64"`.
+    pub architecture: String,
+    /// Operating system, e.g. `"linux"`.
+    pub os: String,
+    /// Environment variables, each as `"KEY=VAL"`.
+    pub env: Vec<String>,
+    /// Entrypoint argv. Empty if the image has no entrypoint.
+    pub entrypoint: Vec<String>,
+    /// Image-level annotations (used here to carry Atomic provenance).
+    pub annotations: BTreeMap<String, String>,
+}
+
+/// Map the host architecture (`std::env::consts::ARCH`) to its OCI name.
+///
+/// `"aarch64"` becomes `"arm64"`, `"x86_64"` becomes `"amd64"`; any other value
+/// is passed through unchanged.
+pub fn host_arch() -> String {
+    match std::env::consts::ARCH {
+        "aarch64" => "arm64",
+        "x86_64" => "amd64",
+        other => other,
+    }
+    .to_string()
+}
+
+/// Build a gzipped tar layer from a directory's contents (recursive).
+///
+/// Paths inside the tar are relative to `dir`. Regular files and symlinks are
+/// included; directory entries themselves are omitted (their paths are implied
+/// by the files within). Entries are emitted in a deterministic (sorted) order.
+/// Computes `diff_id` (sha256 of the uncompressed tar stream) and `digest`
+/// (sha256 of the gzipped bytes).
+pub fn layer_from_dir(dir: &Path) -> std::io::Result<OciLayer> {
+    let mut entries: Vec<(String, PathBuf, bool)> = Vec::new();
+    for entry in WalkDir::new(dir) {
+        let entry = entry.map_err(std::io::Error::from)?;
+        let file_type = entry.file_type();
+        if file_type.is_dir() {
+            continue;
+        }
+        let rel = match entry.path().strip_prefix(dir) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        if rel.as_os_str().is_empty() {
+            continue;
+        }
+        entries.push((
+            rel.to_string_lossy().into_owned(),
+            entry.path().to_path_buf(),
+            file_type.is_symlink(),
+        ));
+    }
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut tar_buf = Vec::new();
+    {
+        let mut builder = Builder::new(&mut tar_buf);
+        for (rel, full, is_symlink) in &entries {
+            if *is_symlink {
+                let target = std::fs::read_link(full)?;
+                let mut header = Header::new_gnu();
+                header.set_entry_type(EntryType::Symlink);
+                header.set_size(0);
+                header.set_mode(0o777);
+                header.set_mtime(0);
+                builder.append_link(&mut header, rel, &target)?;
+            } else {
+                let data = std::fs::read(full)?;
+                let mut header = Header::new_gnu();
+                header.set_entry_type(EntryType::Regular);
+                header.set_size(data.len() as u64);
+                header.set_mode(0o644);
+                header.set_mtime(0);
+                builder.append_data(&mut header, rel, data.as_slice())?;
+            }
+        }
+        builder.finish()?;
+    }
+
+    finish_layer(tar_buf)
+}
+
+/// Build a single layer from an in-memory set of `(relative_path, bytes)` files
+/// plus optional whiteouts.
+///
+/// Whiteouts mark deletions relative to a lower layer: a deleted path `foo/bar`
+/// is encoded as a zero-byte tar entry `foo/.wh.bar`, per the OCI spec. Entries
+/// are emitted in a deterministic (sorted) order. Useful for delta layers where
+/// staging files on disk is undesirable.
+pub fn layer_from_entries(
+    files: &[(String, Vec<u8>)],
+    whiteouts: &[String],
+) -> std::io::Result<OciLayer> {
+    let mut items: Vec<(String, Vec<u8>)> = Vec::with_capacity(files.len() + whiteouts.len());
+    for (path, bytes) in files {
+        items.push((path.clone(), bytes.clone()));
+    }
+    for path in whiteouts {
+        items.push((whiteout_path(path), Vec::new()));
+    }
+    items.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut tar_buf = Vec::new();
+    {
+        let mut builder = Builder::new(&mut tar_buf);
+        for (path, data) in &items {
+            let mut header = Header::new_gnu();
+            header.set_entry_type(EntryType::Regular);
+            header.set_size(data.len() as u64);
+            header.set_mode(0o644);
+            header.set_mtime(0);
+            builder.append_data(&mut header, path, data.as_slice())?;
+        }
+        builder.finish()?;
+    }
+
+    finish_layer(tar_buf)
+}
+
+/// Write a complete OCI image layout under `out` (created if needed):
+/// `out/oci-layout`, `out/index.json`, and `out/blobs/sha256/<...>` blobs.
+///
+/// `layers` are ordered base→top. Returns the manifest digest (`"sha256:..."`).
+/// The image config records the layers' uncompressed `diff_id`s; the manifest
+/// records the gzipped layer digests; `config.annotations` are passed through to
+/// the manifest.
+pub fn write_image_layout(
+    out: &Path,
+    layers: &[OciLayer],
+    config: &OciImageConfig,
+) -> std::io::Result<String> {
+    let blobs = out.join("blobs").join("sha256");
+    std::fs::create_dir_all(&blobs)?;
+
+    // Image config blob. diff_ids are the UNCOMPRESSED layer digests.
+    let diff_ids: Vec<String> = layers.iter().map(|l| l.diff_id.clone()).collect();
+    let history: Vec<serde_json::Value> = layers
+        .iter()
+        .map(|_| serde_json::json!({ "created_by": "atomic sandbox" }))
+        .collect();
+    let config_json = serde_json::json!({
+        "architecture": config.architecture,
+        "os": config.os,
+        "config": {
+            "Env": config.env,
+            "Entrypoint": config.entrypoint,
+        },
+        "rootfs": {
+            "type": "layers",
+            "diff_ids": diff_ids,
+        },
+        "history": history,
+    });
+    let config_bytes = json_to_vec(&config_json)?;
+    let config_hex = sha256_hex(&config_bytes);
+    std::fs::write(blobs.join(&config_hex), &config_bytes)?;
+    let config_digest = format!("sha256:{config_hex}");
+
+    // Layer blobs (the gzipped bytes), keyed by their gzipped digest.
+    for layer in layers {
+        std::fs::write(blobs.join(digest_hex(&layer.digest)), &layer.tar_gz)?;
+    }
+
+    // Manifest blob. Layer digests here are the GZIPPED digests.
+    let manifest_layers: Vec<serde_json::Value> = layers
+        .iter()
+        .map(|l| {
+            serde_json::json!({
+                "mediaType": MEDIA_TYPE_LAYER,
+                "digest": l.digest,
+                "size": l.size,
+            })
+        })
+        .collect();
+    let manifest_json = serde_json::json!({
+        "schemaVersion": 2,
+        "mediaType": MEDIA_TYPE_MANIFEST,
+        "config": {
+            "mediaType": MEDIA_TYPE_CONFIG,
+            "digest": config_digest,
+            "size": config_bytes.len(),
+        },
+        "layers": manifest_layers,
+        "annotations": config.annotations,
+    });
+    let manifest_bytes = json_to_vec(&manifest_json)?;
+    let manifest_hex = sha256_hex(&manifest_bytes);
+    std::fs::write(blobs.join(&manifest_hex), &manifest_bytes)?;
+    let manifest_digest = format!("sha256:{manifest_hex}");
+
+    // index.json references the manifest by digest + size.
+    let index_json = serde_json::json!({
+        "schemaVersion": 2,
+        "mediaType": MEDIA_TYPE_INDEX,
+        "manifests": [{
+            "mediaType": MEDIA_TYPE_MANIFEST,
+            "digest": manifest_digest,
+            "size": manifest_bytes.len(),
+            "platform": {
+                "architecture": config.architecture,
+                "os": config.os,
+            },
+        }],
+    });
+    let index_bytes = json_to_vec(&index_json)?;
+    std::fs::write(out.join("index.json"), &index_bytes)?;
+
+    // The layout marker file.
+    std::fs::write(out.join("oci-layout"), br#"{"imageLayoutVersion":"1.0.0"}"#)?;
+
+    Ok(manifest_digest)
+}
+
+/// Finalize an uncompressed tar buffer into an [`OciLayer`]: compute the
+/// uncompressed digest (`diff_id`), gzip the bytes, and compute the gzipped
+/// digest and size.
+fn finish_layer(tar_buf: Vec<u8>) -> std::io::Result<OciLayer> {
+    let diff_id = format!("sha256:{}", sha256_hex(&tar_buf));
+
+    let mut tar_gz = Vec::new();
+    {
+        let mut encoder = GzEncoder::new(&mut tar_gz, Compression::default());
+        encoder.write_all(&tar_buf)?;
+        encoder.finish()?;
+    }
+
+    let digest = format!("sha256:{}", sha256_hex(&tar_gz));
+    let size = tar_gz.len() as u64;
+    Ok(OciLayer {
+        tar_gz,
+        diff_id,
+        digest,
+        size,
+    })
+}
+
+/// Encode the OCI whiteout entry name for a deleted path.
+fn whiteout_path(path: &str) -> String {
+    match path.rfind('/') {
+        Some(idx) => format!("{}/.wh.{}", &path[..idx], &path[idx + 1..]),
+        None => format!(".wh.{path}"),
+    }
+}
+
+/// Strip the `sha256:` prefix from a digest, yielding the bare hex used as a
+/// blob filename.
+fn digest_hex(digest: &str) -> &str {
+    digest.strip_prefix("sha256:").unwrap_or(digest)
+}
+
+/// Lowercase-hex encode bytes.
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Compute the lowercase-hex sha256 of `bytes`.
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex_encode(&hasher.finalize())
+}
+
+/// Serialize a JSON value to bytes, mapping serialization failure to an IO error
+/// so callers can use `?` against `std::io::Result`.
+fn json_to_vec(value: &serde_json::Value) -> std::io::Result<Vec<u8>> {
+    serde_json::to_vec(value).map_err(std::io::Error::other)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+    use tempfile::tempdir;
+
+    /// Read all entries (path, bytes) from a gzipped tar layer.
+    fn read_layer_entries(tar_gz: &[u8]) -> Vec<(String, Vec<u8>)> {
+        let decoder = flate2::read::GzDecoder::new(tar_gz);
+        let mut archive = tar::Archive::new(decoder);
+        let mut out = Vec::new();
+        for entry in archive.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            let path = entry.path().unwrap().to_string_lossy().into_owned();
+            let mut bytes = Vec::new();
+            entry.read_to_end(&mut bytes).unwrap();
+            out.push((path, bytes));
+        }
+        out
+    }
+
+    #[test]
+    fn layer_from_dir_produces_valid_gzipped_tar() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/main.rs"), b"fn main() {}").unwrap();
+        std::fs::write(dir.path().join("README.md"), b"# hello").unwrap();
+
+        let layer = layer_from_dir(dir.path()).unwrap();
+
+        assert!(layer.diff_id.starts_with("sha256:"));
+        assert!(layer.digest.starts_with("sha256:"));
+        // The uncompressed digest must differ from the compressed digest.
+        assert_ne!(layer.diff_id, layer.digest);
+        assert_eq!(layer.size, layer.tar_gz.len() as u64);
+
+        let entries = read_layer_entries(&layer.tar_gz);
+        let paths: Vec<&str> = entries.iter().map(|(p, _)| p.as_str()).collect();
+        assert!(paths.contains(&"src/main.rs"));
+        assert!(paths.contains(&"README.md"));
+
+        let main = entries.iter().find(|(p, _)| p == "src/main.rs").unwrap();
+        assert_eq!(main.1, b"fn main() {}");
+    }
+
+    #[test]
+    fn layer_from_entries_encodes_whiteouts() {
+        let files = vec![("a/b.txt".to_string(), b"content".to_vec())];
+        let whiteouts = vec!["a/gone.txt".to_string()];
+
+        let layer = layer_from_entries(&files, &whiteouts).unwrap();
+        let entries = read_layer_entries(&layer.tar_gz);
+        let paths: Vec<&str> = entries.iter().map(|(p, _)| p.as_str()).collect();
+
+        assert!(paths.contains(&"a/b.txt"));
+        assert!(paths.contains(&"a/.wh.gone.txt"));
+        let wh = entries.iter().find(|(p, _)| p == "a/.wh.gone.txt").unwrap();
+        assert!(wh.1.is_empty());
+    }
+
+    #[test]
+    fn whiteout_path_handles_root_and_nested() {
+        assert_eq!(whiteout_path("foo"), ".wh.foo");
+        assert_eq!(whiteout_path("a/b/c"), "a/b/.wh.c");
+    }
+
+    #[test]
+    fn write_image_layout_creates_addressable_blobs() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("file.txt"), b"data").unwrap();
+
+        let layer = layer_from_dir(&src).unwrap();
+        let layer_digest = layer.digest.clone();
+
+        let mut annotations = BTreeMap::new();
+        annotations.insert("org.atomic.view".to_string(), "dev".to_string());
+        let config = OciImageConfig {
+            architecture: host_arch(),
+            os: "linux".to_string(),
+            env: vec!["FOO=bar".to_string()],
+            entrypoint: vec!["/bin/sh".to_string()],
+            annotations,
+        };
+
+        let out = dir.path().join("image");
+        let manifest_digest = write_image_layout(&out, &[layer], &config).unwrap();
+
+        // oci-layout
+        let layout = std::fs::read_to_string(out.join("oci-layout")).unwrap();
+        assert_eq!(layout, r#"{"imageLayoutVersion":"1.0.0"}"#);
+
+        // index.json references the manifest by digest + size.
+        let index_bytes = std::fs::read(out.join("index.json")).unwrap();
+        let index: serde_json::Value = serde_json::from_slice(&index_bytes).unwrap();
+        let manifest_ref = &index["manifests"][0];
+        assert_eq!(manifest_ref["digest"], manifest_digest);
+
+        // Every blob filename equals the sha256 of its contents.
+        let blobs = out.join("blobs").join("sha256");
+        for entry in std::fs::read_dir(&blobs).unwrap() {
+            let entry = entry.unwrap();
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let bytes = std::fs::read(entry.path()).unwrap();
+            assert_eq!(name, sha256_hex(&bytes), "blob filename must match content");
+        }
+
+        // The manifest blob exists and resolves config + layer to real blobs.
+        let manifest_hex = manifest_digest.strip_prefix("sha256:").unwrap();
+        let manifest_bytes = std::fs::read(blobs.join(manifest_hex)).unwrap();
+        let manifest: serde_json::Value = serde_json::from_slice(&manifest_bytes).unwrap();
+
+        let config_digest = manifest["config"]["digest"].as_str().unwrap();
+        assert!(blobs
+            .join(config_digest.strip_prefix("sha256:").unwrap())
+            .is_file());
+
+        let manifest_layer_digest = manifest["layers"][0]["digest"].as_str().unwrap();
+        assert_eq!(manifest_layer_digest, layer_digest);
+        assert!(blobs
+            .join(manifest_layer_digest.strip_prefix("sha256:").unwrap())
+            .is_file());
+
+        // Annotations are passed through.
+        assert_eq!(manifest["annotations"]["org.atomic.view"], "dev");
+    }
+}

--- a/atomic-repository/src/repository/history.rs
+++ b/atomic-repository/src/repository/history.rs
@@ -1,9 +1,16 @@
+use std::collections::HashSet;
+
 use super::*;
 
 impl Repository {
     // History Methods
 
     /// Get a forward history log for the current view.
+    ///
+    /// For **draft** views, only changes that are "new" on this view are
+    /// returned — inherited changes from ancestor views are filtered out.
+    /// Pass `--all` (via [`HistoryOptions::include_inherited`]) to see
+    /// the full change log including inherited entries.
     ///
     /// Returns an iterator over history entries starting from the given
     /// sequence number and proceeding forward (oldest to newest).
@@ -41,6 +48,17 @@ impl Repository {
                 name: view_name.to_string(),
             })?;
 
+        // For draft views, build a set of ancestor change NodeIds so we
+        // can filter out inherited entries.  This makes `atomic log` on a
+        // draft view show only "what's new" rather than the full history
+        // of every ancestor view.
+        let ancestor_ids: Option<HashSet<NodeId>> =
+            if view.kind.is_draft() && !options.include_inherited {
+                Some(Self::collect_ancestor_change_ids(&txn, &view)?)
+            } else {
+                None
+            };
+
         let iter = crate::history::log(&txn, &view, &options)
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
@@ -48,6 +66,13 @@ impl Repository {
         let mut entries = Vec::new();
         for result in iter {
             let mut entry = result.map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+            // Skip inherited entries on draft views
+            if let Some(ref ids) = ancestor_ids {
+                if ids.contains(&entry.node_id) {
+                    continue;
+                }
+            }
 
             // Load header if requested
             if options.load_headers {
@@ -91,6 +116,12 @@ impl Repository {
         let mut entries = crate::history::reverse_log(&txn, &view, &options)
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
+        // For draft views, filter out inherited entries
+        if view.kind.is_draft() && !options.include_inherited {
+            let ancestor_ids = Self::collect_ancestor_change_ids(&txn, &view)?;
+            entries.retain(|e| !ancestor_ids.contains(&e.node_id));
+        }
+
         // Load headers if requested
         if options.load_headers {
             for entry in &mut entries {
@@ -101,6 +132,33 @@ impl Repository {
         }
 
         Ok(entries)
+    }
+
+    /// Collect all change NodeIds from ancestor views' VIEW_CHANGES.
+    ///
+    /// Walks the parent chain and gathers each ancestor view's own
+    /// change entries.  The result is used by `log()` / `reverse_log()`
+    /// to filter out inherited entries on draft views.
+    fn collect_ancestor_change_ids<T: ViewTxnT>(
+        txn: &T,
+        view: &atomic_core::pristine::ViewState,
+    ) -> Result<HashSet<NodeId>, RepositoryError> {
+        let mut ids = HashSet::new();
+        let mut cursor = view.parent;
+        while let Some(pid) = cursor {
+            let parent = txn
+                .get_view_by_id(pid)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+            match parent {
+                Some(p) => {
+                    let parent_ids = super::filter::collect_view_change_ids(txn, &p)?;
+                    ids.extend(parent_ids);
+                    cursor = p.parent;
+                }
+                None => break,
+            }
+        }
+        Ok(ids)
     }
 
     /// Get a summary of the current view's history.

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -126,7 +126,9 @@ pub use vault_goal::{
     GoalInfo, GoalStartOptions, GoalStartResult, GoalStopOptions, GoalStopResult,
 };
 pub use vault_identity::VaultIdentity;
-pub use vault_intent::{IntentCreateOptions, IntentCreateResult, IntentInfo, IntentUpdateOptions};
+pub use vault_intent::{
+    IntentCreateOptions, IntentCreateResult, IntentDeleteResult, IntentInfo, IntentUpdateOptions,
+};
 pub use vault_kg_enrich::KgEnrichStats;
 pub use vault_names::{derive_intent_prefix, generate_goal_name};
 

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -77,6 +77,7 @@ use crate::RepositoryError;
 
 mod filter;
 mod materialize;
+mod sandbox;
 mod semantic_materialize;
 mod switch;
 mod views;
@@ -87,6 +88,7 @@ pub use filter::{
     collect_view_change_ids, collect_visible_change_ids, collect_visible_change_ids_with_deps,
     expand_indexed_dependency_closure,
 };
+pub use sandbox::{SealOptions, SealResult, StageOptions, StageResult, SANDBOX_POINTER};
 pub use views::ViewInfo;
 
 // Re-import workspace helpers from `switch` so they are available to
@@ -299,6 +301,9 @@ default = "{}"
     ///
     /// Returns an error if no repository is found.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, RepositoryError> {
+        if let Some((working_root, canonical, view)) = sandbox::detect_sandbox(path.as_ref()) {
+            return Self::open_sandbox(working_root, canonical, &view);
+        }
         let root = Self::find_root(path.as_ref())?;
         let dot_dir = root.join(DOT_DIR);
 
@@ -335,6 +340,9 @@ default = "{}"
     /// Use this for short-lived processes (agent hooks, background jobs)
     /// where blocking on the init write lock would hang the process.
     pub fn open_existing<P: AsRef<Path>>(path: P) -> Result<Self, RepositoryError> {
+        if let Some((working_root, canonical, view)) = sandbox::detect_sandbox(path.as_ref()) {
+            return Self::open_sandbox(working_root, canonical, &view);
+        }
         let root = Self::find_root(path.as_ref())?;
         let dot_dir = root.join(DOT_DIR);
 
@@ -389,6 +397,9 @@ default = "{}"
     /// let status = repo.status(StatusOptions::default())?;
     /// ```
     pub fn open_readonly<P: AsRef<Path>>(path: P) -> Result<Self, RepositoryError> {
+        if let Some((working_root, canonical, view)) = sandbox::detect_sandbox(path.as_ref()) {
+            return Self::open_sandbox(working_root, canonical, &view);
+        }
         let root = Self::find_root(path.as_ref())?;
         let dot_dir = root.join(DOT_DIR);
 

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -193,6 +193,12 @@ pub struct Repository {
     pristine: Arc<Pristine>,
     /// The change store for persisting changes
     change_store: ChangeStore,
+    /// Whether this handle was opened for an agent sandbox (via
+    /// [`Repository::open_sandbox`]). A sandbox's `dot_dir`/`pristine`/
+    /// `change_store` point at the canonical repository while `current_view`
+    /// holds the sandbox's view (from its pointer file); it must not repoint
+    /// the canonical `current_view` on disk.
+    is_sandbox: bool,
 }
 
 impl std::fmt::Debug for Repository {
@@ -203,6 +209,7 @@ impl std::fmt::Debug for Repository {
             .field("current_view", &self.current_view)
             .field("pristine", &"<Pristine>")
             .field("change_store", &self.change_store)
+            .field("is_sandbox", &self.is_sandbox)
             .finish()
     }
 }
@@ -285,6 +292,7 @@ default = "{}"
             current_view: DEFAULT_VIEW.to_string(),
             pristine,
             change_store,
+            is_sandbox: false,
         })
     }
 
@@ -327,6 +335,7 @@ default = "{}"
             current_view,
             pristine,
             change_store,
+            is_sandbox: false,
         })
     }
 
@@ -363,6 +372,7 @@ default = "{}"
             current_view,
             pristine,
             change_store,
+            is_sandbox: false,
         })
     }
 
@@ -423,6 +433,7 @@ default = "{}"
             current_view,
             pristine,
             change_store,
+            is_sandbox: false,
         })
     }
 
@@ -460,6 +471,7 @@ default = "{}"
             current_view,
             pristine,
             change_store,
+            is_sandbox: false,
         })
     }
 
@@ -539,6 +551,17 @@ default = "{}"
     #[inline]
     pub fn current_view(&self) -> &str {
         &self.current_view
+    }
+
+    /// Whether this handle was opened for an agent sandbox.
+    ///
+    /// A sandbox records into the canonical graph on the view named in its
+    /// pointer file (held in `current_view`, never written back to the
+    /// canonical `current_view` on disk), so callers must not fork a new view
+    /// or repoint the current view for it.
+    #[inline]
+    pub fn is_sandbox(&self) -> bool {
+        self.is_sandbox
     }
 
     /// Get the config file path.

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -630,6 +630,15 @@ default = "{}"
         Ok(())
     }
 
+    /// Set the current view on this handle only.
+    ///
+    /// This does not validate the view or persist `.atomic/current_view`. It is
+    /// intended for read-only handles that need `status()` to read another view.
+    #[inline]
+    pub fn set_current_view_in_memory(&mut self, view: &str) {
+        self.current_view = view.to_string();
+    }
+
     // ── Internal helpers ────────────────────────────────────────────────
 
     /// Get a reference to the pristine database.

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -523,6 +523,25 @@ default = "{}"
         Self::find_root(path.as_ref()).is_ok()
     }
 
+    /// Resolve the **canonical** `.atomic` directory for a working path
+    /// *without* opening the database.
+    ///
+    /// If `path` is inside an agent sandbox, follows the `.atomic-sandbox`
+    /// pointer to the canonical repository; otherwise finds the enclosing
+    /// repository root. Returns `<canonical_root>/.atomic`.
+    ///
+    /// Use this for lock-free filesystem access to the canonical graph — e.g.
+    /// writing a provenance graph through [`ChangeStore`] —
+    /// where opening a full [`Repository`] would take the redb lock. In a
+    /// sandbox `path/.atomic` is a throwaway local dir (or absent), so joining
+    /// `.atomic` onto the working root would miss the real graph entirely.
+    pub fn canonical_dot_dir<P: AsRef<Path>>(path: P) -> Result<PathBuf, RepositoryError> {
+        if let Some((_working, canonical, _view)) = sandbox::detect_sandbox(path.as_ref()) {
+            return Ok(Self::find_root(&canonical)?.join(DOT_DIR));
+        }
+        Ok(Self::find_root(path.as_ref())?.join(DOT_DIR))
+    }
+
     /// Get the repository root path.
     #[inline]
     pub fn root(&self) -> &Path {

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -645,7 +645,7 @@ default = "{}"
     /// Use this only when the caller will immediately populate the working
     /// copy itself (e.g. the agent record hook, which creates files and
     /// then records them).  For interactive view switches, use
-    /// [`switch_view`] instead — it materializes the working copy and
+    /// [`Repository::switch_view`] instead — it materializes the working copy and
     /// prevents desync between the pointer and disk state.
     ///
     /// `status()` handles the desynchronised state gracefully: files that

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -593,20 +593,25 @@ default = "{}"
 
     /// Set the current view (internal, does not update working copy).
     ///
+    /// Update the view pointer on disk without materializing.
+    ///
     /// This updates both the in-memory state and persists the change to disk,
-    /// but does NOT update the working copy. Use `switch_view` instead for
-    /// the full switch operation that also updates the working copy.
+    /// but does **NOT** update the working copy.  The working copy may be
+    /// left inconsistent with the view pointer — `status()` handles this
+    /// gracefully (files tracked on other views show as `Added` rather than
+    /// `Untracked`), but callers should prefer `switch_view()` for any
+    /// user-facing view change.
     ///
-    /// # Arguments
-    ///
-    /// * `view` - The name of the view to switch to
+    /// This is `pub(crate)` to prevent external code from accidentally
+    /// desynchronising the view pointer and working copy.  Internal uses
+    /// (init, git import, agent record alignment) know they will
+    /// materialise or record immediately afterward.
     ///
     /// # Errors
     ///
-    /// Returns an error if:
-    /// - The view does not exist in the pristine database
-    /// - The view file cannot be written
-    pub fn set_current_view(&mut self, view: &str) -> Result<(), RepositoryError> {
+    /// Returns an error if the view does not exist or the pointer file
+    /// cannot be written.
+    pub(crate) fn set_current_view(&mut self, view: &str) -> Result<(), RepositoryError> {
         // Verify the view exists in the pristine database
         {
             let txn = self
@@ -628,6 +633,33 @@ default = "{}"
         self.current_view = view.to_string();
         self.write_current_view(view)?;
         Ok(())
+    }
+
+    /// Align the view pointer without materializing the working copy.
+    ///
+    /// This persists the new view name to `.atomic/current_view` so that
+    /// subsequent `status()`, `add()`, and `record()` calls target the
+    /// correct view, but it does **not** add, remove, or update any files
+    /// on disk.
+    ///
+    /// Use this only when the caller will immediately populate the working
+    /// copy itself (e.g. the agent record hook, which creates files and
+    /// then records them).  For interactive view switches, use
+    /// [`switch_view`] instead — it materializes the working copy and
+    /// prevents desync between the pointer and disk state.
+    ///
+    /// `status()` handles the desynchronised state gracefully: files that
+    /// are tracked globally (in TREE) but whose introducing change belongs
+    /// to another view appear as `Added` (not `Untracked`), so there is
+    /// no contradictory "Untracked + already tracked" state even if the
+    /// caller forgets to materialise.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the view does not exist or the pointer file
+    /// cannot be written.
+    pub fn align_to_view(&mut self, view: &str) -> Result<(), RepositoryError> {
+        self.set_current_view(view)
     }
 
     /// Set the current view on this handle only.

--- a/atomic-repository/src/repository/sandbox.rs
+++ b/atomic-repository/src/repository/sandbox.rs
@@ -1,0 +1,506 @@
+//! Concurrent agent sandboxes.
+//!
+//! A sandbox lets several agents work at once, each in its own working tree,
+//! while sharing a single canonical graph. Two pieces make that work:
+//!
+//! 1. [`Repository::provision_sandbox`] — give an agent a private working tree
+//!    that is a **copy-on-write clone** of the canonical one. On filesystems
+//!    that support it (APFS, Btrfs, XFS, ReFS) the clone shares blocks until
+//!    written, so five agents off a 200 MB base cost a few MB, not a gigabyte.
+//!    Build artifacts (`node_modules`, `target`) land in the agent's own tree
+//!    and never collide.
+//!
+//! 2. [`Repository::open_sandbox`] — open the repository with the agent's
+//!    working tree as the root, but the **canonical** `.atomic/` as the graph.
+//!    The graph (`pristine` + `changes`) is never cloned: there is one graph,
+//!    and views are filters over it. Every `atomic` command the agent runs —
+//!    `record`, `status`, `diff`, `vault query` — works unchanged, because it
+//!    is a normal repository whose working tree just happens to live elsewhere.
+//!
+//! The only OS-specific concern (how to clone a file copy-on-write) is owned by
+//! the `reflink-copy` crate, which falls back to a plain copy when the
+//! filesystem cannot reflink. Our code has a single path.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use atomic_core::pristine::Pristine;
+use serde::{Deserialize, Serialize};
+
+use crate::changestore::{ChangeStore, DEFAULT_CACHE_CAPACITY};
+use crate::oci::{self, OciImageConfig};
+
+use super::{Repository, DOT_DIR};
+use crate::RepositoryError;
+
+/// Options for [`Repository::stage`].
+pub struct StageOptions {
+    /// The sandbox's draft view (the working view to package).
+    pub view: String,
+    /// The shared base view this sandbox forked from.
+    pub base_view: String,
+    /// Output directory for the OCI image layout (created if needed).
+    pub out: PathBuf,
+}
+
+/// Result of [`Repository::stage`].
+pub struct StageResult {
+    /// Digest (`"sha256:..."`) of the written image manifest.
+    pub manifest_digest: String,
+    /// `diff_id` of the base layer — its content-address, by which a cached
+    /// base can be matched and reused across staged iterations.
+    pub base_diff_id: String,
+    /// Number of files in the delta layer (new or changed vs. the base).
+    pub delta_files: usize,
+    /// The output directory the layout was written to.
+    pub out: PathBuf,
+}
+
+/// Options for [`Repository::seal`].
+pub struct SealOptions {
+    /// The view to package as a flattened, self-contained image.
+    pub view: String,
+    /// Output directory for the OCI image layout (created if needed).
+    pub out: PathBuf,
+    /// Image entrypoint argv. Empty for none.
+    pub entrypoint: Vec<String>,
+    /// Image environment variables, each as `"KEY=VAL"`.
+    pub env: Vec<String>,
+}
+
+/// Result of [`Repository::seal`].
+pub struct SealResult {
+    /// Digest (`"sha256:..."`) of the written image manifest.
+    pub manifest_digest: String,
+    /// Number of files written into the (single) layer.
+    pub files: usize,
+    /// The output directory the layout was written to.
+    pub out: PathBuf,
+}
+
+/// Marker file written at the root of a sandbox working tree. Its presence
+/// tells `Repository::open*` to resolve the graph from the canonical repo
+/// instead of looking for a local `.atomic/`.
+pub const SANDBOX_POINTER: &str = ".atomic-sandbox";
+
+/// Persisted contents of a sandbox pointer: where the canonical graph lives
+/// and which view this sandbox operates on.
+#[derive(Debug, Serialize, Deserialize)]
+struct SandboxPointer {
+    /// Absolute path to the canonical repository root (the one with `.atomic/`).
+    canonical: PathBuf,
+    /// View this sandbox operates on.
+    view: String,
+}
+
+/// Walk up from `start` looking for a [`SANDBOX_POINTER`] file. If found,
+/// return `(working_root, canonical_root, view)`.
+pub(super) fn detect_sandbox(start: &Path) -> Option<(PathBuf, PathBuf, String)> {
+    let mut dir = if start.is_absolute() {
+        start.to_path_buf()
+    } else {
+        std::env::current_dir().ok()?.join(start)
+    };
+
+    loop {
+        let pointer = dir.join(SANDBOX_POINTER);
+        if pointer.is_file() {
+            let bytes = std::fs::read(&pointer).ok()?;
+            let parsed: SandboxPointer = serde_json::from_slice(&bytes).ok()?;
+            return Some((dir.clone(), parsed.canonical, parsed.view));
+        }
+        // Stop if we reach a real repository root — that's not a sandbox.
+        if dir.join(DOT_DIR).join("pristine.redb").is_file() {
+            return None;
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
+impl Repository {
+    /// Open a repository for an agent sandbox.
+    ///
+    /// The agent's private working tree is at `working_root`, but the graph
+    /// lives in the **canonical** repository found from `canonical`. All
+    /// sandboxes opened this way read and write the same `pristine` and
+    /// `changes` store, so there is exactly one graph. `view` selects which
+    /// view this sandbox operates on (typically the agent's own draft view).
+    ///
+    /// The canonical `current_view` file on disk is left untouched — the view
+    /// is held in memory for this handle only, so concurrent agents on
+    /// different views never clobber one another.
+    ///
+    /// redb serialises writers, so concurrent `record`s from several agents
+    /// take turns; reads run concurrently via MVCC.
+    pub fn open_sandbox<P, Q>(
+        working_root: P,
+        canonical: Q,
+        view: &str,
+    ) -> Result<Self, RepositoryError>
+    where
+        P: AsRef<Path>,
+        Q: AsRef<Path>,
+    {
+        let working_root = working_root.as_ref().to_path_buf();
+        let canonical_root = Self::find_root(canonical.as_ref())?;
+        let dot_dir = canonical_root.join(DOT_DIR);
+
+        let pristine = Arc::new(
+            Pristine::open_existing(dot_dir.join("pristine.redb"))
+                .map_err(|e| RepositoryError::Database(e.to_string()))?,
+        );
+        let change_store = ChangeStore::new(dot_dir.join("changes"), DEFAULT_CACHE_CAPACITY)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        Ok(Self {
+            root: working_root,
+            dot_dir,
+            current_view: view.to_string(),
+            pristine,
+            change_store,
+        })
+    }
+
+    /// Provision an agent's private working tree as a copy-on-write clone of
+    /// this repository's working tree.
+    ///
+    /// Copies every tracked-or-untracked working file into `dest`, reflinking
+    /// where the filesystem supports it (so unchanged blocks are shared on
+    /// disk) and falling back to a plain copy otherwise. The `.atomic/`
+    /// directory is **never** cloned — the sandbox shares the canonical graph
+    /// via [`Repository::open_sandbox`].
+    ///
+    /// Returns the number of files provisioned.
+    ///
+    /// Also writes a [`SANDBOX_POINTER`] file into `dest` so that `atomic`
+    /// commands run inside the sandbox resolve to this repository's canonical
+    /// graph and the given `view`.
+    pub fn provision_sandbox<P: AsRef<Path>>(
+        &self,
+        dest: P,
+        view: &str,
+    ) -> Result<usize, RepositoryError> {
+        let dest = dest.as_ref();
+        let count = provision_working_tree(&self.root, dest)?;
+
+        let pointer = SandboxPointer {
+            canonical: self.root.clone(),
+            view: view.to_string(),
+        };
+        let bytes = serde_json::to_vec_pretty(&pointer)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        std::fs::write(dest.join(SANDBOX_POINTER), bytes)?;
+
+        Ok(count)
+    }
+
+    /// Materialize a view's visible file content into `dir` (created if needed).
+    ///
+    /// Writes each visible file's bytes exactly as they appear on `view` (the
+    /// view's own changes plus its parent chain). Returns the number of files
+    /// written.
+    pub fn materialize_view_to(&self, view: &str, dir: &Path) -> Result<usize, RepositoryError> {
+        std::fs::create_dir_all(dir)?;
+
+        let mut count = 0usize;
+        for path in self.visible_file_paths(view)? {
+            let bytes = match self.get_file_content_on_view(&path, view)? {
+                Some(bytes) => bytes,
+                None => continue,
+            };
+            let target = dir.join(&path);
+            if let Some(parent) = target.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(&target, &bytes)?;
+            count += 1;
+        }
+
+        Ok(count)
+    }
+
+    /// Produce a two-layer OCI image: a base layer (the `base_view`
+    /// materialized) plus a thin delta layer (files that differ on `view`
+    /// versus `base_view`, with whiteouts for files removed on `view`).
+    ///
+    /// Built for the inner loop: the base is content-addressed by its `diff_id`
+    /// and can be pulled once and cached, so each iteration ships only the small
+    /// delta. Provenance (view names and Merkle states) is recorded in the
+    /// manifest annotations. Returns the manifest digest and base `diff_id`.
+    pub fn stage(&self, opts: StageOptions) -> Result<StageResult, RepositoryError> {
+        // 1. Base layer: materialize the shared base view to a temp dir.
+        let base_dir = tempfile::tempdir()?;
+        self.materialize_view_to(&opts.base_view, base_dir.path())?;
+        let base_layer = oci::layer_from_dir(base_dir.path())?;
+        let base_diff_id = base_layer.diff_id.clone();
+
+        // 2. Delta: files new or changed on `view` vs. `base_view`, plus
+        //    whiteouts for files present on the base but gone on `view`.
+        let view_paths = self.visible_file_paths(&opts.view)?;
+        let base_paths = self.visible_file_paths(&opts.base_view)?;
+
+        let mut changed: Vec<(String, Vec<u8>)> = Vec::new();
+        for path in &view_paths {
+            let view_bytes = match self.get_file_content_on_view(path, &opts.view)? {
+                Some(bytes) => bytes,
+                None => continue,
+            };
+            let base_bytes = self.get_file_content_on_view(path, &opts.base_view)?;
+            if base_bytes.as_deref() != Some(view_bytes.as_slice()) {
+                changed.push((path.clone(), view_bytes));
+            }
+        }
+
+        let mut whiteouts: Vec<String> = Vec::new();
+        for path in &base_paths {
+            if !view_paths.contains(path) {
+                whiteouts.push(path.clone());
+            }
+        }
+
+        let delta_files = changed.len();
+        let delta_layer = oci::layer_from_entries(&changed, &whiteouts)?;
+
+        // 3. Assemble the layout with provenance annotations.
+        let view_info = self.get_view_info(&opts.view)?;
+        let base_info = self.get_view_info(&opts.base_view)?;
+        let mut annotations = BTreeMap::new();
+        annotations.insert("org.atomic.view".to_string(), opts.view.clone());
+        annotations.insert("org.atomic.base-view".to_string(), opts.base_view.clone());
+        annotations.insert(
+            "org.atomic.view-merkle".to_string(),
+            view_info.state_base32(),
+        );
+        annotations.insert(
+            "org.atomic.base-merkle".to_string(),
+            base_info.state_base32(),
+        );
+
+        let config = OciImageConfig {
+            architecture: oci::host_arch(),
+            os: "linux".to_string(),
+            env: Vec::new(),
+            entrypoint: Vec::new(),
+            annotations,
+        };
+
+        let manifest_digest =
+            oci::write_image_layout(&opts.out, &[base_layer, delta_layer], &config)?;
+
+        Ok(StageResult {
+            manifest_digest,
+            base_diff_id,
+            delta_files,
+            out: opts.out,
+        })
+    }
+
+    /// Produce a single-layer (flattened) OCI image of the full merged state of
+    /// `view`.
+    ///
+    /// Because a draft view sees its entire parent chain, the materialized
+    /// content is the complete, self-contained rootfs — a deployable runtime.
+    /// Provenance (view name and Merkle state) is recorded in the manifest
+    /// annotations. Returns the manifest digest and file count.
+    pub fn seal(&self, opts: SealOptions) -> Result<SealResult, RepositoryError> {
+        let work_dir = tempfile::tempdir()?;
+        let files = self.materialize_view_to(&opts.view, work_dir.path())?;
+        let layer = oci::layer_from_dir(work_dir.path())?;
+
+        let view_info = self.get_view_info(&opts.view)?;
+        let mut annotations = BTreeMap::new();
+        annotations.insert("org.atomic.view".to_string(), opts.view.clone());
+        annotations.insert(
+            "org.atomic.view-merkle".to_string(),
+            view_info.state_base32(),
+        );
+
+        let config = OciImageConfig {
+            architecture: oci::host_arch(),
+            os: "linux".to_string(),
+            env: opts.env.clone(),
+            entrypoint: opts.entrypoint.clone(),
+            annotations,
+        };
+
+        let manifest_digest = oci::write_image_layout(&opts.out, &[layer], &config)?;
+
+        Ok(SealResult {
+            manifest_digest,
+            files,
+            out: opts.out,
+        })
+    }
+}
+
+/// Clone a working tree from `src` to `dest`, one file at a time, reflinking
+/// where possible. Skips the `.atomic/` graph directory.
+fn provision_working_tree(src: &Path, dest: &Path) -> Result<usize, RepositoryError> {
+    use walkdir::WalkDir;
+
+    let mut count = 0usize;
+    std::fs::create_dir_all(dest)?;
+
+    for entry in WalkDir::new(src).into_iter().filter_entry(|e| {
+        // Never descend into the canonical graph — it is shared, not cloned.
+        if e.file_name() == DOT_DIR {
+            return false;
+        }
+        // Never descend into a nested sandbox (a dir holding its own pointer).
+        if e.file_type().is_dir() && e.path().join(SANDBOX_POINTER).is_file() {
+            return false;
+        }
+        true
+    }) {
+        let entry = entry.map_err(std::io::Error::from)?;
+        let rel = match entry.path().strip_prefix(src) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        if rel.as_os_str().is_empty() {
+            continue;
+        }
+        let target = dest.join(rel);
+
+        let ft = entry.file_type();
+        if ft.is_dir() {
+            std::fs::create_dir_all(&target)?;
+        } else if ft.is_file() {
+            if let Some(parent) = target.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            // Single cross-platform path: reflink (CoW) where the filesystem
+            // supports it, plain copy where it does not.
+            reflink_copy::reflink_or_copy(entry.path(), &target)?;
+            count += 1;
+        } else if ft.is_symlink() {
+            if let Some(parent) = target.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let _ = recreate_symlink(entry.path(), &target);
+        }
+    }
+
+    Ok(count)
+}
+
+/// Recreate a symlink found at `src` into `dest`, preserving its target.
+///
+/// Unix has a dedicated definition; everything else falls back below.
+#[cfg(unix)]
+fn recreate_symlink(src: &Path, dest: &Path) -> std::io::Result<()> {
+    let link_target = std::fs::read_link(src)?;
+    std::os::unix::fs::symlink(link_target, dest)
+}
+
+/// Non-Unix fallback: symlink creation needs special privileges, so copy the
+/// file the link resolves to (correct content-wise).
+#[cfg(not(unix))]
+fn recreate_symlink(src: &Path, dest: &Path) -> std::io::Result<()> {
+    std::fs::copy(src, dest).map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::record::RecordOptions;
+    use crate::tracking::TrackingOptions;
+    use crate::InsertOptions;
+    use atomic_core::change::ChangeHeader;
+    use tempfile::tempdir;
+
+    /// Initialize a repository at `root` and record+apply a single file on the
+    /// default `dev` view, returning the opened repository.
+    fn repo_with_recorded_file(root: &Path, rel: &str, contents: &[u8]) -> Repository {
+        std::fs::create_dir_all(root).unwrap();
+        let repo = Repository::init(root).unwrap();
+
+        let path = root.join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&path, contents).unwrap();
+
+        repo.add(rel, TrackingOptions::default()).unwrap();
+        let header = ChangeHeader::new("add file");
+        let options = RecordOptions::new()
+            .with_all(true)
+            .save_to_store(true)
+            .apply_after_record(false);
+        let outcome = repo.record(header, options).unwrap();
+        repo.write_recorded(&outcome, InsertOptions::default())
+            .unwrap();
+
+        repo
+    }
+
+    #[test]
+    fn materialize_view_to_writes_visible_files() {
+        let dir = tempdir().unwrap();
+        let repo = repo_with_recorded_file(&dir.path().join("repo"), "src/hello.txt", b"hi\n");
+
+        let out = dir.path().join("mat");
+        let count = repo.materialize_view_to("dev", &out).unwrap();
+
+        assert_eq!(count, 1);
+        assert_eq!(std::fs::read(out.join("src/hello.txt")).unwrap(), b"hi\n");
+    }
+
+    #[test]
+    fn seal_produces_single_layer_oci_layout() {
+        let dir = tempdir().unwrap();
+        let repo = repo_with_recorded_file(&dir.path().join("repo"), "hello.txt", b"hello world\n");
+
+        let out = dir.path().join("image");
+        let result = repo
+            .seal(SealOptions {
+                view: "dev".to_string(),
+                out: out.clone(),
+                entrypoint: vec!["/bin/sh".to_string()],
+                env: vec!["FOO=bar".to_string()],
+            })
+            .unwrap();
+
+        assert_eq!(result.files, 1);
+        assert!(result.manifest_digest.starts_with("sha256:"));
+        assert!(out.join("oci-layout").is_file());
+        assert!(out.join("index.json").is_file());
+
+        // The manifest blob exists and references exactly one layer.
+        let manifest_hex = result.manifest_digest.strip_prefix("sha256:").unwrap();
+        let manifest_path = out.join("blobs").join("sha256").join(manifest_hex);
+        assert!(manifest_path.is_file());
+        let manifest: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+        assert_eq!(manifest["layers"].as_array().unwrap().len(), 1);
+        assert_eq!(manifest["annotations"]["org.atomic.view"], "dev");
+    }
+
+    #[test]
+    fn provision_clones_working_tree_and_skips_dot_dir() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("repo");
+        std::fs::create_dir_all(src.join("src")).unwrap();
+        std::fs::create_dir_all(src.join(DOT_DIR)).unwrap();
+        std::fs::write(src.join("src/main.rs"), b"fn main() {}").unwrap();
+        std::fs::write(src.join("Cargo.toml"), b"[package]").unwrap();
+        std::fs::write(src.join(DOT_DIR).join("pristine.redb"), b"GRAPH").unwrap();
+
+        let dest = dir.path().join("agent-1");
+        let count = provision_working_tree(&src, &dest).unwrap();
+
+        assert_eq!(count, 2, "two working files cloned");
+        assert_eq!(
+            std::fs::read(dest.join("src/main.rs")).unwrap(),
+            b"fn main() {}"
+        );
+        assert!(dest.join("Cargo.toml").exists());
+        assert!(
+            !dest.join(DOT_DIR).exists(),
+            "the canonical graph must not be cloned into the sandbox"
+        );
+    }
+}

--- a/atomic-repository/src/repository/sandbox.rs
+++ b/atomic-repository/src/repository/sandbox.rs
@@ -161,6 +161,7 @@ impl Repository {
             current_view: view.to_string(),
             pristine,
             change_store,
+            is_sandbox: true,
         })
     }
 

--- a/atomic-repository/src/repository/status.rs
+++ b/atomic-repository/src/repository/status.rs
@@ -80,6 +80,12 @@ impl Repository {
         let mut directory_inodes: HashSet<atomic_core::types::Inode> = HashSet::new();
         // Cache inode → has_graph_content so we don't call inode_position twice
         let mut has_graph_content_cache: HashMap<PathBuf, bool> = HashMap::new();
+        // Files tracked globally (in TREE) but whose introducing change
+        // belongs to another view.  These must stay in `tracked_paths` so
+        // they don't surface as "Untracked" in the filesystem walk, but if
+        // they are absent from disk they must be silently skipped (not
+        // reported as "Deleted" — they were never on this view).
+        let mut foreign_paths: HashSet<PathBuf> = HashSet::new();
 
         let tree_iter = txn
             .iter_tree()
@@ -88,25 +94,39 @@ impl Repository {
         for result in tree_iter {
             let (path, inode) = result.map_err(|e| RepositoryError::Database(e.to_string()))?;
 
-            // View filter: skip files whose creating change is not on
-            // the current view.  Files in TREE without a graph position
-            // must be classified as Added, not Clean.  Files whose
-            // creating change is not in the current view's filter are
-            // skipped entirely — they belong to other views and must not
-            // appear in this view's status.
+            // Normalize path once (before view filter so foreign_paths
+            // uses the same key as tracked_paths).
+            let normalized = normalize_tracked_path(&path, &self.root);
+
+            // View filter: decide whether this file's graph content is
+            // visible on the current view.
+            //
+            // Files in TREE without a graph position → Added (not yet
+            // recorded).  Files whose creating change IS in the current
+            // view's filter → tracked normally.  Files whose creating
+            // change is NOT in the filter → "foreign": they belong to
+            // another view.  We keep them in tracked_paths (so the
+            // filesystem walk doesn't mark them Untracked) but flag them
+            // so that if they're absent from disk we skip them silently
+            // instead of reporting Deleted.
             let has_graph = if let Ok(Some(position)) = txn.inode_position(inode) {
                 if let Some(ref ids) = current_view_change_ids {
                     if !position.change.is_root() && !ids.contains(&position.change) {
-                        continue;
+                        // Foreign file — tracked globally, not on this view.
+                        // Include in tracked_paths with has_graph=false so
+                        // it shows as Added if on disk, and track it as
+                        // foreign so we skip it when not on disk.
+                        foreign_paths.insert(normalized.clone());
+                        false
+                    } else {
+                        true
                     }
+                } else {
+                    true
                 }
-                true
             } else {
                 false
             };
-
-            // Normalize path once
-            let normalized = normalize_tracked_path(&path, &self.root);
 
             // Apply path filter if specified
             if !options.path_filters.is_empty() {
@@ -208,6 +228,17 @@ impl Repository {
             let metadata = match std::fs::metadata(&abs_path) {
                 Ok(m) if m.is_file() => m,
                 _ => {
+                    // Foreign file not on disk — skip silently.
+                    // This file is tracked globally (in TREE) but its
+                    // graph content belongs to another view and it does
+                    // not exist on disk for THIS view.  Reporting it as
+                    // "Deleted" would be wrong (it was never present on
+                    // this view).
+                    if foreign_paths.contains(path) {
+                        found_on_disk.insert(path.clone());
+                        continue;
+                    }
+
                     // File missing from disk.  Check whether the deletion
                     // has already been recorded in the graph.
                     //

--- a/atomic-repository/src/repository/tests/status_tests.rs
+++ b/atomic-repository/src/repository/tests/status_tests.rs
@@ -375,6 +375,190 @@ fn test_repo_status_ignores_node_modules_no_trailing_newline() {
 }
 
 #[test]
+fn test_status_no_untracked_for_files_tracked_on_other_view() {
+    // Reproduces the customer bug report:
+    //   "I run atomic status and it shows me tons of things that aren't
+    //    tracked, then I run atomic add and it says there's nothing to add."
+    //
+    // Root cause: status() filters TREE entries by the view's change filter
+    // (view-aware), excluding files whose introducing change isn't visible.
+    // Those files then appear as "Untracked" during the filesystem walk.
+    // But is_tracked() (used by add) checks the global TREE table without
+    // any view filter — so those same files are "already tracked."
+    //
+    // Scenario: agent hook creates a draft view, adds+records files on it,
+    // then the user checks status on the parent (dev) view while the files
+    // still exist on disk.
+    use crate::record::RecordOptions;
+    use crate::status::FileStatus;
+    use atomic_core::pristine::{MutTxnT, ViewScope, ViewTxnT};
+
+    let (temp_dir, mut repo) = create_temp_repo();
+
+    // Step 1: Record a base file on dev so the view isn't empty
+    std::fs::write(temp_dir.path().join("base.txt"), b"base content").unwrap();
+    repo.add("base.txt", TrackingOptions::default()).unwrap();
+    let header = ChangeHeader::new("Add base.txt");
+    repo.record(header, RecordOptions::new().with_all(true))
+        .expect("base record failed");
+
+    // Step 2: Create a draft child view (simulates agent session)
+    {
+        let mut txn = repo.pristine.write_txn().unwrap();
+        let dev = txn.get_view("dev").unwrap().unwrap();
+        txn.create_view("agent-draft", ViewScope::Draft, Some(dev.id))
+            .unwrap();
+        txn.commit().unwrap();
+    }
+
+    // Step 3: Switch to draft, add+record files, switch back
+    repo.set_current_view("agent-draft").unwrap();
+
+    std::fs::write(temp_dir.path().join("agent_file.txt"), b"created by agent").unwrap();
+    std::fs::create_dir_all(temp_dir.path().join("src")).unwrap();
+    std::fs::write(temp_dir.path().join("src/module.rs"), b"pub fn agent() {}").unwrap();
+
+    repo.add("agent_file.txt", TrackingOptions::default())
+        .unwrap();
+    repo.add("src/module.rs", TrackingOptions::default())
+        .unwrap();
+
+    let header = ChangeHeader::new("Agent adds files");
+    repo.record(header, RecordOptions::new().with_all(true))
+        .expect("agent record failed");
+
+    // Step 4: Switch back to dev (but leave files on disk — simulates
+    // agent creating files in the working copy without cleaning up)
+    repo.set_current_view("dev").unwrap();
+
+    // Files still exist on disk (agent created them, switch_view wasn't
+    // called so no materialization cleanup happened)
+    assert!(temp_dir.path().join("agent_file.txt").exists());
+    assert!(temp_dir.path().join("src/module.rs").exists());
+
+    // Step 5: Check status on dev — THE BUG
+    let status = repo
+        .status(StatusOptions::default())
+        .expect("status failed");
+
+    // These files should NOT appear as Untracked
+    let untracked_paths: Vec<String> = status
+        .entries()
+        .iter()
+        .filter(|e| e.status() == FileStatus::Untracked)
+        .map(|e| e.path().to_string_lossy().to_string())
+        .collect();
+
+    assert!(
+        !untracked_paths.iter().any(|p| p == "agent_file.txt"),
+        "agent_file.txt must NOT appear as Untracked on dev. \
+         It is in TREE (from draft view) and should be Added or hidden. \
+         Untracked entries: {:?}",
+        untracked_paths
+    );
+    assert!(
+        !untracked_paths.iter().any(|p| p == "src/module.rs"),
+        "src/module.rs must NOT appear as Untracked on dev. \
+         Untracked entries: {:?}",
+        untracked_paths
+    );
+
+    // Step 6: Verify the contradictory state doesn't exist
+    // is_tracked should return true (file is in global TREE)
+    assert!(
+        repo.is_tracked("agent_file.txt").unwrap(),
+        "agent_file.txt should be tracked (in global TREE)"
+    );
+
+    // If status says Untracked AND is_tracked says true, that's the bug
+    let is_untracked_in_status = untracked_paths.iter().any(|p| p == "agent_file.txt");
+    let is_tracked_globally = repo.is_tracked("agent_file.txt").unwrap();
+    assert!(
+        !(is_untracked_in_status && is_tracked_globally),
+        "CONTRADICTION: status says Untracked but is_tracked says true. \
+         This is the exact bug the customer reported."
+    );
+
+    // Step 7: The correct behavior — these files should show as Added
+    // (tracked in TREE, but not yet recorded on THIS view)
+    let added_paths: Vec<String> = status
+        .entries()
+        .iter()
+        .filter(|e| e.status() == FileStatus::Added)
+        .map(|e| e.path().to_string_lossy().to_string())
+        .collect();
+
+    assert!(
+        added_paths.iter().any(|p| p == "agent_file.txt"),
+        "agent_file.txt should appear as Added on dev (tracked but not \
+         recorded on this view). Added entries: {:?}, All entries: {:?}",
+        added_paths,
+        status
+            .entries()
+            .iter()
+            .map(|e| (e.path().to_string_lossy().to_string(), e.status()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_status_foreign_file_not_on_disk_is_invisible() {
+    // Complement to the test above: when a file is tracked on another view
+    // but does NOT exist on disk, it should not appear in status at all.
+    // It should not be Deleted (it was never on this view) or Untracked.
+    use crate::record::RecordOptions;
+    use crate::status::FileStatus;
+    use atomic_core::pristine::{MutTxnT, ViewScope, ViewTxnT};
+
+    let (temp_dir, mut repo) = create_temp_repo();
+
+    // Record base on dev
+    std::fs::write(temp_dir.path().join("base.txt"), b"base").unwrap();
+    repo.add("base.txt", TrackingOptions::default()).unwrap();
+    let header = ChangeHeader::new("Base commit");
+    repo.record(header, RecordOptions::new().with_all(true))
+        .unwrap();
+
+    // Create draft, record a file on it
+    {
+        let mut txn = repo.pristine.write_txn().unwrap();
+        let dev = txn.get_view("dev").unwrap().unwrap();
+        txn.create_view("draft", ViewScope::Draft, Some(dev.id))
+            .unwrap();
+        txn.commit().unwrap();
+    }
+    repo.set_current_view("draft").unwrap();
+
+    std::fs::write(temp_dir.path().join("draft_only.txt"), b"draft content").unwrap();
+    repo.add("draft_only.txt", TrackingOptions::default())
+        .unwrap();
+    let header = ChangeHeader::new("Draft file");
+    repo.record(header, RecordOptions::new().with_all(true))
+        .unwrap();
+
+    // Switch back to dev AND remove the file from disk
+    repo.set_current_view("dev").unwrap();
+    std::fs::remove_file(temp_dir.path().join("draft_only.txt")).unwrap();
+
+    // Status on dev should NOT mention draft_only.txt at all
+    let status = repo
+        .status(StatusOptions::default())
+        .expect("status failed");
+    let all_paths: Vec<(String, FileStatus)> = status
+        .entries()
+        .iter()
+        .map(|e| (e.path().to_string_lossy().to_string(), e.status()))
+        .collect();
+
+    assert!(
+        !all_paths.iter().any(|(p, _)| p == "draft_only.txt"),
+        "draft_only.txt should not appear in status on dev at all \
+         (not on disk, belongs to another view). Entries: {:?}",
+        all_paths
+    );
+}
+
+#[test]
 fn test_status_detects_modification_when_file_index_missing() {
     // Repro for the silent-data-loss bug: when a tracked file has no
     // FILE_INDEX entry (e.g. after `atomic insert` / `atomic clone` /

--- a/atomic-repository/src/repository/vault.rs
+++ b/atomic-repository/src/repository/vault.rs
@@ -791,6 +791,12 @@ pub struct VaultFileChange {
 /// after the closing `---`.
 ///
 /// If there's no frontmatter, returns `("{}", full_content)`.
+/// Parse vault markdown frontmatter. Public within the crate so that
+/// `vault_intent_update` can read disk content before storing.
+pub(crate) fn parse_vault_frontmatter(content: &str) -> (String, String) {
+    parse_markdown_frontmatter(content)
+}
+
 fn parse_markdown_frontmatter(content: &str) -> (String, String) {
     // Check for frontmatter delimiter
     if !content.starts_with("---\n") && !content.starts_with("---\r\n") {
@@ -906,7 +912,10 @@ fn parse_yaml_value(s: &str) -> serde_json::Value {
 
     // Try as array [a, b, c]
     if s.starts_with('[') && s.ends_with(']') {
-        let inner = &s[1..s.len() - 1];
+        let inner = s[1..s.len() - 1].trim();
+        if inner.is_empty() {
+            return serde_json::Value::Array(Vec::new());
+        }
         let items: Vec<serde_json::Value> = inner
             .split(',')
             .map(|item| parse_yaml_value(item.trim()))

--- a/atomic-repository/src/repository/vault_intent.rs
+++ b/atomic-repository/src/repository/vault_intent.rs
@@ -18,6 +18,7 @@ const INTENT_TEMPLATE: &str = include_str!("../../vault/templates/intent.md");
 use super::*;
 use atomic_core::pristine::vault::{IntentSummary, VaultEntry, VaultEntryType, VaultManifest};
 use atomic_core::pristine::{VaultMutTxnT, VaultTxnT};
+use std::fs;
 
 /// Options for creating a new intent.
 #[derive(Debug, Clone)]
@@ -47,6 +48,15 @@ pub struct IntentCreateResult {
     pub intent_file: String,
     /// The view the intent was created on.
     pub view_name: String,
+}
+
+/// Result of deleting an intent.
+#[derive(Debug, Clone)]
+pub struct IntentDeleteResult {
+    /// The normalized intent ID that was deleted.
+    pub id: String,
+    /// Vault-relative path to the removed intent.md file.
+    pub intent_file: String,
 }
 
 /// Options for updating an intent.
@@ -300,6 +310,88 @@ impl Repository {
             .ok_or_else(|| RepositoryError::InvalidOperation {
                 message: format!("Intent '{}' not found", full_id),
             })
+    }
+
+    /// Delete an unstarted backlog intent.
+    ///
+    /// This is intentionally conservative: only backlog intents with no linked
+    /// goals can be deleted. Started work should be closed or superseded
+    /// instead of removed from the vault.
+    pub fn vault_intent_delete(
+        &self,
+        intent_id: &str,
+    ) -> Result<IntentDeleteResult, RepositoryError> {
+        let full_id = self.normalize_intent_id(intent_id)?;
+        let intent_file =
+            self.find_intent_path(&full_id)?
+                .ok_or_else(|| RepositoryError::InvalidOperation {
+                    message: format!("Intent '{}' not found", full_id),
+                })?;
+
+        let manifest = self.vault_manifest()?;
+        let summary =
+            manifest
+                .intents
+                .get(&full_id)
+                .ok_or_else(|| RepositoryError::InvalidOperation {
+                    message: format!("Intent '{}' not found", full_id),
+                })?;
+
+        if summary.status != "backlog" {
+            return Err(RepositoryError::InvalidOperation {
+                message: format!(
+                    "Intent '{}' has status '{}'; only backlog intents can be deleted",
+                    full_id, summary.status
+                ),
+            });
+        }
+
+        if summary.goals > 0 {
+            return Err(RepositoryError::InvalidOperation {
+                message: format!(
+                    "Intent '{}' is linked to {} goal(s); unlink or close the work instead",
+                    full_id, summary.goals
+                ),
+            });
+        }
+
+        let deleted = self.vault_delete(&intent_file)?;
+        if !deleted {
+            return Err(RepositoryError::InvalidOperation {
+                message: format!("Intent '{}' not found", full_id),
+            });
+        }
+
+        {
+            let mut txn = self
+                .pristine
+                .write_txn()
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+            let mut manifest = txn
+                .get_vault_manifest()
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+            manifest.intents.remove(&full_id);
+            txn.put_vault_manifest(&manifest)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+            txn.commit()
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        }
+
+        let materialized = self.vault_dir().join(&intent_file);
+        match fs::remove_file(&materialized) {
+            Ok(()) => {
+                if let Some(parent) = materialized.parent() {
+                    let _ = remove_empty_dirs_up_to(parent, &self.vault_dir().join("intents"));
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(RepositoryError::Io(e)),
+        }
+
+        Ok(IntentDeleteResult {
+            id: full_id,
+            intent_file,
+        })
     }
 
     /// Update an intent's fields.
@@ -576,6 +668,33 @@ impl Repository {
     }
 }
 
+fn remove_empty_dirs_up_to(
+    mut dir: &std::path::Path,
+    stop_at: &std::path::Path,
+) -> Result<(), std::io::Error> {
+    while dir.starts_with(stop_at) && dir != stop_at {
+        match fs::remove_dir(dir) {
+            Ok(()) => {
+                if let Some(parent) = dir.parent() {
+                    dir = parent;
+                } else {
+                    break;
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                if let Some(parent) = dir.parent() {
+                    dir = parent;
+                } else {
+                    break;
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::DirectoryNotEmpty => break,
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -772,6 +891,67 @@ mod tests {
         // Manifest should reflect update
         let manifest = repo.vault_manifest().unwrap();
         assert_eq!(manifest.intents[&result.id].status, "in-progress");
+    }
+
+    #[test]
+    fn test_intent_delete_backlog_removes_manifest_entry_and_file() {
+        let dir = tempdir().unwrap();
+        let repo = init_repo_with_vault(dir.path());
+
+        let result = repo.vault_intent_create(create_opts("Delete me")).unwrap();
+        let materialized = repo.vault_dir().join(&result.intent_file);
+        assert!(materialized.exists());
+
+        let deleted = repo.vault_intent_delete(&result.id).unwrap();
+        assert_eq!(deleted.id, result.id);
+        assert_eq!(deleted.intent_file, result.intent_file);
+
+        let manifest = repo.vault_manifest().unwrap();
+        assert!(!manifest.intents.contains_key(&result.id));
+        assert!(repo.vault_retrieve(&result.intent_file).unwrap().is_none());
+        assert!(!materialized.exists());
+    }
+
+    #[test]
+    fn test_intent_delete_rejects_non_backlog_intent() {
+        let dir = tempdir().unwrap();
+        let repo = init_repo_with_vault(dir.path());
+
+        let result = repo.vault_intent_create(create_opts("Started")).unwrap();
+        repo.vault_intent_update(
+            &result.id,
+            IntentUpdateOptions {
+                status: Some("in-progress".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let err = repo.vault_intent_delete(&result.id).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("only backlog intents can be deleted"));
+        assert!(repo.vault_retrieve(&result.intent_file).unwrap().is_some());
+    }
+
+    #[test]
+    fn test_intent_delete_rejects_linked_goal() {
+        let dir = tempdir().unwrap();
+        let repo = init_repo_with_vault(dir.path());
+
+        let intent = repo.vault_intent_create(create_opts("Linked")).unwrap();
+        repo.vault_store(
+            "goals/test-goal/_goal.md",
+            VaultEntryType::Session,
+            b"# Goal".to_vec(),
+            r#"{"goal_id":"test-goal","status":"active"}"#.to_string(),
+        )
+        .unwrap();
+        repo.vault_intent_link(&intent.id, "test-goal").unwrap();
+
+        let err = repo.vault_intent_delete(&intent.id).unwrap_err();
+        assert!(err.to_string().contains("linked to 1 goal"));
+        assert!(repo.vault_retrieve(&intent.intent_file).unwrap().is_some());
     }
 
     #[test]

--- a/atomic-repository/src/repository/vault_intent.rs
+++ b/atomic-repository/src/repository/vault_intent.rs
@@ -346,11 +346,22 @@ impl Repository {
             });
         }
 
-        if summary.goals > 0 {
+        let referenced_goals = manifest
+            .goals
+            .values()
+            .filter(|goal| {
+                goal.intent
+                    .as_deref()
+                    .is_some_and(|id| id.eq_ignore_ascii_case(&full_id))
+            })
+            .count() as u32;
+        let linked_goals = summary.goals.max(referenced_goals);
+
+        if linked_goals > 0 {
             return Err(RepositoryError::InvalidOperation {
                 message: format!(
                     "Intent '{}' is linked to {} goal(s); unlink or close the work instead",
-                    full_id, summary.goals
+                    full_id, linked_goals
                 ),
             });
         }
@@ -948,6 +959,35 @@ mod tests {
         )
         .unwrap();
         repo.vault_intent_link(&intent.id, "test-goal").unwrap();
+
+        let err = repo.vault_intent_delete(&intent.id).unwrap_err();
+        assert!(err.to_string().contains("linked to 1 goal"));
+        assert!(repo.vault_retrieve(&intent.intent_file).unwrap().is_some());
+    }
+
+    #[test]
+    fn test_intent_delete_rejects_goal_started_with_intent() {
+        let dir = tempdir().unwrap();
+        let repo = init_repo_with_vault(dir.path());
+
+        let intent = repo
+            .vault_intent_create(create_opts("Started from goal"))
+            .unwrap();
+        repo.vault_goal_start(GoalStartOptions {
+            name: Some("test-goal".to_string()),
+            intent: Some(intent.id.clone()),
+            ..Default::default()
+        })
+        .unwrap();
+
+        // Goal start stores the canonical relationship on the goal summary.
+        // Deletion must not rely only on the intent's cached goal count.
+        let manifest = repo.vault_manifest().unwrap();
+        assert_eq!(manifest.intents[&intent.id].goals, 0);
+        assert_eq!(
+            manifest.goals["test-goal"].intent.as_deref(),
+            Some(intent.id.as_str())
+        );
 
         let err = repo.vault_intent_delete(&intent.id).unwrap_err();
         assert!(err.to_string().contains("linked to 1 goal"));

--- a/atomic-repository/src/repository/vault_intent.rs
+++ b/atomic-repository/src/repository/vault_intent.rs
@@ -425,15 +425,26 @@ impl Repository {
                     message: format!("Intent '{}' not found", full_id),
                 })?;
 
-        let entry = self.vault_retrieve(&intent_file)?.ok_or_else(|| {
-            RepositoryError::InvalidOperation {
-                message: format!("Intent '{}' not found", full_id),
-            }
-        })?;
+        // Read from disk first so we pick up any user/agent edits to the
+        // markdown body. If the file doesn't exist on disk, fall back to
+        // the redb entry.
+        let disk_path = self.vault_dir().join(&intent_file);
+        let (content_bytes, frontmatter_json) = if disk_path.exists() {
+            let file_content = std::fs::read_to_string(&disk_path)?;
+            let (fm_json, body) = crate::repository::vault::parse_vault_frontmatter(&file_content);
+            (body.into_bytes(), fm_json)
+        } else {
+            let entry = self.vault_retrieve(&intent_file)?.ok_or_else(|| {
+                RepositoryError::InvalidOperation {
+                    message: format!("Intent '{}' not found", full_id),
+                }
+            })?;
+            (entry.content_bytes.clone(), entry.frontmatter_json.clone())
+        };
 
         // Update frontmatter
         let mut fm: serde_json::Map<String, serde_json::Value> =
-            serde_json::from_str(&entry.frontmatter_json).unwrap_or_default();
+            serde_json::from_str(&frontmatter_json).unwrap_or_default();
 
         if options.content.is_some() && !options.force {
             let manifest = self.vault_manifest()?;
@@ -488,7 +499,7 @@ impl Repository {
 
         let new_content = match options.content {
             Some(ref body) => body.clone().into_bytes(),
-            None => entry.content_bytes.clone(),
+            None => content_bytes,
         };
 
         self.vault_store(&intent_file, VaultEntryType::Intent, new_content, new_fm)?;
@@ -556,11 +567,21 @@ impl Repository {
                     message: format!("Intent '{}' not found", full_id),
                 })?;
 
-        let entry = self.vault_retrieve(&intent_file)?.ok_or_else(|| {
-            RepositoryError::InvalidOperation {
-                message: format!("Intent '{}' not found", full_id),
-            }
-        })?;
+        // Read from disk first so we pick up any user/agent edits to the
+        // markdown body (same pattern as vault_intent_update).
+        let disk_path = self.vault_dir().join(&intent_file);
+        let (content_bytes, frontmatter_json) = if disk_path.exists() {
+            let file_content = std::fs::read_to_string(&disk_path)?;
+            let (fm_json, body) = crate::repository::vault::parse_vault_frontmatter(&file_content);
+            (body.into_bytes(), fm_json)
+        } else {
+            let entry = self.vault_retrieve(&intent_file)?.ok_or_else(|| {
+                RepositoryError::InvalidOperation {
+                    message: format!("Intent '{}' not found", full_id),
+                }
+            })?;
+            (entry.content_bytes.clone(), entry.frontmatter_json.clone())
+        };
 
         // Verify goal exists
         let goal_file = format!("goals/{}/_goal.md", goal_name);
@@ -572,7 +593,7 @@ impl Repository {
 
         // Update frontmatter to add goal to the list
         let mut fm: serde_json::Map<String, serde_json::Value> =
-            serde_json::from_str(&entry.frontmatter_json).unwrap_or_default();
+            serde_json::from_str(&frontmatter_json).unwrap_or_default();
 
         let goals = fm
             .entry("goals".to_string())
@@ -585,12 +606,7 @@ impl Repository {
         }
         let new_fm = serde_json::to_string(&fm).unwrap_or_else(|_| "{}".to_string());
 
-        self.vault_store(
-            &intent_file,
-            VaultEntryType::Intent,
-            entry.content_bytes.clone(),
-            new_fm,
-        )?;
+        self.vault_store(&intent_file, VaultEntryType::Intent, content_bytes, new_fm)?;
 
         // Update manifest goal count
         {
@@ -936,6 +952,89 @@ mod tests {
     }
 
     #[test]
+    fn test_intent_update_preserves_disk_edits() {
+        let dir = tempdir().unwrap();
+        let repo = init_repo_with_vault(dir.path());
+
+        let result = repo
+            .vault_intent_create(create_opts("Preserve me"))
+            .unwrap();
+
+        // Simulate user/agent editing the intent file on disk
+        let intent_path = repo.vault_dir().join(&result.intent_file);
+        assert!(intent_path.exists(), "intent file should exist on disk");
+
+        // Read the current file, replace the template body with real content
+        let original = std::fs::read_to_string(&intent_path).unwrap();
+        assert!(
+            original.contains("REPLACE"),
+            "template should have REPLACE placeholders"
+        );
+
+        // Write a fully filled-in intent body (keep frontmatter, replace body)
+        let edited = original.split("---\n").collect::<Vec<_>>();
+        // edited[0] is empty (before first ---), edited[1] is frontmatter, edited[2..] is body
+        let new_body = r#"
+## Problem
+The authentication module has no rate limiting.
+
+## Acceptance Criteria
+- [ ] Login attempts are rate-limited to 5 per minute
+- [ ] Failed attempts return 429 status code
+
+## TODOs
+- [ ] `PRES-1/1` Add rate limiter middleware
+"#;
+        let new_content = format!("---\n{}---\n{}", edited[1], new_body);
+        std::fs::write(&intent_path, &new_content).unwrap();
+
+        // Now run update — this should preserve the disk body
+        let updated = repo
+            .vault_intent_update(
+                &result.id,
+                IntentUpdateOptions {
+                    status: Some("done".to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        assert_eq!(updated.status, "done");
+
+        // Read the file back from disk — body must still have our edits
+        let final_content = std::fs::read_to_string(&intent_path).unwrap();
+        assert!(
+            final_content.contains("rate limiting"),
+            "Problem statement should survive update. Got:\n{}",
+            final_content
+        );
+        assert!(
+            final_content.contains("429 status code"),
+            "Acceptance criteria should survive update. Got:\n{}",
+            final_content
+        );
+        assert!(
+            final_content.contains("PRES-1/1"),
+            "TODOs should survive update. Got:\n{}",
+            final_content
+        );
+        assert!(
+            !final_content.contains("REPLACE"),
+            "Template placeholders should NOT reappear. Got:\n{}",
+            final_content
+        );
+
+        // Also verify redb has the updated content
+        let entry = repo.vault_intent_show(&result.id).unwrap();
+        let stored_body = String::from_utf8_lossy(&entry.content_bytes);
+        assert!(
+            stored_body.contains("rate limiting"),
+            "redb body should have disk edits. Got:\n{}",
+            stored_body
+        );
+    }
+
+    #[test]
     fn test_intent_update_body_content() {
         let dir = tempdir().unwrap();
         let repo = init_repo_with_vault(dir.path());
@@ -962,7 +1061,10 @@ mod tests {
         let repo = init_repo_with_vault(dir.path());
 
         let result = repo.vault_intent_create(create_opts("Keep body")).unwrap();
-        let original_body = repo.vault_intent_show(&result.id).unwrap().content_bytes;
+        // Read the original content from disk (since update without content reads from disk)
+        let intent_path = repo.vault_dir().join(&result.intent_file);
+        let disk_content = std::fs::read_to_string(&intent_path).unwrap();
+        let (_, original_body) = crate::repository::vault::parse_vault_frontmatter(&disk_content);
 
         repo.vault_intent_update(
             &result.id,
@@ -973,9 +1075,11 @@ mod tests {
         )
         .unwrap();
 
+        let after = repo.vault_intent_show(&result.id).unwrap();
         assert_eq!(
-            repo.vault_intent_show(&result.id).unwrap().content_bytes,
-            original_body
+            String::from_utf8_lossy(&after.content_bytes),
+            original_body,
+            "body should be unchanged after frontmatter-only update"
         );
     }
 

--- a/atomic-repository/src/repository/vault_intent.rs
+++ b/atomic-repository/src/repository/vault_intent.rs
@@ -75,6 +75,8 @@ pub struct IntentUpdateOptions {
     pub title: Option<String>,
     /// New Markdown body content. When `None`, the existing body is kept.
     pub content: Option<String>,
+    /// Allow rewriting the body after the intent has started or been linked.
+    pub force: bool,
 }
 
 /// Info for listing intents.
@@ -432,6 +434,31 @@ impl Repository {
         // Update frontmatter
         let mut fm: serde_json::Map<String, serde_json::Value> =
             serde_json::from_str(&entry.frontmatter_json).unwrap_or_default();
+
+        if options.content.is_some() && !options.force {
+            let manifest = self.vault_manifest()?;
+            let summary = manifest.intents.get(&full_id);
+            let current_status = summary
+                .map(|intent| intent.status.as_str())
+                .or_else(|| fm.get("status").and_then(|value| value.as_str()))
+                .unwrap_or("unknown");
+            let has_linked_goal = summary.is_some_and(|intent| intent.goals > 0)
+                || manifest.goals.values().any(|goal| {
+                    goal.intent
+                        .as_deref()
+                        .is_some_and(|id| id.eq_ignore_ascii_case(&full_id))
+                });
+
+            if current_status != "backlog" || has_linked_goal {
+                return Err(RepositoryError::InvalidOperation {
+                    message: format!(
+                        "Intent '{}' has started or is linked to a goal; rewriting its body would \
+                         change the execution context. Retry with force enabled.",
+                        full_id
+                    ),
+                });
+            }
+        }
 
         if let Some(ref status) = options.status {
             fm.insert(
@@ -1069,6 +1096,97 @@ mod tests {
         let err = repo.vault_intent_delete(&intent.id).unwrap_err();
         assert!(err.to_string().contains("linked to 1 goal"));
         assert!(repo.vault_retrieve(&intent.intent_file).unwrap().is_some());
+    }
+
+    #[test]
+    fn test_intent_update_body_rejects_started_intent_without_force() {
+        let dir = tempdir().unwrap();
+        let repo = init_repo_with_vault(dir.path());
+
+        let result = repo.vault_intent_create(create_opts("Started")).unwrap();
+        repo.vault_intent_update(
+            &result.id,
+            IntentUpdateOptions {
+                status: Some("in-progress".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let before = repo.vault_intent_show(&result.id).unwrap().content_bytes;
+        let err = repo
+            .vault_intent_update(
+                &result.id,
+                IntentUpdateOptions {
+                    content: Some("# Rewritten".to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+
+        assert!(err.to_string().contains("Retry with force enabled"));
+        assert_eq!(
+            repo.vault_intent_show(&result.id).unwrap().content_bytes,
+            before
+        );
+    }
+
+    #[test]
+    fn test_intent_update_body_rejects_goal_reference_without_force() {
+        let dir = tempdir().unwrap();
+        let repo = init_repo_with_vault(dir.path());
+
+        let intent = repo.vault_intent_create(create_opts("Linked")).unwrap();
+        repo.vault_goal_start(GoalStartOptions {
+            name: Some("test-goal".to_string()),
+            intent: Some(intent.id.clone()),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let err = repo
+            .vault_intent_update(
+                &intent.id,
+                IntentUpdateOptions {
+                    content: Some("# Rewritten".to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+
+        assert!(err.to_string().contains("Retry with force enabled"));
+    }
+
+    #[test]
+    fn test_intent_update_body_force_allows_started_intent() {
+        let dir = tempdir().unwrap();
+        let repo = init_repo_with_vault(dir.path());
+
+        let result = repo.vault_intent_create(create_opts("Started")).unwrap();
+        repo.vault_intent_update(
+            &result.id,
+            IntentUpdateOptions {
+                status: Some("in-progress".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let new_body = "# Rewritten with explicit force\n";
+        repo.vault_intent_update(
+            &result.id,
+            IntentUpdateOptions {
+                content: Some(new_body.to_string()),
+                force: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            String::from_utf8_lossy(&repo.vault_intent_show(&result.id).unwrap().content_bytes),
+            new_body
+        );
     }
 
     #[test]

--- a/atomic-repository/src/repository/vault_intent.rs
+++ b/atomic-repository/src/repository/vault_intent.rs
@@ -60,6 +60,9 @@ pub struct IntentDeleteResult {
 }
 
 /// Options for updating an intent.
+///
+/// `content` replaces the intent's Markdown body. When it is `None`, the
+/// existing body is preserved unchanged.
 #[derive(Debug, Clone, Default)]
 pub struct IntentUpdateOptions {
     /// New status (backlog, planned, in-progress, review, done).
@@ -70,6 +73,8 @@ pub struct IntentUpdateOptions {
     pub priority: Option<String>,
     /// New title.
     pub title: Option<String>,
+    /// New Markdown body content. When `None`, the existing body is kept.
+    pub content: Option<String>,
 }
 
 /// Info for listing intents.
@@ -454,13 +459,12 @@ impl Repository {
         }
         let new_fm = serde_json::to_string(&fm).unwrap_or_else(|_| "{}".to_string());
 
-        // Re-store with updated frontmatter
-        self.vault_store(
-            &intent_file,
-            VaultEntryType::Intent,
-            entry.content_bytes.clone(),
-            new_fm,
-        )?;
+        let new_content = match options.content {
+            Some(ref body) => body.clone().into_bytes(),
+            None => entry.content_bytes.clone(),
+        };
+
+        self.vault_store(&intent_file, VaultEntryType::Intent, new_content, new_fm)?;
 
         // Update manifest
         {
@@ -902,6 +906,79 @@ mod tests {
         // Manifest should reflect update
         let manifest = repo.vault_manifest().unwrap();
         assert_eq!(manifest.intents[&result.id].status, "in-progress");
+    }
+
+    #[test]
+    fn test_intent_update_body_content() {
+        let dir = tempdir().unwrap();
+        let repo = init_repo_with_vault(dir.path());
+
+        let result = repo.vault_intent_create(create_opts("Body edit")).unwrap();
+        let new_body = "# Body edit\n\n## Problem\n\nThe widget leaks memory.\n";
+
+        repo.vault_intent_update(
+            &result.id,
+            IntentUpdateOptions {
+                content: Some(new_body.to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let after = repo.vault_intent_show(&result.id).unwrap();
+        assert_eq!(String::from_utf8_lossy(&after.content_bytes), new_body);
+    }
+
+    #[test]
+    fn test_intent_update_without_content_preserves_body() {
+        let dir = tempdir().unwrap();
+        let repo = init_repo_with_vault(dir.path());
+
+        let result = repo.vault_intent_create(create_opts("Keep body")).unwrap();
+        let original_body = repo.vault_intent_show(&result.id).unwrap().content_bytes;
+
+        repo.vault_intent_update(
+            &result.id,
+            IntentUpdateOptions {
+                priority: Some("high".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            repo.vault_intent_show(&result.id).unwrap().content_bytes,
+            original_body
+        );
+    }
+
+    #[test]
+    fn test_intent_update_body_and_frontmatter_together() {
+        let dir = tempdir().unwrap();
+        let repo = init_repo_with_vault(dir.path());
+
+        let result = repo.vault_intent_create(create_opts("Combined")).unwrap();
+        let new_body = "# Combined\n\nFully rewritten.\n";
+        let updated = repo
+            .vault_intent_update(
+                &result.id,
+                IntentUpdateOptions {
+                    status: Some("review".to_string()),
+                    priority: Some("high".to_string()),
+                    content: Some(new_body.to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        assert_eq!(updated.status, "review");
+        assert_eq!(updated.priority, "high");
+        assert_eq!(
+            String::from_utf8_lossy(
+                &repo.vault_intent_show(&result.id).unwrap().content_bytes
+            ),
+            new_body
+        );
     }
 
     #[test]

--- a/atomic-repository/src/repository/vault_intent.rs
+++ b/atomic-repository/src/repository/vault_intent.rs
@@ -1001,9 +1001,7 @@ mod tests {
         assert_eq!(updated.status, "review");
         assert_eq!(updated.priority, "high");
         assert_eq!(
-            String::from_utf8_lossy(
-                &repo.vault_intent_show(&result.id).unwrap().content_bytes
-            ),
+            String::from_utf8_lossy(&repo.vault_intent_show(&result.id).unwrap().content_bytes),
             new_body
         );
     }

--- a/atomic-repository/src/repository/vault_kg_enrich.rs
+++ b/atomic-repository/src/repository/vault_kg_enrich.rs
@@ -45,16 +45,13 @@ impl Repository {
         };
 
         // Phase 4: AST entities → nodes + DEFINES edges
-        #[cfg(feature = "ast")]
-        {
-            stats.entities = self.kg_enrich_entities()?;
-        }
+        stats.entities = self.kg_enrich_entities()?;
 
         // Phase 4b: INCLUDES edges (from import entities)
-        #[cfg(feature = "ast")]
-        {
-            stats.includes = self.kg_enrich_includes()?;
-        }
+        stats.includes = self.kg_enrich_includes()?;
+
+        // Phase 4c: CALLS edges (caller entity → callee entity)
+        stats.calls = self.kg_enrich_calls()?;
 
         Ok(stats)
     }
@@ -463,7 +460,6 @@ impl Repository {
         }
 
         // AST entity extraction for changed files
-        #[cfg(feature = "ast")]
         {
             let mut parser_registry = atomic_semantic::ParserRegistry::new();
 
@@ -514,6 +510,16 @@ impl Repository {
                     ))
                     .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
+                    // EXPORTS edge: only for publicly visible entities
+                    if entity.exported {
+                        txn.upsert_kg_edge(&KgEdge::new(
+                            format!("file:{}", entity.file),
+                            &entity_id,
+                            edge_kind::EXPORTS,
+                        ))
+                        .map_err(|e| RepositoryError::Database(e.to_string()))?;
+                    }
+
                     // Change MODIFIES entity (more precise than file-level)
                     txn.upsert_kg_edge(&KgEdge::new(
                         format!("change:{}", short_hash),
@@ -538,7 +544,6 @@ impl Repository {
     /// resolve each import path to an existing `file:{path}` node in the KG.
     /// If a match is found, creates an `INCLUDES` edge from the source file
     /// to the included file. Best-effort — unresolvable imports are skipped.
-    #[cfg(feature = "ast")]
     pub fn kg_enrich_includes(&self) -> Result<usize, RepositoryError> {
         let files = self
             .list_tracked_files()
@@ -657,11 +662,153 @@ impl Repository {
         Ok(count)
     }
 
+    /// Parses all tracked source files and writes `CALLS` edges between entity nodes.
+    ///
+    /// For every tracked file, this function:
+    /// 1. Extracts function/method entities (to build a name → entity-ID index).
+    /// 2. Extracts call sites via tree-sitter reference extraction.
+    /// 3. For each call site, finds the innermost enclosing function (the caller entity)
+    ///    and resolves the callee name to known entity nodes in the graph.
+    /// 4. Writes `KgEdge { from: caller_entity, to: callee_entity, kind: CALLS }`.
+    ///
+    /// Callee resolution is name-based: a call to `foo()` matches any entity named `foo`
+    /// across all tracked files. Calls to external crates / stdlib are silently skipped.
+    pub fn kg_enrich_calls(&self) -> Result<usize, RepositoryError> {
+        let files = self
+            .list_tracked_files()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        let mut parser_registry = atomic_semantic::ParserRegistry::new();
+
+        // ── Pass 1: Parse every file to build the name → entity-ID index.
+        struct FileData {
+            path: String,
+            source: String,
+            entities: Vec<atomic_semantic::Entity>,
+        }
+
+        let mut all_file_data: Vec<FileData> = Vec::new();
+        // function/method name → list of entity IDs (names can appear in multiple files)
+        let mut name_to_entity_ids: HashMap<String, Vec<String>> = HashMap::new();
+
+        for file in &files {
+            if file.is_directory {
+                continue;
+            }
+            let path_str = file.path.to_string_lossy().to_string();
+            if !atomic_semantic::is_supported(&path_str) {
+                continue;
+            }
+            let abs_path = self.root().join(&file.path);
+            let source = match std::fs::read_to_string(&abs_path) {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+
+            let entities = parser_registry.extract(&path_str, &source);
+
+            for entity in &entities {
+                match entity.kind {
+                    atomic_semantic::EntityKind::Function | atomic_semantic::EntityKind::Method => {
+                        let entity_id =
+                            format!("entity:{}:{}:{}", entity.file, entity.name, entity.line);
+                        name_to_entity_ids
+                            .entry(entity.name.clone())
+                            .or_default()
+                            .push(entity_id);
+                    }
+                    _ => {}
+                }
+            }
+
+            all_file_data.push(FileData {
+                path: path_str,
+                source,
+                entities,
+            });
+        }
+
+        // ── Pass 2: Extract call sites and write CALLS edges.
+        let mut txn = self
+            .pristine
+            .write_txn()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        let mut count = 0;
+
+        for file_data in &all_file_data {
+            let refs = parser_registry.extract_references(&file_data.path, &file_data.source);
+            if refs.is_empty() {
+                continue;
+            }
+
+            // Build a (start_line, end_line, entity_id) list for this file's callable
+            // entities so we can find which function encloses each call site by line.
+            let mut callable_entities: Vec<(u32, u32, String)> = file_data
+                .entities
+                .iter()
+                .filter(|e| {
+                    matches!(
+                        e.kind,
+                        atomic_semantic::EntityKind::Function | atomic_semantic::EntityKind::Method
+                    )
+                })
+                .map(|e| {
+                    (
+                        e.line,
+                        e.end_line,
+                        format!("entity:{}:{}:{}", e.file, e.name, e.line),
+                    )
+                })
+                .collect();
+            callable_entities.sort_by_key(|(start, _, _)| *start);
+
+            for r in &refs {
+                // Find the innermost (smallest range) enclosing function.
+                let caller_id = callable_entities
+                    .iter()
+                    .filter(|(start, end, _)| r.line >= *start && r.line <= *end)
+                    .min_by_key(|(start, end, _)| end - start)
+                    .map(|(_, _, id)| id.as_str());
+
+                let caller_id = match caller_id {
+                    Some(id) => id,
+                    None => continue, // call outside any function (top-level, macro, etc.)
+                };
+
+                // Skip names that resolve to too many definitions — they are almost
+                // certainly common trait-method names (new, clone, fmt, from, into,
+                // push, len, …) where name-only matching produces pure noise.
+                // A call to `Vec::new()` should not write edges to every `fn new()`
+                // across all 600+ files.
+                const MAX_CALLEE_FANOUT: usize = 10;
+
+                let callee_ids = match name_to_entity_ids.get(&r.symbol) {
+                    Some(ids) if ids.len() <= MAX_CALLEE_FANOUT => ids,
+                    Some(_) => continue, // too ambiguous — common trait method, skip
+                    None => continue,    // callee not in repo (stdlib / external dep)
+                };
+
+                for callee_id in callee_ids {
+                    if callee_id == caller_id {
+                        continue; // skip direct recursion
+                    }
+                    txn.upsert_kg_edge(&KgEdge::new(caller_id, callee_id, edge_kind::CALLS))
+                        .map_err(|e| RepositoryError::Database(e.to_string()))?;
+                    count += 1;
+                }
+            }
+        }
+
+        txn.commit()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        Ok(count)
+    }
+
     /// Parses all supported source files in the working copy and creates
     /// `entity:{file}:{name}:{line}` nodes with `DEFINES` edges from
     /// the corresponding file nodes. Runs during bulk enrichment
     /// (`atomic vault query enrich`, `atomic git import`).
-    #[cfg(feature = "ast")]
     pub fn kg_enrich_entities(&self) -> Result<usize, RepositoryError> {
         let files = self
             .list_tracked_files()
@@ -720,6 +867,16 @@ impl Repository {
                 ))
                 .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
+                // EXPORTS edge: only for publicly visible entities
+                if entity.exported {
+                    txn.upsert_kg_edge(&KgEdge::new(
+                        format!("file:{}", entity.file),
+                        &entity_id,
+                        edge_kind::EXPORTS,
+                    ))
+                    .map_err(|e| RepositoryError::Database(e.to_string()))?;
+                }
+
                 count += 1;
             }
         }
@@ -745,12 +902,20 @@ pub struct KgEnrichStats {
     pub entities: usize,
     /// Number of INCLUDES edges created.
     pub includes: usize,
+    /// Number of CALLS edges created.
+    pub calls: usize,
 }
 
 impl KgEnrichStats {
     /// Total number of nodes created across all phases.
     pub fn total(&self) -> usize {
-        self.views + self.files + self.modules + self.changes + self.entities + self.includes
+        self.views
+            + self.files
+            + self.modules
+            + self.changes
+            + self.entities
+            + self.includes
+            + self.calls
     }
 }
 
@@ -758,8 +923,14 @@ impl std::fmt::Display for KgEnrichStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{} views, {} files, {} modules, {} changes, {} entities, {} includes",
-            self.views, self.files, self.modules, self.changes, self.entities, self.includes
+            "{} views, {} files, {} modules, {} changes, {} entities, {} includes, {} calls",
+            self.views,
+            self.files,
+            self.modules,
+            self.changes,
+            self.entities,
+            self.includes,
+            self.calls
         )
     }
 }
@@ -786,10 +957,11 @@ mod tests {
             changes: 5,
             entities: 8,
             includes: 4,
+            calls: 0,
         };
         assert_eq!(
             stats.to_string(),
-            "3 views, 10 files, 2 modules, 5 changes, 8 entities, 4 includes"
+            "3 views, 10 files, 2 modules, 5 changes, 8 entities, 4 includes, 0 calls"
         );
     }
 
@@ -802,8 +974,9 @@ mod tests {
             changes: 3,
             entities: 4,
             includes: 1,
+            calls: 5,
         };
-        assert_eq!(stats.total(), 20);
+        assert_eq!(stats.total(), 25);
     }
 
     #[test]
@@ -815,10 +988,11 @@ mod tests {
         assert_eq!(stats.changes, 0);
         assert_eq!(stats.entities, 0);
         assert_eq!(stats.includes, 0);
+        assert_eq!(stats.calls, 0);
         assert_eq!(stats.total(), 0);
         assert_eq!(
             stats.to_string(),
-            "0 views, 0 files, 0 modules, 0 changes, 0 entities, 0 includes"
+            "0 views, 0 files, 0 modules, 0 changes, 0 entities, 0 includes, 0 calls"
         );
     }
 

--- a/atomic-repository/src/repository/vault_triples.rs
+++ b/atomic-repository/src/repository/vault_triples.rs
@@ -5,7 +5,7 @@
 
 use super::*;
 use crate::content_search::{has_content_index, search_content, ContentSearchOptions};
-use atomic_core::pristine::ontology::edge_kind;
+use atomic_core::pristine::ontology::{edge_kind, predicate};
 use atomic_core::pristine::vault::{KgEdge, KgNode, KgSubgraph, VaultEntry, VaultEntryType};
 use atomic_core::pristine::{KgMutTxnT, KgTxnT};
 
@@ -56,12 +56,19 @@ impl Repository {
         if let Ok(fm) = serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(
             &entry.frontmatter_json,
         ) {
-            extract_frontmatter_kg(&subject, entry.entry_type, &fm, &mut node, &mut edges);
+            extract_frontmatter_kg(
+                &subject,
+                entry.entry_type,
+                &fm,
+                &mut node,
+                &mut nodes,
+                &mut edges,
+            );
         }
 
         // Extract from content
         let content = String::from_utf8_lossy(&entry.content_bytes);
-        extract_content_edges(&subject, &content, &mut edges);
+        extract_content_edges(&subject, entry.entry_type, &content, &mut edges);
 
         nodes.push(node);
         Ok((nodes, edges))
@@ -574,6 +581,7 @@ fn extract_frontmatter_kg(
     entry_type: VaultEntryType,
     fm: &serde_json::Map<String, serde_json::Value>,
     node: &mut KgNode,
+    nodes: &mut Vec<KgNode>,
     edges: &mut Vec<KgEdge>,
 ) {
     // Common fields → edges
@@ -636,7 +644,7 @@ fn extract_frontmatter_kg(
                     obj.insert("priority".to_string(), serde_json::json!(s));
                 }
             }
-            // blocked_by array
+            // blocked_by array — write both directions for symmetric traversal
             if let Some(arr) = fm.get("blocked_by").and_then(|v| v.as_array()) {
                 for item in arr {
                     if let Some(s) = item.as_str() {
@@ -645,10 +653,16 @@ fn extract_frontmatter_kg(
                             format!("intent:{}", s),
                             edge_kind::BLOCKED_BY,
                         ));
+                        // Symmetric: the blocker also BLOCKS this intent
+                        edges.push(KgEdge::new(
+                            format!("intent:{}", s),
+                            subject,
+                            edge_kind::BLOCKS,
+                        ));
                     }
                 }
             }
-            // labels array -> HAS_LABEL edges
+            // labels array -> HAS_LABEL edges + concept nodes
             if let Some(arr) = fm.get("labels").and_then(|v| v.as_array()) {
                 for item in arr {
                     if let Some(s) = item.as_str() {
@@ -657,6 +671,8 @@ fn extract_frontmatter_kg(
                             format!("concept:{}", s),
                             edge_kind::HAS_LABEL,
                         ));
+                        // Ensure the concept node exists so it is searchable
+                        nodes.push(KgNode::new(format!("concept:{}", s), "concept", s, "vault"));
                     }
                 }
             }
@@ -687,13 +703,31 @@ fn extract_frontmatter_kg(
                 }
             }
         }
+        VaultEntryType::ToolResult => {
+            // ToolResult files always live at goals/{goal-name}/toolu_*.md.
+            // Derive the parent goal from the subject: "tool:goals:{goal}:{file}"
+            if let Some(rest) = subject.strip_prefix("tool:goals:") {
+                if let Some((goal_name, _)) = rest.split_once(':') {
+                    edges.push(KgEdge::new(
+                        subject,
+                        format!("goal:{}", goal_name),
+                        predicate::WAS_ASSOCIATED_WITH,
+                    ));
+                }
+            }
+        }
         _ => {}
     }
 }
 
 /// Extract edges from content text (wiki-links, file paths).
-fn extract_content_edges(subject: &str, content: &str, edges: &mut Vec<KgEdge>) {
-    // Extract [[wiki-links]]
+fn extract_content_edges(
+    subject: &str,
+    entry_type: VaultEntryType,
+    content: &str,
+    edges: &mut Vec<KgEdge>,
+) {
+    // Extract [[wiki-links]] — always REFERENCES regardless of entry type
     let mut pos = 0;
     while let Some(start) = content[pos..].find("[[") {
         let abs_start = pos + start + 2;
@@ -712,7 +746,14 @@ fn extract_content_edges(subject: &str, content: &str, edges: &mut Vec<KgEdge>) 
         }
     }
 
-    // Extract file paths (simple heuristic: paths with extensions)
+    // File paths: ToolResult content represents files the agent actually read/used,
+    // so emit USED edges.  All other entry types emit REFERENCES edges.
+    let file_edge_kind = if entry_type == VaultEntryType::ToolResult {
+        predicate::USED
+    } else {
+        edge_kind::REFERENCES
+    };
+
     for word in content.split_whitespace() {
         let clean = word.trim_matches(|c: char| {
             c == '`' || c == '"' || c == '\'' || c == '(' || c == ')' || c == ','
@@ -721,7 +762,7 @@ fn extract_content_edges(subject: &str, content: &str, edges: &mut Vec<KgEdge>) 
             edges.push(KgEdge::new(
                 subject,
                 format!("file:{}", clean),
-                edge_kind::REFERENCES,
+                file_edge_kind,
             ));
         }
     }
@@ -810,10 +851,17 @@ mod tests {
             .vault_extract_kg("intents/pimo-1/intent.md", &entry)
             .unwrap();
 
-        assert_eq!(nodes.len(), 1);
-        assert_eq!(nodes[0].kind, "intent");
-        assert_eq!(nodes[0].id, "intent:PIMO-1");
-        assert_eq!(nodes[0].summary.as_deref(), Some("Fix auth"));
+        // 1 intent node + 1 concept node per label ("auth", "security")
+        assert_eq!(nodes.len(), 3);
+        let intent_node = nodes.iter().find(|n| n.kind == "intent").unwrap();
+        assert_eq!(intent_node.id, "intent:PIMO-1");
+        assert_eq!(intent_node.summary.as_deref(), Some("Fix auth"));
+        assert!(nodes
+            .iter()
+            .any(|n| n.kind == "concept" && n.id == "concept:auth"));
+        assert!(nodes
+            .iter()
+            .any(|n| n.kind == "concept" && n.id == "concept:security"));
 
         assert!(
             edges
@@ -985,6 +1033,7 @@ mod tests {
         let mut edges = Vec::new();
         extract_content_edges(
             "goal:test",
+            VaultEntryType::Session,
             "Check [[architecture]] and [[auth-design]] for details.",
             &mut edges,
         );
@@ -1007,6 +1056,7 @@ mod tests {
         let mut edges = Vec::new();
         extract_content_edges(
             "goal:test",
+            VaultEntryType::Session,
             "Modified `src/main.rs` and crates/core/src/lib.rs today.",
             &mut edges,
         );
@@ -1051,11 +1101,13 @@ mod tests {
             "blocked_by".to_string(),
             serde_json::json!(["PIMO-2", "PIMO-3"]),
         );
+        let mut nodes = Vec::new();
         extract_frontmatter_kg(
             "intent:PIMO-1",
             VaultEntryType::Intent,
             &fm,
             &mut node,
+            &mut nodes,
             &mut edges,
         );
         assert!(
@@ -1070,6 +1122,13 @@ mod tests {
                 .any(|e| e.kind == edge_kind::BLOCKED_BY && e.to_id == "intent:PIMO-3"),
             "Missing BLOCKED_BY edge for PIMO-3"
         );
+        // Reverse BLOCKS edges should also be present
+        assert!(
+            edges.iter().any(|e| e.kind == edge_kind::BLOCKS
+                && e.from_id == "intent:PIMO-2"
+                && e.to_id == "intent:PIMO-1"),
+            "Missing reverse BLOCKS edge from PIMO-2"
+        );
     }
 
     #[test]
@@ -1081,11 +1140,13 @@ mod tests {
             "goals".to_string(),
             serde_json::json!(["swift-meadow-a3f2"]),
         );
+        let mut nodes = Vec::new();
         extract_frontmatter_kg(
             "intent:PIMO-1",
             VaultEntryType::Intent,
             &fm,
             &mut node,
+            &mut nodes,
             &mut edges,
         );
         assert!(
@@ -1099,7 +1160,12 @@ mod tests {
     #[test]
     fn test_wiki_link_with_newline_ignored() {
         let mut edges = Vec::new();
-        extract_content_edges("goal:test", "See [[bad\nlink]] here.", &mut edges);
+        extract_content_edges(
+            "goal:test",
+            VaultEntryType::Session,
+            "See [[bad\nlink]] here.",
+            &mut edges,
+        );
         assert!(
             edges.iter().all(|e| e.kind != edge_kind::REFERENCES),
             "Should not extract wiki-link with newline"
@@ -1109,7 +1175,12 @@ mod tests {
     #[test]
     fn test_unclosed_wiki_link_ignored() {
         let mut edges = Vec::new();
-        extract_content_edges("goal:test", "See [[unclosed link here.", &mut edges);
+        extract_content_edges(
+            "goal:test",
+            VaultEntryType::Session,
+            "See [[unclosed link here.",
+            &mut edges,
+        );
         assert!(
             edges.iter().all(|e| e.kind != edge_kind::REFERENCES),
             "Should not extract unclosed wiki-link"

--- a/atomic-semantic/src/parsers/cpp.rs
+++ b/atomic-semantic/src/parsers/cpp.rs
@@ -20,7 +20,7 @@
 //! | `#define FOO` | `preproc_def` | Const |
 
 use super::{Language, LanguageParser};
-use crate::entity::{Entity, EntityKind};
+use crate::entity::{Confidence, Entity, EntityKind, Reference};
 use tree_sitter::{Node, Parser};
 
 /// C/C++ AST entity extractor using tree-sitter.
@@ -694,6 +694,64 @@ impl CppParser {
             String::new()
         }
     }
+
+    fn walk_tree_for_calls(
+        &self,
+        node: &Node,
+        source: &str,
+        file_path: &str,
+        refs: &mut Vec<Reference>,
+    ) {
+        if node.kind() == "call_expression" {
+            if let Some(func_node) = node.child_by_field_name("function") {
+                if let Some(name) = self.extract_call_name(&func_node, source) {
+                    if !name.is_empty() {
+                        refs.push(Reference {
+                            symbol: name,
+                            file: file_path.to_string(),
+                            line: (node.start_position().row as u32) + 1,
+                            column: Some(node.start_position().column as u32),
+                            context: None,
+                            confidence: Confidence::High,
+                        });
+                    }
+                }
+            }
+        }
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.walk_tree_for_calls(&child, source, file_path, refs);
+        }
+    }
+
+    fn extract_call_name(&self, func_node: &Node, source: &str) -> Option<String> {
+        match func_node.kind() {
+            "identifier" => {
+                let name = self.node_text(func_node, source);
+                if name.is_empty() {
+                    None
+                } else {
+                    Some(name)
+                }
+            }
+            "field_expression" => {
+                // obj.method() or ptr->method() — extract just the member name
+                func_node
+                    .child_by_field_name("field")
+                    .map(|f| self.node_text(&f, source))
+                    .filter(|s| !s.is_empty())
+            }
+            "scoped_identifier" => {
+                // Namespace::func() — extract just "func"
+                func_node
+                    .child_by_field_name("name")
+                    .map(|n| self.node_text(&n, source))
+                    .filter(|s| !s.is_empty())
+            }
+            _ => None,
+        }
+    }
 }
 
 impl Default for CppParser {
@@ -727,6 +785,16 @@ impl LanguageParser for CppParser {
             false,
         );
         entities
+    }
+
+    fn extract_references(&mut self, source: &str, file_path: &str) -> Vec<Reference> {
+        let tree = match self.parser.parse(source, None) {
+            Some(t) => t,
+            None => return vec![],
+        };
+        let mut refs = Vec::new();
+        self.walk_tree_for_calls(&tree.root_node(), source, file_path, &mut refs);
+        refs
     }
 }
 

--- a/atomic-semantic/src/parsers/go.rs
+++ b/atomic-semantic/src/parsers/go.rs
@@ -17,7 +17,7 @@
 //! | `import "fmt"` | Import | Import declaration |
 
 use super::{Language, LanguageParser};
-use crate::entity::{Entity, EntityKind};
+use crate::entity::{Confidence, Entity, EntityKind, Reference};
 use tree_sitter::{Node, Parser};
 
 /// Go AST entity extractor using tree-sitter.
@@ -327,6 +327,57 @@ impl GoParser {
             String::new()
         }
     }
+
+    fn walk_tree_for_calls(
+        &self,
+        node: &Node,
+        source: &str,
+        file_path: &str,
+        refs: &mut Vec<Reference>,
+    ) {
+        if node.kind() == "call_expression" {
+            if let Some(func_node) = node.child_by_field_name("function") {
+                if let Some(name) = self.extract_call_name(&func_node, source) {
+                    if !name.is_empty() {
+                        refs.push(Reference {
+                            symbol: name,
+                            file: file_path.to_string(),
+                            line: (node.start_position().row as u32) + 1,
+                            column: Some(node.start_position().column as u32),
+                            context: None,
+                            confidence: Confidence::High,
+                        });
+                    }
+                }
+            }
+        }
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.walk_tree_for_calls(&child, source, file_path, refs);
+        }
+    }
+
+    fn extract_call_name(&self, func_node: &Node, source: &str) -> Option<String> {
+        match func_node.kind() {
+            "identifier" => {
+                let name = self.node_text(func_node, source);
+                if name.is_empty() {
+                    None
+                } else {
+                    Some(name)
+                }
+            }
+            "selector_expression" => {
+                // pkg.Func() or receiver.Method() — extract just the function/method name
+                func_node
+                    .child_by_field_name("field")
+                    .map(|f| self.node_text(&f, source))
+                    .filter(|s| !s.is_empty())
+            }
+            _ => None,
+        }
+    }
 }
 
 impl Default for GoParser {
@@ -349,6 +400,16 @@ impl LanguageParser for GoParser {
         let mut entities = Vec::new();
         self.walk_tree(&tree.root_node(), source, file_path, &mut entities);
         entities
+    }
+
+    fn extract_references(&mut self, source: &str, file_path: &str) -> Vec<Reference> {
+        let tree = match self.parser.parse(source, None) {
+            Some(t) => t,
+            None => return vec![],
+        };
+        let mut refs = Vec::new();
+        self.walk_tree_for_calls(&tree.root_node(), source, file_path, &mut refs);
+        refs
     }
 }
 

--- a/atomic-semantic/src/parsers/java.rs
+++ b/atomic-semantic/src/parsers/java.rs
@@ -18,7 +18,7 @@
 //! | `import java.util.List;` | Import | Import statement |
 
 use super::{Language, LanguageParser};
-use crate::entity::{Entity, EntityKind};
+use crate::entity::{Confidence, Entity, EntityKind, Reference};
 use tree_sitter::{Node, Parser};
 
 /// Java AST entity extractor using tree-sitter.
@@ -599,6 +599,35 @@ impl JavaParser {
             String::new()
         }
     }
+
+    fn walk_tree_for_calls(
+        &self,
+        node: &Node,
+        source: &str,
+        file_path: &str,
+        refs: &mut Vec<Reference>,
+    ) {
+        if node.kind() == "method_invocation" {
+            if let Some(name_node) = node.child_by_field_name("name") {
+                let name = self.node_text(&name_node, source);
+                if !name.is_empty() {
+                    refs.push(Reference {
+                        symbol: name,
+                        file: file_path.to_string(),
+                        line: (node.start_position().row as u32) + 1,
+                        column: Some(node.start_position().column as u32),
+                        context: None,
+                        confidence: Confidence::High,
+                    });
+                }
+            }
+        }
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.walk_tree_for_calls(&child, source, file_path, refs);
+        }
+    }
 }
 
 impl Default for JavaParser {
@@ -621,6 +650,16 @@ impl LanguageParser for JavaParser {
         let mut entities = Vec::new();
         self.walk_tree(&tree.root_node(), source, file_path, &mut entities, None);
         entities
+    }
+
+    fn extract_references(&mut self, source: &str, file_path: &str) -> Vec<Reference> {
+        let tree = match self.parser.parse(source, None) {
+            Some(t) => t,
+            None => return vec![],
+        };
+        let mut refs = Vec::new();
+        self.walk_tree_for_calls(&tree.root_node(), source, file_path, &mut refs);
+        refs
     }
 }
 

--- a/atomic-semantic/src/parsers/python.rs
+++ b/atomic-semantic/src/parsers/python.rs
@@ -17,7 +17,7 @@
 //! | `from x import y` | Import | From-import statement |
 
 use super::{Language, LanguageParser};
-use crate::entity::{Entity, EntityKind};
+use crate::entity::{Confidence, Entity, EntityKind, Reference};
 use tree_sitter::{Node, Parser};
 
 /// Python AST entity extractor using tree-sitter.
@@ -352,6 +352,57 @@ impl PythonParser {
             String::new()
         }
     }
+
+    fn walk_tree_for_calls(
+        &self,
+        node: &Node,
+        source: &str,
+        file_path: &str,
+        refs: &mut Vec<Reference>,
+    ) {
+        if node.kind() == "call" {
+            if let Some(func_node) = node.child_by_field_name("function") {
+                if let Some(name) = self.extract_call_name(&func_node, source) {
+                    if !name.is_empty() {
+                        refs.push(Reference {
+                            symbol: name,
+                            file: file_path.to_string(),
+                            line: (node.start_position().row as u32) + 1,
+                            column: Some(node.start_position().column as u32),
+                            context: None,
+                            confidence: Confidence::High,
+                        });
+                    }
+                }
+            }
+        }
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.walk_tree_for_calls(&child, source, file_path, refs);
+        }
+    }
+
+    fn extract_call_name(&self, func_node: &Node, source: &str) -> Option<String> {
+        match func_node.kind() {
+            "identifier" => {
+                let name = self.node_text(func_node, source);
+                if name.is_empty() {
+                    None
+                } else {
+                    Some(name)
+                }
+            }
+            "attribute" => {
+                // obj.method() — extract just "method"
+                func_node
+                    .child_by_field_name("attribute")
+                    .map(|f| self.node_text(&f, source))
+                    .filter(|s| !s.is_empty())
+            }
+            _ => None,
+        }
+    }
 }
 
 impl Default for PythonParser {
@@ -374,6 +425,16 @@ impl LanguageParser for PythonParser {
         let mut entities = Vec::new();
         self.walk_tree(&tree.root_node(), source, file_path, &mut entities, None);
         entities
+    }
+
+    fn extract_references(&mut self, source: &str, file_path: &str) -> Vec<Reference> {
+        let tree = match self.parser.parse(source, None) {
+            Some(t) => t,
+            None => return vec![],
+        };
+        let mut refs = Vec::new();
+        self.walk_tree_for_calls(&tree.root_node(), source, file_path, &mut refs);
+        refs
     }
 }
 

--- a/atomic-semantic/src/parsers/rust.rs
+++ b/atomic-semantic/src/parsers/rust.rs
@@ -23,7 +23,7 @@
 //! | `use std::io` | Import | Use statement |
 
 use super::{Language, LanguageParser};
-use crate::entity::{Entity, EntityKind};
+use crate::entity::{Confidence, Entity, EntityKind, Reference};
 use tree_sitter::{Node, Parser};
 
 /// Rust AST entity extractor using tree-sitter.
@@ -502,6 +502,78 @@ impl RustParser {
         let first = text.lines().next()?;
         Some(first.trim_end_matches('{').trim().to_string())
     }
+
+    /// Walk the AST collecting function call sites.
+    ///
+    /// Visits every `call_expression` node and extracts the simple callee name.
+    /// Recurses into all children including function bodies.
+    fn walk_tree_for_calls(
+        &self,
+        node: &Node,
+        source: &str,
+        file_path: &str,
+        refs: &mut Vec<Reference>,
+    ) {
+        if node.kind() == "call_expression" {
+            if let Some(func_node) = node.child_by_field_name("function") {
+                if let Some(name) = self.extract_call_name(&func_node, source) {
+                    if !name.is_empty() {
+                        refs.push(Reference {
+                            symbol: name,
+                            file: file_path.to_string(),
+                            line: (node.start_position().row as u32) + 1,
+                            column: Some(node.start_position().column as u32),
+                            context: None,
+                            confidence: Confidence::High,
+                        });
+                    }
+                }
+            }
+        }
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.walk_tree_for_calls(&child, source, file_path, refs);
+        }
+    }
+
+    /// Extract the simple function name from the callee sub-node of a `call_expression`.
+    ///
+    /// Returns `None` for call targets we cannot name simply (closures, raw pointers, etc.).
+    fn extract_call_name(&self, func_node: &Node, source: &str) -> Option<String> {
+        match func_node.kind() {
+            "identifier" => {
+                let name = self.node_text(func_node, source);
+                if name.is_empty() {
+                    None
+                } else {
+                    Some(name)
+                }
+            }
+            "field_expression" => {
+                // self.method() or obj.method() — extract just "method"
+                func_node
+                    .child_by_field_name("field")
+                    .map(|f| self.node_text(&f, source))
+                    .filter(|s| !s.is_empty())
+            }
+            "scoped_identifier" => {
+                // Module::func() — extract just "func"
+                func_node
+                    .child_by_field_name("name")
+                    .map(|n| self.node_text(&n, source))
+                    .filter(|s| !s.is_empty())
+            }
+            "generic_function" => {
+                // func::<T>() — recurse into the inner function node
+                func_node
+                    .child_by_field_name("function")
+                    .as_ref()
+                    .and_then(|f| self.extract_call_name(f, source))
+            }
+            _ => None,
+        }
+    }
 }
 
 impl Default for RustParser {
@@ -524,6 +596,23 @@ impl LanguageParser for RustParser {
         let mut entities = Vec::new();
         self.walk_tree(&tree.root_node(), source, file_path, &mut entities, None);
         entities
+    }
+
+    /// Extract all function call sites from a Rust source file.
+    ///
+    /// Each `Reference` has:
+    /// - `symbol`  — the simple callee name (e.g., `"authenticate"`, not `"auth::authenticate"`)
+    /// - `file`    — the caller file path
+    /// - `line`    — 1-based line of the call expression
+    /// - `confidence` — always `High` (tree-sitter parse is exact)
+    fn extract_references(&mut self, source: &str, file_path: &str) -> Vec<Reference> {
+        let tree = match self.parser.parse(source, None) {
+            Some(t) => t,
+            None => return vec![],
+        };
+        let mut refs = Vec::new();
+        self.walk_tree_for_calls(&tree.root_node(), source, file_path, &mut refs);
+        refs
     }
 }
 

--- a/atomic-semantic/src/parsers/swift.rs
+++ b/atomic-semantic/src/parsers/swift.rs
@@ -32,7 +32,7 @@
 //! | `private` / `fileprivate` | `false` |
 
 use super::{Language, LanguageParser};
-use crate::entity::{Entity, EntityKind};
+use crate::entity::{Confidence, Entity, EntityKind, Reference};
 use tree_sitter::{Node, Parser};
 
 /// Swift AST entity extractor using tree-sitter.
@@ -563,6 +563,71 @@ impl SwiftParser {
             String::new()
         }
     }
+
+    fn walk_tree_for_calls(
+        &self,
+        node: &Node,
+        source: &str,
+        file_path: &str,
+        refs: &mut Vec<Reference>,
+    ) {
+        if node.kind() == "call_expression" {
+            // In tree-sitter-swift the callee is the first child (no named field)
+            if let Some(func_node) = node.child(0) {
+                if let Some(name) = self.extract_call_name(&func_node, source) {
+                    if !name.is_empty() {
+                        refs.push(Reference {
+                            symbol: name,
+                            file: file_path.to_string(),
+                            line: (node.start_position().row as u32) + 1,
+                            column: Some(node.start_position().column as u32),
+                            context: None,
+                            confidence: Confidence::High,
+                        });
+                    }
+                }
+            }
+        }
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.walk_tree_for_calls(&child, source, file_path, refs);
+        }
+    }
+
+    fn extract_call_name(&self, func_node: &Node, source: &str) -> Option<String> {
+        match func_node.kind() {
+            "simple_identifier" => {
+                let name = self.node_text(func_node, source);
+                if name.is_empty() {
+                    None
+                } else {
+                    Some(name)
+                }
+            }
+            "navigation_expression" => {
+                // obj.method() — find the last navigation_suffix to get the method name
+                for i in (0..func_node.child_count()).rev() {
+                    if let Some(suffix) = func_node.child(i) {
+                        if suffix.kind() == "navigation_suffix" {
+                            for j in 0..suffix.child_count() {
+                                if let Some(name_node) = suffix.child(j) {
+                                    if name_node.kind() == "simple_identifier" {
+                                        let name = self.node_text(&name_node, source);
+                                        if !name.is_empty() {
+                                            return Some(name);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
 }
 
 impl Default for SwiftParser {
@@ -585,6 +650,16 @@ impl LanguageParser for SwiftParser {
         let mut entities = Vec::new();
         self.walk_tree(&tree.root_node(), source, file_path, &mut entities, None);
         entities
+    }
+
+    fn extract_references(&mut self, source: &str, file_path: &str) -> Vec<Reference> {
+        let tree = match self.parser.parse(source, None) {
+            Some(t) => t,
+            None => return vec![],
+        };
+        let mut refs = Vec::new();
+        self.walk_tree_for_calls(&tree.root_node(), source, file_path, &mut refs);
+        refs
     }
 }
 

--- a/docs/CONCURRENT-AGENT-SANDBOXES.md
+++ b/docs/CONCURRENT-AGENT-SANDBOXES.md
@@ -1,0 +1,148 @@
+# Concurrent Agent Sandboxes
+
+**Status:** `create` / `--from` implemented and tested. `stage` / `seal` are
+design investigations (this doc).
+
+## The model
+
+Several agents work at once, each in a private working tree, sharing **one**
+canonical graph. Two facts make it simple:
+
+1. **The working tree is cloned copy-on-write; the graph is not.** A sandbox is
+   a reflink clone of the working tree (APFS `clonefile`, Btrfs/XFS `FICLONE`,
+   ReFS block-clone — one path via the `reflink-copy` crate, falling back to a
+   plain copy). Five agents off a 200 MB base cost a few MB, not a gigabyte, and
+   run at bare-metal filesystem speed — no FUSE, no virtio, no VM.
+2. **There is exactly one pristine.** The sandbox carries a small pointer file
+   (`.atomic-sandbox`) naming the canonical repo and the sandbox's view. Every
+   `atomic` command run inside the sandbox resolves the graph from there, so
+   `status`, `record`, `diff`, `vault query` all work as in a normal repo.
+
+This is "views, not forks" taken to the filesystem: one graph, many cheap
+working-tree projections.
+
+### Why not the things we tried first
+
+Recorded here so nobody re-walks them: a host-side FUSE overlay (macFUSE) is
+impractical to deploy on Apple Silicon + macOS 26 (Recovery-Mode security
+downgrade, kext staging, and a fuser/libfuse2 ABI break) and showed no speed
+win; virtio-fs virtualizes the filesystem protocol and is death for the
+metadata-heavy workloads (git, cargo, npm) we care about. Copy-on-write on the
+real filesystem needs none of it.
+
+## Implemented
+
+### `Repository` (atomic-repository/src/repository/sandbox.rs)
+
+- `provision_sandbox(dest, view)` — reflink-clone the working tree into `dest`,
+  skipping `.atomic/` (shared) and nested sandboxes; write the `.atomic-sandbox`
+  pointer. In-process in the binary — no shell.
+- `open_sandbox(working_root, canonical, view)` — working tree in one place, the
+  one canonical graph in another.
+- `detect_sandbox()` — wired into `open` / `open_existing` / `open_readonly`, and
+  the CLI's `find_repository_root`, so any command inside a sandbox routes to the
+  canonical graph.
+
+### CLI
+
+```text
+atomic sandbox create <NAME> [--dest <PATH>] [--view <VIEW>] [--from <VIEW>]
+```
+
+- `--from <view>` forks a per-agent **draft** view (named after the sandbox)
+  from `<view>`, so the agent's records land in its own draft — isolating each
+  agent's history as well as its files.
+- `--view <view>` records into an existing view; default is the current view.
+
+Covered by `tests/harness/20_sandbox.sh` (18 assertions): clone happens, graph
+is not cloned, artifacts are per-agent, commands work inside the sandbox, records
+land in the canonical graph / the per-agent draft, the canonical working tree is
+untouched.
+
+### Concurrency caveat
+
+The harness is sequential. Multiple agent **processes** opening the canonical
+pristine concurrently rely on redb's cross-process locking — records serialize
+(the intended model), but simultaneous writers haven't been load-tested. Verify
+before relying on true parallelism.
+
+---
+
+## Investigation: `atomic sandbox stage` and `atomic sandbox seal`
+
+Both turn a sandbox into a shippable OCI artifact. They differ in *what* they
+package and *why*.
+
+| | `stage` | `seal` |
+|--|--|--|
+| Purpose | inner-loop CI / circuit-breaker runs | deployable runtime |
+| Shape | **layered**: shared base + thin delta | **flattened**: one self-contained rootfs |
+| Base sharing | yes — base keyed by the shared view's Merkle, pulled once and cached | no — fully self-contained |
+| Ships each iteration | only the delta (small, fast) | the whole image (release artifact) |
+| Lifecycle | ephemeral, per turn | versioned release |
+
+### What each side already provides
+
+**atomic** (graph → rootfs + dependency metadata):
+- Materialize a view's visible state to a directory (the core `materialize_view`
+  over a `FileSystem` working copy rooted at an arbitrary dir — the same path
+  `Repository::materialize` uses, pointed elsewhere).
+- The dependency closure of a view: `collect_visible_change_ids_with_deps`
+  (already public) — the "dependency xxxx" the artifact must carry.
+- Per-view change sets: `collect_visible_change_ids` — the symmetric difference
+  between the draft and its base is the "delta yyyy".
+- Merkle state per view — a stable content-address for the shared base.
+
+**smolvm** (rootfs → OCI artifact, registry):
+- `pack create` already accepts `--image`, `--from-vm`, and a hidden
+  `--rootfs-dir` — i.e. packing a directory into a `.smolmachine` is mostly
+  plumbed.
+- `pack push` / `pull` move `.smolmachine` artifacts to/from an OCI registry.
+- `BlobCache` + the registry are content-addressed (sha256) — the substrate for
+  "base pulled once, cached, delta ships each time."
+- `ContainerizationEXT4` (Apple) can build ext4 images natively on macOS (drops
+  the e2fsprogs dependency) if we want block images instead of layer dirs.
+
+### `atomic sandbox stage` — flow
+
+1. Resolve base = the shared view (`--from`) at its current Merkle `M`.
+2. If the base layer for `M` isn't in the registry, materialize the shared view
+   to a dir, pack it (`pack --rootfs-dir`), push it tagged by `M`. Otherwise
+   reuse it (this is the win — built once, shared across all stagings).
+3. Materialize **only the delta** (changes in the sandbox's draft not in the
+   base) to a dir → pack as a thin layer on top of base `M`.
+4. Emit an OCI image = `[base@M] + [delta]` plus a reinflate manifest (which base
+   to pull, how to stack). Push.
+5. CI pulls base (cached) + delta (small) → smolvm reinflates → runs build/test
+   and circuit-breaker checks against the agent's WIP. Cheap inner loop.
+
+### `atomic sandbox seal` — flow
+
+1. Compute the full dependency closure of the view (base deps + draft changes).
+2. Materialize the **merged** state (base + delta flattened) to a single rootfs.
+3. Add a runtime layer (toolchain/entrypoint needed to *run* the app).
+4. Pack as a self-contained `.smolmachine` / OCI image, push as a versioned
+   release. Runs "this exact version" as a runtime anywhere smolvm runs.
+
+### Gaps to close (the actual work)
+
+- **atomic:** a `materialize_view_to(view, dir)` helper (re-introduces the
+  directory-targeted materialize), and a `delta-vs-base` change-set computation
+  surfaced as a stable list for packing.
+- **smolvm:** a supported (un-hidden) `pack --rootfs-dir` entry or a library API
+  to pack a directory + a parent-layer reference into a layered `.smolmachine`;
+  base-by-digest reuse on push.
+- **shared:** the reinflate manifest schema (base digest + delta + how smolvm
+  stacks them — in-guest overlayfs over two block layers, or a flattened rootfs).
+
+### Open questions
+
+- Layer boundary: ship base/delta as two ext4 block images (overlayfs in-guest)
+  or as OCI tar layers (merged at unpack)? Block images keep native FS speed in
+  CI; tar layers are more registry-standard.
+- Does `stage` include build artifacts (`target`, `node_modules`) to skip a cold
+  build in CI, or only source? Artifacts bloat the delta but cut CI time —
+  probably a flag.
+- Provenance: seal/stage artifacts should embed the view Merkle + change hashes
+  so a shipped image is traceable back to exact graph state (ties into the
+  existing attestation/provenance model).

--- a/tests/harness/10_git_import.sh
+++ b/tests/harness/10_git_import.sh
@@ -88,6 +88,13 @@ echo "  Found $expected_commits first-parent commits on branch '$default_branch'
 # Initialize atomic and import
 assert_success "atomic git import succeeds" atomic git import
 
+git_status_after_import="$(git status --short)"
+if [[ -z "$git_status_after_import" ]]; then
+    _pass "git status stays clean after import"
+else
+    _fail "git status dirty after import" "$git_status_after_import"
+fi
+
 # Verify view created (should use default branch name)
 assert_view_exists "view '$default_branch' created" "$default_branch"
 
@@ -564,6 +571,13 @@ if [[ "$_status_lines" -eq 0 ]]; then
 else
     _dirty=$(cd "$GIT_REPO" && atomic status --short 2>/dev/null | head -10)
     _fail "status not clean after import" "$_status_lines dirty entries: $_dirty"
+fi
+
+_git_status_lines=$(cd "$GIT_REPO" && git status --short)
+if [[ -z "$_git_status_lines" ]]; then
+    _pass "git status is clean after import"
+else
+    _fail "git status dirty after import" "$_git_status_lines"
 fi
 
 # 7. Change count matches git commit count

--- a/tests/harness/20_sandbox.sh
+++ b/tests/harness/20_sandbox.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# 20_sandbox.sh — Concurrent agent sandbox tests.
+#
+# A sandbox is a private, copy-on-write clone of the working tree. Several
+# agents can each work in their own sandbox at once — isolated build
+# artifacts, no collisions — while sharing the ONE canonical graph.
+#
+# Key principles ("views, not forks", taken further):
+#   - The working tree is cloned (copy-on-write); the graph is NOT.
+#   - There is exactly one pristine. A sandbox shares it via a pointer file.
+#   - `atomic` commands run inside a sandbox resolve to the canonical graph,
+#     so `status` / `record` work as if it were a normal repo.
+#   - Recording in a sandbox lands the change in the canonical graph.
+#   - Each sandbox's untracked artifacts are independent.
+#
+# What this verifies:
+#   1. `sandbox create` clones the working tree into a private directory
+#   2. The canonical `.atomic/` graph is NOT cloned into the sandbox
+#   3. Untracked artifacts (node_modules) ARE cloned (per-agent isolation)
+#   4. A sandbox pointer file is written
+#   5. `atomic status` works INSIDE the sandbox (resolves to canonical graph)
+#   6. Editing + recording inside the sandbox lands in the canonical graph
+#   7. The canonical working tree is untouched by sandbox edits
+#   8. Two sandboxes have independent artifacts
+
+HARNESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$HARNESS_DIR/helpers.sh"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Sandbox: create clones the working tree, not the graph"
+# ═══════════════════════════════════════════════════════════════════════════
+
+make_temp_repo "sandbox-create"
+CANON="$REPO_DIR"
+init_repo
+
+create_file "src/main.rs" "fn main() {}"
+create_file "Cargo.toml" "[package]"
+assert_success "add tracked files" atomic add src/main.rs Cargo.toml
+record_change "init" >/dev/null 2>&1 || true
+
+# Untracked build artifact (simulates npm install output)
+mkdir -p node_modules/lodash
+create_file "node_modules/lodash/index.js" "module.exports = {}"
+
+# Sandboxes live OUTSIDE the canonical repo (as the default dest does), so
+# provisioning never recurses into them.
+SBROOT="$(mktemp -d "${TMPDIR:-/tmp}/atomic-sandboxes-XXXXXX")"
+_HARNESS_TMPDIRS+=("$SBROOT")
+SB="$SBROOT/agent-1"
+assert_success "sandbox create" atomic sandbox create agent-1 --dest "$SB"
+
+assert_file_exists "tracked file cloned into sandbox" "$SB/src/main.rs"
+assert_file_exists "Cargo.toml cloned into sandbox" "$SB/Cargo.toml"
+assert_file_exists "untracked artifact cloned into sandbox" "$SB/node_modules/lodash/index.js"
+assert_dir_not_exists "graph .atomic NOT cloned into sandbox" "$SB/.atomic"
+assert_file_exists "sandbox pointer written" "$SB/.atomic-sandbox"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Sandbox: atomic commands inside resolve to the canonical graph"
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Running status from inside the sandbox must succeed even though there is no
+# local .atomic/ — it resolves the graph from the canonical repo via the pointer.
+assert_success "status works inside sandbox" bash -c "cd '$SB' && '$ATOMIC_BIN' status"
+
+# The tracked file should be clean (it was recorded in the canonical graph).
+assert_output_not_contains \
+    "tracked file is clean inside sandbox" \
+    "src/main.rs" \
+    bash -c "cd '$SB' && '$ATOMIC_BIN' status --short"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Sandbox: record inside lands in the canonical graph"
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Edit a file inside the sandbox and record from there.
+overwrite_file "$SB/src/main.rs" "fn main() { println!(\"from sandbox\"); }"
+
+RECORD_OUT="$(cd "$SB" && "$ATOMIC_BIN" record -m "edit from sandbox" 2>&1)" || true
+
+# The change must be visible in the canonical repo's log.
+assert_output_contains \
+    "sandbox change appears in canonical log" \
+    "edit from sandbox" \
+    bash -c "cd '$CANON' && '$ATOMIC_BIN' log"
+
+# The canonical working-tree file on disk is untouched (the edit was isolated
+# to the sandbox clone; the change lives in the graph until materialized).
+assert_file_content \
+    "canonical working file unchanged by sandbox edit" \
+    "$CANON/src/main.rs" \
+    "fn main() {}"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Sandbox: two sandboxes have independent artifacts"
+# ═══════════════════════════════════════════════════════════════════════════
+
+SB2="$SBROOT/agent-2"
+assert_success "second sandbox create" atomic sandbox create agent-2 --dest "$SB2"
+
+# Agent 1 installs a dep that agent 2 does not.
+mkdir -p "$SB/node_modules/only-in-1"
+create_file "$SB/node_modules/only-in-1/x.js" "1"
+
+assert_file_exists "agent-1 has its own dep" "$SB/node_modules/only-in-1/x.js"
+assert_file_not_exists "agent-2 does NOT see agent-1's dep" "$SB2/node_modules/only-in-1/x.js"
+
+# Both sandboxes still share the same canonical graph (one pristine).
+assert_file_exists "canonical pristine is single source" "$CANON/.atomic/pristine.redb"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Sandbox: --from creates a per-agent draft view"
+# ═══════════════════════════════════════════════════════════════════════════
+
+SB3="$SBROOT/agent-3"
+assert_success "sandbox create --from dev" \
+    bash -c "cd '$CANON' && '$ATOMIC_BIN' sandbox create agent-3 --dest '$SB3' --from dev"
+
+# The new draft view exists in the canonical repo.
+assert_output_contains \
+    "draft view 'agent-3' created" \
+    "agent-3" \
+    bash -c "cd '$CANON' && '$ATOMIC_BIN' view list"
+
+# Recording in the sandbox lands in the agent-3 draft, not in dev.
+overwrite_file "$SB3/src/main.rs" "fn main() { println!(\"draft work\"); }"
+(cd "$SB3" && "$ATOMIC_BIN" record -m "work in draft" >/dev/null 2>&1) || true
+
+assert_output_contains \
+    "draft change visible on agent-3 view" \
+    "work in draft" \
+    bash -c "cd '$CANON' && '$ATOMIC_BIN' log --view agent-3"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Sandbox: seal produces a valid OCI image layout"
+# ═══════════════════════════════════════════════════════════════════════════
+
+SEAL_OUT="$SBROOT/seal-dev"
+assert_success "seal dev view" \
+    bash -c "cd '$CANON' && '$ATOMIC_BIN' sandbox seal dev -o '$SEAL_OUT' --entrypoint /app/run --env PORT=8080"
+
+assert_file_exists "oci-layout written" "$SEAL_OUT/oci-layout"
+assert_file_exists "index.json written" "$SEAL_OUT/index.json"
+assert_dir_exists "blobs/sha256 written" "$SEAL_OUT/blobs/sha256"
+assert_output_contains "oci-layout has version" "imageLayoutVersion" cat "$SEAL_OUT/oci-layout"
+
+# Every blob filename must equal the sha256 of its contents (content-addressed).
+BLOB_OK=1
+for blob in "$SEAL_OUT"/blobs/sha256/*; do
+    name="$(basename "$blob")"
+    actual="$(shasum -a 256 "$blob" | awk '{print $1}')"
+    [ "$name" = "$actual" ] || BLOB_OK=0
+done
+if [ "$BLOB_OK" = "1" ]; then
+    _pass "every blob is content-addressed (filename == sha256)"
+else
+    _fail "every blob is content-addressed (filename == sha256)" "a blob filename did not match its sha256"
+fi
+
+# The manifest the index points to must reference exactly one layer (flattened).
+INDEX_MANIFEST="$(grep -o 'sha256:[0-9a-f]\{64\}' "$SEAL_OUT/index.json" | head -1 | cut -d: -f2)"
+assert_file_exists "index references a manifest blob" "$SEAL_OUT/blobs/sha256/$INDEX_MANIFEST"
+assert_output_contains \
+    "sealed image carries provenance annotation" \
+    "org.atomic.view" \
+    cat "$SEAL_OUT/blobs/sha256/$INDEX_MANIFEST"
+
+# Seal of the SHARED dev view must contain dev's recorded GRAPH content (not
+# the working tree on disk). Extract the single layer and inspect it.
+SEAL_LAYER="$(python3 -c "import json,sys; m=json.load(open('$SEAL_OUT/blobs/sha256/$INDEX_MANIFEST')); print(m['layers'][0]['digest'].split(':')[1])")"
+SEAL_EXTRACT="$SBROOT/seal-dev-extract"
+mkdir -p "$SEAL_EXTRACT"
+tar -xzf "$SEAL_OUT/blobs/sha256/$SEAL_LAYER" -C "$SEAL_EXTRACT" 2>/dev/null || true
+
+assert_file_exists "sealed dev layer contains src/main.rs" "$SEAL_EXTRACT/src/main.rs"
+assert_file_exists "sealed dev layer contains Cargo.toml" "$SEAL_EXTRACT/Cargo.toml"
+
+# dev's graph state for src/main.rs is the change recorded from the agent-1
+# sandbox earlier ("from sandbox"), proving seal reads recorded view state
+# rather than the canonical working copy (which still has the original).
+assert_file_content \
+    "sealed dev content is the recorded graph state" \
+    "$SEAL_EXTRACT/src/main.rs" \
+    'fn main() { println!("from sandbox"); }'
+
+assert_file_content \
+    "canonical working copy still has original (graph != disk)" \
+    "$CANON/src/main.rs" \
+    "fn main() {}"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Sandbox: stage produces a two-layer (base + delta) image"
+# ═══════════════════════════════════════════════════════════════════════════
+
+# agent-3 has the "work in draft" change on top of dev — stage it as base+delta.
+STAGE_OUT="$SBROOT/stage-agent-3"
+assert_success "stage agent-3 over dev" \
+    bash -c "cd '$CANON' && '$ATOMIC_BIN' sandbox stage agent-3 --base dev -o '$STAGE_OUT'"
+
+assert_file_exists "staged oci-layout written" "$STAGE_OUT/oci-layout"
+
+# The staged manifest must reference TWO layers (base + delta).
+STAGE_MANIFEST="$(grep -o 'sha256:[0-9a-f]\{64\}' "$STAGE_OUT/index.json" | head -1 | cut -d: -f2)"
+LAYER_COUNT="$(grep -o 'tar+gzip' "$STAGE_OUT/blobs/sha256/$STAGE_MANIFEST" | wc -l | tr -d ' ')"
+if [ "$LAYER_COUNT" = "2" ]; then
+    _pass "staged image has two layers (base + delta)"
+else
+    _fail "staged image has two layers (base + delta)" "expected 2 tar+gzip layers, got $LAYER_COUNT"
+fi
+
+assert_output_contains \
+    "staged image records base-view provenance" \
+    "org.atomic.base-view" \
+    cat "$STAGE_OUT/blobs/sha256/$STAGE_MANIFEST"
+
+# ═══════════════════════════════════════════════════════════════════════════
+
+print_summary

--- a/tests/harness/21_status_add_asymmetry.sh
+++ b/tests/harness/21_status_add_asymmetry.sh
@@ -1,0 +1,396 @@
+#!/usr/bin/env bash
+# 21_status_add_asymmetry.sh — Status/Add view-filter asymmetry bug.
+#
+# Reproduces the bug report:
+#   "I run atomic status and it shows me tons of things that aren't tracked,
+#    then I run atomic add and it says there's nothing to add."
+#
+# Root cause: `status` uses the view's change filter to decide which TREE
+# entries are "tracked" (view-aware), while `add` / `is_tracked` checks the
+# global TREE table (view-unaware).  Files recorded on a child/sibling view
+# are in TREE but their introducing change isn't visible on the current
+# view.  Result:
+#   - status: file in TREE but filtered out → filesystem walk finds it → "Untracked"
+#   - add: file in TREE → is_tracked() = true → "already tracked" → skip
+#
+# Scenarios tested:
+#   1. File recorded on child draft view, parent view shows it as untracked
+#   2. File recorded on sibling view, other sibling shows it as untracked
+#   3. Agent workflow: auto-created draft view records files, parent is confused
+#   4. After fix: no file should be simultaneously "Untracked" AND "already tracked"
+
+HARNESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$HARNESS_DIR/helpers.sh"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Status/Add Asymmetry: Child draft view leaks into parent"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Workflow (simulates the agent hook creating files on a draft view):
+#   1. Init repo on dev (shared)
+#   2. Record a base file on dev
+#   3. Create a draft child view (like the agent would)
+#   4. Switch to draft, create+add+record a new file
+#   5. Switch back to dev
+#   6. BUG: status shows the file as Untracked (it's on disk from the
+#           draft view's record, but the change isn't in dev's filter)
+#   7. BUG: atomic add says "already tracked" (it's in the global TREE)
+#
+# Expected after fix:
+#   - The file should NOT appear as Untracked on dev
+#   - atomic add should not produce a contradictory state
+
+make_temp_repo "status-add-child-draft"
+init_repo
+
+# Step 1: Record a base file on dev so the view isn't empty
+create_file "base.txt" "base content"
+assert_success "add base.txt on dev" atomic add base.txt
+record_change "Add base.txt on dev" >/dev/null 2>&1 || true
+assert_clean "dev is clean after recording base.txt"
+
+# Step 2: Create a draft child view (simulates agent session)
+out="$(atomic view create agent-session --draft --parent dev 2>&1)" || true
+if echo "$out" | grep -qiE "created|view"; then
+    _pass "create draft view agent-session"
+else
+    _fail "create draft view agent-session" "output: $out"
+fi
+
+# Step 3: Switch to the draft view and create+add+record a file
+switch_view "agent-session" >/dev/null 2>&1 || true
+assert_current_view "on agent-session" "agent-session"
+
+create_file "agent_file.txt" "created by agent"
+assert_success "add agent_file.txt on agent-session" atomic add agent_file.txt
+record_change "Agent creates agent_file.txt" >/dev/null 2>&1 || true
+
+# Verify it's clean on the draft view
+out="$(get_status_short)"
+if echo "$out" | grep -qE "^[MADU?].*agent_file\.txt"; then
+    _fail "agent_file.txt is clean on agent-session" "still dirty: $out"
+else
+    _pass "agent_file.txt is clean on agent-session after record"
+fi
+
+# Step 4: Switch back to dev
+switch_view "dev" >/dev/null 2>&1 || true
+assert_current_view "back on dev" "dev"
+
+# Step 5: THE BUG — status should NOT show agent_file.txt as Untracked
+out="$(get_status_short)"
+if echo "$out" | grep -qE "^\?.*agent_file\.txt"; then
+    _fail "agent_file.txt NOT shown as Untracked on dev" \
+        "BUG: status shows '?' for a file that is in TREE (from draft view). Status: $out"
+else
+    _pass "agent_file.txt NOT shown as Untracked on dev"
+fi
+
+# Step 6: THE BUG — add should not claim "already tracked" for an "Untracked" file
+# If the file shows as Untracked, trying to add it should succeed.
+# If the file doesn't show at all (correct behavior), add should say "already tracked".
+# The BROKEN state is: status=Untracked + add=already-tracked (contradictory).
+add_out="$(atomic add agent_file.txt 2>&1)" || true
+status_out="$(get_status_short)"
+has_untracked=$(echo "$status_out" | grep -cE "^\?.*agent_file\.txt" || true)
+has_already_tracked=$(echo "$add_out" | grep -ci "already tracked" || true)
+
+if [[ "$has_untracked" -gt 0 && "$has_already_tracked" -gt 0 ]]; then
+    _fail "no contradictory status+add state" \
+        "BUG: status says Untracked but add says 'already tracked'. Status: $status_out | Add: $add_out"
+else
+    _pass "no contradictory status+add state"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Status/Add Asymmetry: Sibling views don't leak"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Workflow:
+#   1. On dev, record a base file
+#   2. Create two sibling views: feature-a, feature-b (both children of dev)
+#   3. Record a file on feature-a
+#   4. Switch to feature-b
+#   5. The feature-a file should not show as Untracked on feature-b
+#   6. add on feature-b should not be contradictory
+
+make_temp_repo "status-add-sibling"
+init_repo
+
+# Record base on dev
+create_file "base.txt" "base"
+assert_success "add base.txt" atomic add base.txt
+record_change "Add base" >/dev/null 2>&1 || true
+
+# Create two sibling draft views
+atomic view create feature-a --draft --parent dev >/dev/null 2>&1 || true
+atomic view create feature-b --draft --parent dev >/dev/null 2>&1 || true
+
+# Record on feature-a
+switch_view "feature-a" >/dev/null 2>&1 || true
+create_file "only_on_a.txt" "feature-a content"
+assert_success "add only_on_a.txt on feature-a" atomic add only_on_a.txt
+record_change "Add only_on_a.txt on feature-a" >/dev/null 2>&1 || true
+
+# Switch to feature-b
+switch_view "feature-b" >/dev/null 2>&1 || true
+assert_current_view "on feature-b" "feature-b"
+
+# File from feature-a should NOT appear as Untracked on feature-b
+out="$(get_status_short)"
+if echo "$out" | grep -qE "^\?.*only_on_a\.txt"; then
+    _fail "only_on_a.txt NOT shown as Untracked on feature-b" \
+        "BUG: sibling view file leaks as Untracked. Status: $out"
+else
+    _pass "only_on_a.txt NOT shown as Untracked on feature-b"
+fi
+
+# No contradictory state
+add_out="$(atomic add only_on_a.txt 2>&1)" || true
+status_out="$(get_status_short)"
+has_untracked=$(echo "$status_out" | grep -cE "^\?.*only_on_a\.txt" || true)
+has_already_tracked=$(echo "$add_out" | grep -ci "already tracked" || true)
+
+if [[ "$has_untracked" -gt 0 && "$has_already_tracked" -gt 0 ]]; then
+    _fail "no contradictory state on feature-b" \
+        "BUG: status=Untracked + add='already tracked'. Status: $status_out | Add: $add_out"
+else
+    _pass "no contradictory state on feature-b"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Status/Add Asymmetry: Agent batch-add workflow"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Simulates the exact agent workflow that triggers the bug:
+#   1. Agent hook creates a draft view
+#   2. Agent creates multiple files, calls add_batch + record
+#   3. Parent view should not see any of those files as Untracked
+#   4. atomic add --all on parent should not find contradictory files
+
+make_temp_repo "status-add-agent-batch"
+init_repo
+
+# Base content on dev
+create_file "README.md" "# Project"
+assert_success "add README.md" atomic add README.md
+record_change "Initial commit" >/dev/null 2>&1 || true
+
+# Agent creates a draft view and records multiple files
+atomic view create agent-turn-1 --draft --parent dev >/dev/null 2>&1 || true
+switch_view "agent-turn-1" >/dev/null 2>&1 || true
+
+create_file "src/main.rs" "fn main() {}"
+create_file "src/lib.rs" "pub mod util;"
+create_file "src/util.rs" "pub fn helper() {}"
+create_file "Cargo.toml" "[package]\nname = \"test\""
+
+assert_success "add src/main.rs" atomic add src/main.rs
+assert_success "add src/lib.rs" atomic add src/lib.rs
+assert_success "add src/util.rs" atomic add src/util.rs
+assert_success "add Cargo.toml" atomic add Cargo.toml
+record_change "Agent adds project structure" >/dev/null 2>&1 || true
+
+# Switch back to dev
+switch_view "dev" >/dev/null 2>&1 || true
+assert_current_view "on dev after agent work" "dev"
+
+# NO agent files should appear as Untracked on dev
+out="$(get_status_short)"
+agent_untracked=0
+for f in "src/main.rs" "src/lib.rs" "src/util.rs" "Cargo.toml"; do
+    if echo "$out" | grep -qE "^\?.*$(echo "$f" | sed 's/[\/\.]/\\&/g')"; then
+        agent_untracked=$((agent_untracked + 1))
+    fi
+done
+
+if [[ "$agent_untracked" -gt 0 ]]; then
+    _fail "no agent files shown as Untracked on dev (found $agent_untracked)" \
+        "BUG: $agent_untracked agent files leak as Untracked on parent. Status: $out"
+else
+    _pass "no agent files shown as Untracked on dev"
+fi
+
+# atomic add --all should not find contradictory files
+add_all_out="$(atomic add --all 2>&1)" || true
+if echo "$add_all_out" | grep -qiE "already tracked"; then
+    # Check if any of those "already tracked" files were shown as Untracked
+    status_out="$(get_status_short)"
+    has_contradiction=false
+    for f in "src/main.rs" "src/lib.rs" "src/util.rs" "Cargo.toml"; do
+        escaped_f="$(echo "$f" | sed 's/[\/\.]/\\&/g')"
+        is_untracked=$(echo "$status_out" | grep -cE "^\?.*$escaped_f" || true)
+        if [[ "$is_untracked" -gt 0 ]]; then
+            has_contradiction=true
+            break
+        fi
+    done
+    if $has_contradiction; then
+        _fail "add --all not contradictory with status" \
+            "BUG: files shown as Untracked but add says 'already tracked'"
+    else
+        _pass "add --all not contradictory with status"
+    fi
+else
+    _pass "add --all not contradictory with status"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Status/Add Asymmetry: No-switch agent workflow (THE BUG)"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# This is the EXACT scenario from the customer report and the wordl project.
+# The agent creates files on disk WITHOUT switching views. The agent hook
+# then creates a draft view and records on it. The user never leaves dev.
+#
+# Workflow:
+#   1. User is on dev, has a base file recorded
+#   2. Agent creates files on disk (user's working copy)
+#   3. Agent hook creates a draft view (child of dev)
+#   4. Agent hook does: switch to draft → add files → record → switch back to dev
+#   5. User runs `atomic status` on dev
+#   6. BUG: agent's files show as Untracked (they're on disk, in TREE,
+#           but the change is on the draft view, not dev)
+#   7. User runs `atomic add` — says "already tracked"
+#
+# The critical difference from the switch tests above: the FILES REMAIN
+# ON DISK because the agent created them in the working copy. The switch
+# back to dev removes them via materialization, but then they're recreated
+# by the fact that the working copy still has pending content.
+#
+# Actually, the most common trigger is simpler: the agent hook adds files
+# to TREE and records on the draft view, but the user stays on dev the
+# whole time (or the switch back leaves files on disk).
+
+make_temp_repo "status-add-no-switch"
+init_repo
+
+# Base content on dev
+create_file "base.txt" "base"
+assert_success "add base.txt" atomic add base.txt
+record_change "Initial commit" >/dev/null 2>&1 || true
+assert_clean "dev is clean"
+
+# --- Simulate agent hook: create draft, add+record, switch back ---
+# Step 1: Agent creates files on disk while user is on dev
+create_file "agent_created.txt" "agent was here"
+create_file "src/agent_module.rs" "pub fn agent_fn() {}"
+
+# Step 2: Agent hook creates draft view
+atomic view create agent-draft --draft --parent dev >/dev/null 2>&1 || true
+
+# Step 3: Agent hook switches to draft, adds, records, switches back
+switch_view "agent-draft" >/dev/null 2>&1 || true
+assert_success "add agent_created.txt on draft" atomic add agent_created.txt
+assert_success "add src/agent_module.rs on draft" atomic add "src/agent_module.rs"
+record_change "Agent turn: add files" >/dev/null 2>&1 || true
+
+# Step 4: Switch back to dev (this is what the hook does after recording)
+switch_view "dev" >/dev/null 2>&1 || true
+assert_current_view "back on dev after agent hook" "dev"
+
+# Step 5: User manually re-creates files (or they leaked from switch)
+# In the real scenario, the agent might still be writing to disk,
+# or the files persist because the agent didn't clean up.
+# Simulate this by re-creating the files:
+create_file "agent_created.txt" "agent was here"
+create_file "src/agent_module.rs" "pub fn agent_fn() {}"
+
+# THE BUG: These files are in TREE (agent added them), the change is on
+# the draft view. On dev:
+#   - status: change not in dev's filter → skip from tracked → Untracked
+#   - add: is_tracked() checks global TREE → already tracked → skip
+
+out="$(get_status_short)"
+echo "  DEBUG status output: $out" >&2
+
+# Test 1: Files should NOT be shown as Untracked
+if echo "$out" | grep -qE "^\?.*agent_created\.txt"; then
+    _fail "agent_created.txt NOT Untracked on dev" \
+        "BUG: file in TREE from draft view shows as Untracked. Status: $out"
+else
+    _pass "agent_created.txt NOT Untracked on dev"
+fi
+
+if echo "$out" | grep -qE "^\?.*agent_module\.rs"; then
+    _fail "agent_module.rs NOT Untracked on dev" \
+        "BUG: file in TREE from draft view shows as Untracked. Status: $out"
+else
+    _pass "agent_module.rs NOT Untracked on dev"
+fi
+
+# Test 2: The contradictory state must not exist
+add_out="$(atomic add agent_created.txt 2>&1)" || true
+status_out="$(get_status_short)"
+has_untracked=$(echo "$status_out" | grep -cE "^\?.*agent_created\.txt" || true)
+has_already_tracked=$(echo "$add_out" | grep -ci "already tracked" || true)
+
+if [[ "$has_untracked" -gt 0 && "$has_already_tracked" -gt 0 ]]; then
+    _fail "no status+add contradiction for agent_created.txt" \
+        "BUG: status=Untracked + add='already tracked'. Status: $status_out | Add: $add_out"
+else
+    _pass "no status+add contradiction for agent_created.txt"
+fi
+
+# Test 3: If on disk + in TREE, the correct status should be Added
+# (tracked but not recorded on THIS view)
+if echo "$out" | grep -qE "^A.*agent_created\.txt"; then
+    _pass "agent_created.txt shown as Added (correct: tracked, needs record on dev)"
+else
+    # Also acceptable: not shown at all (file shouldn't be on disk)
+    if echo "$out" | grep -q "agent_created\.txt"; then
+        _fail "agent_created.txt shown as Added" \
+            "File shown with wrong status. Status: $out"
+    else
+        _pass "agent_created.txt shown as Added (or correctly hidden)"
+    fi
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Status/Add Asymmetry: File on disk from other view shows as Added"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# If a file IS on disk and IS in TREE (from another view), the correct
+# status should be "Added" (tracked, needs recording on this view) — NOT
+# "Untracked" (which implies it's unknown to the system).
+#
+# This test verifies that the file shows as Added when it's on disk but
+# its graph content belongs to another view.
+
+make_temp_repo "status-add-shows-added"
+init_repo
+
+# Record base on dev
+create_file "base.txt" "base"
+assert_success "add base.txt" atomic add base.txt
+record_change "Base commit" >/dev/null 2>&1 || true
+
+# Create draft, record a file on it
+atomic view create feature --draft --parent dev >/dev/null 2>&1 || true
+switch_view "feature" >/dev/null 2>&1 || true
+create_file "feature.txt" "feature content"
+assert_success "add feature.txt" atomic add feature.txt
+record_change "Feature file" >/dev/null 2>&1 || true
+
+# Switch to dev — file should be removed from disk by materialization
+switch_view "dev" >/dev/null 2>&1 || true
+
+# If the file was properly removed by switch_view, it should not appear at all
+# If it still exists on disk (materialization bug), it should show as Added, NOT Untracked
+if [[ -f "feature.txt" ]]; then
+    # File leaked onto disk — at minimum it should be Added, not Untracked
+    out="$(get_status_short)"
+    if echo "$out" | grep -qE "^\?.*feature\.txt"; then
+        _fail "leaked file shows as Added not Untracked" \
+            "BUG: file on disk from another view shows as '?' instead of 'A'. Status: $out"
+    elif echo "$out" | grep -qE "^A.*feature\.txt"; then
+        _pass "leaked file shows as Added not Untracked"
+    else
+        _pass "leaked file handled correctly (not shown or shown with other status)"
+    fi
+else
+    _pass "leaked file shows as Added not Untracked (file correctly removed by switch)"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+print_summary


### PR DESCRIPTION
This pull request introduces several new documentation and workflow files to the `.vault/` directory, updates the workspace version, and revises the project description in `README.md`. The main focus is on improving project onboarding, code exploration, and intent-driven development by providing detailed guides and templates for the Atomic VCS workflow.

**Key changes include:**

### Project Workflow and Knowledge Management

* Added `.vault/prompts/system_prompt.md`, a comprehensive system prompt for the AI coding agent, detailing tool usage, workflow, knowledge graph (KG) queries, and intent/goal management.
* Added `.vault/skills/atomic-vault.md`, a guide on using the Atomic Vault for managing goals, intents, and shared project memory, including example commands and workflow steps.
* Added `.vault/skills/code-intelligence.md`, explaining how to leverage the knowledge graph for code navigation and planning, including best practices for entity search and neighbors queries.
* Added `.vault/memory/MEMORY.md`, an index file for shared project knowledge and memory files.

### Intent and Planning Templates

* Added intent scaffolds in `.vault/intents/` for two tasks: understanding B-tree graph building (`ATOM-1`) and explaining identity mapping to change records (`ATOM-2`), each with placeholders for problem statements, acceptance criteria, and scope. [[1]](diffhunk://#diff-4046d08a0e7d0aee67a67194b9186622b6589970d74d9c259e65f18268fc0296R1-R66) [[2]](diffhunk://#diff-2dae6756669892612207be0526e3289b5d1153a2ede34590e70a9705a2fc161dR1-R55)

### Project Metadata

* Updated `Cargo.toml` workspace version to `0.8.1`.
* Updated the `README.md` project description to clarify Atomic's focus on semantic change graphs and agentic workflows.