### PR TITLE
fix(vault): keep derived state consistent

### DIFF
--- a/atomic-cli/src/commands/query/mod.rs
+++ b/atomic-cli/src/commands/query/mod.rs
@@ -16,7 +16,7 @@ use crate::output::{create_spinner, finish_error, finish_success};
 pub enum QueryCommands {
     /// Search the knowledge graph by keywords.
     ///
-    /// Performs full-text search over KG node labels and summaries,
+    /// Performs full-text search over KG node IDs, labels, and summaries,
     /// returning matching nodes ranked by relevance.
     ///
     /// # Examples
@@ -1027,14 +1027,14 @@ fn emit_html(query: &str, nodes: &[KgNode], edges: &[KgEdge]) -> String {
 /// Search the knowledge graph.
 #[derive(Parser, Debug)]
 pub struct QueryNodes {
-    /// Search query text (keyword search over node labels and summaries).
+    /// Search query text (keyword search over node IDs, labels, and summaries).
     pub query: String,
 
     /// Maximum results.
     #[arg(long, short = 'k', default_value = "10")]
     pub limit: usize,
 
-    /// Filter by node kind (change, entity, file, view).
+    /// Filter by node kind (change, entity, file, view, memory, intent, goal).
     ///
     /// When set, only nodes of this kind are returned.
     /// Without this flag, all kinds are returned.

--- a/atomic-cli/src/commands/vault/context.rs
+++ b/atomic-cli/src/commands/vault/context.rs
@@ -1121,6 +1121,51 @@ mod tests {
     }
 
     #[test]
+    fn test_memory_scan_tracks_metadata_body_update_and_delete() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        repo.init_vault().unwrap();
+
+        let path = "memory/auth-decision.md";
+        repo.vault_store(
+            path,
+            VaultEntryType::Memory,
+            b"Use oldnarwhal for service tokens".to_vec(),
+            r#"{"name":"auth-decision","description":"Authentication choice","status":"active"}"#
+                .to_string(),
+        )
+        .unwrap();
+
+        let mut request = request();
+        request.intent = None;
+        request.files.clear();
+        request.query = vec!["oldnarwhal".to_string()];
+        assert_eq!(request.gather_candidates(&repo, 5).unwrap().len(), 1);
+
+        repo.vault_store(
+            path,
+            VaultEntryType::Memory,
+            b"Use newmanatee for service tokens".to_vec(),
+            r#"{"name":"auth-decision","description":"OIDC zanzibar choice","status":"active"}"#
+                .to_string(),
+        )
+        .unwrap();
+        assert!(request.gather_candidates(&repo, 5).unwrap().is_empty());
+
+        request.query = vec!["newmanatee".to_string()];
+        assert_eq!(request.gather_candidates(&repo, 5).unwrap().len(), 1);
+        request.query = vec!["zanzibar".to_string()];
+        assert_eq!(
+            request.gather_candidates(&repo, 5).unwrap().len(),
+            1,
+            "description-only terms should be searchable without a content index"
+        );
+
+        assert!(repo.vault_delete(path).unwrap());
+        assert!(request.gather_candidates(&repo, 5).unwrap().is_empty());
+    }
+
+    #[test]
     fn test_frontmatter_labels() {
         assert_eq!(
             frontmatter_labels(r#"{"labels":["auth","backend"]}"#),

--- a/atomic-core/src/pristine/tables.rs
+++ b/atomic-core/src/pristine/tables.rs
@@ -590,9 +590,18 @@ pub const KG_EDGES_TO: MultimapTableDefinition<&str, &str> =
 
 /// KG full-text search inverted index: token → \[node_id\] (multimap)
 ///
-/// Simple inverted index for keyword search over node labels and summaries.
-/// Tokens are lowercase, alphanumeric words extracted from label + summary.
+/// Simple inverted index for keyword search over node IDs, labels, and summaries.
 pub const KG_FTS: MultimapTableDefinition<&str, &str> = MultimapTableDefinition::new("kg_fts");
+
+/// Reverse KG full-text index: node_id → \[token\] (multimap)
+///
+/// Lets node replacement and deletion remove every token previously associated
+/// with that node without scanning the whole inverted index.
+pub const KG_FTS_BY_NODE: MultimapTableDefinition<&str, &str> =
+    MultimapTableDefinition::new("kg_fts_by_node");
+
+/// KG index metadata used for transactional index migrations.
+pub const KG_INDEX_META: TableDefinition<&str, u32> = TableDefinition::new("kg_index_meta");
 
 // Embedding Tables (vector similarity search)
 

--- a/atomic-core/src/pristine/traits/triples.rs
+++ b/atomic-core/src/pristine/traits/triples.rs
@@ -67,7 +67,7 @@ pub trait KgTxnT {
         })
     }
 
-    /// Full-text search over node labels and summaries.
+    /// Full-text search over node IDs, labels, and summaries.
     fn kg_fts_search(&self, query: &str, limit: usize) -> Result<Vec<KgNode>, PristineError>;
 
     /// Return ALL matching node IDs with hit counts (no truncation, no node fetching).
@@ -86,13 +86,13 @@ pub trait KgTxnT {
 
 /// Write operations on the knowledge graph.
 pub trait KgMutTxnT: KgTxnT {
-    /// Insert or update a KG node.
+    /// Insert or update a KG node, replacing its previous full-text tokens.
     fn upsert_kg_node(&mut self, node: &KgNode) -> Result<(), PristineError>;
 
     /// Insert a KG edge (idempotent — ignores duplicates).
     fn upsert_kg_edge(&mut self, edge: &KgEdge) -> Result<(), PristineError>;
 
-    /// Delete a KG node and all its edges.
+    /// Delete a KG node, all its edges, and all its full-text tokens.
     fn del_kg_node(&mut self, id: &str) -> Result<bool, PristineError>;
 
     /// Delete a specific edge.

--- a/atomic-core/src/pristine/txn/write/triples.rs
+++ b/atomic-core/src/pristine/txn/write/triples.rs
@@ -9,6 +9,150 @@ use crate::pristine::vault::{KgEdge, KgNode};
 
 use super::WriteTxn;
 
+const KG_FTS_REVERSE_SCHEMA_KEY: &str = "fts_reverse_schema";
+const KG_FTS_REVERSE_SCHEMA_VERSION: u32 = 2;
+
+fn kg_node_fts_text(node: &KgNode) -> String {
+    let mut text = String::with_capacity(node.id.len() + node.label.len() + 64);
+    text.push_str(&node.id);
+    text.push(' ');
+    text.push_str(&node.label);
+    if let Some(summary) = &node.summary {
+        text.push(' ');
+        text.push_str(summary);
+    }
+    text
+}
+
+impl WriteTxn<'_> {
+    /// Ensure the reverse FTS index exists and rebuild both directions once for
+    /// databases created before replacement-safe indexing was introduced.
+    fn ensure_kg_fts_schema(&mut self) -> PristineResult<()> {
+        self.txn.open_multimap_table(KG_FTS)?;
+        self.txn.open_multimap_table(KG_FTS_BY_NODE)?;
+
+        let current_version = {
+            let metadata = self.txn.open_table(KG_INDEX_META)?;
+            let stored_version = metadata.get(KG_FTS_REVERSE_SCHEMA_KEY)?;
+            match stored_version {
+                Some(value) => value.value(),
+                None => 0,
+            }
+        };
+        if current_version >= KG_FTS_REVERSE_SCHEMA_VERSION {
+            return Ok(());
+        }
+
+        // Legacy KG FTS only ever appended postings. Rebuild from KG_NODES so
+        // both orphan postings and obsolete label/summary tokens disappear.
+        let nodes_to_index = {
+            let nodes = self.txn.open_table(KG_NODES)?;
+            let mut indexed = Vec::new();
+            for entry in nodes.iter()? {
+                let (node_id, node_bytes) = entry?;
+                let node: KgNode = serde_json::from_slice(node_bytes.value()).map_err(|e| {
+                    PristineError::Serialization {
+                        message: e.to_string(),
+                    }
+                })?;
+                let tokens: std::collections::HashSet<String> =
+                    tokenize_for_fts(&kg_node_fts_text(&node))
+                        .into_iter()
+                        .collect();
+                indexed.push((node_id.value().to_string(), tokens));
+            }
+            indexed
+        };
+
+        let forward_keys = {
+            let fts = self.txn.open_multimap_table(KG_FTS)?;
+            let mut keys = Vec::new();
+            for entry in fts.iter()? {
+                keys.push(entry?.0.value().to_string());
+            }
+            keys
+        };
+        {
+            let mut fts = self.txn.open_multimap_table(KG_FTS)?;
+            for token in forward_keys {
+                fts.remove_all(token.as_str())?;
+            }
+        }
+
+        let reverse_keys = {
+            let reverse = self.txn.open_multimap_table(KG_FTS_BY_NODE)?;
+            let mut keys = Vec::new();
+            for entry in reverse.iter()? {
+                keys.push(entry?.0.value().to_string());
+            }
+            keys
+        };
+        {
+            let mut reverse = self.txn.open_multimap_table(KG_FTS_BY_NODE)?;
+            for node_id in reverse_keys {
+                reverse.remove_all(node_id.as_str())?;
+            }
+        }
+
+        {
+            let mut fts = self.txn.open_multimap_table(KG_FTS)?;
+            let mut reverse = self.txn.open_multimap_table(KG_FTS_BY_NODE)?;
+            for (node_id, tokens) in nodes_to_index {
+                for token in tokens {
+                    fts.insert(token.as_str(), node_id.as_str())?;
+                    reverse.insert(node_id.as_str(), token.as_str())?;
+                }
+            }
+        }
+        {
+            let mut metadata = self.txn.open_table(KG_INDEX_META)?;
+            metadata.insert(KG_FTS_REVERSE_SCHEMA_KEY, KG_FTS_REVERSE_SCHEMA_VERSION)?;
+        }
+
+        Ok(())
+    }
+
+    fn remove_kg_fts_entries(&mut self, node_id: &str) -> PristineResult<()> {
+        self.ensure_kg_fts_schema()?;
+
+        let tokens = {
+            let mut reverse = self.txn.open_multimap_table(KG_FTS_BY_NODE)?;
+            let removed = reverse.remove_all(node_id)?;
+            let mut tokens = Vec::new();
+            for token in removed {
+                tokens.push(token?.value().to_string());
+            }
+            tokens
+        };
+
+        let mut fts = self.txn.open_multimap_table(KG_FTS)?;
+        for token in tokens {
+            fts.remove(token.as_str(), node_id)?;
+        }
+        Ok(())
+    }
+
+    fn add_kg_fts_entries(&mut self, node_id: &str, text: &str) -> PristineResult<()> {
+        self.ensure_kg_fts_schema()?;
+        let tokens: std::collections::HashSet<String> =
+            tokenize_for_fts(text).into_iter().collect();
+
+        {
+            let mut fts = self.txn.open_multimap_table(KG_FTS)?;
+            for token in &tokens {
+                fts.insert(token.as_str(), node_id)?;
+            }
+        }
+        {
+            let mut reverse = self.txn.open_multimap_table(KG_FTS_BY_NODE)?;
+            for token in &tokens {
+                reverse.insert(node_id, token.as_str())?;
+            }
+        }
+        Ok(())
+    }
+}
+
 impl<'a> KgTxnT for WriteTxn<'a> {
     fn get_kg_node(&self, id: &str) -> PristineResult<Option<KgNode>> {
         let table = match self.txn.open_table(KG_NODES) {
@@ -199,6 +343,10 @@ impl<'a> KgTxnT for WriteTxn<'a> {
 
 impl<'a> KgMutTxnT for WriteTxn<'a> {
     fn upsert_kg_node(&mut self, node: &KgNode) -> PristineResult<()> {
+        // Replacement semantics are important: old ID/label/summary tokens
+        // must disappear before the same node ID is re-indexed.
+        self.remove_kg_fts_entries(&node.id)?;
+
         let mut table = self.txn.open_table(KG_NODES)?;
         let bytes = serde_json::to_vec(node).map_err(|e| PristineError::Serialization {
             message: e.to_string(),
@@ -206,21 +354,7 @@ impl<'a> KgMutTxnT for WriteTxn<'a> {
         table.insert(node.id.as_str(), bytes.as_slice())?;
         drop(table);
 
-        // Update FTS index: add new tokens (duplicates are harmless
-        // in a multimap — the node_id appears multiple times but deduplication
-        // happens at query time via HashMap).
-        let mut fts_table = self.txn.open_multimap_table(KG_FTS)?;
-        let mut text = String::with_capacity(node.id.len() + node.label.len() + 64);
-        text.push_str(&node.id);
-        text.push(' ');
-        text.push_str(&node.label);
-        if let Some(ref summary) = node.summary {
-            text.push(' ');
-            text.push_str(summary);
-        }
-        for token in tokenize_for_fts(&text) {
-            fts_table.insert(token.as_str(), node.id.as_str())?;
-        }
+        self.add_kg_fts_entries(&node.id, &kg_node_fts_text(node))?;
 
         Ok(())
     }
@@ -250,16 +384,16 @@ impl<'a> KgMutTxnT for WriteTxn<'a> {
         // First delete all edges for this node
         self.del_kg_edges_for_node(id)?;
 
+        // Remove indexed ID/label/summary tokens before the node ID can be
+        // reused. Otherwise old metadata can reappear in search results.
+        self.remove_kg_fts_entries(id)?;
+
         // Delete the node
         let mut table = match self.txn.open_table(KG_NODES) {
             Ok(t) => t,
             Err(redb::TableError::TableDoesNotExist(_)) => return Ok(false),
             Err(e) => return Err(PristineError::from(e)),
         };
-
-        // Note: orphan FTS entries are harmless — get_kg_node returns None for
-        // deleted nodes so they're filtered out at query time. A full reindex
-        // cleans them up.
 
         let result = table.remove(id)?.is_some();
         drop(table);
@@ -310,7 +444,7 @@ impl<'a> KgMutTxnT for WriteTxn<'a> {
         self.txn.open_table(KG_EDGES)?;
         self.txn.open_multimap_table(KG_EDGES_FROM)?;
         self.txn.open_multimap_table(KG_EDGES_TO)?;
-        self.txn.open_multimap_table(KG_FTS)?;
+        self.ensure_kg_fts_schema()?;
         Ok(())
     }
 }
@@ -449,6 +583,83 @@ mod tests {
         let results = txn.kg_fts_search("logging", 10).unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id, "change:def");
+
+        txn.commit().unwrap();
+    }
+
+    #[test]
+    fn test_kg_upsert_replaces_fts_tokens() {
+        let dir = tempdir().unwrap();
+        let pristine = Pristine::open(dir.path().join("db")).unwrap();
+        let mut txn = pristine.write_txn().unwrap();
+        txn.init_kg().unwrap();
+
+        let old = KgNode::new("memory:build", "memory", "Build", "vault")
+            .with_summary("obsoletecapybara summary");
+        txn.upsert_kg_node(&old).unwrap();
+        assert_eq!(txn.kg_fts_match_ids("obsoletecapybara").unwrap().len(), 1);
+
+        let updated = KgNode::new("memory:build", "memory", "Build", "vault")
+            .with_summary("currentwombat summary");
+        txn.upsert_kg_node(&updated).unwrap();
+
+        assert!(txn.kg_fts_match_ids("obsoletecapybara").unwrap().is_empty());
+        assert_eq!(txn.kg_fts_match_ids("currentwombat").unwrap().len(), 1);
+
+        txn.commit().unwrap();
+    }
+
+    #[test]
+    fn test_kg_delete_prevents_stale_tokens_reappearing_when_id_is_reused() {
+        let dir = tempdir().unwrap();
+        let pristine = Pristine::open(dir.path().join("db")).unwrap();
+        let mut txn = pristine.write_txn().unwrap();
+        txn.init_kg().unwrap();
+
+        let node = KgNode::new("memory:reused", "memory", "Original", "vault")
+            .with_summary("ghostplatypus");
+        txn.upsert_kg_node(&node).unwrap();
+        assert!(txn.del_kg_node(&node.id).unwrap());
+
+        let replacement = KgNode::new("memory:reused", "memory", "Replacement", "vault");
+        txn.upsert_kg_node(&replacement).unwrap();
+        assert!(txn.kg_fts_match_ids("ghostplatypus").unwrap().is_empty());
+
+        txn.commit().unwrap();
+    }
+
+    #[test]
+    fn test_kg_init_rebuilds_current_entries_and_prunes_stale_postings() {
+        let dir = tempdir().unwrap();
+        let pristine = Pristine::open(dir.path().join("db")).unwrap();
+        let mut txn = pristine.write_txn().unwrap();
+
+        // Simulate an index written before replacement-safe indexing existed,
+        // including obsolete metadata and a deleted node's orphan posting.
+        {
+            let node = KgNode::new("memory:legacy", "memory", "Legacy", "vault")
+                .with_summary("legacyechidna");
+            let bytes = serde_json::to_vec(&node).unwrap();
+            let mut nodes = txn.txn.open_table(KG_NODES).unwrap();
+            nodes.insert(node.id.as_str(), bytes.as_slice()).unwrap();
+
+            let mut legacy_fts = txn.txn.open_multimap_table(KG_FTS).unwrap();
+            legacy_fts.insert("legacyechidna", "memory:legacy").unwrap();
+            legacy_fts
+                .insert("obsoletecapybara", "memory:legacy")
+                .unwrap();
+            legacy_fts
+                .insert("orphanpangolin", "memory:deleted")
+                .unwrap();
+        }
+
+        txn.init_kg().unwrap();
+        assert_eq!(txn.kg_fts_match_ids("legacyechidna").unwrap().len(), 1);
+        assert!(txn.kg_fts_match_ids("obsoletecapybara").unwrap().is_empty());
+        assert!(txn.kg_fts_match_ids("orphanpangolin").unwrap().is_empty());
+
+        assert!(txn.del_kg_node("memory:legacy").unwrap());
+        assert!(txn.kg_fts_match_ids("legacyechidna").unwrap().is_empty());
 
         txn.commit().unwrap();
     }

--- a/atomic-repository/src/repository/vault.rs
+++ b/atomic-repository/src/repository/vault.rs
@@ -168,7 +168,30 @@ impl Repository {
             .pristine
             .write_txn()
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
-        use atomic_core::pristine::{VaultMutTxnT, VaultTxnT};
+        use atomic_core::pristine::{KgMutTxnT, VaultMutTxnT, VaultTxnT};
+
+        let previous_entry = txn
+            .get_vault_entry(path)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        let cascade_updates = match previous_entry.as_ref() {
+            Some(previous) if previous.entry_type != entry_type => {
+                unlink_goal_from_intent_entries(&mut txn, path, previous, &now)?
+            }
+            _ => Vec::new(),
+        };
+        if let Some(previous_entry_type) = previous_entry
+            .as_ref()
+            .map(|previous| previous.entry_type)
+            .filter(|previous| *previous != entry_type)
+        {
+            txn.init_kg()
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+            txn.del_kg_node(&super::vault_triples::entry_subject(
+                path,
+                previous_entry_type,
+            ))
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        }
 
         txn.put_vault_entry(path, &entry)
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
@@ -177,7 +200,8 @@ impl Repository {
         let mut manifest = txn
             .get_vault_manifest()
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
-        update_manifest_for_store(&mut manifest, path, &entry, &now);
+        update_manifest_for_store(&mut manifest, path, &entry, previous_entry.as_ref(), &now);
+        apply_cascaded_intent_manifest_updates(&mut manifest, &cascade_updates, &now);
         txn.put_vault_manifest(&manifest)
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
@@ -185,6 +209,16 @@ impl Repository {
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
         self.vault_auto_index(path);
+        for update in cascade_updates {
+            self.vault_auto_index(&update.path);
+            if let Err(error) = self.vault_materialize(&update.path) {
+                log::warn!(
+                    "Failed to materialize Intent '{}' after Goal unlink: {}",
+                    update.path,
+                    error
+                );
+            }
+        }
 
         Ok(content_hash)
     }
@@ -200,21 +234,45 @@ impl Repository {
         entry: &VaultEntry,
     ) -> Result<Hash, RepositoryError> {
         let content_hash = Hash::from_bytes(entry.content_hash);
+        let now = chrono::Utc::now().to_rfc3339();
 
         let mut txn = self
             .pristine
             .write_txn()
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
-        use atomic_core::pristine::{VaultMutTxnT, VaultTxnT};
+        use atomic_core::pristine::{KgMutTxnT, VaultMutTxnT, VaultTxnT};
+
+        let previous_entry = txn
+            .get_vault_entry(path)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        let cascade_updates = match previous_entry.as_ref() {
+            Some(previous) if previous.entry_type != entry.entry_type => {
+                unlink_goal_from_intent_entries(&mut txn, path, previous, &now)?
+            }
+            _ => Vec::new(),
+        };
+        if let Some(previous_entry_type) = previous_entry
+            .as_ref()
+            .map(|previous| previous.entry_type)
+            .filter(|previous| *previous != entry.entry_type)
+        {
+            txn.init_kg()
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+            txn.del_kg_node(&super::vault_triples::entry_subject(
+                path,
+                previous_entry_type,
+            ))
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        }
 
         txn.put_vault_entry(path, entry)
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
-        let now = chrono::Utc::now().to_rfc3339();
         let mut manifest = txn
             .get_vault_manifest()
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
-        update_manifest_for_store(&mut manifest, path, entry, &now);
+        update_manifest_for_store(&mut manifest, path, entry, previous_entry.as_ref(), &now);
+        apply_cascaded_intent_manifest_updates(&mut manifest, &cascade_updates, &now);
         txn.put_vault_manifest(&manifest)
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
@@ -222,6 +280,16 @@ impl Repository {
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
         self.vault_auto_index(path);
+        for update in cascade_updates {
+            self.vault_auto_index(&update.path);
+            if let Err(error) = self.vault_materialize(&update.path) {
+                log::warn!(
+                    "Failed to materialize Intent '{}' after Goal unlink: {}",
+                    update.path,
+                    error
+                );
+            }
+        }
 
         Ok(content_hash)
     }
@@ -302,24 +370,59 @@ impl Repository {
             .pristine
             .write_txn()
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
-        use atomic_core::pristine::{VaultMutTxnT, VaultTxnT};
+        use atomic_core::pristine::{EmbeddingsMutTxnT, KgMutTxnT, VaultMutTxnT, VaultTxnT};
+
+        let previous_entry = txn
+            .get_vault_entry(path)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        let now = chrono::Utc::now().to_rfc3339();
+        let cascade_updates = if let Some(previous_entry) = previous_entry.as_ref() {
+            unlink_goal_from_intent_entries(&mut txn, path, previous_entry, &now)?
+        } else {
+            Vec::new()
+        };
+        let entry_type = previous_entry
+            .as_ref()
+            .map(|entry| entry.entry_type)
+            .unwrap_or_else(|| infer_entry_type(path));
+
+        txn.init_kg()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
         let existed = txn
             .del_vault_entry(path)
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
+        // KG and embeddings are derived from the Vault entry. Clean both even
+        // if the source entry is already missing so a retry repairs stale data.
+        let node_id = super::vault_triples::entry_subject(path, entry_type);
+        txn.del_kg_node(&node_id)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        txn.del_embeddings(path)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
         if existed {
-            let now = chrono::Utc::now().to_rfc3339();
             let mut manifest = txn
                 .get_vault_manifest()
                 .map_err(|e| RepositoryError::Database(e.to_string()))?;
-            update_manifest_for_delete(&mut manifest, path, &now);
+            update_manifest_for_delete(&mut manifest, path, previous_entry.as_ref(), &now);
+            apply_cascaded_intent_manifest_updates(&mut manifest, &cascade_updates, &now);
             txn.put_vault_manifest(&manifest)
                 .map_err(|e| RepositoryError::Database(e.to_string()))?;
         }
 
         txn.commit()
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        for update in cascade_updates {
+            self.vault_auto_index(&update.path);
+            if let Err(error) = self.vault_materialize(&update.path) {
+                log::warn!(
+                    "Failed to materialize Intent '{}' after Goal deletion: {}",
+                    update.path,
+                    error
+                );
+            }
+        }
         Ok(existed)
     }
 
@@ -441,7 +544,7 @@ impl Repository {
     ///
     /// Files are identified as changed if:
     /// - They don't exist in redb (new file)
-    /// - Their content hash differs from the stored entry
+    /// - Their body hash or user frontmatter differs from the stored entry
     ///
     /// Ignores non-`.md` files and `_manifest.json`.
     pub fn vault_scan_working_copy(&self) -> Result<Vec<VaultFileChange>, RepositoryError> {
@@ -491,14 +594,19 @@ impl Repository {
             // Parse into frontmatter + body
             let (frontmatter_json, body) = parse_markdown_frontmatter(&file_content);
 
-            // Compute hash of the body (not frontmatter)
+            // Body hashes remain useful for content/embedding caches, but
+            // frontmatter is also knowledge: status, labels, identity, and
+            // descriptions affect retrieval and KG extraction.
             let body_bytes = body.as_bytes();
             let new_hash = Hash::of(body_bytes);
 
             // Check if this is new or changed
             let existing = self.vault_retrieve(&rel_path_str)?;
             let change_type = match &existing {
-                Some(entry) if Hash::from_bytes(entry.content_hash) == new_hash => {
+                Some(entry)
+                    if Hash::from_bytes(entry.content_hash) == new_hash
+                        && frontmatter_json_equal(&entry.frontmatter_json, &frontmatter_json) =>
+                {
                     continue; // Unchanged, skip
                 }
                 Some(_) => VaultChangeType::Modified,
@@ -576,17 +684,153 @@ impl Repository {
 
 // ── Manifest helpers ────────────────────────────────────────────────────
 
+struct CascadedIntentUpdate {
+    path: String,
+    previous_entry: VaultEntry,
+    current_entry: VaultEntry,
+    intent_id: Option<String>,
+    goal_count: u32,
+}
+
+/// Remove a Goal reference from every current Intent source before that Goal
+/// is deleted or reclassified. The Vault entries are updated in the caller's
+/// transaction; KG re-indexing and materialization happen after commit.
+fn unlink_goal_from_intent_entries(
+    txn: &mut atomic_core::pristine::WriteTxn<'_>,
+    path: &str,
+    entry: &VaultEntry,
+    now: &str,
+) -> Result<Vec<CascadedIntentUpdate>, RepositoryError> {
+    use atomic_core::pristine::{VaultMutTxnT, VaultTxnT};
+
+    if entry.entry_type != VaultEntryType::Session {
+        return Ok(Vec::new());
+    }
+    let Some(goal_id) = vault_frontmatter_string(entry, "goal_id").or_else(|| {
+        path.strip_prefix("goals/")
+            .and_then(|rest| rest.strip_suffix("/_goal.md"))
+            .map(str::to_string)
+    }) else {
+        return Ok(Vec::new());
+    };
+
+    let intents = txn
+        .list_vault_entries("intents/", Some(VaultEntryType::Intent))
+        .map_err(|e| RepositoryError::Database(e.to_string()))?;
+    let mut updates = Vec::new();
+    for meta in intents {
+        let Some(mut current_entry) = txn
+            .get_vault_entry(&meta.path)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+        else {
+            continue;
+        };
+        let previous_entry = current_entry.clone();
+        let Ok(mut frontmatter) = serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(
+            &current_entry.frontmatter_json,
+        ) else {
+            continue;
+        };
+
+        let Some(goals) = frontmatter
+            .get_mut("goals")
+            .and_then(serde_json::Value::as_array_mut)
+        else {
+            continue;
+        };
+        let previous_len = goals.len();
+        goals.retain(|goal| goal.as_str() != Some(goal_id.as_str()));
+        if goals.len() == previous_len {
+            continue;
+        }
+        let goal_count = goals.len() as u32;
+        let intent_id = frontmatter
+            .get("id")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string);
+        current_entry.frontmatter_json = serde_json::to_string(&frontmatter)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        current_entry.updated_at = now.to_string();
+        txn.put_vault_entry(&meta.path, &current_entry)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        updates.push(CascadedIntentUpdate {
+            path: meta.path,
+            previous_entry,
+            current_entry,
+            intent_id,
+            goal_count,
+        });
+    }
+    Ok(updates)
+}
+
+fn apply_cascaded_intent_manifest_updates(
+    manifest: &mut VaultManifest,
+    updates: &[CascadedIntentUpdate],
+    now: &str,
+) {
+    for update in updates {
+        update_manifest_for_store(
+            manifest,
+            &update.path,
+            &update.current_entry,
+            Some(&update.previous_entry),
+            now,
+        );
+        let summary_id = update
+            .intent_id
+            .as_ref()
+            .filter(|intent_id| manifest.intents.contains_key(*intent_id))
+            .cloned()
+            .or_else(|| {
+                manifest
+                    .intents
+                    .iter()
+                    .find(|(_, summary)| summary.vault_path == update.path)
+                    .map(|(intent_id, _)| intent_id.clone())
+            });
+        if let Some(summary_id) = summary_id {
+            if let Some(summary) = manifest.intents.get_mut(&summary_id) {
+                summary.goals = update.goal_count;
+            }
+        }
+    }
+}
+
+fn vault_frontmatter_string(entry: &VaultEntry, key: &str) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(&entry.frontmatter_json)
+        .ok()
+        .and_then(|value| {
+            value
+                .get(key)
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
+}
+
 /// Update the manifest when a vault entry is stored.
 fn update_manifest_for_store(
     manifest: &mut VaultManifest,
     path: &str,
     entry: &VaultEntry,
+    previous_entry: Option<&VaultEntry>,
     now: &str,
 ) {
     let hash_str = Hash::from_bytes(entry.content_hash).to_base32();
     let bytes = entry.content_size() as u64;
 
-    // Update type-specific index
+    // A path may change entry type. Remove the old classification and any
+    // higher-level Goal/Intent summary before inserting the new one so the
+    // manifest represents one current entry.
+    if let Some(previous) =
+        previous_entry.filter(|previous| previous.entry_type != entry.entry_type)
+    {
+        remove_manifest_summary_for_entry(manifest, path, previous);
+    }
+    manifest.memory.remove(path);
+    manifest.skills.remove(path);
+
+    // Update type-specific index.
     match entry.entry_type {
         VaultEntryType::Memory => {
             manifest.memory.insert(
@@ -612,10 +856,16 @@ fn update_manifest_for_store(
         _ => {}
     }
 
-    // Recompute totals by iterating all entries would be expensive,
-    // so we do incremental updates.
-    manifest.file_count = manifest.file_count.saturating_add(1);
-    manifest.total_bytes = manifest.total_bytes.saturating_add(bytes);
+    // Maintain exact incremental totals for insert and replacement.
+    if let Some(previous) = previous_entry {
+        manifest.total_bytes = manifest
+            .total_bytes
+            .saturating_sub(previous.content_size() as u64)
+            .saturating_add(bytes);
+    } else {
+        manifest.file_count = manifest.file_count.saturating_add(1);
+        manifest.total_bytes = manifest.total_bytes.saturating_add(bytes);
+    }
 
     // Update merkle: Hash(previous_merkle || content_hash)
     let prev_merkle = if manifest.merkle.is_empty() {
@@ -631,18 +881,26 @@ fn update_manifest_for_store(
 }
 
 /// Update the manifest when a vault entry is deleted.
-fn update_manifest_for_delete(manifest: &mut VaultManifest, path: &str, now: &str) {
+fn update_manifest_for_delete(
+    manifest: &mut VaultManifest,
+    path: &str,
+    previous_entry: Option<&VaultEntry>,
+    now: &str,
+) {
     // Remove from type-specific indexes
     manifest.memory.remove(path);
     manifest.skills.remove(path);
-    manifest.goals.remove(path);
-    manifest.intents.remove(path);
+    if let Some(previous_entry) = previous_entry {
+        remove_manifest_summary_for_entry(manifest, path, previous_entry);
+    }
 
     // Decrement file count (floor at 0)
     manifest.file_count = manifest.file_count.saturating_sub(1);
-
-    // We can't easily adjust total_bytes without knowing the old entry's size,
-    // so we leave it as-is. Use vault_recompute_manifest_totals() for accuracy.
+    if let Some(previous_entry) = previous_entry {
+        manifest.total_bytes = manifest
+            .total_bytes
+            .saturating_sub(previous_entry.content_size() as u64);
+    }
     // The merkle also changes on delete.
     let prev_merkle = if manifest.merkle.is_empty() {
         Merkle::ZERO
@@ -655,6 +913,37 @@ fn update_manifest_for_delete(manifest: &mut VaultManifest, path: &str, now: &st
     manifest.merkle = new_merkle.to_base32();
 
     manifest.updated_at = now.to_string();
+}
+
+/// Remove the manifest summary owned by a Goal or Intent Vault entry.
+///
+/// Goal summaries are keyed by `goal_id`, while Intent summaries are keyed by
+/// display ID and carry their Vault path. Neither map is keyed by `path`, so a
+/// plain `remove(path)` leaves ghost summaries behind.
+fn remove_manifest_summary_for_entry(manifest: &mut VaultManifest, path: &str, entry: &VaultEntry) {
+    match entry.entry_type {
+        VaultEntryType::Session => {
+            let goal_id = vault_frontmatter_string(entry, "goal_id").or_else(|| {
+                path.strip_prefix("goals/")
+                    .and_then(|rest| rest.strip_suffix("/_goal.md"))
+                    .map(str::to_string)
+            });
+            if let Some(goal) = goal_id.and_then(|goal_id| manifest.goals.remove(&goal_id)) {
+                if let Some(intent_id) = goal.intent {
+                    if let Some(intent) = manifest.intents.get_mut(&intent_id) {
+                        intent.goals = intent.goals.saturating_sub(1);
+                    }
+                }
+            }
+        }
+        VaultEntryType::Intent => {
+            let intent_id = vault_frontmatter_string(entry, "id");
+            manifest.intents.retain(|id, summary| {
+                summary.vault_path != path && intent_id.as_deref() != Some(id.as_str())
+            });
+        }
+        _ => {}
+    }
 }
 
 // ── Materialization helpers ─────────────────────────────────────────────
@@ -733,16 +1022,24 @@ fn write_frontmatter_field(output: &mut String, key: &str, value: &serde_json::V
     use std::fmt::Write;
     match value {
         serde_json::Value::String(s) => {
-            // Use bare value for simple strings, quoted for strings with special chars.
-            // Note: bare colons are fine in YAML values (e.g. timestamps "12:00:00");
-            // only ": " (colon-space) is ambiguous as a nested key-value separator.
-            if s.contains(": ")
+            // Keep simple strings readable, but quote values that our parser
+            // would otherwise reinterpret as another scalar/container type.
+            // JSON string syntax is valid YAML and preserves escapes.
+            let parsed_unquoted = parse_yaml_value(s);
+            let has_edge_whitespace = s.chars().next().is_some_and(char::is_whitespace)
+                || s.chars().last().is_some_and(char::is_whitespace);
+            if parsed_unquoted != serde_json::Value::String(s.clone())
+                || s.contains(": ")
                 || s.contains('#')
                 || s.contains('\n')
                 || s.starts_with('{')
                 || s.starts_with('[')
+                || s.starts_with('"')
+                || s.starts_with('\'')
+                || has_edge_whitespace
             {
-                let _ = writeln!(output, "{}: \"{}\"", key, s.replace('\"', "\\\""));
+                let rendered = serde_json::to_string(s).unwrap_or_else(|_| "\"\"".to_string());
+                let _ = writeln!(output, "{}: {}", key, rendered);
             } else {
                 let _ = writeln!(output, "{}: {}", key, s);
             }
@@ -754,14 +1051,8 @@ fn write_frontmatter_field(output: &mut String, key: &str, value: &serde_json::V
             let _ = writeln!(output, "{}: {}", key, b);
         }
         serde_json::Value::Array(arr) => {
-            let items: Vec<String> = arr
-                .iter()
-                .map(|v| match v {
-                    serde_json::Value::String(s) => s.clone(),
-                    other => other.to_string(),
-                })
-                .collect();
-            let _ = writeln!(output, "{}: [{}]", key, items.join(", "));
+            let rendered = serde_json::to_string(arr).unwrap_or_else(|_| "[]".to_string());
+            let _ = writeln!(output, "{}: {}", key, rendered);
         }
         serde_json::Value::Object(_) => {
             // Inline JSON for nested objects
@@ -845,6 +1136,16 @@ fn parse_markdown_frontmatter(content: &str) -> (String, String) {
     (frontmatter_json, body)
 }
 
+fn frontmatter_json_equal(left: &str, right: &str) -> bool {
+    match (
+        serde_json::from_str::<serde_json::Value>(left),
+        serde_json::from_str::<serde_json::Value>(right),
+    ) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => left == right,
+    }
+}
+
 /// Convert simple YAML frontmatter to a JSON string.
 ///
 /// Handles common YAML patterns:
@@ -883,7 +1184,10 @@ fn yaml_frontmatter_to_json(yaml: &str) -> String {
 
         // Skip system fields that we inject during materialization
         // (they'll be reconstructed, not stored in frontmatter_json)
-        if key == "entry_type" || key == "content_hash" {
+        if matches!(
+            key.as_str(),
+            "entry_type" | "content_hash" | "created_at" | "updated_at"
+        ) {
             continue;
         }
 
@@ -896,13 +1200,16 @@ fn yaml_frontmatter_to_json(yaml: &str) -> String {
 
 /// Parse a YAML value string into a serde_json::Value.
 fn parse_yaml_value(s: &str) -> serde_json::Value {
-    // Remove surrounding quotes if present
-    let s =
-        if (s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')) {
-            &s[1..s.len() - 1]
-        } else {
-            s
-        };
+    // Quoted values remain strings even when their contents look like another
+    // scalar type. Decode JSON-style double-quoted escapes losslessly.
+    if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+        return serde_json::from_str::<String>(s)
+            .map(serde_json::Value::String)
+            .unwrap_or_else(|_| serde_json::Value::String(s[1..s.len() - 1].to_string()));
+    }
+    if s.len() >= 2 && s.starts_with('\'') && s.ends_with('\'') {
+        return serde_json::Value::String(s[1..s.len() - 1].replace("''", "'"));
+    }
 
     // Try as integer
     if let Ok(n) = s.parse::<i64>() {
@@ -923,7 +1230,15 @@ fn parse_yaml_value(s: &str) -> serde_json::Value {
         _ => {}
     }
 
-    // Try as array [a, b, c]
+    // Materialized arrays/objects use JSON syntax, which is also valid YAML.
+    // Parse it first so quoted commas and nested values remain lossless.
+    if (s.starts_with('[') && s.ends_with(']')) || (s.starts_with('{') && s.ends_with('}')) {
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(s) {
+            return value;
+        }
+    }
+
+    // Also accept simple hand-authored YAML arrays such as [a, b, c].
     if s.starts_with('[') && s.ends_with(']') {
         let inner = s[1..s.len() - 1].trim();
         if inner.is_empty() {
@@ -934,13 +1249,6 @@ fn parse_yaml_value(s: &str) -> serde_json::Value {
             .map(|item| parse_yaml_value(item.trim()))
             .collect();
         return serde_json::Value::Array(items);
-    }
-
-    // Try as inline JSON object
-    if s.starts_with('{') && s.ends_with('}') {
-        if let Ok(v) = serde_json::from_str::<serde_json::Value>(s) {
-            return v;
-        }
     }
 
     // Default: string
@@ -972,7 +1280,8 @@ fn infer_entry_type(path: &str) -> VaultEntryType {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use atomic_core::pristine::VaultEntryType;
+    use atomic_core::pristine::vault::{GoalSummary, IntentSummary, TokenCounts};
+    use atomic_core::pristine::{EmbeddingsTxnT, VaultEntryType, VaultMutTxnT, VaultTxnT};
     use tempfile::tempdir;
 
     #[test]
@@ -1126,6 +1435,169 @@ mod tests {
     }
 
     #[test]
+    fn test_manifest_replacement_tracks_current_type_and_totals() {
+        let dir = tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        repo.init_vault().unwrap();
+        let baseline = repo.vault_manifest().unwrap();
+        let path = "memory/reclassified.md";
+
+        repo.vault_store(
+            path,
+            VaultEntryType::Memory,
+            b"old".to_vec(),
+            r#"{"name":"old"}"#.to_string(),
+        )
+        .unwrap();
+        let inserted = repo.vault_manifest().unwrap();
+        assert_eq!(inserted.file_count, baseline.file_count + 1);
+        assert_eq!(inserted.total_bytes, baseline.total_bytes + 3);
+        assert!(inserted.memory.contains_key(path));
+
+        repo.vault_store(
+            path,
+            VaultEntryType::Skill,
+            b"new skill".to_vec(),
+            r#"{"name":"new"}"#.to_string(),
+        )
+        .unwrap();
+        let replaced = repo.vault_manifest().unwrap();
+        assert_eq!(replaced.file_count, baseline.file_count + 1);
+        assert_eq!(replaced.total_bytes, baseline.total_bytes + 9);
+        assert!(!replaced.memory.contains_key(path));
+        assert!(replaced.skills.contains_key(path));
+
+        assert!(repo.vault_delete(path).unwrap());
+        let deleted = repo.vault_manifest().unwrap();
+        assert_eq!(deleted.file_count, baseline.file_count);
+        assert_eq!(deleted.total_bytes, baseline.total_bytes);
+        assert!(!deleted.skills.contains_key(path));
+    }
+
+    #[test]
+    fn test_vault_delete_removes_goal_and_intent_manifest_summaries() {
+        let dir = tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        repo.init_vault().unwrap();
+        let goal_path = "goals/test-goal/_goal.md";
+        let intent_path = "intents/manual/alice/1/intent.md";
+
+        repo.vault_store(
+            goal_path,
+            VaultEntryType::Session,
+            b"# Goal".to_vec(),
+            r#"{"goal_id":"test-goal","intent":"TEST-1"}"#.to_string(),
+        )
+        .unwrap();
+        repo.vault_store(
+            intent_path,
+            VaultEntryType::Intent,
+            b"# Intent".to_vec(),
+            r#"{"goals":["test-goal"],"id":"TEST-1","title":"Test"}"#.to_string(),
+        )
+        .unwrap();
+
+        {
+            let mut txn = repo.pristine.write_txn().unwrap();
+            let mut manifest = txn.get_vault_manifest().unwrap();
+            manifest.goals.insert(
+                "test-goal".to_string(),
+                GoalSummary {
+                    developer: "alice".to_string(),
+                    intent: Some("TEST-1".to_string()),
+                    status: "active".to_string(),
+                    started_at: "2025-01-01T00:00:00Z".to_string(),
+                    turns: 0,
+                    tokens: TokenCounts::default(),
+                    tool_results: Vec::new(),
+                    findings_hash: None,
+                    bytes: 0,
+                },
+            );
+            manifest.intents.insert(
+                "TEST-1".to_string(),
+                IntentSummary {
+                    status: "backlog".to_string(),
+                    priority: "medium".to_string(),
+                    assignee: None,
+                    goals: 1,
+                    blocked_by: Vec::new(),
+                    title: "Test".to_string(),
+                    vault_path: intent_path.to_string(),
+                },
+            );
+            txn.put_vault_manifest(&manifest).unwrap();
+            txn.commit().unwrap();
+        }
+
+        assert!(repo.vault_delete(goal_path).unwrap());
+        let after_goal = repo.vault_manifest().unwrap();
+        assert!(!after_goal.goals.contains_key("test-goal"));
+        assert_eq!(after_goal.intents["TEST-1"].goals, 0);
+        let intent = repo.vault_retrieve(intent_path).unwrap().unwrap();
+        let intent_frontmatter: serde_json::Value =
+            serde_json::from_str(&intent.frontmatter_json).unwrap();
+        assert_eq!(intent_frontmatter["goals"], serde_json::json!([]));
+        assert!(repo.vault_dir().join(intent_path).exists());
+
+        // Reclassifying a Goal path follows the same unlink lifecycle.
+        let reclassified_goal_path = "goals/reclassified/_goal.md";
+        repo.vault_store(
+            reclassified_goal_path,
+            VaultEntryType::Session,
+            b"# Reclassified Goal".to_vec(),
+            r#"{"goal_id":"reclassified"}"#.to_string(),
+        )
+        .unwrap();
+        repo.vault_store(
+            intent_path,
+            VaultEntryType::Intent,
+            b"# Intent".to_vec(),
+            r#"{"goals":["reclassified"],"id":"TEST-1","title":"Test"}"#.to_string(),
+        )
+        .unwrap();
+        {
+            let mut txn = repo.pristine.write_txn().unwrap();
+            let mut manifest = txn.get_vault_manifest().unwrap();
+            manifest.goals.insert(
+                "reclassified".to_string(),
+                GoalSummary {
+                    developer: "alice".to_string(),
+                    intent: Some("TEST-1".to_string()),
+                    status: "active".to_string(),
+                    started_at: "2025-01-01T00:00:00Z".to_string(),
+                    turns: 0,
+                    tokens: TokenCounts::default(),
+                    tool_results: Vec::new(),
+                    findings_hash: None,
+                    bytes: 0,
+                },
+            );
+            manifest.intents.get_mut("TEST-1").unwrap().goals = 1;
+            txn.put_vault_manifest(&manifest).unwrap();
+            txn.commit().unwrap();
+        }
+        repo.vault_store(
+            reclassified_goal_path,
+            VaultEntryType::Scratch,
+            b"No longer a Goal".to_vec(),
+            "{}".to_string(),
+        )
+        .unwrap();
+        let after_reclassification = repo.vault_manifest().unwrap();
+        assert!(!after_reclassification.goals.contains_key("reclassified"));
+        assert_eq!(after_reclassification.intents["TEST-1"].goals, 0);
+        let intent = repo.vault_retrieve(intent_path).unwrap().unwrap();
+        let intent_frontmatter: serde_json::Value =
+            serde_json::from_str(&intent.frontmatter_json).unwrap();
+        assert_eq!(intent_frontmatter["goals"], serde_json::json!([]));
+
+        assert!(repo.vault_delete(intent_path).unwrap());
+        let after_intent = repo.vault_manifest().unwrap();
+        assert!(!after_intent.intents.contains_key("TEST-1"));
+    }
+
+    #[test]
     fn test_vault_manifest_merkle() {
         let dir = tempdir().unwrap();
         let repo = Repository::init(dir.path()).unwrap();
@@ -1209,6 +1681,31 @@ mod tests {
 
         let all = repo.vault_list("", None).unwrap();
         assert_eq!(all.len(), 5);
+    }
+
+    #[test]
+    fn test_vault_delete_cleans_embeddings() {
+        let dir = tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        repo.init_vault().unwrap();
+        let path = "memory/delete-embedding.md";
+
+        repo.vault_store(
+            path,
+            VaultEntryType::Memory,
+            b"Unique semantic memory content".to_vec(),
+            r#"{"name":"delete-embedding"}"#.to_string(),
+        )
+        .unwrap();
+
+        {
+            let txn = repo.pristine.read_txn().unwrap();
+            assert!(txn.get_embedding(path, 0).unwrap().is_some());
+        }
+
+        assert!(repo.vault_delete(path).unwrap());
+        let txn = repo.pristine.read_txn().unwrap();
+        assert!(txn.get_embedding(path, 0).unwrap().is_none());
     }
 
     #[test]
@@ -1573,6 +2070,77 @@ mod tests {
             .unwrap();
         let content = String::from_utf8_lossy(&entry.content_bytes);
         assert!(content.contains("Modified content."));
+    }
+
+    #[test]
+    fn test_vault_deflation_detects_frontmatter_only_change() {
+        let dir = tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        repo.init_vault().unwrap();
+        let path = "memory/status-change.md";
+        repo.vault_store(
+            path,
+            VaultEntryType::Memory,
+            b"Same body.\n".to_vec(),
+            r#"{"name":"status-change","status":"active"}"#.to_string(),
+        )
+        .unwrap();
+        repo.vault_materialize(path).unwrap();
+
+        // Materializing without edits must round-trip as unchanged.
+        assert!(repo.vault_scan_working_copy().unwrap().is_empty());
+
+        let disk_path = repo.vault_dir().join(path);
+        let original = std::fs::read_to_string(&disk_path).unwrap();
+        let modified = original.replace("status: active", "status: retracted");
+        std::fs::write(&disk_path, modified).unwrap();
+
+        let changes = repo.vault_scan_working_copy().unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].change_type, VaultChangeType::Modified);
+        repo.vault_record_working_copy().unwrap();
+
+        let entry = repo.vault_retrieve(path).unwrap().unwrap();
+        let frontmatter: serde_json::Value = serde_json::from_str(&entry.frontmatter_json).unwrap();
+        assert_eq!(frontmatter["status"], "retracted");
+    }
+
+    #[test]
+    fn test_vault_frontmatter_materialization_preserves_json_types() {
+        let dir = tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        repo.init_vault().unwrap();
+        let path = "memory/frontmatter-types.md";
+        let frontmatter = serde_json::json!({
+            "boolean": true,
+            "boolean_string": "true",
+            "number": 123,
+            "number_string": "123",
+            "null_string": "null",
+            "array_string": "[draft]",
+            "labels": ["true", "a,b", 123, false],
+            "nested": {"status": "null"}
+        });
+
+        repo.vault_store(
+            path,
+            VaultEntryType::Memory,
+            b"Same body.\n".to_vec(),
+            frontmatter.to_string(),
+        )
+        .unwrap();
+        repo.vault_materialize(path).unwrap();
+
+        assert!(
+            repo.vault_scan_working_copy().unwrap().is_empty(),
+            "materializing an entry must not create a semantic frontmatter change"
+        );
+        let markdown = std::fs::read_to_string(repo.vault_dir().join(path)).unwrap();
+        let (parsed, _) = parse_markdown_frontmatter(&markdown);
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&parsed).unwrap(),
+            frontmatter
+        );
     }
 
     #[test]

--- a/atomic-repository/src/repository/vault_embeddings.rs
+++ b/atomic-repository/src/repository/vault_embeddings.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 use atomic_core::pristine::vault::{EmbeddingRecord, SearchResult, VaultEntryType};
-use atomic_core::pristine::{EmbeddingsMutTxnT, EmbeddingsTxnT};
+use atomic_core::pristine::{EmbeddingsMutTxnT, EmbeddingsTxnT, VaultTxnT};
 
 /// Configuration for the embedding pipeline.
 #[derive(Debug, Clone)]
@@ -72,6 +72,17 @@ impl Repository {
                 .pristine
                 .read_txn()
                 .map_err(|e| RepositoryError::Database(e.to_string()))?;
+            let still_current = txn
+                .get_vault_entry(path)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?
+                .is_some_and(|current| {
+                    current.entry_type == entry.entry_type
+                        && current.content_hash == content_hash
+                        && current.introduced_by == entry.introduced_by
+                });
+            if !still_current {
+                return Ok(0);
+            }
             if let Ok(Some(existing)) = txn.get_embedding(path, 0) {
                 if existing.content_hash == content_hash {
                     return Ok(0); // Content unchanged, skip
@@ -82,45 +93,48 @@ impl Repository {
         // Chunk the content
         let chunks = chunk_by_heading(&content, config.max_chunk_tokens);
 
-        // Delete old embeddings for this path
-        {
-            let mut txn = self
-                .pristine
-                .write_txn()
-                .map_err(|e| RepositoryError::Database(e.to_string()))?;
-            let _ = txn
-                .del_embeddings(path)
-                .map_err(|e| RepositoryError::Database(e.to_string()))?;
-            txn.commit()
-                .map_err(|e| RepositoryError::Database(e.to_string()))?;
-        }
-
-        // Embed and store each chunk
-        let mut txn = self
-            .pristine
-            .write_txn()
-            .map_err(|e| RepositoryError::Database(e.to_string()))?;
-
-        let mut count = 0;
+        // Compute vectors before opening the write transaction. This keeps the
+        // database lock short and gives us one final source validation before
+        // atomically replacing all derived chunks.
+        let mut records = Vec::new();
         for (idx, chunk) in chunks.iter().enumerate() {
             if chunk.text.trim().is_empty() {
                 continue;
             }
 
-            let vector = embed_fn(&chunk.text);
-            let preview = chunk.text.chars().take(200).collect::<String>();
-
             let record = EmbeddingRecord {
-                vector,
+                vector: embed_fn(&chunk.text),
                 content_hash,
                 introduced_by: entry.introduced_by,
                 chunk_idx: idx as u32,
-                preview,
+                preview: chunk.text.chars().take(200).collect(),
             };
+            records.push((idx as u32, record));
+        }
 
-            txn.put_embedding(path, idx as u32, &record)
+        let mut txn = self
+            .pristine
+            .write_txn()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        let still_current = txn
+            .get_vault_entry(path)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+            .is_some_and(|current| {
+                current.entry_type == entry.entry_type
+                    && current.content_hash == content_hash
+                    && current.introduced_by == entry.introduced_by
+            });
+        if !still_current {
+            return Ok(0);
+        }
+
+        txn.del_embeddings(path)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        let count = records.len();
+        for (idx, record) in records {
+            txn.put_embedding(path, idx, &record)
                 .map_err(|e| RepositoryError::Database(e.to_string()))?;
-            count += 1;
         }
 
         txn.commit()
@@ -436,6 +450,47 @@ mod tests {
             .vault_embed("memory/test.md", &test_embed, &config)
             .unwrap();
         assert_eq!(c2, 0);
+    }
+
+    #[test]
+    fn test_vault_embed_does_not_recreate_chunks_after_concurrent_delete() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        repo.init_vault().unwrap();
+        let path = "memory/delete-during-embed.md";
+
+        repo.vault_store(
+            path,
+            VaultEntryType::Memory,
+            b"# Delete during embed\n\nOne chunk of content.\n".to_vec(),
+            "{}".to_string(),
+        )
+        .unwrap();
+
+        // Force a fresh embedding pass, then delete the source while vectors
+        // are being computed. The stale pass must not recreate derived chunks.
+        {
+            let mut txn = repo.pristine.write_txn().unwrap();
+            txn.del_embeddings(path).unwrap();
+            txn.commit().unwrap();
+        }
+        let config = EmbedConfig {
+            max_chunk_tokens: 512,
+            dimensions: 8,
+        };
+        let delete_during_embed = |text: &str| {
+            assert!(repo.vault_delete(path).unwrap());
+            test_embed(text)
+        };
+
+        assert_eq!(
+            repo.vault_embed(path, &delete_during_embed, &config)
+                .unwrap(),
+            0
+        );
+        let txn = repo.pristine.read_txn().unwrap();
+        assert!(txn.get_vault_entry(path).unwrap().is_none());
+        assert!(txn.get_embedding(path, 0).unwrap().is_none());
     }
 
     #[test]

--- a/atomic-repository/src/repository/vault_intent.rs
+++ b/atomic-repository/src/repository/vault_intent.rs
@@ -608,12 +608,16 @@ impl Repository {
         let goals = fm
             .entry("goals".to_string())
             .or_insert_with(|| serde_json::Value::Array(Vec::new()));
-        if let serde_json::Value::Array(ref mut arr) = goals {
-            let goal_val = serde_json::Value::String(goal_name.to_string());
-            if !arr.contains(&goal_val) {
-                arr.push(goal_val);
-            }
+        let goals = goals
+            .as_array_mut()
+            .ok_or_else(|| RepositoryError::InvalidOperation {
+                message: format!("Intent '{}' has a non-array goals field", full_id),
+            })?;
+        let goal_val = serde_json::Value::String(goal_name.to_string());
+        if !goals.contains(&goal_val) {
+            goals.push(goal_val);
         }
+        let goal_count = goals.len() as u32;
         let new_fm = serde_json::to_string(&fm).unwrap_or_else(|_| "{}".to_string());
 
         self.vault_store(&intent_file, VaultEntryType::Intent, content_bytes, new_fm)?;
@@ -628,7 +632,10 @@ impl Repository {
                 .get_vault_manifest()
                 .map_err(|e| RepositoryError::Database(e.to_string()))?;
             if let Some(summary) = manifest.intents.get_mut(&full_id) {
-                summary.goals = summary.goals.saturating_add(1);
+                summary.goals = goal_count;
+            }
+            if let Some(goal) = manifest.goals.get_mut(goal_name) {
+                goal.intent = Some(full_id.clone());
             }
             txn.put_vault_manifest(&manifest)
                 .map_err(|e| RepositoryError::Database(e.to_string()))?;
@@ -1453,9 +1460,9 @@ The authentication module has no rate limiting.
         let goals = fm.get("goals").unwrap().as_array().unwrap();
         assert_eq!(goals.len(), 1);
 
-        // But manifest counter increments each time
+        // The manifest count follows unique links as well.
         let manifest = repo.vault_manifest().unwrap();
-        assert_eq!(manifest.intents[&intent.id].goals, 2);
+        assert_eq!(manifest.intents[&intent.id].goals, 1);
     }
 
     #[test]

--- a/atomic-repository/src/repository/vault_triples.rs
+++ b/atomic-repository/src/repository/vault_triples.rs
@@ -8,7 +8,7 @@ use crate::content_search::{has_content_index, search_content, ContentSearchOpti
 use atomic_core::pristine::ontology::{edge_kind, predicate};
 use atomic_core::pristine::tables::tokenize_for_fts;
 use atomic_core::pristine::vault::{KgEdge, KgNode, KgSubgraph, VaultEntry, VaultEntryType};
-use atomic_core::pristine::{KgMutTxnT, KgTxnT};
+use atomic_core::pristine::{KgMutTxnT, KgTxnT, VaultTxnT};
 
 impl Repository {
     /// Initialize the knowledge graph tables.
@@ -76,31 +76,125 @@ impl Repository {
         let content = String::from_utf8_lossy(&entry.content_bytes);
         extract_content_edges(&subject, entry.entry_type, &content, &mut edges);
 
+        // Edge direction is not enough to determine ownership. In particular,
+        // an Intent's symmetric `BLOCKS` edge points *into* the Intent node.
+        // Persist the source Vault path so an update replaces only edges
+        // derived from that entry while preserving RDF links owned elsewhere.
+        for edge in &mut edges {
+            let metadata = edge.metadata.get_or_insert_with(|| serde_json::json!({}));
+            if let Some(object) = metadata.as_object_mut() {
+                object.insert(
+                    "derived_from_vault_path".to_string(),
+                    serde_json::json!(path),
+                );
+            }
+        }
+
         nodes.push(node);
         Ok((nodes, edges))
     }
 
-    /// Store KG nodes and edges for a vault entry, replacing any existing
-    /// nodes/edges derived from that path.
+    /// Store KG nodes and edges previously returned by [`Self::vault_extract_kg`],
+    /// replacing existing derived data for that path.
+    ///
+    /// The supplied triples must still match the current Vault entry. Prefer
+    /// [`Self::vault_index_kg`] when the caller does not need the two-step API.
     pub fn vault_store_kg(
         &self,
         path: &str,
         nodes: &[KgNode],
         edges: &[KgEdge],
     ) -> Result<usize, RepositoryError> {
+        let current_entry =
+            self.vault_retrieve(path)?
+                .ok_or_else(|| RepositoryError::FileNotFound {
+                    path: std::path::PathBuf::from(path),
+                })?;
+        let (current_nodes, current_edges) = self.vault_extract_kg(path, &current_entry)?;
+        if nodes != current_nodes || edges != current_edges {
+            return Err(RepositoryError::InvalidOperation {
+                message: format!(
+                    "KG data for '{path}' no longer matches the current Vault entry; re-extract or call vault_index_kg"
+                ),
+            });
+        }
+        self.vault_store_kg_inner(path, nodes, edges, Some(&current_entry))
+    }
+
+    fn vault_store_kg_inner(
+        &self,
+        path: &str,
+        nodes: &[KgNode],
+        edges: &[KgEdge],
+        expected_entry: Option<&VaultEntry>,
+    ) -> Result<usize, RepositoryError> {
+        // Today vault KG identities are path-derived. Prefer the primary node
+        // identified by its vault_path metadata so ToolResult updates remove
+        // their real `tool:` node rather than a guessed `vault:` node.
+        let subject = nodes
+            .iter()
+            .find(|node| {
+                node.metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.get("vault_path"))
+                    .and_then(serde_json::Value::as_str)
+                    == Some(path)
+            })
+            .or_else(|| nodes.iter().find(|node| node.id == path_to_subject(path)))
+            .or_else(|| (nodes.len() == 1).then(|| &nodes[0]))
+            .map(|node| node.id.clone())
+            .unwrap_or_else(|| path_to_subject(path));
+
         let mut txn = self
             .pristine
             .write_txn()
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
-        // Delete old data keyed by the path's primary node ID
-        let subject = path_to_subject(path);
-        let _ = txn
-            .del_kg_edges_for_node(&subject)
+        // Extraction happens before the write transaction. If the source was
+        // updated or deleted meanwhile, this result is stale and must not
+        // recreate derived KG data after the newer source operation commits.
+        if let Some(expected) = expected_entry {
+            let current = txn
+                .get_vault_entry(path)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+            let still_current = current.is_some_and(|entry| {
+                entry.entry_type == expected.entry_type
+                    && entry.content_hash == expected.content_hash
+                    && entry.frontmatter_json == expected.frontmatter_json
+            });
+            if !still_current {
+                return Ok(0);
+            }
+        }
+
+        txn.init_kg()
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
-        let _ = txn
-            .del_kg_node(&subject)
-            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        if nodes.iter().any(|node| node.id == subject) {
+            // This is an in-place replacement of the same resource. Remove
+            // relationships derived from this Vault entry, but preserve edges
+            // from other resources that point at it (for example an Intent's
+            // RDF/PROV link to a source Memory). `upsert_kg_node` below replaces
+            // the node metadata and FTS terms transactionally.
+            let outgoing = txn
+                .get_kg_edges_from(&subject)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+            let incoming = txn
+                .get_kg_edges_to(&subject)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+            for edge in outgoing.iter().chain(&incoming) {
+                if !edge_is_owned_by_vault_entry(edge, path, &subject) {
+                    continue;
+                }
+                txn.del_kg_edge(&edge.from_id, &edge.to_id, &edge.kind)
+                    .map_err(|e| RepositoryError::Database(e.to_string()))?;
+            }
+        } else {
+            // No replacement node was extracted (for example an entry that no
+            // longer participates in the KG), so remove the resource fully.
+            txn.del_kg_node(&subject)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        }
 
         // Store new nodes
         for node in nodes {
@@ -127,7 +221,7 @@ impl Repository {
                 path: std::path::PathBuf::from(path),
             })?;
         let (nodes, edges) = self.vault_extract_kg(path, &entry)?;
-        self.vault_store_kg(path, &nodes, &edges)
+        self.vault_store_kg_inner(path, &nodes, &edges, Some(&entry))
     }
 
     /// Re-index all vault entries into the knowledge graph.
@@ -167,14 +261,31 @@ impl Repository {
             .read_txn()
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
-        // ── Phase 1: Collect ALL matching node IDs (cheap — no node fetching) ──
+        // ── Phase 1: Collect and validate matching node IDs ─────────────────
 
-        // KG FTS: every node ID that matches any query token, with hit counts.
-        let kg_matches: HashMap<String, usize> = txn
+        // Legacy KG FTS only appended postings, and a read-only repository
+        // cannot run the reverse-index migration. Treat the index as a
+        // candidate generator, then recompute hits from the current KG node.
+        // This prevents stale label/summary terms from being served before the
+        // next write-time migration and also protects against mixed-version
+        // writers that may have appended an obsolete posting.
+        let query_tokens: HashSet<String> = tokenize_for_fts(query).into_iter().collect();
+        let indexed_matches = txn
             .kg_fts_match_ids(query)
-            .map_err(|e| RepositoryError::Database(e.to_string()))?
-            .into_iter()
-            .collect();
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        let mut kg_matches: HashMap<String, usize> = HashMap::new();
+        for (node_id, _) in indexed_matches {
+            let Some(node) = txn
+                .get_kg_node(&node_id)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?
+            else {
+                continue;
+            };
+            let current_hits = kg_node_fts_hit_count(&node, &query_tokens);
+            if current_hits > 0 {
+                kg_matches.insert(node_id, current_hits);
+            }
+        }
 
         // Content search: file-level matches from syntext, grouped by path.
         let mut content_counts: HashMap<String, usize> = HashMap::new();
@@ -401,6 +512,26 @@ fn kg_node_fts_hit_count(node: &KgNode, query_tokens: &std::collections::HashSet
     query_tokens.intersection(&node_tokens).count()
 }
 
+/// Whether an existing edge should be replaced when `path` is re-indexed.
+///
+/// New edges carry explicit ownership. The direction/kind fallbacks clean up
+/// legacy edges created before ownership metadata existed:
+/// - outgoing edges were derived from the subject entry;
+/// - incoming `BLOCKS` edges were the symmetric half of that Intent's
+///   `blocked_by` relationship.
+fn edge_is_owned_by_vault_entry(edge: &KgEdge, path: &str, subject: &str) -> bool {
+    if let Some(owner) = edge
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("derived_from_vault_path"))
+        .and_then(serde_json::Value::as_str)
+    {
+        return owner == path;
+    }
+
+    edge.from_id == subject || (edge.to_id == subject && edge.kind == edge_kind::BLOCKS)
+}
+
 /// Compute a ranking score from a node ID and match counts.
 ///
 /// Higher score = more relevant.  Works on IDs only (no node fetching needed).
@@ -595,7 +726,7 @@ impl Repository {
 // ── Extraction helpers ──────────────────────────────────────────
 
 /// Derive a subject URI from a vault path and entry type.
-fn entry_subject(path: &str, entry_type: VaultEntryType) -> String {
+pub(super) fn entry_subject(path: &str, entry_type: VaultEntryType) -> String {
     match entry_type {
         VaultEntryType::Session => {
             // goals/swift-meadow-a3f2/_goal.md -> goal:swift-meadow-a3f2
@@ -1046,33 +1177,231 @@ mod tests {
         let dir = tempdir().unwrap();
         let repo = Repository::init(dir.path()).unwrap();
         repo.init_vault().unwrap();
+        let path = "goals/abc/_goal.md";
+        repo.vault_store(
+            path,
+            VaultEntryType::Session,
+            b"Used src/main.rs".to_vec(),
+            r#"{"developer":"alice"}"#.to_string(),
+        )
+        .unwrap();
+        let first_entry = repo.vault_retrieve(path).unwrap().unwrap();
+        let (first_nodes, first_edges) = repo.vault_extract_kg(path, &first_entry).unwrap();
+        assert!(
+            repo.vault_store_kg(path, &first_nodes, &first_edges)
+                .unwrap()
+                > 0
+        );
 
-        let nodes = vec![KgNode::new("goal:abc", "goal", "abc", "vault")];
-        let edges = vec![KgEdge::new(
-            "goal:abc",
-            "file:src/main.rs",
-            edge_kind::REFERENCES,
-        )];
+        repo.vault_store(
+            path,
+            VaultEntryType::Session,
+            b"Used src/lib.rs".to_vec(),
+            r#"{"developer":"alice"}"#.to_string(),
+        )
+        .unwrap();
 
-        let count = repo
-            .vault_store_kg("goals/abc/_goal.md", &nodes, &edges)
+        // A delayed caller cannot write triples extracted from the old source.
+        assert!(repo
+            .vault_store_kg(path, &first_nodes, &first_edges)
+            .is_err());
+
+        let current_entry = repo.vault_retrieve(path).unwrap().unwrap();
+        let (current_nodes, current_edges) = repo.vault_extract_kg(path, &current_entry).unwrap();
+        repo.vault_store_kg(path, &current_nodes, &current_edges)
             .unwrap();
-        assert_eq!(count, 2);
 
-        // Store again with different edges — old data should be replaced
-        let edges2 = vec![KgEdge::new(
-            "goal:abc",
-            "file:src/lib.rs",
-            edge_kind::REFERENCES,
-        )];
-        let count2 = repo
-            .vault_store_kg("goals/abc/_goal.md", &nodes, &edges2)
-            .unwrap();
-        assert_eq!(count2, 2);
+        let subgraph = repo.vault_kg_neighbors("goal:abc", 1).unwrap();
+        assert!(subgraph
+            .edges
+            .iter()
+            .any(|edge| edge.to_id == "file:src/lib.rs"));
+        assert!(!subgraph
+            .edges
+            .iter()
+            .any(|edge| edge.to_id == "file:src/main.rs"));
+    }
 
-        // The node should still exist
-        let node = repo.vault_kg_node("goal:abc").unwrap();
-        assert!(node.is_some());
+    #[test]
+    fn test_tool_result_update_and_delete_clean_derived_data() {
+        let dir = tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        repo.init_vault().unwrap();
+
+        let path = "goals/demo/toolu_123.md";
+        let node_id = entry_subject(path, VaultEntryType::ToolResult);
+        let previous_node_id = entry_subject(path, VaultEntryType::Memory);
+
+        // Reclassifying an existing path must remove the identity derived from
+        // the previous entry type before the new node is indexed.
+        repo.vault_store(
+            path,
+            VaultEntryType::Memory,
+            b"temporary memory".to_vec(),
+            r#"{"name":"temporary"}"#.to_string(),
+        )
+        .unwrap();
+        assert!(repo.vault_kg_node(&previous_node_id).unwrap().is_some());
+
+        repo.vault_store(
+            path,
+            VaultEntryType::ToolResult,
+            b"read src/auth.rs".to_vec(),
+            r#"{"description":"staletooltoken"}"#.to_string(),
+        )
+        .unwrap();
+
+        assert!(repo.vault_kg_node(&previous_node_id).unwrap().is_none());
+        assert!(repo.vault_kg_node(&node_id).unwrap().is_some());
+        assert!(repo
+            .vault_kg_search("staletooltoken", 10, None)
+            .unwrap()
+            .iter()
+            .any(|node| node.id == node_id));
+        let stale_entry = repo.vault_retrieve(path).unwrap().unwrap();
+        let (stale_nodes, stale_edges) = repo.vault_extract_kg(path, &stale_entry).unwrap();
+
+        repo.vault_store(
+            path,
+            VaultEntryType::ToolResult,
+            b"read src/main.rs".to_vec(),
+            r#"{"description":"currenttooltoken"}"#.to_string(),
+        )
+        .unwrap();
+
+        // A slow indexer that extracted the previous entry must not overwrite
+        // the newer KG state after the source update has committed.
+        assert_eq!(
+            repo.vault_store_kg_inner(path, &stale_nodes, &stale_edges, Some(&stale_entry),)
+                .unwrap(),
+            0
+        );
+
+        assert!(repo
+            .vault_kg_search("staletooltoken", 10, None)
+            .unwrap()
+            .is_empty());
+        assert!(repo
+            .vault_kg_search("currenttooltoken", 10, None)
+            .unwrap()
+            .iter()
+            .any(|node| node.id == node_id));
+        let graph = repo.vault_kg_neighbors(&node_id, 1).unwrap();
+        assert!(!graph
+            .edges
+            .iter()
+            .any(|edge| edge.to_id == "file:src/auth.rs"));
+        assert!(graph
+            .edges
+            .iter()
+            .any(|edge| edge.to_id == "file:src/main.rs"));
+
+        assert!(repo.vault_delete(path).unwrap());
+        assert!(repo.vault_kg_node(&node_id).unwrap().is_none());
+        assert!(repo
+            .vault_kg_search("currenttooltoken", 10, None)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn test_vault_node_update_preserves_incoming_relationships() {
+        let dir = tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        repo.init_vault().unwrap();
+
+        repo.vault_store(
+            "memory/target.md",
+            VaultEntryType::Memory,
+            b"Original target knowledge".to_vec(),
+            r#"{"name":"target"}"#.to_string(),
+        )
+        .unwrap();
+        repo.vault_store(
+            "memory/source.md",
+            VaultEntryType::Memory,
+            b"This decision uses [[target]]".to_vec(),
+            r#"{"name":"source"}"#.to_string(),
+        )
+        .unwrap();
+
+        let incoming_exists = |repo: &Repository| {
+            repo.vault_kg_neighbors("memory:source", 1)
+                .unwrap()
+                .edges
+                .iter()
+                .any(|edge| {
+                    edge.from_id == "memory:source"
+                        && edge.to_id == "memory:target"
+                        && edge.kind == edge_kind::REFERENCES
+                })
+        };
+        assert!(incoming_exists(&repo));
+
+        // Replacing the target's metadata/body must not erase another Vault
+        // entry's RDF/KG relationship to that same resource.
+        repo.vault_store(
+            "memory/target.md",
+            VaultEntryType::Memory,
+            b"Updated target knowledge".to_vec(),
+            r#"{"name":"target","description":"current target"}"#.to_string(),
+        )
+        .unwrap();
+        assert!(incoming_exists(&repo));
+
+        // A real delete still cascades the now-dangling relationship.
+        assert!(repo.vault_delete("memory/target.md").unwrap());
+        assert!(!incoming_exists(&repo));
+    }
+
+    #[test]
+    fn test_vault_node_update_removes_owned_reverse_relationships() {
+        let dir = tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        repo.init_vault().unwrap();
+        let path = "intents/demo/intent.md";
+
+        repo.vault_store(
+            path,
+            VaultEntryType::Intent,
+            b"# Demo".to_vec(),
+            r#"{"title":"Demo","blocked_by":["BLOCKER"]}"#.to_string(),
+        )
+        .unwrap();
+        let has_reverse_block = |repo: &Repository| {
+            repo.vault_kg_neighbors("intent:DEMO", 1)
+                .unwrap()
+                .edges
+                .iter()
+                .any(|edge| {
+                    edge.from_id == "intent:BLOCKER"
+                        && edge.to_id == "intent:DEMO"
+                        && edge.kind == edge_kind::BLOCKS
+                })
+        };
+        assert!(has_reverse_block(&repo));
+
+        repo.vault_store(
+            path,
+            VaultEntryType::Intent,
+            b"# Demo".to_vec(),
+            r#"{"title":"Demo","blocked_by":[]}"#.to_string(),
+        )
+        .unwrap();
+        assert!(!has_reverse_block(&repo));
+    }
+
+    #[test]
+    fn test_current_node_validation_rejects_obsolete_fts_term() {
+        let node = KgNode::new("memory:payment-decision", "memory", "payments", "vault")
+            .with_summary("Use payment service v2");
+        let old_query: std::collections::HashSet<String> =
+            tokenize_for_fts("authentication").into_iter().collect();
+        let current_query: std::collections::HashSet<String> =
+            tokenize_for_fts("payments").into_iter().collect();
+
+        assert_eq!(kg_node_fts_hit_count(&node, &old_query), 0);
+        assert_eq!(kg_node_fts_hit_count(&node, &current_query), 1);
     }
 
     #[test]

--- a/docs/vault-context-design.md
+++ b/docs/vault-context-design.md
@@ -1,124 +1,155 @@
 # Vault Context: Memory Research Before Work
 
-**Status:** PR #108 implements the read-only retrieval primitive. Derived-index
-lifecycle, agent skills, Intent lineage, and automatic integrations are separate
-steps.
+**Status:** Phase A (`atomic vault context`) is implemented in PR #108. Phase B
+(derived-index lifecycle) is implemented in this stacked PR. Agent workflow,
+Intent lineage, and automatic integrations remain follow-up work.
 
-## Target knowledge flywheel
+## Why
 
-The workflow agreed with Lee is Intent-centered:
+Atomic already stores Vault memories, Intents, changes, and provenance, but
+stored knowledge only compounds when it is found before a decision is made.
+The target workflow is Intent-centered:
 
 ```text
 memory-based research
   → select relevant source memories
-  → create an Intent with problem statement, acceptance criteria, and todos
+  → create Intent with problem statement, acceptance criteria, and todos
   → human acceptance
   → implement changes mapped to the Intent
-  → update todos, complete, and sync the Intent
-  → write a learning Memory linked to the completed Intent and source memories
+  → update todos and complete/sync the Intent
+  → create a learning Memory linked to the Intent and its source memories
 ```
 
-Those links should be RDF relationships so Atomic can build an ontology around
-the taxonomy. Retrieval is not proof of use: a memory returned by a search is a
-candidate, and only memories actually selected for the Intent should later be
-linked as sources.
+RDF links provide lineage and build an ontology around that taxonomy. Retrieval
+is not the same as use: a memory returned as a candidate must not automatically
+be recorded as `prov:used`. The Intent workflow should persist links only for
+the source memories actually selected.
 
-## What already exists
+PR #108 supplies the read-only retrieval primitive. PR #111 makes the derived
+KG/FTS/embedding lifecycle safe enough for that retrieval to represent current
+Vault state. Neither PR creates Intents, writes lineage links, injects prompts
+automatically, or distills new memories.
 
-- Vault is the source of truth for full memory bodies.
-- KG FTS searches node IDs, labels, and summaries.
-- KG relationships connect Vault entries, files, changes, and other resources.
-- Vault vector search exists as a separate path; normal KG search does not use
-  those embeddings.
+## What exists already (verified)
 
-Atomic was missing a task-oriented way to research current Vault memories
-before creating or implementing an Intent.
+- `vault_kg_search` searches KG node IDs, labels, and summaries together with
+  the repository source-content index. `vault_kg_search_by_kind` applies a node
+  kind before top-N selection for typed callers such as memory retrieval.
+- `vault_kg_neighbors` traverses relationships created from wiki links and file
+  references in Vault entries.
+- `vault_search` is a separate vector-search path. Normal KG search does not use
+  Vault embeddings.
+- Vault remains the source of truth for full memory bodies.
+- The existing `atomic-vault` skill covers Vault operations, but does not yet
+  define this memory-research workflow.
 
-## What PR #108 adds
+## Phase A: `atomic vault context` (PR #108)
 
 ```text
 atomic vault context [QUERY]... [--intent <id>] [--files <path>]
                      [--limit 5] [--budget-chars 8000] [--format md|json]
 ```
 
-The command is read-only and supports two moments in the workflow:
+The command is read-only and supports two workflow moments:
 
-1. Before Intent creation, use a free-text problem query to discover candidate
-   source memories.
-2. After human acceptance, use `--intent <id>` to retrieve implementation
-   context from that Intent's title, labels, body, and KG relationships.
+1. Before Intent creation, free-text research finds candidate source memories.
+2. After human acceptance, `--intent <id>` retrieves implementation context
+   from the accepted problem statement, criteria, todos, and relationships.
 
-Candidates come from:
+Candidates come from memory-only KG metadata search, Intent/file graph
+neighbors, and a scan of current Vault memory bodies. Ranking combines
+metadata rank, exact body-token match, graph adjacency, and recency. Explicit
+seeds with no match return no context; only an unseeded request falls back to
+recent memories.
 
-- memory-only KG metadata search, filtered by kind before top-N selection;
-- one/two-hop KG neighbors of the supplied Intent;
-- one-hop KG neighbors of supplied repo-relative files;
-- exact-token matching against current Vault memory bodies.
+JSON returns the prompt-ready Markdown once and records both identities:
 
-Ranking combines metadata rank, body-token match, graph adjacency, and recency.
-Index, superseded, retracted, and malformed-status memories are excluded.
-Explicit seeds with no match return no context; only an unseeded request falls
-back to recent active memories.
-
-Markdown is prompt-ready but remains untrusted historical data. JSON returns
-the same Markdown once plus the selected candidates and their identities:
-
-- `memory_id`: canonical memory/RDF identity when present;
+- `memory_id`: canonical memory resource identity when present;
 - `kg_node_id`: identity used by the current KG;
-- `revision_hash`: entry type + stored frontmatter + body, identifying the exact
-  knowledge revision returned;
-- `content_hash`: existing body-only hash used by body/embedding caches.
+- `revision_hash`: entry type + frontmatter + body, identifying the exact
+  knowledge revision exposed;
+- `content_hash`: body-only hash used by body/embedding caches.
 
-This identity split lets a later Intent workflow create RDF links deliberately
-without assuming a canonical ID is already the node used by today's KG.
+This separation avoids treating a body hash as a full knowledge revision or
+creating RDF links to a canonical ID that the current graph does not yet know.
 
-## Example
+## Phase B: derived-index lifecycle (PR #111)
 
-```json
-$ atomic vault context "JWT signing algorithm" --json
+- KG FTS remains an index of node IDs, labels, and summaries. Memory bodies are
+  not copied into it.
+- A transactional reverse FTS index lets node replacement/deletion remove old
+  metadata tokens. On the next KG initialization/write, a one-time rebuild uses
+  current KG nodes and prunes obsolete or posting-only orphan terms.
+- Read-only search treats FTS as a candidate index and validates every hit
+  against the current node ID/label/summary. Upgraded repositories therefore do
+  not serve an obsolete term while waiting for the next write-time migration.
+- Vault node updates replace only edges owned by that Vault entry. Edge metadata
+  records `derived_from_vault_path`, so incoming RDF/KG links owned by another
+  resource survive a target update, while symmetric relationships owned by the
+  updated entry are removed correctly.
+- Vault deletion removes the source entry, its current path-derived KG node and
+  edges, and embedding chunks in one transaction. Entry-type changes remove the
+  previous KG identity, including ToolResult identities.
+- Working-copy sync detects frontmatter-only changes such as `status`, labels,
+  or description without changing JSON types during materialize/parse. Manifest
+  type indexes, Goal/Intent summaries, file count, and byte totals follow
+  replacement and deletion instead of leaving old entries behind. Removing or
+  reclassifying a Goal also removes that Goal from linked Intent sources.
+- KG and embedding writers verify that their source Vault entry is still the
+  same revision before committing, preventing slow internal indexers from
+  resurrecting older data after an update or deletion.
+- `vault context` reads current Vault memory bodies directly, so body updates
+  and deletions take effect without a separate body index.
 
-{
-  "schema_version": 1,
-  "memories": [
-    {
-      "memory_id": "urn:atomic:memory:auth-decision",
-      "kg_node_id": "memory:auth-decision",
-      "body": "Use RS256 signing, not HS256."
-    }
-  ]
-}
-```
+### Deliberate limits
 
-An agent or human may select that result while writing the Intent. A later
-workflow can then add an RDF source link from the Intent to
-`urn:atomic:memory:auth-decision`. Merely appearing in these results must not
-create the link.
+- Write-side automatic indexing remains best-effort; this PR does not add a
+  durable indexing outbox/retry system.
+- The migration repairs FTS postings, not stale full KG nodes or embeddings left
+  by older failed lifecycle operations. A source-aware reconciliation command is
+  a separate follow-up.
+- Embedding model/provider/chunker provenance and forced re-embedding belong to
+  the vector-search lifecycle, not this metadata/source cleanup.
+- Schema migration still runs on a KG write/init; read-only retrieval uses
+  current-node validation instead of acquiring a write lock.
 
-## Follow-ups (not in this PR)
+## Follow-ups
 
-- PR #111 keeps KG FTS, KG nodes/edges, and embeddings consistent with current
-  Vault entries.
-- Add a focused skill tied to the existing `atomic-vault` skill, and describe
-  the research → Intent workflow in agent context files. This belongs with the
-  agent package rather than the CLI retrieval primitive.
-- Add Intent commands/schema for explicitly selecting source memory IDs and
-  writing RDF lineage after human acceptance.
-- Integrate the workflow with Noname/Sherpa only after the direct-agent flow is
-  useful and the trust/provenance contract is clear.
-- After Intent completion, distill a new learning Memory and link it to both the
-  completed Intent/change and the original selected source memories.
+- **Direct-agent workflow:** add an `atomic-vault-context` skill linked from the
+  existing `atomic-vault` skill. `AGENTS.md`, `CLAUDE.md`, and equivalents say
+  *when* to run memory research; the skill says *how*.
+- **Intent source lineage:** after source selection, write typed RDF/PROV links
+  from the Intent to the selected source Memories. Candidate retrieval alone
+  must not create these links.
+- **Sherpa/noname:** run free-text research while authoring an Intent, then use
+  `--intent` after human acceptance. Inject `context_markdown` at untrusted
+  user/tool-data authority and record exact exposed revisions separately from
+  the smaller set selected as sources.
+- **Completion distillation:** after the Intent is complete and synced, create a
+  typed learning Memory and link it to the completed Intent and original source
+  Memories with RDF. Session transcripts and `agent explain --save` are evidence
+  for this step, not the lifecycle trigger by themselves.
 
 ## Verification
 
-Tests cover free-text, Intent, and file-seeded retrieval; memory-only top-N
-selection; exact body tokens; active-memory fallback; legacy Intent paths;
-identity/revision fields; output budgets; and explicit no-match behavior.
+- PR #108 covers free-text, Intent, and file seeds; memory-only top-N selection;
+  inactive-memory exclusion; exact-token matching; identity/revision fields;
+  delimiter integrity; budget allocation; and explicit no-match behavior.
+- Core KG tests cover reverse-FTS migration, metadata-token replacement, and
+  deletion.
+- Repository tests cover target updates preserving incoming links, owned reverse
+  edge replacement, read-side stale-term rejection, frontmatter-only updates,
+  lossless frontmatter round-trips, manifest replacement and Goal/Intent
+  deletion, entry-type/ToolResult cleanup, source-aware deletion, embedding
+  cleanup, and stale-writer rejection for both automatic and public two-step KG
+  indexing.
 
 ## Known limits
 
-- Body retrieval linearly scans the memory corpus. Add a specialized body index
-  only after corpus-size and latency measurements justify it.
-- `--intent` currently expects the full ID; `--files` expects repo-relative
-  forward-slash paths.
-- Prompt delimiters are advisory. Integrations must keep memory text in an
-  untrusted-data boundary rather than merge it into system instructions.
+- Vaults have few memories until completion distillation exists; seed a small
+  set of high-value memories for initial use.
+- Body retrieval scans the memory corpus. Add a specialized body index only
+  after corpus-size and latency measurements justify it.
+- `--intent` requires the full ID; `--files` expects repo-relative paths.
+- Prompt delimiters are an advisory trust boundary. Integrations must preserve
+  memory as untrusted data rather than merging it into system instructions.


### PR DESCRIPTION
Builds on merged #108.

## Problem

For Vault-derived knowledge, the Vault entry is the source of truth. KG nodes and relationships, KG FTS postings, embeddings, and manifest summaries are derived representations used by search and retrieval.

Before this PR, those derived representations did not consistently follow a Vault entry through replacement, entry-type change, and deletion.

### Concrete example: an obsolete FTS term survives an update

Suppose `memory/auth.md` produces this KG node:

```text
node: memory:auth
summary: Use HS256 for service tokens
```

KG FTS stores a posting such as:

```text
hs256 -> memory:auth
```

The memory is then updated and the current node becomes:

```text
node: memory:auth
summary: Use RS256 for service tokens
```

Previously, `KG_NODES[memory:auth]` was replaced and a new `rs256 -> memory:auth` posting was added, but the old `hs256 -> memory:auth` posting was not removed. A search for `hs256` could therefore still return the current node even though its current ID, label, and summary no longer contained that term.

Deletion and re-indexing had related lifecycle gaps: the Vault source could disappear while its KG data or embedding chunks remained, and replacing a node could remove RDF/KG relationships owned by another Vault entry.

## Behavior before this PR

### 1. KG FTS was append-only on node update

- `upsert_kg_node` replaced the current row in `KG_NODES`, then added the node's current ID/label/summary tokens to `KG_FTS`.
- There was no `node_id -> tokens` reverse mapping, so update and deletion could not efficiently remove the node's previous postings.
- `del_kg_node` removed the node and its edges but left its FTS postings behind.
- Normal KG search trusted the posting list, so an obsolete posting for a reused/current node ID could produce a stale match.

### 2. Re-indexing a Vault node could remove relationships owned elsewhere

`vault_store_kg` deleted the existing subject node before inserting the replacement. Deleting the node removed all incident edges, including incoming relationships generated by another Vault entry.

For example, if an Intent had an RDF/PROV link to a Memory, re-indexing that Memory could erase the Intent-owned link because edge ownership was not recorded.

### 3. Vault deletion and entry-type changes did not fully clean derived state

- `vault_delete` removed the Vault entry and updated the manifest, but did not delete its KG node/edges or embedding chunks.
- If an entry changed type, its KG identity could change while the previous identity remained.
- ToolResult nodes use a `tool:` identity rather than the generic path-derived identity, so guessed cleanup could target the wrong node.
- Goal and Intent summaries are keyed by logical IDs rather than Vault paths; removing them by path could leave ghost manifest entries.
- Removing or reclassifying a Goal could leave that Goal referenced by an Intent.
- Manifest file counts and byte totals did not correctly distinguish insert, replacement, and deletion.

### 4. A slow indexer could write an obsolete result

Vault storage commits before best-effort KG indexing and embedding run. Previously, an indexer could read revision A, then revision B could be stored or deleted, and the slower revision-A indexer could still commit its old KG or embedding result afterward.

Embedding replacement also deleted old chunks and wrote new chunks in separate transactions, leaving a larger race window.

### 5. Frontmatter-only changes could be missed or change value types

Working-copy sync compared the body hash but did not include user frontmatter in change detection. Changes to fields such as status, labels, description, or identity could therefore be skipped when the Markdown body was unchanged.

Materialize/parse round-trips could also reinterpret JSON values, for example turning a string that looks like a boolean or number into a different value type.

## What this PR changes

### 1. Makes KG FTS replacement- and deletion-safe

- Adds a transactional `node_id -> tokens` reverse index.
- Removes a node's previous ID/label/summary postings before indexing its current values.
- Removes the postings when the node is deleted.
- On the next KG initialization/write, performs a one-time rebuild from current `KG_NODES` to remove legacy obsolete and posting-only orphan terms.
- Treats FTS as a candidate index during read-only search and validates each candidate against the current node, so obsolete terms are not served while waiting for the write-time migration.

KG FTS still indexes only node IDs, labels, and summaries. This PR does not copy Vault memory bodies into KG FTS.

### 2. Adds ownership-aware KG edge replacement

- Records `derived_from_vault_path` on relationships extracted from a Vault entry.
- When a Vault node is updated, removes only relationships owned by that entry.
- Preserves incoming RDF/KG links owned by other Vault entries.
- Still removes reverse/symmetric relationships owned by the updated entry when their source data changes.

### 3. Aligns deletion and type changes with the Vault source

- Deletes a Vault entry, its current path-derived KG node/edges, its embedding chunks, and its manifest state in one redb transaction.
- Removes the previous KG identity when an entry changes type.
- Uses the extracted node's real identity for ToolResult updates.
- Replaces the correct manifest classification and Goal/Intent summaries.
- Removes a deleted or reclassified Goal from current Intent sources and updates their summary counts.

### 4. Rejects stale KG and embedding writers

- KG and embedding writers verify that the source Vault entry is still the same revision before committing.
- If the source changed or was deleted while indexing was in progress, the obsolete result is discarded.
- Embedding chunks are replaced together in one transaction after the final source check.

### 5. Keeps working-copy and manifest state lossless

- Detects changes to user frontmatter even when the body hash is unchanged.
- Preserves JSON scalar, array, and object types through Markdown materialize/parse round-trips.
- Maintains manifest type indexes, Goal/Intent summaries, file count, and total bytes across insert, replacement, type change, and deletion.

## Why this matters

Search and future Intent/RDF workflows should operate on the current Vault knowledge, not obsolete metadata or deleted derived data. Edge ownership is also required so future source-memory links are not erased when their target is re-indexed.

This is a data-integrity foundation for the Intent-centered knowledge flow. It does not create source-Memory-to-Intent links, generate learning memories, or implement the full flywheel.

`atomic vault context` continues to read current memory bodies directly from Vault, so body updates and deletions take effect without a separate body index.

## Deliberate limits

- Automatic write-side indexing remains best-effort; this PR does not add a durable outbox or retry worker.
- The one-time migration repairs KG FTS postings. Historical orphan KG nodes or embeddings created by older failed lifecycle operations still require a separate source-aware reconciliation pass.
- This PR does not add automatic memory distillation, session-start retrieval, prompt injection, or Noname/Sherpa integration.

## Test

- `cargo test -p atomic-core`
- `cargo test -p atomic-repository`
- `cargo test -p atomic-cli`
- `cargo fmt --all -- --check`
- `cargo clippy -p atomic-core -p atomic-repository -p atomic-cli --all-targets -- -D warnings`

Added coverage for FTS migration/replacement/deletion, read-side stale-term rejection, edge ownership, entry-type and ToolResult cleanup, Goal/Intent unlinking, lossless frontmatter sync, manifest replacement, embedding cleanup, and stale-writer rejection.
