### PR TITLE
feat(intent): --reason for icebox + unmet/met acceptance-criterion status

### DIFF
--- a/atomic-canonical/src/vocab.rs
+++ b/atomic-canonical/src/vocab.rs
@@ -39,11 +39,12 @@ impl NodeType {
 
 /// Intent status value set (mirrors the doc's `IntentShape` `sh:in`).
 /// `rejected` is a terminal state (an intent that was reviewed and turned down).
-pub const INTENT_STATUS: &[&str] =
-    &["backlog", "todo", "in_progress", "done", "rejected"];
+pub const INTENT_STATUS: &[&str] = &["backlog", "todo", "in_progress", "done", "rejected"];
 
-/// Acceptance-criterion status value set.
-pub const AC_STATUS: &[&str] = &["open", "met"];
+/// Acceptance-criterion status value set. `unmet`/`met` are the official values
+/// (an acceptance criterion is either met or not); the legacy `open` is still
+/// accepted by [`is_known_ac_status`] so pre-existing intents keep conforming.
+pub const AC_STATUS: &[&str] = &["unmet", "met"];
 
 /// Directive names recognized by the parser + lift (closed set).
 /// Container directives wrap prose; leaf directives carry only edges.
@@ -127,9 +128,10 @@ pub fn is_known_intent_status(value: &str) -> bool {
     INTENT_STATUS.contains(&value)
 }
 
-/// Is this a valid acceptance-criterion status value?
+/// Is this a valid acceptance-criterion status value? Accepts the official
+/// `unmet`/`met` plus the deprecated legacy `open` (== `unmet`) for back-compat.
 pub fn is_known_ac_status(value: &str) -> bool {
-    AC_STATUS.contains(&value)
+    AC_STATUS.contains(&value) || value == "open"
 }
 
 /// Is this a valid memory kind? Unknown ⇒ gate error (closed vocabulary).

--- a/atomic-canonical/src/vocab.rs
+++ b/atomic-canonical/src/vocab.rs
@@ -38,8 +38,8 @@ impl NodeType {
 }
 
 /// Intent status value set (mirrors the doc's `IntentShape` `sh:in`).
-/// `rejected` is a terminal state (an intent that was reviewed and turned down).
-pub const INTENT_STATUS: &[&str] = &["backlog", "todo", "in_progress", "done", "rejected"];
+/// `icebox` is a terminal state (an intent reviewed and set aside — not built).
+pub const INTENT_STATUS: &[&str] = &["backlog", "todo", "in_progress", "done", "icebox"];
 
 /// Acceptance-criterion status value set. `unmet`/`met` are the official values
 /// (an acceptance criterion is either met or not); the legacy `open` is still

--- a/atomic-canonical/src/vocab.rs
+++ b/atomic-canonical/src/vocab.rs
@@ -38,7 +38,9 @@ impl NodeType {
 }
 
 /// Intent status value set (mirrors the doc's `IntentShape` `sh:in`).
-pub const INTENT_STATUS: &[&str] = &["backlog", "todo", "in_progress", "done"];
+/// `rejected` is a terminal state (an intent that was reviewed and turned down).
+pub const INTENT_STATUS: &[&str] =
+    &["backlog", "todo", "in_progress", "done", "rejected"];
 
 /// Acceptance-criterion status value set.
 pub const AC_STATUS: &[&str] = &["open", "met"];

--- a/atomic-cli/src/commands/intent/new.rs
+++ b/atomic-cli/src/commands/intent/new.rs
@@ -29,11 +29,11 @@ const FEATURE_SCAFFOLD: &str = "\
      content is never graded — but it must be present. Replace this stub. -->
 :::
 
-:::acceptance-criterion{#{id}-ac-1 status=open}
+:::acceptance-criterion{#{id}-ac-1 status=unmet}
 <!-- A single, checkable outcome that means this intent is done. -->
 :::
 
-:::task{#{id}-1 status=open criteria={id}-ac-1}
+:::task{#{id}-1 status=unmet criteria={id}-ac-1}
 <!-- A concrete work item toward the criterion above. Name the file(s) it
      touches with one or more ::file-ref leaves. -->
 ::file-ref{path=path/to/file}

--- a/atomic-cli/src/commands/intent/update.rs
+++ b/atomic-cli/src/commands/intent/update.rs
@@ -40,8 +40,8 @@ pub struct IntentUpdate {
     #[arg(long)]
     pub title: Option<String>,
 
-    /// Rejection reason. Persisted as `rejection_reason` + `rejected_at`
-    /// (normally passed alongside `--status rejected`).
+    /// Reason the intent is being iceboxed. Persisted as `icebox_reason` +
+    /// `iceboxed_at` (normally passed alongside `--status icebox`).
     #[arg(long)]
     pub reason: Option<String>,
 

--- a/atomic-cli/src/commands/intent/update.rs
+++ b/atomic-cli/src/commands/intent/update.rs
@@ -40,6 +40,11 @@ pub struct IntentUpdate {
     #[arg(long)]
     pub title: Option<String>,
 
+    /// Rejection reason. Persisted as `rejection_reason` + `rejected_at`
+    /// (normally passed alongside `--status rejected`).
+    #[arg(long)]
+    pub reason: Option<String>,
+
     /// New Markdown body content, provided inline.
     #[arg(long, conflicts_with = "body_stdin")]
     pub body: Option<String>,
@@ -80,12 +85,13 @@ impl Command for IntentUpdate {
             && self.assignee.is_none()
             && self.priority.is_none()
             && self.title.is_none()
+            && self.reason.is_none()
             && content.is_none()
         {
             return Err(CliError::InvalidArgument {
                 message: "Nothing to update. Provide at least one of \
-                    --status, --assignee, --priority, --title, --body, \
-                    or --body-stdin."
+                    --status, --assignee, --priority, --title, --reason, \
+                    --body, or --body-stdin."
                     .to_string(),
             });
         }
@@ -100,6 +106,7 @@ impl Command for IntentUpdate {
                     priority: self.priority.clone(),
                     title: self.title.clone(),
                     content,
+                    reason: self.reason.clone(),
                     force: self.force,
                 },
             )

--- a/atomic-cli/src/commands/vault/intent.rs
+++ b/atomic-cli/src/commands/vault/intent.rs
@@ -482,6 +482,7 @@ impl Command for IntentUpdate {
                     priority: self.priority.clone(),
                     title: self.title.clone(),
                     content,
+                    reason: None,
                     force: self.force,
                 },
             )

--- a/atomic-repository/src/repository/vault_intent.rs
+++ b/atomic-repository/src/repository/vault_intent.rs
@@ -75,8 +75,8 @@ pub struct IntentUpdateOptions {
     pub title: Option<String>,
     /// New Markdown body content. When `None`, the existing body is kept.
     pub content: Option<String>,
-    /// Rejection reason. When set, persists `rejection_reason` and stamps
-    /// `rejected_at` (normally accompanies `status = rejected`).
+    /// Icebox reason. When set, persists `icebox_reason` and stamps
+    /// `iceboxed_at` (normally accompanies `status = icebox`).
     pub reason: Option<String>,
     /// Allow rewriting the body after the intent has started or been linked.
     pub force: bool,
@@ -500,11 +500,11 @@ impl Repository {
         }
         if let Some(ref reason) = options.reason {
             fm.insert(
-                "rejection_reason".to_string(),
+                "icebox_reason".to_string(),
                 serde_json::Value::String(reason.clone()),
             );
             fm.insert(
-                "rejected_at".to_string(),
+                "iceboxed_at".to_string(),
                 serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
             );
         }

--- a/atomic-repository/src/repository/vault_intent.rs
+++ b/atomic-repository/src/repository/vault_intent.rs
@@ -75,6 +75,9 @@ pub struct IntentUpdateOptions {
     pub title: Option<String>,
     /// New Markdown body content. When `None`, the existing body is kept.
     pub content: Option<String>,
+    /// Rejection reason. When set, persists `rejection_reason` and stamps
+    /// `rejected_at` (normally accompanies `status = rejected`).
+    pub reason: Option<String>,
     /// Allow rewriting the body after the intent has started or been linked.
     pub force: bool,
 }
@@ -493,6 +496,16 @@ impl Repository {
             fm.insert(
                 "title".to_string(),
                 serde_json::Value::String(title.clone()),
+            );
+        }
+        if let Some(ref reason) = options.reason {
+            fm.insert(
+                "rejection_reason".to_string(),
+                serde_json::Value::String(reason.clone()),
+            );
+            fm.insert(
+                "rejected_at".to_string(),
+                serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
             );
         }
         let new_fm = serde_json::to_string(&fm).unwrap_or_else(|_| "{}".to_string());


### PR DESCRIPTION
## Summary
- `atomic intent update` gains a `--reason` flag; when set (typically with `--status icebox`) it persists `icebox_reason` + an `iceboxed_at` (RFC 3339) timestamp to the intent frontmatter (additive; source body untouched).
- Make **unmet/met** the official acceptance-criterion status vocabulary (`vocab::AC_STATUS`); the legacy `open` is still accepted by `is_known_ac_status` so pre-existing intents keep conforming. `intent new` now scaffolds criteria/tasks with `status=unmet`.
- Add `icebox` to `INTENT_STATUS` — a terminal "reviewed but not built" state.

## Notes
This touches the shared canonical vocab, so the full test suite should run in CI.