### PR TITLE
fix(repository): make set_current_view pub — dev fails to compile after #96

### DIFF
--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -611,7 +611,7 @@ default = "{}"
     ///
     /// Returns an error if the view does not exist or the pointer file
     /// cannot be written.
-    pub(crate) fn set_current_view(&mut self, view: &str) -> Result<(), RepositoryError> {
+    pub fn set_current_view(&mut self, view: &str) -> Result<(), RepositoryError> {
         // Verify the view exists in the pristine database
         {
             let txn = self


### PR DESCRIPTION
dev is currently broken: #96's `session_start.rs:362` calls `Repository::set_current_view` across crates, but the method is `pub(crate)` in atomic-repository, so `cargo build` fails with E0624. Clean textual merge, broken semantics — CI didn't catch the cross-PR combination.

One-line visibility fix. Verified: `cargo build -p atomic-cli` succeeds and `atomic agent lifecycle status --json` works; noname's bridge e2e (`full_run_against_real_binary`) passes against the rebuilt binary.