### PR TITLE
ci: add dispatchable Prepare Release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,77 @@
+name: Prepare Release
+
+# Manual "one button" release. From the GitHub Actions UI, run this workflow
+# with the new version (e.g. 0.9.1). It:
+#   1. Bumps the workspace version in Cargo.toml (+ Cargo.lock) on dev.
+#   2. Merges dev into release.
+#   3. Invokes the Release workflow to build binaries and cut the GitHub
+#      release + v<version> tag.
+#
+# No PAT required: step 3 runs the release build via workflow_call in this
+# same run, so the default GITHUB_TOKEN is sufficient.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "New version, semver without leading v (e.g. 0.9.1)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    name: Bump version and merge to release
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.merge.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Validate version
+        run: |
+          echo "${{ inputs.version }}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$' \
+            || { echo "::error::Invalid version '${{ inputs.version }}' (expected e.g. 0.9.1)"; exit 1; }
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump workspace version in Cargo.toml
+        run: |
+          sed -i -E 's/^version = "[^"]*"/version = "${{ inputs.version }}"/' Cargo.toml
+          grep -m1 '^version = ' Cargo.toml
+
+      - name: Update Cargo.lock
+        run: cargo update --workspace
+
+      - name: Commit and push to dev
+        run: |
+          git add Cargo.toml Cargo.lock
+          git commit -m "Bump version to ${{ inputs.version }}"
+          git push origin HEAD:dev
+
+      - name: Merge dev into release
+        id: merge
+        run: |
+          git fetch origin release
+          git checkout -B release origin/release
+          git merge --no-ff dev -m "Merge dev into release"
+          git push origin HEAD:release
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  release:
+    name: Build and release
+    needs: bump
+    uses: ./.github/workflows/release.yml
+    permissions:
+      contents: write
+    secrets: inherit
+    with:
+      ref: ${{ needs.bump.outputs.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,21 @@
 name: Release
 
 on:
+  # Push to the release branch (legacy/manual path) or a version tag.
   push:
     branches: [release]
+    tags: ['v*']
+  # Callable from the Prepare Release dispatch workflow, which bumps the
+  # version, merges dev into release, and then invokes this build directly.
+  # Invoking via workflow_call runs in the same workflow run, so it works
+  # with the default GITHUB_TOKEN (no PAT needed to chain the build).
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref (branch, tag, or SHA) to build the release from."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: write
@@ -23,6 +36,8 @@ jobs:
       tag: ${{ steps.version.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Extract version from Cargo.toml
         id: version
@@ -71,6 +86,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.90
@@ -145,6 +162,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref || github.ref }}
           # Full history so generate-notes can diff against the previous tag
           fetch-depth: 0
 
@@ -248,6 +266,12 @@ jobs:
           echo "Generated release notes:"
           cat release-notes.md
 
+      - name: Resolve target commit
+        id: target
+        # Use the commit actually checked out (the release branch/tag/SHA),
+        # not github.sha — under workflow_call the latter is the caller's ref.
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -261,7 +285,7 @@ jobs:
 
           gh release create "$TAG" \
             --repo "${{ github.repository }}" \
-            --target "${{ github.sha }}" \
+            --target "${{ steps.target.outputs.sha }}" \
             --title "Atomic ${TAG}" \
             --notes-file release-notes.md \
             $PRERELEASE_FLAG \


### PR DESCRIPTION
## What

Adds a one-button, manually-dispatched release process — no PAT required.

### `prepare-release.yml` (new)
Run from the Actions UI with a version (e.g. \`0.9.1\`). It:
1. Validates the semver and bumps \`[workspace.package].version\` in \`Cargo.toml\`, syncing \`Cargo.lock\` via \`cargo update --workspace\`.
2. Commits \`Bump version to <version>\` to \`dev\`.
3. Merges \`dev\` → \`release\` (\`--no-ff\`, matching existing history).
4. Invokes the release build via \`workflow_call\`, passing the merged commit SHA.

### `release.yml` (modified — now triggerable 3 ways)
- **`workflow_call`** with an optional \`ref\` input — lets the dispatch workflow chain the build in the *same run*, so the default \`GITHUB_TOKEN\` is sufficient (the anti-recursion rule only blocks *cross-run* triggers).
- **`tags: ['v*']`** push trigger — a plain tag push still cuts a release.
- Existing **`push: branches: [release]`** trigger retained — current manual path unchanged.
- All checkouts honor \`inputs.ref\` (fallback \`github.ref\`); release \`--target\` is resolved from checked-out \`HEAD\` rather than \`github.sha\` (wrong under \`workflow_call\`).

## Notes for reviewers
- The "Run workflow" button only appears once \`prepare-release.yml\` reaches the repo's **default branch** (\`release\`), i.e. after this merges to \`dev\` and \`dev\` → \`release\`.
- The workflow pushes to \`dev\`/\`release\` with \`GITHUB_TOKEN\`; if those branches have protection requiring PRs, Actions needs bypass permission.