### PR TITLE
fix(agent): sandbox turn-end silently switches the user's current_view

### DIFF
--- a/atomic-agent/src/record/mod.rs
+++ b/atomic-agent/src/record/mod.rs
@@ -210,20 +210,27 @@ pub fn record_turn(
     // Keep the write handle on the same view for post-add status and record.
     // First turns may target a view that record/apply will create; other failures
     // mean we cannot trust the detection/apply alignment.
-    match repo.align_to_view(&options.session.view_name) {
-        Ok(()) => {}
-        Err(atomic_repository::RepositoryError::ViewNotFound { .. }) => {
-            log::debug!(
-                "session view '{}' not yet created; first-turn apply will create it",
-                options.session.view_name
-            );
-        }
-        Err(e) => {
-            return Err(AgentError::RecordFailed {
-                session_id: options.session.session_id.clone(),
-                turn_number: options.turn_number,
-                reason: format!("Failed to align current view before record: {}", e),
-            });
+    //
+    // Sandboxes share the canonical .atomic: align_to_view would persist
+    // current_view and switch the real user's tree (same hazard as #99).
+    if repo.is_sandbox() {
+        repo.set_current_view_in_memory(&options.session.view_name);
+    } else {
+        match repo.align_to_view(&options.session.view_name) {
+            Ok(()) => {}
+            Err(atomic_repository::RepositoryError::ViewNotFound { .. }) => {
+                log::debug!(
+                    "session view '{}' not yet created; first-turn apply will create it",
+                    options.session.view_name
+                );
+            }
+            Err(e) => {
+                return Err(AgentError::RecordFailed {
+                    session_id: options.session.session_id.clone(),
+                    turn_number: options.turn_number,
+                    reason: format!("Failed to align current view before record: {}", e),
+                });
+            }
         }
     }
 

--- a/atomic-agent/src/turn/orchestrator/tests.rs
+++ b/atomic-agent/src/turn/orchestrator/tests.rs
@@ -296,7 +296,10 @@ async fn test_sandbox_turn_end_leaves_canonical_current_view_untouched() {
         .await
         .unwrap();
     fs::write(sandbox_dir.path().join("agent.txt"), "agent work\n").unwrap();
-    let result = orch.dispatch(turn_end_event("sess-sbx-view")).await.unwrap();
+    let result = orch
+        .dispatch(turn_end_event("sess-sbx-view"))
+        .await
+        .unwrap();
     assert!(result.was_recorded(), "sandbox turn must record");
 
     let canonical_repo = Repository::open_existing(canonical.path()).unwrap();

--- a/atomic-agent/src/turn/orchestrator/tests.rs
+++ b/atomic-agent/src/turn/orchestrator/tests.rs
@@ -267,6 +267,46 @@ async fn test_full_turn_in_sandbox_records_provenance_into_canonical_graph() {
     );
 }
 
+/// Recording a sandbox turn must not persist the session view into the
+/// shared canonical current_view (#99 fixed session-start; this covers the
+/// record path). The sandbox is bound to a DIFFERENT view than the user's,
+/// so a persisted alignment would flip the pointer and fail the assert.
+#[tokio::test]
+async fn test_sandbox_turn_end_leaves_canonical_current_view_untouched() {
+    let canonical = TempDir::new().unwrap();
+    let mut repo = Repository::init(canonical.path()).unwrap();
+    let user_view = repo.current_view().to_string();
+    repo.create_view_from("agent-draft", &user_view).unwrap();
+
+    let sandbox_dir = TempDir::new().unwrap();
+    repo.provision_sandbox(sandbox_dir.path(), "agent-draft")
+        .unwrap();
+    drop(repo);
+
+    let session_store = SessionStore::for_repo(sandbox_dir.path()).unwrap();
+    let watcher = FallbackWatcher::new(WatcherConfig::new(sandbox_dir.path()));
+    let mut orch =
+        TurnOrchestrator::with_watcher(sandbox_dir.path(), session_store, Box::new(watcher));
+    orch.set_agent("claude-code", "Claude Code");
+
+    orch.dispatch(session_start_event("sess-sbx-view"))
+        .await
+        .unwrap();
+    orch.dispatch(turn_start_event("sess-sbx-view", "Create agent.txt"))
+        .await
+        .unwrap();
+    fs::write(sandbox_dir.path().join("agent.txt"), "agent work\n").unwrap();
+    let result = orch.dispatch(turn_end_event("sess-sbx-view")).await.unwrap();
+    assert!(result.was_recorded(), "sandbox turn must record");
+
+    let canonical_repo = Repository::open_existing(canonical.path()).unwrap();
+    assert_eq!(
+        canonical_repo.current_view(),
+        user_view,
+        "recording a sandbox turn must not switch the user's current view"
+    );
+}
+
 // TurnStart tests
 
 #[tokio::test]

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -611,7 +611,7 @@ default = "{}"
     ///
     /// Returns an error if the view does not exist or the pointer file
     /// cannot be written.
-    pub(crate) fn set_current_view(&mut self, view: &str) -> Result<(), RepositoryError> {
+    pub fn set_current_view(&mut self, view: &str) -> Result<(), RepositoryError> {
         // Verify the view exists in the pristine database
         {
             let txn = self


### PR DESCRIPTION
## The bug

A sandbox clones the working tree but **shares the canonical `.atomic`** — pristine, change store, and the `current_view` pointer. Anything that runs inside a sandbox and *persists* `current_view` is therefore rewriting the real user's repo state.

`record`'s turn-end path does exactly that. The flow aligns twice:

1. The **read-only** handle aligns for the status/delta check with `set_current_view_in_memory` — handle-local, never touches disk. Correct.
2. The **write** handle then calls `align_to_view(session.view_name)` — which is literally `set_current_view`, i.e. it **writes `.atomic/current_view`**. In a sandbox that's the shared canonical pointer.

So every recorded sandbox turn switches the user's working tree onto the agent's session view (think: every commit in a git worktree also checking out that branch in your main repo). And nothing ever switches it back: sandbox sessions carry no `parent_view`, so session-end restores nothing. One turn → permanently stranded.

This is how a dogfooding repo ended up on `sherpa-run-22d5fb0f` with an empty work queue and its `.vault/intents/` "gone" — the tree had been re-materialized into the agent's run view. Pipeline builds hit this on every completed turn.

Why the existing tests missed it: #99's test doesn't run a turn; #100's runs a full cycle but binds the sandbox to the **same** view as the user, so the flip writes back the same name and is invisible.

## The fix

One branch, applying #99's policy (sandboxes adopt, never persist) to the record path — the third missed site in the series after session-start (#99) and provenance placement (#100):

```rust
if repo.is_sandbox() {
    repo.set_current_view_in_memory(&options.session.view_name);
} else {
    /* align_to_view as before */
}
```

Safe because alignment only serves the status/delta check: `record` writes the explicit `session.view_name`, and provenance (post-#100) resolves the canonical change store directly — neither reads the persisted pointer. The non-sandbox path is unchanged, including its ViewNotFound tolerance.

## Verification

- New regression test `test_sandbox_turn_end_leaves_canonical_current_view_untouched`: sandbox bound to a **non-user** view (`agent-draft`), full session-start → turn → turn-end cycle, then assert the canonical view is untouched. **Red without the fix** (`left: "agent-draft", right: "dev"`), green with it. Sibling sandbox tests still pass.
- Manual hook replay in a sandbox: the turn still records onto the run view (hash + harvest intact), canonical stays on `dev`.
- noname suite 26/26 against this binary, including its `ask_sandbox_isolates_user_worktree` e2e — which is what caught this in the first place.