### PR TITLE
Resolve conflicts in view switch functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,17 @@ fuzz/artifacts/
 
 packages/node_modules/
 packages/dist/
+/outputs/.drafts/atomic-neural-graph-cited.md
+/outputs/.drafts/atomic-neural-graph-draft.md
+/outputs/.drafts/atomic-neural-graph-research-T1.md
+/outputs/.drafts/atomic-neural-graph-research-T2.md
+/outputs/.drafts/atomic-neural-graph-research-T3.md
+/outputs/.drafts/atomic-neural-graph-research-T4.md
+/outputs/.drafts/atomic-neural-graph-research-T5.md
+/outputs/.drafts/atomic-neural-graph-revised.md
+/outputs/.drafts/atomic-neural-graph-verification.md
+/outputs/.plans/atomic-neural-graph-T1.md
+/outputs/.plans/atomic-neural-graph-T2.md
+/outputs/.plans/atomic-neural-graph-T3.md
+/outputs/.plans/atomic-neural-graph-T4.md
+/outputs/.plans/atomic-neural-graph.md

--- a/atomic-agent/src/turn/orchestrator/session_end.rs
+++ b/atomic-agent/src/turn/orchestrator/session_end.rs
@@ -1,7 +1,8 @@
 //! Session end handling for the turn orchestrator.
 
-use crate::error::AgentResult;
+use crate::error::{AgentError, AgentResult};
 use crate::event::TurnEvent;
+use crate::record::{record_turn, TurnRecordOptions};
 use crate::turn::phase::{self, Event, Phase, TransitionContext};
 
 use super::{DispatchResult, TurnOrchestrator};
@@ -39,6 +40,92 @@ impl TurnOrchestrator {
                     session_id,
                     e
                 );
+            }
+        }
+
+        // Flush any unrecorded turn BEFORE finalizing. Headless agents such as
+        // Cursor's CLI fire sessionStart/postToolUse/sessionEnd but no per-turn
+        // `stop` (TurnEnd), so the turn's file changes are still uncommitted at
+        // session end. Record them now — crucially *before* switching back to
+        // the parent view below, which restores the working copy and would
+        // otherwise discard the agent's work. Idempotent: agents that already
+        // recorded each turn on `stop` leave a clean working copy here, so
+        // `record_turn` returns `EmptyTurn` and this is a no-op for them.
+        {
+            // Ensure the working copy is on the session's agent view before
+            // recording. session-start aligns to it, but that can drift back to
+            // the parent view by session end (observed with Cursor's CLI), which
+            // makes `record_turn` see a view mismatch and record nothing. Align
+            // explicitly so the agent's uncommitted files are recorded on the
+            // agent view. Best-effort — non-fatal if it can't switch.
+            match atomic_repository::Repository::open_existing(&self.repo_root) {
+                Ok(mut repo) => {
+                    if repo.current_view() != session.view_name {
+                        if let Err(e) = repo.align_to_view(&session.view_name) {
+                            log::warn!(
+                                "SessionEnd: could not align to agent view '{}': {} (non-fatal)",
+                                session.view_name,
+                                e,
+                            );
+                        } else {
+                            log::info!(
+                                "SessionEnd: aligned working copy to agent view '{}' before flush",
+                                session.view_name,
+                            );
+                        }
+                    }
+                }
+                Err(e) => log::warn!(
+                    "SessionEnd: could not open repo to align view: {} (non-fatal)",
+                    e
+                ),
+            }
+
+            let prompt = event
+                .prompt
+                .clone()
+                .or_else(|| session.current_prompt.clone())
+                .or_else(|| session.first_prompt.clone());
+            let turn_number = session.turn_count + 1;
+            let turn_duration_ms = session.current_turn_duration_ms().unwrap_or(0);
+            let record_result = {
+                let record_options = TurnRecordOptions {
+                    session: &session,
+                    event: &event,
+                    turn_number,
+                    turn_duration_ms,
+                    prompt,
+                };
+                record_turn(&self.repo_root, &record_options)
+            };
+            match record_result {
+                Ok(outcome) => {
+                    session.end_turn();
+                    let recorded_files: Vec<String> = outcome.recorded_file_list().to_vec();
+                    session.add_files_touched(&recorded_files);
+                    session.recorded_change_hashes.push(outcome.hash);
+                    session.clear_current_prompt();
+                    self.inject_reasoning_nodes(session_id, &event);
+                    self.save_turn_provenance(session_id, &session, &outcome, &event);
+                    log::info!(
+                        "SessionEnd flushed a pending turn for session {}: {}",
+                        session_id,
+                        outcome
+                    );
+                }
+                Err(AgentError::EmptyTurn { .. }) => {
+                    log::info!(
+                        "SessionEnd for session {}: no pending changes to flush",
+                        session_id
+                    );
+                }
+                Err(e) => {
+                    log::error!(
+                        "SessionEnd flush-record failed for session {}: {}",
+                        session_id,
+                        e
+                    );
+                }
             }
         }
 

--- a/atomic-cli/src/commands/view/list.rs
+++ b/atomic-cli/src/commands/view/list.rs
@@ -9,26 +9,24 @@
 //! atomic view list [OPTIONS]
 //!
 //! Options:
-//!   -v, --verbose  Show additional details (state hash, change count)
+//!   -s, --short    Show only view names (no metadata)
 //!   -h, --help     Print help information
 //! ```
 //!
 //! # Examples
 //!
-//! List all views:
+//! List all views (default — shows metadata):
 //! ```text
 //! $ atomic view list
-//!   dev
-//! * feature-auth
-//!   release-1.0
+//!   dev              [shared]    (3 changes)                 state: 2AAAAAAAA...
+//! * feature-auth     [draft]     (2 changes, 3 inherited)   state: XYZABCDEF...  parent: dev
 //! ```
 //!
-//! List with verbose output:
+//! Short listing (names only):
 //! ```text
-//! $ atomic view list --verbose
-//!   dev           (0 changes)   state: 2AAAAAAAA...
-//! * feature-auth  (3 changes)   state: XYZABCDEF...
-//!   release-1.0   (10 changes)  state: 123456789...
+//! $ atomic view list --short
+//!   dev
+//! * feature-auth
 //! ```
 
 use clap::Parser;
@@ -47,22 +45,29 @@ use std::path::PathBuf;
 /// List all views.
 ///
 /// Shows all views in the repository with the current view marked
-/// with an asterisk (*).
+/// with an asterisk (*). By default, displays metadata (scope, change
+/// count, state hash, parent). Use `--short` for names only.
 #[derive(Parser, Debug, Default)]
 #[command(name = "list")]
 pub struct List {
+    /// Show only view names (no metadata).
+    #[arg(long, short = 's')]
+    pub short: bool,
+
     /// Show additional details (state hash, change count).
     ///
-    /// When enabled, displays the Merkle state hash and number of
-    /// changes for each view.
-    #[arg(long, short = 'v')]
+    /// This is now the default behavior. Kept for backward compatibility.
+    #[arg(long, short = 'v', hide = true)]
     pub verbose: bool,
 }
 
 impl List {
     /// Create a new List command with default settings.
     pub fn new() -> Self {
-        Self { verbose: false }
+        Self {
+            short: false,
+            verbose: false,
+        }
     }
 
     /// Builder: set the verbose flag.
@@ -99,22 +104,18 @@ impl Command for List {
         let mut sorted_views = views;
         sorted_views.sort();
 
-        // Calculate padding for alignment in verbose mode
+        // Calculate padding for alignment
         let max_name_len = sorted_views.iter().map(|s| s.len()).max().unwrap_or(0);
 
         for view in sorted_views {
             let is_current = view == current;
             let marker = if is_current { "*" } else { " " };
 
-            if self.verbose {
-                // Get view info for verbose output
+            if self.short {
+                println!("{} {}", marker, style_view(&view));
+            } else {
                 match repo.get_view_info(&view) {
                     Ok(info) => {
-                        let change_word = if info.change_count == 1 {
-                            "change"
-                        } else {
-                            "changes"
-                        };
                         let kind_tag = match info.kind_label() {
                             "draft" => "[draft]",
                             _ => "[shared]",
@@ -123,13 +124,27 @@ impl Command for List {
                             Some(p) => format!("  parent: {}", style_view(p)),
                             None => String::new(),
                         };
+                        // Show own changes for views with a parent;
+                        // show total for root views.
+                        let change_display = if info.parent_name.is_some() {
+                            let own = info.own_change_count;
+                            let inherited = info.change_count.saturating_sub(info.own_change_count);
+                            if own == 1 {
+                                format!("({} change, {} inherited)", own, inherited)
+                            } else {
+                                format!("({} changes, {} inherited)", own, inherited)
+                            }
+                        } else if info.change_count == 1 {
+                            format!("({} change)", info.change_count)
+                        } else {
+                            format!("({} changes)", info.change_count)
+                        };
                         println!(
-                            "{} {:<width$}  {:<10}  ({} {})  state: {}{}",
+                            "{} {:<width$}  {:<10}  {}  state: {}{}",
                             marker,
                             style_view(&view),
                             kind_tag,
-                            info.change_count,
-                            change_word,
+                            change_display,
                             info.state_short(),
                             parent_info,
                             width = max_name_len
@@ -140,8 +155,6 @@ impl Command for List {
                         println!("{} {}", marker, style_view(&view));
                     }
                 }
-            } else {
-                println!("{} {}", marker, style_view(&view));
             }
         }
 
@@ -185,13 +198,14 @@ mod tests {
     #[test]
     fn test_default() {
         let cmd = List::default();
+        assert!(!cmd.short);
         assert!(!cmd.verbose);
     }
 
     #[test]
     fn test_new() {
         let cmd = List::new();
-        assert!(!cmd.verbose);
+        assert!(!cmd.short);
     }
 
     #[test]
@@ -221,7 +235,7 @@ mod tests {
         // Change to the repo directory
         std::env::set_current_dir(repo_path).unwrap();
 
-        // List views
+        // List views (default = verbose)
         let cmd = List::new();
         let result = cmd.run();
         assert!(result.is_ok());
@@ -271,7 +285,7 @@ mod tests {
         // Change to the repo directory
         std::env::set_current_dir(repo_path).unwrap();
 
-        // List views with verbose output
+        // List views with verbose output (same as default now)
         let cmd = List::new().with_verbose(true);
         let result = cmd.run();
         assert!(result.is_ok());

--- a/atomic-core/src/merge/engine.rs
+++ b/atomic-core/src/merge/engine.rs
@@ -13,7 +13,7 @@
 //! * `T` — a read-only graph transaction implementing [`GraphTxnT`]
 //! * `C` — a change store implementing [`ChangeStore`]
 
-use super::three_way::{three_way_merge, tokenize, ThreeWayResult};
+use super::three_way::{three_way_merge, tokenize, MergeToken, ThreeWayResult};
 use super::{ConflictGroup, MergeOutcome, MergeSource};
 use crate::change::ChangeStore;
 use crate::pristine::{GraphTxnT, PristineError};
@@ -87,99 +87,189 @@ impl<'a, T: GraphTxnT, C: ChangeStore> SemanticMergeEngine<'a, T, C> {
     ///
     /// Returns [`PristineError`] on database access failure.
     pub fn try_merge(&self, group: &ConflictGroup) -> Result<MergeOutcome, PristineError> {
-        // Only two-way conflicts are candidates (the most common case).
-        if group.vertex_count() != 2 {
+        // ── Step 1: Read content for every vertex in the group ────────
+        //
+        // If any vertex's content is unreadable we give up immediately.
+        let mut vertex_contents: Vec<(GraphNode<NodeId>, Vec<u8>)> = Vec::new();
+        for v in &group.vertices {
+            match self.get_vertex_content(v) {
+                Ok(c) => vertex_contents.push((*v, c)),
+                Err(e) => {
+                    log::debug!("try_merge: cannot read vertex {}: {}", v, e);
+                    return Ok(MergeOutcome::NoCrdtData);
+                }
+            }
+        }
+        if vertex_contents.is_empty() {
+            return Ok(MergeOutcome::NoCrdtData);
+        }
+
+        // ── Step 2: Deduplicate identical-content vertices ────────────
+        //
+        // Collapse vertices that share byte-identical content into a
+        // single representative.  This handles the common N-way fork
+        // where multiple concurrent changes insert the same whitespace
+        // or the same boilerplate line.  Indices of surviving (unique)
+        // vertices are collected in `unique`; everything else lands in
+        // `skipped` so the caller can mark them.
+        let mut unique: Vec<usize> = vec![0];
+        let mut skipped: Vec<usize> = Vec::new();
+        for i in 1..vertex_contents.len() {
+            if unique
+                .iter()
+                .any(|&j| vertex_contents[j].1 == vertex_contents[i].1)
+            {
+                skipped.push(i);
+            } else {
+                unique.push(i);
+            }
+        }
+
+        // All vertices identical — no conflict at all.
+        if unique.len() == 1 && !skipped.is_empty() {
+            log::info!(
+                "try_merge: all {} vertices identical ({} bytes), deduplicating",
+                vertex_contents.len(),
+                vertex_contents[0].1.len(),
+            );
+            return Ok(MergeOutcome::AutoMerged {
+                content: vertex_contents[0].1.clone(),
+                sources: vec![MergeSource::new(vertex_contents[0].0.change, 0)],
+            });
+        }
+
+        // Partial dedup: log, but continue with the unique subset.
+        if !skipped.is_empty() {
+            log::info!(
+                "try_merge: dedup reduced {}-way fork to {}-way",
+                vertex_contents.len(),
+                unique.len(),
+            );
+        }
+
+        // After dedup we need exactly 2 unique sides for the merge
+        // pipeline below.  If there are still >2 unique sides, return
+        // NoCrdtData and let the caller emit markers for what remains.
+        if unique.len() != 2 {
             log::debug!(
-                "SemanticMergeEngine::try_merge: skipping {}-way conflict (only 2-way supported)",
-                group.vertex_count(),
+                "try_merge: {}-way conflict after dedup (only 2-way supported)",
+                unique.len(),
             );
             return Ok(MergeOutcome::NoCrdtData);
         }
 
-        let v_left = &group.vertices[0];
-        let v_right = &group.vertices[1];
+        let (v_left, left_content) = &vertex_contents[unique[0]];
+        let (v_right, right_content) = &vertex_contents[unique[1]];
 
-        // Step 1-2: Get content bytes for both competing vertices.
-        let left_content = match self.get_vertex_content(v_left) {
-            Ok(c) => c,
-            Err(e) => {
-                log::debug!(
-                    "SemanticMergeEngine::try_merge: cannot read left vertex {}: {}",
-                    v_left,
-                    e,
-                );
-                return Ok(MergeOutcome::NoCrdtData);
-            }
-        };
-
-        let right_content = match self.get_vertex_content(v_right) {
-            Ok(c) => c,
-            Err(e) => {
-                log::debug!(
-                    "SemanticMergeEngine::try_merge: cannot read right vertex {}: {}",
-                    v_right,
-                    e,
-                );
-                return Ok(MergeOutcome::NoCrdtData);
-            }
-        };
-
-        // Step 3: Find the common ancestor vertex (the dead vertex both sides
-        // replaced). Try the explicit `ancestor` field first, then fall back
-        // to graph-based discovery using the `parent` field.
+        // ── Step 3: Find the base (ancestor) for three-way merge ─────
+        //
+        // Strategy:
+        //   a) Explicit ancestor on the ConflictGroup
+        //   b) Graph-based ancestor discovery (dead vertex deleted by both)
+        //   c) Subsumption: use the shorter side as base (handles
+        //      concurrent insertions where one side is a token-level
+        //      superset of the other)
         let base_content = if let Some(ref ancestor) = group.ancestor {
             match self.get_vertex_content(ancestor) {
-                Ok(c) => c,
+                Ok(c) => Some(c),
                 Err(e) => {
-                    log::debug!(
-                        "SemanticMergeEngine::try_merge: cannot read ancestor {}: {}",
-                        ancestor,
-                        e,
-                    );
-                    return Ok(MergeOutcome::NoCrdtData);
+                    log::debug!("try_merge: cannot read ancestor {}: {}", ancestor, e);
+                    None
                 }
             }
         } else if let Some(ref parent) = group.parent {
             match self.find_ancestor_content(parent, v_left.change, v_right.change) {
-                Ok(Some(content)) => content,
-                Ok(None) => {
-                    log::debug!(
-                        "SemanticMergeEngine::try_merge: no ancestor found from parent {}",
-                        parent,
-                    );
-                    return Ok(MergeOutcome::NoCrdtData);
-                }
+                Ok(content) => content, // Some or None
                 Err(e) => {
-                    log::debug!(
-                        "SemanticMergeEngine::try_merge: ancestor search failed: {}",
-                        e,
-                    );
-                    return Ok(MergeOutcome::NoCrdtData);
+                    log::debug!("try_merge: ancestor search failed: {}", e);
+                    None
                 }
             }
         } else {
-            log::debug!(
-                "SemanticMergeEngine::try_merge: no ancestor or parent available, \
-                 falling back to NoCrdtData",
-            );
-            return Ok(MergeOutcome::NoCrdtData);
+            None
         };
 
-        // Step 5: Tokenize all three versions.
-        let base_tokens = tokenize(&base_content);
-        let left_tokens = tokenize(&left_content);
-        let right_tokens = tokenize(&right_content);
+        // ── Step 4: Three-way merge (ancestor → left, ancestor → right) ─
+        if let Some(ref base) = base_content {
+            let result = self.run_three_way(base, left_content, right_content, v_left, v_right);
+            if !matches!(result, Ok(MergeOutcome::NoCrdtData)) {
+                return result;
+            }
+        }
 
-        // Step 6-7-8: Three-way merge at the token level.
+        // ── Step 5: Subsumption for concurrent insertions ────────────
+        //
+        // No dead ancestor exists (both sides are pure additions).
+        // Check if one side's tokens are a subsequence of the other's.
+        // If so, the superset side subsumes the other and wins.
+        //
+        // This handles:
+        //   "{A, B, C}"  vs  "{A, B, C, D, E}"  →  keep the superset
+        //   "\n"         vs  "use HashMap;\n"    →  keep the longer one
+        let left_tokens = tokenize(left_content);
+        let right_tokens = tokenize(right_content);
+
+        // Check: are right's tokens a subsequence of left's? (left ⊇ right)
+        if is_token_subsequence(&right_tokens, &left_tokens) {
+            log::info!(
+                "try_merge: subsumption resolved ({} ⊇ {} bytes)",
+                left_content.len(),
+                right_content.len(),
+            );
+            return Ok(MergeOutcome::AutoMerged {
+                content: left_content.clone(),
+                sources: vec![
+                    MergeSource::new(v_left.change, left_tokens.len()),
+                    MergeSource::new(v_right.change, 0),
+                ],
+            });
+        }
+
+        // Check: are left's tokens a subsequence of right's? (right ⊇ left)
+        if is_token_subsequence(&left_tokens, &right_tokens) {
+            log::info!(
+                "try_merge: subsumption resolved ({} ⊇ {} bytes, reverse)",
+                right_content.len(),
+                left_content.len(),
+            );
+            return Ok(MergeOutcome::AutoMerged {
+                content: right_content.clone(),
+                sources: vec![
+                    MergeSource::new(v_right.change, right_tokens.len()),
+                    MergeSource::new(v_left.change, 0),
+                ],
+            });
+        }
+
+        log::debug!(
+            "try_merge: no resolution for concurrent insertion ({} vs {} bytes)",
+            left_content.len(),
+            right_content.len(),
+        );
+        Ok(MergeOutcome::NoCrdtData)
+    }
+
+    /// Run a three-way merge given a known base.
+    fn run_three_way(
+        &self,
+        base: &[u8],
+        left: &[u8],
+        right: &[u8],
+        v_left: &GraphNode<NodeId>,
+        v_right: &GraphNode<NodeId>,
+    ) -> Result<MergeOutcome, PristineError> {
+        let base_tokens = tokenize(base);
+        let left_tokens = tokenize(left);
+        let right_tokens = tokenize(right);
+
         match three_way_merge(&base_tokens, &left_tokens, &right_tokens) {
             ThreeWayResult::Merged(content) => {
                 log::debug!(
-                    "SemanticMergeEngine::try_merge: auto-merged {} + {} → {} bytes",
-                    left_content.len(),
-                    right_content.len(),
+                    "try_merge: auto-merged {} + {} → {} bytes",
+                    left.len(),
+                    right.len(),
                     content.len(),
                 );
-
                 let left_token_count = left_tokens
                     .iter()
                     .zip(base_tokens.iter())
@@ -190,7 +280,6 @@ impl<'a, T: GraphTxnT, C: ChangeStore> SemanticMergeEngine<'a, T, C> {
                     .zip(base_tokens.iter())
                     .filter(|(r, b)| r != b)
                     .count();
-
                 Ok(MergeOutcome::AutoMerged {
                     content,
                     sources: vec![
@@ -200,15 +289,11 @@ impl<'a, T: GraphTxnT, C: ChangeStore> SemanticMergeEngine<'a, T, C> {
                 })
             }
             ThreeWayResult::Conflict => {
-                log::debug!(
-                    "SemanticMergeEngine::try_merge: conflict between {} and {}",
-                    v_left,
-                    v_right,
-                );
+                log::debug!("try_merge: conflict between {} and {}", v_left, v_right);
                 Ok(MergeOutcome::Conflict {
-                    base: base_content,
-                    left: left_content,
-                    right: right_content,
+                    base: base.to_vec(),
+                    left: left.to_vec(),
+                    right: right.to_vec(),
                     left_change: v_left.change,
                     right_change: v_right.change,
                 })
@@ -290,6 +375,33 @@ impl<'a, T: GraphTxnT, C: ChangeStore> SemanticMergeEngine<'a, T, C> {
 
         Ok(None)
     }
+}
+
+/// Check whether `sub`'s tokens are a subsequence of `sup`'s tokens.
+///
+/// A subsequence means every token in `sub` appears in `sup` in the
+/// same order, possibly with extra tokens interspersed in `sup`.
+///
+/// This is used for concurrent insertion resolution: if side A's tokens
+/// are a subsequence of side B's, then B is a superset that contains
+/// everything A has plus more — B subsumes A.
+fn is_token_subsequence(sub: &[MergeToken], sup: &[MergeToken]) -> bool {
+    if sub.is_empty() {
+        return true;
+    }
+    if sub.len() > sup.len() {
+        return false;
+    }
+    let mut si = 0; // index into sub
+    for token in sup {
+        if token == &sub[si] {
+            si += 1;
+            if si == sub.len() {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 // ===========================================================================

--- a/atomic-core/src/output/repo/content.rs
+++ b/atomic-core/src/output/repo/content.rs
@@ -411,8 +411,8 @@ where
                 resolved.insert_unresolved_fork(fork.children.clone());
             }
             Ok(MergeOutcome::NoCrdtData) | Ok(MergeOutcome::Clean(_)) => {
-                // No CRDT data — still need to wrap the fork in markers
-                // so both sides are visible to the user.
+                // NoCrdtData after dedup means >2 unique sides remain.
+                // Emit markers for all children.
                 resolved.insert_unresolved_fork(fork.children.clone());
             }
             Err(e) => {

--- a/atomic-repository/src/repository/views.rs
+++ b/atomic-repository/src/repository/views.rs
@@ -10,8 +10,12 @@ pub struct ViewInfo {
     pub name: String,
     /// The current Merkle state (hash of all inserted changes)
     pub state: Merkle,
-    /// The number of changes inserted into this view
+    /// Total number of changes in this view's VIEW_CHANGES
+    /// (includes inherited changes for draft views).
     pub change_count: u64,
+    /// Number of changes unique to this view (not in the parent).
+    /// For shared views or views without a parent, this equals `change_count`.
+    pub own_change_count: u64,
     /// View scope (Draft or Shared)
     pub scope: ViewScope,
     /// Parent view name, if any
@@ -509,19 +513,30 @@ impl Repository {
                 name: name.to_string(),
             })?;
 
-        // Resolve parent name if the view has a parent
-        let parent_name = if let Some(parent_id) = view.parent {
-            txn.get_view_by_id(parent_id)
+        // Resolve parent name and compute own change count.
+        let (parent_name, parent_change_count) = if let Some(parent_id) = view.parent {
+            match txn
+                .get_view_by_id(parent_id)
                 .map_err(|e| RepositoryError::Database(e.to_string()))?
-                .map(|p| p.name)
+            {
+                Some(p) => (Some(p.name), p.change_count),
+                None => (None, 0),
+            }
         } else {
-            None
+            (None, 0)
+        };
+
+        let own_change_count = if view.parent.is_some() {
+            view.change_count.saturating_sub(parent_change_count)
+        } else {
+            view.change_count
         };
 
         Ok(ViewInfo {
             name: view.name.clone(),
             state: view.state,
             change_count: view.change_count,
+            own_change_count,
             scope: view.kind,
             parent_name,
         })

--- a/papers/atomic-neural-graph.md
+++ b/papers/atomic-neural-graph.md
@@ -1,0 +1,332 @@
+# Learned Representations of the Patch Monoid: A Position Paper on Neural Graph Embeddings for the Semantic Change Graph
+
+**Lee Faus, July 2026**
+
+---
+
+## Abstract
+
+We argue that the *semantic change graph* — a content-addressed DAG where changes are composable operations with typed edges, CRDT hierarchy, and view-filter semantics — admits a natural class of neural representations that no snapshot-based VCS can support. The key insight is that the patch monoid $(M, \circ)$ underlying such systems has structure that a learned homomorphism $\rho: M \to \text{GL}(V)$ can exploit: composition becomes matrix multiplication, independence becomes commutativity, and **conflict detection reduces to measuring non-commutativity** via the Lie bracket $\|[\rho_A, \rho_B]\|$.
+
+We formalize five invariants that such a representation must satisfy, propose a four-layer encoder architecture that mirrors the data model of Atomic (a patch-theory VCS built in Rust), and show that the resulting system — a *Patch Language Model* (PLM) — is feasible at repository scale (10⁴–10⁶ vertices) on commodity hardware. We further argue that content-addressed hashing provides a free, exact join key for cross-project federation, enabling workspace-scale models without entity resolution.
+
+This is a position paper. No experimental results are reported. The contribution is the mathematical framework linking patch algebra to representation theory, the architecture that enforces algebraic invariants by construction, and the argument that this specific combination of properties is unique to the semantic change graph and cannot be replicated atop Git.
+
+---
+
+## 1. Introduction: Why the Semantic Change Graph Changes Everything
+
+Version control systems store code history. The dominant paradigm — Git — represents history as a DAG of *snapshots*: each commit is a complete tree of file contents, and diffs are computed post hoc by comparing trees. Machine learning over Git histories therefore operates on *derived* structure: commit messages, file-level diffs, co-change frequencies, AST deltas. The underlying data model offers no algebraic guarantees.
+
+Atomic takes a fundamentally different approach. Its core data structure is the **semantic change graph**: a content-addressed DAG where changes are first-class composable operations with typed edges, a CRDT semantic hierarchy (Trunk → Branch → Leaf), view-filter semantics, and well-defined dependency relations and commutativity conditions. A file is not a blob; it is a DAG of vertices (content hunks) and edges (ordering relations with typed flags). A "merge" is not a three-way text diff; it is the insertion of change references into a view's filter set, with conflict arising when two changes' graph operations fail to commute.
+
+This structure — the semantic change graph — is precisely the kind of inductive bias that neural networks can exploit, but only if the representation is designed to preserve it. A naive graph neural network over the repository graph would learn *something*, but would not be constrained to respect the patch algebra. We propose a representation that is.
+
+### 1.1 Thesis
+
+**The semantic change graph admits a learned representation — a monoid homomorphism from the patch monoid into a matrix group — that (a) preserves composition, (b) detects conflict via non-commutativity, (c) encodes the CRDT semantic hierarchy in hyperbolic space, and (d) enables four practically useful downstream tasks (conflict prediction, dependency link prediction, content reconstruction, next-change forecasting) via a single self-supervised training objective. This representation is unique to the semantic change graph: no snapshot-based system provides the structure to define or enforce it.**
+
+### 1.2 Why This Cannot Be Done on Git
+
+Three properties of the semantic change graph are essential and absent from Git:
+
+1. **Typed, relational edges.** Atomic's graph has edges carrying `EdgeFlags` (BLOCK, PSEUDO, FOLDER, PARENT, DELETED — 5 base flags, up to 32 combinations). Each edge records which change introduced it (`introduced_by`). Git has no edge types; its DAG is commits pointing to parent commits.
+
+2. **Explicit commutativity.** In Atomic, two changes are independent ($p_A \perp p_B$) if and only if their graph operations touch disjoint vertices and edges. This is a *decidable, structural property* of the changes themselves. In Git, whether two commits "conflict" is an emergent property of the three-way merge algorithm applied to text — it depends on the merge strategy, not the commits' algebraic relationship.
+
+3. **View filters as change-set masks.** Atomic's views are not branches (pointers to commits); they are ordered sets of change references filtering a single canonical graph. The VIEW_CHANGES table *is* the attention mask for neural inference — the architecture constraint (invariant I4) has a direct physical realization in the storage layer.
+
+---
+
+## 2. The Representation: Patch Monoid → Matrix Group
+
+### 2.1 Formal Setup
+
+Let $(M, \circ)$ be the patch monoid: the set of all changes under composition. We seek a representation
+
+$$\rho: M \to \text{GL}(\mathbb{R}^d)$$
+
+such that the homomorphism property holds approximately:
+
+$$\|\rho(p_1 \circ p_2) - \rho(p_1) \cdot \rho(p_2)\| < \epsilon$$
+
+This is enforced during training via a **composition loss**: sample change pairs $(p_1, p_2)$ where $p_1 \circ p_2$ is recorded, compute $\rho$ for all three, and penalize deviation from multiplicativity.
+
+### 2.2 Five Invariants
+
+The representation must satisfy five invariants, each enforced by a specific architectural or training mechanism:
+
+| ID | Invariant | Statement | Mechanism |
+|----|-----------|-----------|-----------|
+| **I1** | Composition | $\rho(p_1 \circ p_2) \approx \rho(p_1) \cdot \rho(p_2)$ | Composition loss |
+| **I2** | Independence = commutativity | $p_A \perp p_B \Rightarrow \rho(p_A)\rho(p_B) = \rho(p_B)\rho(p_A)$ | DeepSets pooling (permutation-invariant by construction) |
+| **I3** | Conflict = non-commutativity | $\|[\rho_A, \rho_B]\| > \tau \Leftrightarrow \text{conflict}(p_A, p_B)$ | Conflict head with bracket loss |
+| **I4** | View filter = attention mask | VIEW_CHANGES membership ≡ forward-pass visibility | Architectural constraint |
+| **I5** | Hierarchy = hyperbolic distance | Trunk–Branch–Leaf ordering preserved by $d_{\mathbb{H}}$ | Curvature objective |
+
+The bracket $[\rho_A, \rho_B] = \rho_A\rho_B - \rho_B\rho_A$ is the Lie bracket (commutator). Its norm is zero for independent changes and non-zero for conflicting ones. This is the core mathematical contribution: **conflict detection is a measurement of non-commutativity in representation space.**
+
+In practice, the full bracket requires $d \times d$ matrix representations per change ($d^2$ parameters). The default is a **bilinear approximation**:
+
+$$\text{conflict\_score}(p_A, p_B) = \sigma\!\left(z_A^\top W_{\text{bracket}}\, z_B \;-\; z_B^\top W_{\text{bracket}}\, z_A\right)$$
+
+where $z_A, z_B \in \mathbb{R}^d$ are change embeddings and $W_{\text{bracket}} \in \mathbb{R}^{d \times d}$ is learned. This captures the antisymmetric structure of the bracket without the $O(d^2)$-per-change storage cost.
+
+### 2.3 Why Hyperbolic Geometry for the CRDT Layer
+
+Atomic's semantic layer is a three-level hierarchy: **Trunk** (file) → **Branch** (line) → **Leaf** (token). Each level has typed IDs (TrunkId, BranchId, LeafId — all 12 bytes: 8-byte NodeId + 4-byte index). This is a tree with branching factor proportional to lines-per-file and tokens-per-line.
+
+Poincaré embeddings [Nickel & Kiela, NeurIPS 2017] demonstrated that **5-dimensional hyperbolic embeddings match 200-dimensional Euclidean embeddings** for hierarchy encoding on WordNet. HGCN [Chami et al., NeurIPS 2019] showed up to **63.1% error reduction** in ROC AUC for link prediction on tree-like graphs (Gromov hyperbolicity δ ≈ 0) using trainable per-layer curvature. Atomic's CRDT tree has δ = 0 — precisely the regime where hyperbolic geometry provides maximum advantage.
+
+The curvature objective enforces:
+
+$$d_{\mathbb{H}}(\text{trunk}, \text{branch}_i) < d_{\mathbb{H}}(\text{trunk}, \text{leaf}_{ij})$$
+$$d_{\mathbb{H}}(\text{branch}_i, \text{branch}_j) > d_{\mathbb{H}}(\text{trunk}, \text{branch}_i) \quad \text{(siblings more distant than parent–child)}$$
+
+Each hierarchy level gets its own learned curvature $c_\ell$ (scalar), following HGCN's approach.
+
+---
+
+## 3. Architecture: Four Layers Mirroring the Data Model
+
+The encoder stack has four layers, each corresponding to a level of Atomic's data model:
+
+```
+L1  Vertex Encoder      GRAPH + INODE_GRAPH       CompGCN (relational convolution)
+L2  Semantic Encoder     CRDT tables (T/B/L)       Poincaré pooling (hyperbolic)
+L3  Change Encoder       touched vertices + ops     DeepSets (set pooling)
+L4  View Encoder         VIEW_CHANGES + DEPS       DAG attention (causal)
+```
+
+This is not an accident. The architecture is the data model's mirror image — each table family maps to exactly one encoder layer, and the encoder invariants map to the algebraic properties of the corresponding data structures.
+
+### 3.1 L1: Relational Graph Convolution (CompGCN)
+
+The repository graph has 32 typed edge relations (combinations of BLOCK, PSEUDO, FOLDER, PARENT, DELETED flags) and each edge records its introducing change. CompGCN [Vashishth et al., ICLR 2020] jointly embeds nodes and relations via composition:
+
+$$h_v^{(\ell+1)} = f\!\left(\sum_{(u,r)\in\mathcal{N}(v)} W_\lambda^{(\ell)} \;\phi(h_u^{(\ell)}, h_r^{(\ell)})\right)$$
+
+where $\phi$ is a composition function (subtraction, multiplication, or circular correlation) and $\lambda \in \{O, I, S\}$ indexes original, inverse, and self-loop weight matrices. This achieves MRR=0.355 on FB15k-237 vs R-GCN's 0.248, with parameter complexity $O(Kd^2 + Bd + B|R|)$ vs R-GCN's $O(BKd^2 + BK|R|)$ — though for Atomic's small $|R| \leq 32$, R-GCN's parameter explosion is manageable and remains a viable baseline.
+
+Relational Graph Attention Networks [Busbridge et al., 2019] were considered and rejected: they empirically underperform spectral methods on transductive tasks with fixed schemas.
+
+**Vertex input features:** content length, content hash (learnable embedding with hash_embed cold-start), is-empty flag (inode markers), change ID embedding, and temporal position (normalized sequence index within the view). The temporal feature is motivated by the finding that static graph structure alone does not improve over sequence models for JIT defect prediction [Milewicz et al., JITGNN, JSS 2024], while temporal graph representations significantly outperform static ones for change propagation [Zaraket et al., IST 2024].
+
+**Configuration:** $d = 64$, 2 layers, $B = 5$ basis vectors, ReLU activation. ~50K parameters.
+
+### 3.2 L2: Poincaré Hierarchy Pooling
+
+L1 vertex embeddings are projected into the Poincaré ball $\mathbb{B}^{16}$ via the exponential map. Leaf embeddings within a branch are aggregated via the Möbius midpoint; branch embeddings are pooled to trunk embeddings likewise. Each level has a learnable curvature scalar $c_\ell$.
+
+$d = 16$ in hyperbolic space. ~5K parameters.
+
+### 3.3 L3: DeepSets Change Encoder
+
+A change touches a *set* of vertices (no canonical ordering). DeepSets [Zaheer et al., NeurIPS 2017] provides a universal approximator for permutation-invariant functions:
+
+$$z_c = \text{MLP}_\phi\!\left(\sum_{v \in \text{touched}(c)} \text{MLP}_\psi(z_v) \;+\; \text{OpEmbed}(c)\right)$$
+
+where OpEmbed$(c)$ sums learned embeddings for each operation in the change (TrunkOp × 4, BranchOp × 3, LeafOp × 4, TokenKind × $k$). This satisfies I2 by construction: permuting the inputs does not change the output.
+
+Set Transformer [Lee et al., ICML 2019] is a richer alternative (attention over sets with inducing points) but adds cost without clear benefit at repository scale. Retained as an ablation option.
+
+$d = 64$. ~20K parameters.
+
+### 3.4 L4: DAG-Aware View Encoder
+
+A view is an ordered set of change references (VIEW_CHANGES) with dependency structure (DEPS). The base encoder is DeepSets over change embeddings; the upgrade applies causal attention after topological sorting by the DEPS partial order — each change attends only to its dependencies.
+
+This naturally implements I4: the VIEW_CHANGES filter *is* the attention mask. Changes outside the view are invisible to the encoder, matching the semantic guarantee of Atomic's view model.
+
+$d = 64$. ~15K parameters.
+
+### 3.5 Total: ~90K Parameters
+
+This is intentionally tiny. A per-repo model should train in minutes on CPU, infer in milliseconds, and cold-start gracefully. The existing `hash_embed` fallback in Atomic's AI module provides the precedent for local-only, no-API-key operation.
+
+---
+
+## 4. Four Prediction Heads, One Self-Supervised Objective
+
+All four heads are trained jointly via self-supervised objectives derived from the repository's own history. No external labels are needed.
+
+### 4.1 Conflict Prediction (Bracket Head)
+
+**Signal:** When two changes produce PSEUDO edges or conflict markers during apply, they are labeled as conflicting. Negative samples: change pairs coexisting in the same view without conflict.
+
+**Evaluation:** F1, precision, recall. The literature baseline is F1 = 0.57–0.68 for the conflict minority class on 267K merge scenarios from 744 GitHub repos [Owhadi-Kareshk et al., ESEM 2019]. Microsoft's ConE system — a non-ML heuristic using file overlap and rarity — achieves >70% developer approval in production on 234 repos [Nitu et al., FSE 2021]. Any learned system must demonstrably outperform these baselines.
+
+**Design note:** Conflict prediction is asymmetric. Safe merges are easy to predict (F1 ~0.96); actual conflicts are the minority class and are hard. The practical application is **filtering likely-safe scenarios**, not precisely predicting conflict.
+
+### 4.2 Dependency Link Prediction
+
+**Signal:** Positive edges from DEPS; negatives from random non-dependent pairs (filtered setting).
+
+**Evaluation:** Filtered MRR, Hits@{1,3,10} with time-split (train on past, test on future). Use strat-MRR [Mohamed et al., AISTATS 2020] to avoid bias toward popular files. Ali et al. (PyKEEN, 2021) found many published KGE results non-reproducible — the evaluation harness must log exact hyperparameters and seeds.
+
+### 4.3 Content Reconstruction (Masked Vertex)
+
+**Signal:** Mask 15% of vertex features; predict from neighborhood context (BERT-style, adapted to graphs). The striff-gnn project uses this exact objective on software graphs.
+
+**Evaluation:** Reconstruction MSE.
+
+### 4.4 Next-Change Forecasting
+
+**Signal:** Given a view's change sequence $[c_1, \ldots, c_t]$, predict $c_{t+1}$.
+
+This is the "language modeling" objective that makes the system a Patch Language Model. The vocabulary is graph operations; the grammar is the patch algebra; a sentence is a view's change history.
+
+**Evaluation:** MRR, Hits@k. Baseline: frequency and recency heuristics. For context, CoEdPilot [ISSTA 2024] achieves 70.8–85.3% edit location accuracy on 180K commits using multi-component neural transformers — the next-change head is a structural analogue at the change level.
+
+---
+
+## 5. The Patch Language Model
+
+### 5.1 Per-Project PLM
+
+A single repository's history (10³–10⁵ changes) trains a small foundation model of that project's evolution:
+
+| Language Model Concept | Patch Language Model |
+|------------------------|---------------------|
+| Vocabulary | GraphOps + TrunkOp/BranchOp/LeafOp + TokenKind + 32 EdgeFlags |
+| Grammar | Patch algebra (composition, dependency closure, context positions) |
+| Sentence | A view's change sequence (VIEW_CHANGES + DEPS partial order) |
+| Next-token objective | $P(c_{t+1} \mid z_{\text{view}})$ |
+| Masked-token objective | Masked vertex/edge prediction over GRAPH |
+
+The PLM is not a prose LLM. It does not generate text or explain code. It computes embeddings, conflict scores, and next-change distributions. It *fronts* an LLM: the PLM provides structural retrieval and scoring; the LLM verbalizes. Math does the reasoning; the LLM does the talking.
+
+### 5.2 Workspace Federation
+
+Three mathematical properties of the semantic change graph make cross-project federation possible — two are unique to content-addressed patch systems:
+
+**Shared structural grammar.** The relation alphabet (EdgeFlags combinations, op types, dependency rules) is project-independent. The L1/L2 encoder layers transfer across projects; only content and change embeddings are project-specific. This parallels multilingual language models: shared syntactic layers, per-language lexicons.
+
+**Content-addressed join keys.** Blake3 hashes are globally content-defined. Two repos recording identical hunks produce identical hashes. A multi-repo corpus requires *zero entity resolution* — concatenation is deduplication. No other VCS-ML pipeline gets this property for free; Git SHAs are content-addressed but Git's data model lacks the semantic change graph's typed-edge structure to make the hashes useful as embedding keys.
+
+**Graph of graphs.** Real cross-repo dependencies exist (atomic-cli depends on atomic-core). The workspace model uses cross-repo attention over a super-graph whose inter-repo edges come from dependency manifests. Blast radius crosses repo boundaries — a capability no tool on the market provides.
+
+### 5.3 The Recursion (Speculative)
+
+Model merging is itself patch theory. Fine-tune the workspace model per project: $\Delta\theta$ is a parameter-space patch. Two divergent fine-tunes are two views; merging them (model soup / task arithmetic) is a weight-space merge whose conflict measure is the same bracket norm $\|[\rho_A, \rho_B]\|$. Atomic can version the weights of the model that versions Atomic's changes — the change DAG of the PLM's own training runs, stored in Atomic, content-addressed, diffable. This is noted as a speculative observation, not a near-term deliverable.
+
+---
+
+## 6. Feasibility and Risks
+
+### 6.1 Scale
+
+At 10⁴–10⁶ vertices per repository, this is tiny by GNN standards. All architectures discussed (R-GCN, CompGCN, HGCN) operate comfortably at this scale on single GPU or CPU. The HGCN reference implementation trains with $d = 16$, 2 layers, 5000 epochs on datasets of comparable size.
+
+### 6.2 Inference in Pure Rust
+
+Candle (Hugging Face's pure-Rust ML framework) supports the operations needed for GNN message passing: `index_select`, `index_add`, `scatter_add`, `matmul`. A complete GCN training implementation in candle exists [wdoppenberg, GitHub gist]. Candle loads safetensors natively via zero-copy memory mapping and achieves near-parity with PyTorch for matmul-dominated workloads (35 tok/s vs 34 tok/s, Llama-3.2-1B, M4 Max). Candle has no C dependencies, matching Atomic's redb choice philosophy. If candle CPU performance proves insufficient, the `ort` crate (ONNX Runtime for Rust, 13M+ downloads) provides a fallback path.
+
+### 6.3 Risk Matrix
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Per-repo distribution shift | Medium | Per-repo self-supervision + hash_embed cold start (precedented) |
+| Small training data (10³–10⁵ changes) | Medium | Intentionally small model (90K params); corpus mode adds generalization |
+| Hyperbolic numerical instability | Medium | Hyperboloid model for computation, Poincaré for display [HGCN]; norm clamping |
+| **Learned indexes on correctness path** | **High** | **Strict policy: embeddings are advisory only.** Merkle stays the identity layer. Conflict scores are warnings, not vetoes. No learned component gates record/apply. |
+| Graph structure adds no value (JITGNN negative result) | Medium | Atomic's graph is richer than ASTs (typed edges, CRDT hierarchy, views). Combine structural + semantic features [Athena pattern]. Ablate to verify. |
+| Evaluation reproducibility | Medium | Log exact hyperparameters, seeds, timestamps. Use strat-MRR for unbiased evaluation. |
+
+The highest-severity risk is deliberate: **learned indexes must never enter the correctness path.** Merkle hashes provide identity, integrity, and convergence. Embeddings provide suggestions, rankings, and early warnings. The separation is a hard architectural constraint, not a policy preference.
+
+---
+
+## 7. Related Work
+
+### 7.1 GNN on Version Control
+
+No prior work applies relational GNNs to semantic change graphs. Existing approaches operate on Git:
+
+- **CC2Vec / commit2vec**: Embed commit diffs as fixed-size vectors for defect prediction. Operate on text diffs, not typed graph operations.
+- **DeepJIT** [Hoang et al., MSR 2019]: End-to-end CNN on commit messages + code diffs. No graph structure.
+- **JITGNN** [Milewicz et al., JSS 2024]: GNN on ASTs of changed code. Notable negative result: graph structure did *not* improve over sequence models. We argue Atomic's richer graph (typed edges, CRDT hierarchy, view structure) provides inductive bias that ASTs lack.
+- **striff-gnn** [GitHub]: Heterogeneous Graph Transformer on software architecture graphs with masked edge reconstruction. Closest in spirit to our content reconstruction head.
+
+### 7.2 Conflict Prediction
+
+- **Owhadi-Kareshk et al.** [ESEM 2019]: ML on Git metadata features. F1 0.57–0.68 on conflict minority class across 267K merge scenarios.
+- **ConE** [Microsoft, FSE 2021]: Non-ML heuristic (file overlap + rarity). Deployed on 234 repos, >70% developer approval.
+- **Al-Refai et al.** [JSMR 2025]: Stacking ensembles. Social + technical features both matter.
+- **Merge-Bench** [Schesch et al., 2025]: 7,938 hunks from 1,439 repos, 11 languages. Best available benchmark for conflict resolution.
+
+All operate on Git. None exploit the semantic change graph's algebraic commutativity.
+
+### 7.3 Impact Analysis
+
+- **Athena** [FSE 2024]: CodeBERT + program dependence graphs for method-level impact analysis. mRR 60.32%, HIT@10 81.48%. Demonstrates that combining structural and semantic information outperforms either alone — a finding we build on.
+- **Rex** [Microsoft, NSDI 2020]: Correlated change analysis for production services.
+- **CoEdPilot** [ISSTA 2024]: Multi-component neural system for ripple-effect estimation. Edit location accuracy 70.8–85.3%.
+- **Temporal graph approaches** [Zaraket et al., IST 2024]: Temporal Graph Networks outperform static graphs for change propagation.
+
+### 7.4 Hyperbolic Embeddings
+
+- **Poincaré Embeddings** [Nickel & Kiela, NeurIPS 2017]: 5D hyperbolic ≈ 200D Euclidean for hierarchy encoding.
+- **HGCN** [Chami et al., NeurIPS 2019]: First inductive hyperbolic GCN. Trainable per-layer curvature. Up to 63.1% error reduction on tree-like graphs.
+- **MuRP** [Balažević et al., NeurIPS 2019]: Per-relation transformations in Poincaré ball for multi-relational KGs.
+
+---
+
+## 8. Conclusion
+
+We have argued that the semantic change graph possesses mathematical structure — the patch monoid, typed relational edges, explicit commutativity, CRDT hierarchies, and view-filter semantics — that admits a class of learned representations unavailable to snapshot-based systems. The representation is a monoid homomorphism enforced by five invariants, realized through a four-layer encoder mirroring the data model, and trained via self-supervised objectives requiring no external labels.
+
+The practical payoff is a *Patch Language Model*: a small (~90K parameter), local, per-project foundation model that provides conflict early-warning, dependency prediction, blast-radius estimation, and next-change forecasting — all advisory, never on the correctness path. Content-addressed hashing provides free cross-project join keys for workspace federation.
+
+The unique contribution is not any individual component (GNNs, hyperbolic embeddings, DeepSets, and conflict prediction all exist independently) but their *composition under the constraints of patch algebra*. The invariants are not regularizers added for aesthetic reasons; they are structural properties of the data model that the representation must preserve to be useful. This is the sense in which the architecture is the data model's mirror image.
+
+No experiments are reported. The position is falsifiable: if the bracket norm does not separate conflicting from independent change pairs, the central thesis fails. We consider this the first experiment worth running.
+
+---
+
+## References
+
+1. Schlichtkrull, M. et al. "Modeling Relational Data with Graph Convolutional Networks." ESWC 2018. https://arxiv.org/abs/1703.06103
+2. Vashishth, S. et al. "Composition-based Multi-Relational Graph Convolutional Networks." ICLR 2020. https://arxiv.org/abs/1911.03082
+3. Busbridge, D. et al. "Relational Graph Attention Networks." 2019. https://arxiv.org/abs/1904.05811
+4. Nickel, M. & Kiela, D. "Poincaré Embeddings for Learning Hierarchical Representations." NeurIPS 2017. https://arxiv.org/abs/1705.08039
+5. Chami, I. et al. "Hyperbolic Graph Convolutional Neural Networks." NeurIPS 2019. https://arxiv.org/abs/1910.12933
+6. Balažević, I. et al. "Multi-relational Poincaré Graph Embeddings." NeurIPS 2019.
+7. Zaheer, M. et al. "Deep Sets." NeurIPS 2017. https://arxiv.org/abs/1703.06114
+8. Lee, J. et al. "Set Transformer: A Framework for Attention-based Permutation-Invariant Input." ICML 2019. https://arxiv.org/abs/1810.00825
+9. Owhadi-Kareshk, M. et al. "Predicting Merge Conflicts in Collaborative Software Development." ESEM 2019. https://arxiv.org/abs/1907.06274
+10. Nitu, P. et al. "ConE: A Concurrent Edit Detection Tool for Large Scale Software Development." FSE 2021. https://ar5iv.labs.arxiv.org/html/2101.06542
+11. Al-Refai, M. et al. "Merge Conflict Prediction Using Feature Selection and Stacking Heterogeneous Ensembles." JSMR 2025. https://doi.org/10.1002/smr.70047
+12. Milewicz, R. et al. "JITGNN: A Deep Graph Neural Network Framework for Just-In-Time Bug Prediction." JSS 2024. https://doi.org/10.1016/j.jss.2024.111984
+13. Yan, Y. et al. "Athena: Enhancing Code Understanding for Impact Analysis by Combining Transformers and PDGs." FSE 2024. https://doi.org/10.1145/3643770
+14. Zaraket, F. et al. "Change propagation using Temporal Graphs and GNNs." IST 2024.
+15. Mehta, S. et al. "Rex: Preventing Bugs and Misconfiguration Failures Using Correlated Change Analysis." NSDI 2020. https://www.usenix.org/system/files/nsdi20-paper-mehta.pdf
+16. Hoang, T. et al. "DeepJIT: An End-to-End Deep Learning Framework for Just-In-Time Defect Prediction." MSR 2019.
+17. CoEdPilot. ISSTA 2024. https://arxiv.org/html/2408.01733v1
+18. Schesch, B. et al. "Merge-Bench." 2025. https://github.com/benedikt-schesch/Merge-Bench
+19. Bordes, A. et al. "Translating Embeddings for Modeling Multi-relational Data." NeurIPS 2013.
+20. Berrendorf, M. et al. "A Unified Framework for Rank-based Evaluation Metrics for Link Prediction in Knowledge Graphs." 2022. https://arxiv.org/abs/2203.07544
+21. Mohamed, E. et al. "Popularity Agnostic Evaluation of Knowledge Graph Embeddings." AISTATS 2020.
+22. Ali, M. et al. "Bringing Light Into the Dark: A Large-scale Evaluation of Knowledge Graph Embedding Models Under a Unified Framework." (PyKEEN). 2021.
+23. Vale, G. et al. "Predicting merge conflicts considering social and technical assets." EMSE 2023. https://link.springer.com/article/10.1007/s10664-023-10395-8
+24. Candle ML Framework. Hugging Face. https://github.com/huggingface/candle
+25. Safetensors Format. Hugging Face. https://github.com/huggingface/safetensors
+26. wdoppenberg. "GCN ENZYMES in Candle." GitHub Gist. https://gist.github.com/wdoppenberg/a22847d84ab55002e002d7828eb03934
+27. Candle GCNConv Discussion #2151. https://github.com/huggingface/candle/discussions/2151
+28. ort — ONNX Runtime for Rust. https://github.com/pykeio/ort
+29. striff-gnn. https://github.com/hadi-technology/striff-gnn
+30. Dias, A. et al. "On the Prediction of Software Merge Conflicts: A Systematic Literature Review." ACM 2023. https://dl.acm.org/doi/fullHtml/10.1145/3592813.3592931
+
+---
+
+## Appendix A: Proposed Implementation Outline
+
+The position paper's architecture maps to two codebases:
+
+**Rust crate (`atomic-neural`):** Export pipeline (read-only pristine → Parquet), candle-based inference (CompGCN + Poincaré + DeepSets + DAG attention + 4 heads), CHANGE_EMBEDDINGS table in pristine, CLI integration (`atomic neural export`, `atomic neural embed`, conflict score in `record` output, `atomic change --similar`).
+
+**Python package (`neural/`):** PyTorch Geometric training with geoopt for Poincaré operations. Self-supervised multi-objective training loop. Weight export via safetensors. Evaluation harness with filtered MRR, Hits@k, F1, strat-MRR, and seed logging.
+
+**Export schema:** Corpus-ready from day one. Per-repo directories with `manifest.json` + Parquet tables (nodes, edges, changes, views, CRDT trunks/branches/leaves, deps). `repo_id` + content-addressed `hash` columns provide globally unique join keys across repos.
+
+**Schema addition:** `CHANGE_EMBEDDINGS: TableDefinition<u64, &[u8]>` in redb, keyed by change NodeId, following the existing EMBEDDINGS table pattern.

--- a/papers/atomic-neural-graph.provenance.md
+++ b/papers/atomic-neural-graph.provenance.md
@@ -1,0 +1,24 @@
+# Provenance: Learned Representations of the Patch Monoid — Position Paper
+
+- **Date:** 2026-07-19
+- **Rounds:** 1 research round (4 parallel researchers + lead codebase inspection), 1 review pass, 1 rewrite (implementation plan → position paper)
+- **Sources consulted:** 40+ (13 GNN/hyperbolic papers, 27 conflict/evaluation/software-ML papers, 18 Rust ML sources, 6 Atomic codebase modules)
+- **Sources accepted:** 30 (numbered references in final paper)
+- **Sources rejected:** None dead; safetensors URL returns 301 redirect (still accessible)
+- **Verification:** PASS WITH NOTES
+  - Bracket computation: bilinear approximation set as default; full bracket noted as ablation
+  - Temporal features: added to L1 input features per JITGNN/temporal-graph evidence
+  - All key source URLs verified reachable (curl spot-check)
+  - Codebase claims verified via direct code inspection (EdgeFlags, CRDT tables, ai/ module, EMBEDDINGS table)
+  - No experimental results reported or claimed — position paper explicitly states this
+- **Plan:** outputs/.plans/atomic-neural-graph.md
+- **Research files:**
+  - outputs/.drafts/atomic-neural-graph-research-T1.md (GNN + hyperbolic)
+  - outputs/.drafts/atomic-neural-graph-research-T2.md (self-supervised VCS ML)
+  - outputs/.drafts/atomic-neural-graph-research-T3.md (candle/Rust inference)
+  - outputs/.drafts/atomic-neural-graph-research-T4.md (conflict prediction + eval)
+  - outputs/.drafts/atomic-neural-graph-research-T5.md (Atomic codebase inspection)
+  - outputs/.drafts/atomic-neural-graph-draft.md (original implementation plan draft)
+  - outputs/.drafts/atomic-neural-graph-verification.md (review findings)
+  - outputs/.drafts/atomic-neural-graph-revised.md (revised implementation plan)
+- **Final form:** Position paper (merged from design doc + provenance; implementation details condensed to Appendix A)

--- a/research.md
+++ b/research.md
@@ -1,0 +1,340 @@
+# T4: Conflict Prediction + Software Graph ML Evaluation — Research Findings
+
+## Evidence Table
+
+| # | Source | URL | Key Claim | Type | Confidence |
+|---|--------|-----|-----------|------|------------|
+| 1 | Owhadi-Kareshk et al., "Predicting Merge Conflicts in Collaborative Software Development" (ESEM 2019) | https://arxiv.org/abs/1907.06274 | F1 0.95–0.97 for safe merges, 0.57–0.68 for conflicts; 9 Git feature sets; 267K merge scenarios from 744 repos | primary | high |
+| 2 | Dias et al., "On the Prediction of Software Merge Conflicts" (ACM 2023, systematic review) | https://dl.acm.org/doi/fullHtml/10.1145/3592813.3592931 | 50% of conflict prediction studies use ML; hybrid multi-factor approaches recommended | secondary | high |
+| 3 | Al-Refai et al., "Merge Conflict Prediction Using Feature Selection and Stacking Heterogeneous Ensembles" (JSMR 2025) | https://doi.org/10.1002/smr.70047 | Stack-SVM best ensemble; social + technical features both important; DT best individual model | primary | high |
+| 4 | Vale et al., "Predicting merge conflicts considering social and technical assets" (EMSE 2023) | https://link.springer.com/article/10.1007/s10664-023-10395-8 | Social features (developer identity, team overlap) improve conflict prediction beyond technical-only | primary | medium |
+| 5 | Ziegler, "GITCoP: ML-Based Approach to Predicting Merge Conflicts from Repository Metadata" (Master's thesis) | https://www.se.cs.uni-saarland.de/theses/ThomasZieglerMA.pdf | Repository metadata features for conflict prediction | primary | medium |
+| 6 | ConE: Concurrent Edit Detection (Microsoft, FSE 2021) | https://ar5iv.labs.arxiv.org/html/2101.06542 | Deployed on 234 Microsoft repos; 26K PRs assessed, 775 recommendations, >70% rated useful; uses Extent of Overlap + Rarely Concurrently Edited files | primary | high |
+| 7 | Berrendorf et al., "A Unified Framework for Rank-based Evaluation Metrics for Link Prediction in KGs" (2022) | https://arxiv.org/abs/2203.07544 | Unified framework for MRR, Hits@k; proposes adjusted metrics for interpretability | primary | high |
+| 8 | Sun et al., "Revisiting the Evaluation Protocol of KG Completion Methods" (WWW 2021) | https://dl.acm.org/doi/fullHtml/10.1145/3442381.3449856 | Standard ranking protocol critique; filtered vs raw setting matters | primary | high |
+| 9 | Bordes et al., "Translating Embeddings for Modeling Multi-relational Data" (NeurIPS 2013) | https://proceedings.neurips.cc/paper_files/paper/2013/file/1cecc7a77928ca8133fa24680a88d2f9-Paper.pdf | TransE: foundational KG embedding; entity ranking evaluation protocol | primary | high |
+| 10 | Ali et al., "Bringing Light Into the Dark: Large-scale Evaluation of KGE Models" (PyKEEN) | https://backend.orbit.dtu.dk/ws/files/262633429/Bringing_Light_Into_the_Dark_A_Large_scale_Evaluation_of_Knowledge_Graph_Embedding_Models_under_a_Unified_Framework.pdf | Re-implemented 21 KGE models in PyKEEN; many results not reproducible with reported hyperparams | primary | high |
+| 11 | Yan et al., "Athena: Enhancing Code Understanding for Impact Analysis by Combining Transformers and PDGs" (FSE 2024) | https://doi.org/10.1145/3643770 | mRR 60.32%, mAP 35.19%, HIT@10 81.48%; CodeBERT + program dependence graphs; 25 OSS projects | primary | high |
+| 12 | Zaraket et al., "Change propagation using Temporal Graphs and GNNs" (IST 2024) | https://dl.acm.org/doi/10.1016/j.infsof.2023.107368 | Temporal Graph Network + LSTM for file-level change propagation; outperforms prior work | primary | high |
+| 13 | Mehta et al., "Rex: Preventing Bugs via Correlated Change Analysis" (NSDI 2020, Microsoft) | https://www.usenix.org/system/files/nsdi20-paper-mehta.pdf | Correlated change analysis in large services; detects missing co-changes to prevent bugs | primary | high |
+| 14 | Hoang et al., "DeepJIT: End-to-End Deep Learning for JIT Defect Prediction" (MSR 2019) | https://doi.org/10.1109/msr.2019.00016 | CNN on commit messages + code changes; end-to-end, no manual features; outperforms traditional JIT | primary | high |
+| 15 | Milewicz et al., "JITGNN: Deep GNN for Just-In-Time Bug Prediction" (JSS 2024) | https://doi.org/10.1016/j.jss.2024.111984 | GNN on ASTs of changed programs; same AUC as JITLine (state-of-art); graph structure doesn't improve over sequence | primary | high |
+| 16 | Schesch et al., "Resolve Merge Conflicts with LLMs" + Merge-Bench dataset (2025) | https://arxiv.org/html/2605.25890v1 | 7938 hunks from 1439 repos, 11 languages; LLMergeJ 14B via GRPO; best models <60% correct resolution | primary | high |
+| 17 | Merge-Bench GitHub (evaluation toolkit) | https://github.com/benedikt-schesch/Merge-Bench | Public benchmark for merge conflict resolution; 5 evaluation metrics | primary | high |
+| 18 | MergeConflictBench (Create Inc, 2024) | https://github.com/Create-Inc/merge-conflict-bench | 86 real conflicts from React/Next.js/React Native production code | primary | medium |
+| 19 | ConGra dataset (HKU, 2024) | https://github.com/HKU-System-Security-Lab/ConGra | Large-scale multilingual conflict resolution dataset | primary | medium |
+| 20 | AgenticFlict dataset (Zenodo, 2025) | https://zenodo.org/records/20118379 | Merge conflicts from AI coding agent PRs on GitHub | primary | medium |
+| 21 | CoEdPilot (ISSTA 2024) | https://arxiv.org/html/2408.01733v1 | Edit location accuracy 70.8–85.3%, content exact match 41.8%, BLEU4 60.7; ripple effect estimation via neural transformers; 180K commits from 471 projects | primary | high |
+| 22 | NES: Next Edit Suggestion (2025) | https://arxiv.org/html/2508.02473v2 | Instruction-free, low-latency edit prediction from historical editing trajectories; dual-model architecture | primary | medium |
+| 23 | GRACE: Graph-Guided Repository-Aware Code Completion (2025) | https://arxiv.org/html/2509.05980v1 | Uses call chains and inheritance hierarchies for retrieval in repo-level completion | primary | medium |
+| 24 | GNNContext: GNN-based Code Context Prediction (TSE 2025) | https://doi.org/10.1109/tse.2025.3578390 | GNN for predicting code context relevant to programming tasks | primary | medium |
+| 25 | striff-gnn: GNN for Software Architecture Analysis | https://github.com/hadi-technology/striff-gnn | Heterogeneous Graph Transformer for masked edge reconstruction on code graphs; Java/Python/TypeScript | primary | medium |
+| 26 | Mohamed et al., "Popularity Agnostic Evaluation of KGE" (AISTATS 2020) | https://proceedings.mlr.press/v124/mohamed20a/mohamed20a.pdf | Standard Hits@k and MRR biased toward popular entities; proposes strat-hits@k and strat-mrr | primary | high |
+| 27 | Inconsistency among evaluation metrics in link prediction (PMC 2024) | https://pmc.ncbi.nlm.nih.gov/articles/PMC11574622/ | Significant inconsistency across LP evaluation metrics on 100s of real networks | primary | high |
+
+---
+
+## 1. Merge Conflict Prediction — Methods and Results
+
+### 1.1 State of the Art
+
+The dominant approach to merge conflict prediction uses **supervised ML classifiers on repository metadata features** extracted via Git commands [1][3][4][5]. A systematic review found that 50% of published conflict prediction studies use ML techniques, with the remainder using Dependency-based Automatic Locking (30%) or Behavior-Driven Development (10%) [2].
+
+**Key results from Owhadi-Kareshk et al. (2019)** [1]:
+- **Dataset**: 267,657 merge scenarios from 744 GitHub repositories in 7 languages (C, C++, C#, Java, PHP, Python, Ruby)
+- **Features**: 9 lightweight Git feature sets (extractable solely through Git commands)
+- **Results**: F1 = 0.95–0.97 for predicting *safe* (non-conflicting) merges; F1 = 0.57–0.68 for predicting *conflicting* merges
+- **Conclusion**: Conflict prediction is feasible as a pre-filter for speculative merging, but predicting actual conflicts (the minority class) remains challenging
+
+**Al-Refai et al. (2025)** [3] evaluated stacking heterogeneous ensembles:
+- Models compared: DT, SVM (linear), Naive Bayes (3 variants), Logistic Regression, MLP, SGD, KNN
+- Best individual model: Decision Tree (DT)
+- Best ensemble: Stack-SVM (stacking with SVM meta-learner)
+- Finding: Both **social features** (developer identity, team overlap) and **technical features** (file overlap, change size) are important; using all features outperforms feature-selected subsets
+
+**Vale et al. (2023)** [4] confirmed that **social and technical assets combined** improve conflict prediction beyond technical-only approaches.
+
+### 1.2 Non-ML Baselines
+
+**ConE (Microsoft, 2021)** [6] is a production-deployed concurrent edit detection system that does NOT use ML:
+- **Heuristic-based**: Uses two constructs: Extent of Overlap (EOO ≥ 50%) and Rarely Concurrently Edited files (RCE ≥ 2)
+- **Scale**: Deployed on 234 Microsoft repositories; assessed 26,000 PRs
+- **Results**: 775 recommendations, >70% (554) rated useful by developers
+- **User satisfaction**: 90% of 48 interviewed users intended to keep using it daily
+- **Key insight**: Concurrent edits to files correlate more with bug fixes than non-concurrent edits (Spearman correlation)
+
+**Traditional baselines** (non-ML):
+- **Textual overlap detection**: Check if same lines/regions are modified in both branches
+- **Dependency analysis**: Static call graph / import analysis to detect structural conflicts
+- **Speculative merging**: Continuously merge all branch combinations in background (expensive but accurate) [1]
+
+---
+
+## 2. Link Prediction Evaluation Framework
+
+### 2.1 Standard Metrics for Knowledge Graph Completion
+
+The standard evaluation protocol for KG link prediction follows the **entity ranking procedure** introduced by Bordes et al. (TransE, 2013) [9]:
+
+For each test triple (h, r, t):
+1. Replace head entity with every entity → score all candidates
+2. Replace tail entity with every entity → score all candidates
+3. Rank the correct entity among all candidates
+4. Report rank-based metrics
+
+**Core metrics** [7][8][9]:
+
+| Metric | Definition | Range | Interpretation |
+|--------|-----------|-------|----------------|
+| **Mean Rank (MR)** | Average rank of correct entity | [1, \|E\|] | Lower is better; sensitive to outliers |
+| **Mean Reciprocal Rank (MRR)** | Average of 1/rank | (0, 1] | Higher is better; emphasizes top ranks |
+| **Hits@k** | Fraction of correct entities ranked in top k | [0, 1] | Higher is better; k ∈ {1, 3, 10} standard |
+| **AUC** | Area under ROC curve | [0, 1] | Classification-oriented; less common for ranking |
+
+### 2.2 Filtered vs. Raw Setting
+
+The **filtered setting** (standard) removes other known-true triples from the ranking, preventing correct triples from being counted as errors [8][9]. The **raw setting** does not filter, leading to artificially worse metrics.
+
+### 2.3 Known Issues and Improvements
+
+**Berrendorf et al. (2022)** [7] proposed a unified theoretical framework and identified problems:
+- Metrics are not directly comparable across datasets of different sizes
+- Proposed adjusted variants for interpretability
+
+**Mohamed et al. (2020)** [26] showed that **standard Hits@k and MRR are biased toward popular entities** (high-degree nodes). They proposed **strat-hits@k** and **strat-mrr** as unbiased estimators.
+
+**PMC study (2024)** [27] found **significant inconsistency** across evaluation metrics on hundreds of real networks — different metrics can rank algorithms differently.
+
+### 2.4 Applicability to Dependency DAGs
+
+For Atomic's dependency DAGs, the relevant adaptations are:
+
+- **MRR and Hits@k** are directly applicable for predicting missing dependency edges or co-change links
+- The **filtered setting** is essential since many true dependencies exist
+- **AUC** is appropriate when framing as binary classification (will-conflict / won't-conflict)
+- For temporal dependency prediction, evaluation should be **time-split** (train on past, test on future) rather than random split
+- **Strat-MRR** [26] is advisable since popular files (utility modules) will dominate standard metrics
+
+### 2.5 Reproducibility Warning
+
+Ali et al. (PyKEEN, 2021) [10] re-implemented 21 KGE models and found many published results were **not reproducible** with reported hyperparameters, underscoring the importance of rigorous evaluation protocol.
+
+---
+
+## 3. Blast-Radius / Change Impact Analysis
+
+### 3.1 Academic Approaches
+
+**Athena (FSE 2024)** [11] — most directly relevant:
+- **Method**: Combines Transformer-based code embeddings (CodeBERT, UniXCoder, GraphCodeBERT) with Program Dependence Graphs (PDGs)
+- **Task**: Given a changed method, predict which other methods are impacted
+- **Results**: mRR 60.32%, mAP 35.19%, HIT@10 81.48% on benchmark of 25 OSS projects
+- **Improvement**: 10.34% mRR, 9.55% mAP, 11.68% HIT@10 over simpler baseline (statistically significant)
+- **Key insight**: Combining structural (graph) and semantic (embedding) information significantly outperforms either alone
+
+**Temporal Graph approach (IST 2024)** [12]:
+- **Method**: Models software as temporal graph (nodes = files, edges = co-changeability); uses Temporal Graph Network + LSTM
+- **Task**: Predict which files will be impacted by a modification to a given file
+- **Key innovation**: Temporal graph representation captures evolving dependencies, not just static snapshots
+- **Result**: Significantly outperforms prior static-graph approaches
+
+**Rex (Microsoft, NSDI 2020)** [13]:
+- **Method**: Correlated change analysis for large services
+- **Task**: Detect when a code change requires a correlated configuration change (or vice versa)
+- **Application**: Preventing bugs from missing co-changes in production services
+- **Production deployment**: Used at Microsoft scale
+
+### 3.2 JIT Defect Prediction (Related)
+
+**DeepJIT (MSR 2019)** [14]:
+- **Method**: End-to-end CNN on commit messages + code change diffs
+- **Task**: Predict if a commit will introduce a defect (just-in-time)
+- **Innovation**: No manual feature engineering; learns directly from raw commit data
+- **Result**: Outperforms traditional JIT approaches using hand-crafted features
+
+**JITGNN (JSS 2024)** [15]:
+- **Method**: GNN on Abstract Syntax Trees (ASTs) of changed code
+- **Task**: Same JIT bug prediction as DeepJIT
+- **Result**: Same AUC as JITLine (state-of-art sequence model)
+- **Notable finding**: Graph structure did NOT improve over sequence-based models for this task — important negative result for our design
+
+### 3.3 Tool-based Approaches (Industry)
+
+Several open-source blast-radius tools exist but are **static analysis, not ML-based**:
+- Call graph traversal + PageRank-style risk propagation (phoenix-assistant/blastradius)
+- Transitive dependency tracing (ehermanson/blast-radius)
+- AI-augmented call chain analysis (tazwaryayyyy/BlastRadius using IBM Bob)
+
+These serve as useful baselines for comparison with learned approaches.
+
+---
+
+## 4. Code Change Recommendation / Next-Edit Prediction
+
+### 4.1 CoEdPilot (ISSTA 2024) [21]
+
+Most comprehensive system for edit recommendation with ripple-effect awareness:
+- **Architecture**: Orchestrates multiple neural transformers:
+  - Edit-propagating File Locator (coarse-grained)
+  - Edit-propagating Line Locator (fine-grained)
+  - Edit-dependency Analyzer (prior edit relevance)
+  - Edit-content Generator
+- **Training data**: 180K commits from 471 open-source projects, 5 languages
+- **Results**:
+  - Edit location accuracy: 70.8%–85.3%
+  - Edit content exact match: 41.8%
+  - BLEU4 score: 60.7
+  - Boosts GRACE and CoditT5 by 8.57% exact match and 18.08 BLEU4
+- **Relevance to Atomic**: The "ripple effect estimation" component maps directly to blast-radius prediction
+
+### 4.2 NES: Next Edit Suggestion (2025) [22]
+
+- Instruction-free, low-latency framework using learned historical editing trajectories
+- Dual-model architecture: one for edit location, one for edit content
+- Captures developer goals implicitly from edit history
+
+### 4.3 GRACE (2025) [23]
+
+- Graph-guided repository-aware code completion
+- Uses call chains and inheritance hierarchies for retrieval
+- Addresses limitation of pure text-similarity RAG approaches
+
+### 4.4 GNNContext (TSE 2025) [24]
+
+- GNN for predicting code context elements relevant to programming tasks
+- Leverages structural information of code (not just text)
+
+### 4.5 striff-gnn [25]
+
+- Heterogeneous Graph Transformer (HGT) encoder trained via masked edge reconstruction
+- Learns structural representations of codebases across Java, Python, TypeScript
+- **Directly relevant**: Masked edge reconstruction = link prediction on software graphs
+
+---
+
+## 5. Available Datasets and Benchmarks
+
+### 5.1 Merge Conflict Datasets
+
+| Dataset | Size | Languages | Source | URL |
+|---------|------|-----------|--------|-----|
+| **Merge-Bench** [16][17] | 7,938 hunks from 1,439 repos | 11 languages | GitHub (Reaper + top-starred) | https://github.com/benedikt-schesch/Merge-Bench |
+| **MergeConflictBench** [18] | 86 conflicts | React/Next.js/React Native | Production code | https://github.com/Create-Inc/merge-conflict-bench |
+| **ConGra** [19] | Large-scale | Multilingual | GitHub | https://github.com/HKU-System-Security-Lab/ConGra |
+| **AgenticFlict** [20] | Large-scale | Multiple | AI coding agent PRs | https://zenodo.org/records/20118379 |
+| **Owhadi-Kareshk dataset** [1] | 267,657 merge scenarios | 7 languages (C/C++/C#/Java/PHP/Python/Ruby) | 744 GitHub repos (Reaper) | (available via paper) |
+
+### 5.2 Impact Analysis Benchmarks
+
+| Dataset | Size | Granularity | Source | URL |
+|---------|------|-------------|--------|-----|
+| **Athena benchmark** [11] | 25 OSS projects | Method-level | Bug-fix commits | https://github.com/yanyanfu/Athena |
+
+### 5.3 KG Link Prediction Benchmarks (Reference)
+
+Standard benchmarks: FB15k-237, WN18RR, YAGO3-10 — these are the standard KGE evaluation datasets [9][10]. While not directly applicable, the evaluation protocols transfer to software dependency graph prediction.
+
+---
+
+## 6. Baseline Methods for Comparison
+
+### 6.1 For Conflict Prediction
+
+| Baseline | Type | Expected Performance | Notes |
+|----------|------|---------------------|-------|
+| Textual overlap (same lines modified) | Rule-based | High precision, low recall | Catches only syntactic conflicts |
+| File-level overlap counting | Heuristic | Moderate | ConE's approach [6] |
+| Git feature classifiers (RF/DT) | ML | F1 0.57–0.68 on conflicts [1] | Current SOTA for prediction |
+| Speculative merging | Exact | 100% precision/recall | Computationally expensive |
+
+### 6.2 For Blast-Radius Estimation
+
+| Baseline | Type | Expected Performance | Notes |
+|----------|------|---------------------|-------|
+| Static call graph traversal | Structural | Conservative (over-estimates) | No learning, deterministic |
+| Co-change mining (association rules) | Statistical | Data-dependent | Requires change history |
+| Coupling metrics (structural/evolutionary) | Metric-based | mRR ~50% (Athena baseline) [11] | Traditional IA approaches |
+
+### 6.3 For Link Prediction on Software Graphs
+
+| Baseline | Type | Notes |
+|----------|------|-------|
+| Common Neighbors | Topological | Simple, often strong baseline |
+| Jaccard Coefficient | Topological | Normalized overlap |
+| Adamic-Adar | Topological | Weighted common neighbors |
+| TransE [9] | KGE | Translational embedding |
+| DistMult | KGE | Bilinear diagonal |
+| Node2Vec + classifier | GNN-adjacent | Random walk embeddings |
+
+---
+
+## 7. Key Takeaways for Atomic Neural Graph Design
+
+1. **Conflict prediction is feasible but asymmetric** [1]: Safe merges are easy to predict (F1 ~0.96), but actual conflicts are hard (F1 ~0.63). This suggests the system should focus on **filtering likely-safe scenarios** rather than precisely predicting conflicts.
+
+2. **Graph structure alone may not help** [15]: JITGNN showed that GNN on ASTs achieved the same AUC as sequence models for JIT prediction. Graph structure must be combined with semantic information (as Athena does [11]) to show improvement.
+
+3. **Temporal dynamics matter** [12]: Static graphs underperform temporal graphs for change propagation. Atomic's graph evolves over time — the model should capture this.
+
+4. **Social features are significant** [3][4]: Developer identity, team overlap, and collaboration patterns improve prediction beyond purely technical features.
+
+5. **Evaluation protocol**: Use **filtered MRR and Hits@k** for link prediction heads [7][8], **F1/precision/recall** for conflict prediction heads, and **mRR/mAP/HIT@10** for impact analysis [11]. Consider **strat-MRR** [26] to avoid bias toward popular files.
+
+6. **CoEdPilot's architecture** [21] is closest to what Atomic needs: multi-component system that estimates ripple effects, finds relevant prior edits, and generates edit content. Its edit-location accuracy (70.8–85.3%) and edit-dependency analysis provide strong design reference.
+
+7. **Production-validated heuristics** (ConE [6]) provide strong non-ML baselines. Any ML system must demonstrably outperform these simpler approaches.
+
+8. **Merge-Bench** [16][17] is the best available benchmark for conflict resolution evaluation (7,938 hunks, 11 languages, publicly available, scalable construction).
+
+---
+
+## Coverage Status
+
+### Directly checked
+- ✅ Merge conflict prediction methods, features, and reported metrics
+- ✅ Link prediction evaluation metrics (MRR, Hits@k, AUC) and protocols
+- ✅ Blast-radius / change impact analysis approaches (Athena, temporal GNN, Rex, ConE)
+- ✅ Available datasets for merge conflict prediction and resolution
+- ✅ Non-ML baselines for conflict detection
+- ✅ Code change recommendation systems (CoEdPilot, NES, GRACE)
+
+### Partially checked
+- ⚠️ JITGNN and DeepJIT: read abstracts and key findings but not full experimental tables
+- ⚠️ Temporal graph paper [12]: read abstract/summary but not full methodology
+
+### Not checked / needs follow-up
+- ❓ Specific hyperparameters and training details for Athena [11] (would need full paper read)
+- ❓ ConGra [19] and AgenticFlict [20] dataset sizes and detailed schemas
+- ❓ Whether striff-gnn [25] has published evaluation results (appears to be a tool, not a paper)
+
+---
+
+## Sources
+
+1. Owhadi-Kareshk et al., "Predicting Merge Conflicts in Collaborative Software Development" (ESEM 2019) — https://arxiv.org/abs/1907.06274
+2. Dias et al., "On the Prediction of Software Merge Conflicts" (ACM 2023) — https://dl.acm.org/doi/fullHtml/10.1145/3592813.3592931
+3. Al-Refai et al., "Merge Conflict Prediction Using Feature Selection and Stacking Heterogeneous Ensembles" (JSMR 2025) — https://doi.org/10.1002/smr.70047
+4. Vale et al., "Predicting merge conflicts considering social and technical assets" (EMSE 2023) — https://link.springer.com/article/10.1007/s10664-023-10395-8
+5. Ziegler, "GITCoP: ML-Based Approach to Predicting Merge Conflicts" (Master's thesis) — https://www.se.cs.uni-saarland.de/theses/ThomasZieglerMA.pdf
+6. Nitu et al., "ConE: A Concurrent Edit Detection Tool for Large Scale Software Development" (FSE 2021) — https://ar5iv.labs.arxiv.org/html/2101.06542
+7. Berrendorf et al., "A Unified Framework for Rank-based Evaluation Metrics for Link Prediction in KGs" (2022) — https://arxiv.org/abs/2203.07544
+8. Sun et al., "Revisiting the Evaluation Protocol of KG Completion Methods" (WWW 2021) — https://dl.acm.org/doi/fullHtml/10.1145/3442381.3449856
+9. Bordes et al., "Translating Embeddings for Modeling Multi-relational Data" (NeurIPS 2013) — https://proceedings.neurips.cc/paper_files/paper/2013/file/1cecc7a77928ca8133fa24680a88d2f9-Paper.pdf
+10. Ali et al., "Bringing Light Into the Dark: Large-scale Evaluation of KGE Models" (PyKEEN) — https://backend.orbit.dtu.dk/ws/files/262633429/Bringing_Light_Into_the_Dark_A_Large_scale_Evaluation_of_Knowledge_Graph_Embedding_Models_under_a_Unified_Framework.pdf
+11. Yan et al., "Athena: Enhancing Code Understanding for Impact Analysis" (FSE 2024) — https://doi.org/10.1145/3643770
+12. Zaraket et al., "Change propagation using Temporal Graphs and GNNs" (IST 2024) — https://dl.acm.org/doi/10.1016/j.infsof.2023.107368
+13. Mehta et al., "Rex: Preventing Bugs via Correlated Change Analysis" (NSDI 2020) — https://www.usenix.org/system/files/nsdi20-paper-mehta.pdf
+14. Hoang et al., "DeepJIT: End-to-End Deep Learning for JIT Defect Prediction" (MSR 2019) — https://doi.org/10.1109/msr.2019.00016
+15. Milewicz et al., "JITGNN: Deep GNN for Just-In-Time Bug Prediction" (JSS 2024) — https://doi.org/10.1016/j.jss.2024.111984
+16. Schesch et al., "Resolve Merge Conflicts with LLMs" (2025) — https://arxiv.org/html/2605.25890v1
+17. Merge-Bench GitHub — https://github.com/benedikt-schesch/Merge-Bench
+18. MergeConflictBench — https://github.com/Create-Inc/merge-conflict-bench
+19. ConGra dataset — https://github.com/HKU-System-Security-Lab/ConGra
+20. AgenticFlict dataset — https://zenodo.org/records/20118379
+21. CoEdPilot (ISSTA 2024) — https://arxiv.org/html/2408.01733v1
+22. NES: Next Edit Suggestion (2025) — https://arxiv.org/html/2508.02473v2
+23. GRACE: Graph-Guided Repository-Aware Code Completion (2025) — https://arxiv.org/html/2509.05980v1
+24. GNNContext (TSE 2025) — https://doi.org/10.1109/tse.2025.3578390
+25. striff-gnn — https://github.com/hadi-technology/striff-gnn
+26. Mohamed et al., "Popularity Agnostic Evaluation of KGE" (AISTATS 2020) — https://proceedings.mlr.press/v124/mohamed20a/mohamed20a.pdf
+27. Inconsistency among evaluation metrics in link prediction (PMC 2024) — https://pmc.ncbi.nlm.nih.gov/articles/PMC11574622/

--- a/tests/harness/22_switch_conflict_markers.sh
+++ b/tests/harness/22_switch_conflict_markers.sh
@@ -1,0 +1,920 @@
+#!/usr/bin/env bash
+# 22_switch_conflict_markers.sh — View-switch conflict marker regression tests.
+#
+# Validates that switching views NEVER produces conflict markers in the
+# working copy when the target view has a clean, unambiguous graph state.
+#
+# Bug report: switching from a draft view (with changes) to a shared view
+# (DEV) was producing conflict markers instead of a clean materialization
+# of the target view's content.
+#
+# Possible triggers under test:
+#   1. Pure view switch (draft → shared) with divergent file edits
+#   2. Insert from draft → shared, then switch
+#   3. Git shadow + atomic view switch
+#   4. Draft view showing conflict markers due to parent inheritance
+#
+# Key invariant:
+#   After switching to a SHARED view, the working copy NEVER has conflict
+#   markers — the shared view's change filter scopes to its own changes
+#   only, producing a clean build from the graph.
+#
+#   Draft views may show conflict markers when the parent view has
+#   conflicting changes (draft = live perspective, not snapshot).
+
+HARNESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$HARNESS_DIR/helpers.sh"
+
+# ── Conflict marker helpers ─────────────────────────────────────────────────
+
+# Check for conflict markers in a file.
+# Returns 0 if markers found, 1 if clean.
+has_conflict_markers() {
+    local path="$1"
+    grep -qE '>>>>>>|<<<<<<|=======' "$path" 2>/dev/null
+}
+
+# Assert that a file has NO conflict markers.
+assert_no_conflict_markers() {
+    local desc="$1"
+    local path="$2"
+    if [[ ! -f "$path" ]]; then
+        _fail "$desc" "file does not exist: $path"
+        return
+    fi
+    if has_conflict_markers "$path"; then
+        local content
+        content="$(cat "$path")"
+        _fail "$desc" "conflict markers found in $path. Content: $(echo "$content" | head -20)"
+    else
+        _pass "$desc"
+    fi
+}
+
+# Assert that a file contains a specific substring.
+assert_file_contains() {
+    local desc="$1"
+    local path="$2"
+    local needle="$3"
+    if [[ ! -f "$path" ]]; then
+        _fail "$desc" "file does not exist: $path"
+        return
+    fi
+    if grep -qF "$needle" "$path"; then
+        _pass "$desc"
+    else
+        _fail "$desc" "'$needle' not found in $path. Content: $(cat "$path" | head -10)"
+    fi
+}
+
+# Assert that a file does NOT contain a specific substring.
+assert_file_not_contains() {
+    local desc="$1"
+    local path="$2"
+    local needle="$3"
+    if [[ ! -f "$path" ]]; then
+        _pass "$desc"
+        return
+    fi
+    if grep -qF "$needle" "$path"; then
+        _fail "$desc" "'$needle' should not be in $path but was found"
+    else
+        _pass "$desc"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Case 1: Simple view switch — single-line file, complete overwrite"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Baseline: simplest possible divergence.  Each view completely overwrites
+# the file.  No partial edits, no shared content.
+
+make_temp_repo "switch-conflict-1"
+init_repo
+
+# Create file on dev
+create_file "config.txt" "version=1.0"
+assert_success "add config.txt" atomic add config.txt
+record_change "Add config.txt" >/dev/null 2>&1 || true
+
+# Create draft from dev
+new_view "feature" --draft --parent dev >/dev/null 2>&1 || true
+switch_view "feature" >/dev/null 2>&1 || true
+
+# Modify on feature
+overwrite_file "config.txt" "version=2.0"
+record_change "Update config to 2.0 on feature" >/dev/null 2>&1 || true
+
+# Switch to dev — should show dev's version, no conflict markers
+switch_view "dev" >/dev/null 2>&1 || true
+assert_file_content "dev has original version" "config.txt" "version=1.0"
+assert_no_conflict_markers "no conflict markers after switch to dev (case 1)" "config.txt"
+
+# Switch back to feature — should show feature's version
+switch_view "feature" >/dev/null 2>&1 || true
+assert_file_content "feature has v2.0" "config.txt" "version=2.0"
+assert_no_conflict_markers "no conflict markers after switch to feature" "config.txt"
+
+# Round-trip
+switch_view "dev" >/dev/null 2>&1 || true
+assert_file_content "dev still has v1.0 (round 2)" "config.txt" "version=1.0"
+assert_no_conflict_markers "no conflict markers (round 2)" "config.txt"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Case 2: View switch — multi-line file, divergent line edits"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Multi-line file where the draft edits one line.  Switch to shared should
+# show the original.
+
+make_temp_repo "switch-conflict-2"
+init_repo
+
+# Create a multi-line file on dev
+cat > app.py << 'EOF'
+#!/usr/bin/env python3
+"""Application module."""
+
+def main():
+    name = "World"
+    greeting = "Hello"
+    print(f"{greeting}, {name}!")
+
+if __name__ == "__main__":
+    main()
+EOF
+assert_success "add app.py" atomic add app.py
+record_change "Add app.py" >/dev/null 2>&1 || true
+
+ORIGINAL_CONTENT="$(cat app.py)"
+
+# Create draft from dev
+new_view "agent" --draft --parent dev >/dev/null 2>&1 || true
+switch_view "agent" >/dev/null 2>&1 || true
+
+# Modify line 5 on agent (change name)
+sed -i.bak 's/name = "World"/name = "Agent"/' app.py && rm -f app.py.bak
+record_change "Change name to Agent" >/dev/null 2>&1 || true
+
+AGENT_CONTENT="$(cat app.py)"
+
+# Switch to dev — should show ORIGINAL, not agent's version, no conflict
+switch_view "dev" >/dev/null 2>&1 || true
+assert_file_content "dev has original app.py" "app.py" "$ORIGINAL_CONTENT"
+assert_no_conflict_markers "no conflict markers on dev after agent edits (case 2)" "app.py"
+assert_file_contains "dev has World" "app.py" '"World"'
+assert_file_not_contains "dev does NOT have Agent" "app.py" '"Agent"'
+
+# Switch back to agent
+switch_view "agent" >/dev/null 2>&1 || true
+assert_file_content "agent has its version" "app.py" "$AGENT_CONTENT"
+assert_no_conflict_markers "no conflict markers on agent" "app.py"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Case 3: Both views edit same file, different lines — shared is clean"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Dev AND the draft both edit the same multi-line file but at different
+# lines.  The KEY invariant: switching to the SHARED view (dev) must
+# produce a clean build — only dev's changes, no merge with draft.
+#
+# The DRAFT view inherits dev's changes (live perspective), so it sees
+# both sets of changes merged together — this is by design.
+
+make_temp_repo "switch-conflict-3"
+init_repo
+
+# Create multi-line file on dev
+cat > server.conf << 'EOF'
+[server]
+host = localhost
+port = 8080
+workers = 4
+
+[database]
+url = postgres://localhost/mydb
+pool_size = 10
+timeout = 30
+EOF
+assert_success "add server.conf" atomic add server.conf
+record_change "Add server.conf" >/dev/null 2>&1 || true
+
+# Create draft
+new_view "feature" --draft --parent dev >/dev/null 2>&1 || true
+switch_view "feature" >/dev/null 2>&1 || true
+
+# Feature edits: change port and pool_size
+sed -i.bak 's/port = 8080/port = 9090/' server.conf && rm -f server.conf.bak
+sed -i.bak 's/pool_size = 10/pool_size = 20/' server.conf && rm -f server.conf.bak
+record_change "Feature: change port and pool_size" >/dev/null 2>&1 || true
+
+# Switch to dev, edit workers and timeout
+switch_view "dev" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no markers on dev before dev edits" "server.conf"
+
+sed -i.bak 's/workers = 4/workers = 8/' server.conf && rm -f server.conf.bak
+sed -i.bak 's/timeout = 30/timeout = 60/' server.conf && rm -f server.conf.bak
+record_change "Dev: change workers and timeout" >/dev/null 2>&1 || true
+
+DEV_CONF="$(cat server.conf)"
+
+# Switch to feature — draft inherits dev's changes (live perspective)
+# so it sees the merged state of both views' edits
+switch_view "feature" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no conflict markers on feature (merged, different lines)" "server.conf"
+# Feature should see BOTH its own edits AND dev's edits (inherited)
+assert_file_contains "feature has port 9090 (own edit)" "server.conf" "port = 9090"
+assert_file_contains "feature has pool_size 20 (own edit)" "server.conf" "pool_size = 20"
+assert_file_contains "feature has workers 8 (inherited from dev)" "server.conf" "workers = 8"
+assert_file_contains "feature has timeout 60 (inherited from dev)" "server.conf" "timeout = 60"
+
+# THE KEY TEST: Switch to dev — must show ONLY dev's state, no merge
+switch_view "dev" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no conflict markers on dev after round-trip" "server.conf"
+assert_file_content "dev has its own clean version" "server.conf" "$DEV_CONF"
+assert_file_contains "dev has workers 8" "server.conf" "workers = 8"
+assert_file_contains "dev has timeout 60" "server.conf" "timeout = 60"
+# Dev must NOT have feature's edits
+assert_file_contains "dev has port 8080 (not feature's 9090)" "server.conf" "port = 8080"
+assert_file_contains "dev has pool_size 10 (not feature's 20)" "server.conf" "pool_size = 10"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Case 4: Same-line conflict — shared is clean, draft may merge"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Both views edit the exact same line.  The SHARED view must show only
+# its own version (clean build).  The draft may show a CRDT merge since
+# it inherits the parent's changes.
+
+make_temp_repo "switch-conflict-4"
+init_repo
+
+cat > version.txt << 'EOF'
+app_name = MyApp
+version = 1.0.0
+author = original
+description = A sample app
+EOF
+assert_success "add version.txt" atomic add version.txt
+record_change "Add version.txt" >/dev/null 2>&1 || true
+
+# Create draft
+new_view "hotfix" --draft --parent dev >/dev/null 2>&1 || true
+switch_view "hotfix" >/dev/null 2>&1 || true
+
+# Hotfix changes version to 1.0.1
+sed -i.bak 's/version = 1.0.0/version = 1.0.1/' version.txt && rm -f version.txt.bak
+record_change "Hotfix: bump to 1.0.1" >/dev/null 2>&1 || true
+
+# Switch to dev, change version to 2.0.0
+switch_view "dev" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no markers before dev edit" "version.txt"
+
+sed -i.bak 's/version = 1.0.0/version = 2.0.0/' version.txt && rm -f version.txt.bak
+record_change "Dev: bump to 2.0.0" >/dev/null 2>&1 || true
+
+# THE KEY TEST: dev must show ONLY its own version, no merge
+assert_no_conflict_markers "no conflict markers on dev (case 4)" "version.txt"
+assert_file_contains "dev has 2.0.0" "version.txt" "version = 2.0.0"
+
+# Switch to hotfix — draft inherits dev's change, CRDT merges
+# (the exact result depends on token-level merge — may be 2.0.1 or markers)
+switch_view "hotfix" >/dev/null 2>&1 || true
+# Don't assert exact content — just verify no crash and file exists
+assert_file_exists "version.txt exists on hotfix" "version.txt"
+
+# Switch back to dev — MUST be clean, the visit to hotfix must not pollute
+switch_view "dev" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no conflict markers on dev after visiting hotfix" "version.txt"
+assert_file_contains "dev still has 2.0.0" "version.txt" "version = 2.0.0"
+# Verify dev does NOT have hotfix's version mixed in
+assert_file_not_contains "dev does NOT have 1.0.1" "version.txt" "1.0.1"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Case 5: Insert from draft to shared — clean materialization"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# After inserting changes from a draft into the shared view:
+#   1. The shared view should show the merged content with no markers
+#   2. Switching to draft and back should preserve clean shared state
+
+make_temp_repo "switch-conflict-5"
+init_repo
+
+cat > readme.md << 'EOF'
+# My Project
+
+A sample project for testing.
+
+## Features
+
+- Feature A
+- Feature B
+
+## Usage
+
+Run the app with `./run.sh`.
+EOF
+assert_success "add readme.md" atomic add readme.md
+record_change "Add readme.md" >/dev/null 2>&1 || true
+
+# Create draft
+new_view "docs" --draft --parent dev >/dev/null 2>&1 || true
+switch_view "docs" >/dev/null 2>&1 || true
+
+# Add a new section on docs view
+cat >> readme.md << 'EOF'
+
+## Contributing
+
+Please read CONTRIBUTING.md before submitting PRs.
+EOF
+record_change "Docs: add Contributing section" >/dev/null 2>&1 || true
+
+# Switch to dev — should NOT have contributing section
+switch_view "dev" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no markers on dev before insert" "readme.md"
+assert_file_not_contains "dev lacks contributing" "readme.md" "Contributing"
+
+# Insert from docs to dev
+insert_from_view "docs" "dev" >/dev/null 2>&1 || true
+# Dev should now have the contributing section
+assert_no_conflict_markers "no conflict markers after insert" "readme.md"
+assert_file_contains "dev has contributing after insert" "readme.md" "Contributing"
+
+# Switch to docs — should match docs version (identical after insert)
+switch_view "docs" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no conflict markers on docs after insert" "readme.md"
+assert_file_contains "docs still has contributing" "readme.md" "Contributing"
+
+# Switch back to dev — must stay clean
+switch_view "dev" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no markers on dev after round-trip post-insert" "readme.md"
+assert_file_contains "dev still has contributing" "readme.md" "Contributing"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Case 6: Insert divergent edits into shared — then switch"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Two changes (draft edit + dev edit) are both on the shared view after
+# insert.  The shared view should show the merged result cleanly.  Then
+# switching to the draft (which inherits from shared) should also be clean.
+
+make_temp_repo "switch-conflict-6"
+init_repo
+
+cat > api.ts << 'EOF'
+export function getUser(id: string) {
+  return fetch(`/api/users/${id}`);
+}
+
+export function listUsers() {
+  return fetch('/api/users');
+}
+
+export function deleteUser(id: string) {
+  return fetch(`/api/users/${id}`, { method: 'DELETE' });
+}
+EOF
+assert_success "add api.ts" atomic add api.ts
+record_change "Add api.ts" >/dev/null 2>&1 || true
+
+# Create draft
+new_view "refactor" --draft --parent dev >/dev/null 2>&1 || true
+switch_view "refactor" >/dev/null 2>&1 || true
+
+# Refactor: change getUser to async
+sed -i.bak 's/export function getUser/export async function getUser/' api.ts && rm -f api.ts.bak
+sed -i.bak "s/return fetch(\`\/api\/users/return await fetch(\`\/api\/users/" api.ts && rm -f api.ts.bak
+record_change "Make getUser async" >/dev/null 2>&1 || true
+
+# Switch to dev, add a new function at the end
+switch_view "dev" >/dev/null 2>&1 || true
+
+cat >> api.ts << 'EOF'
+
+export function createUser(data: object) {
+  return fetch('/api/users', { method: 'POST', body: JSON.stringify(data) });
+}
+EOF
+record_change "Add createUser function" >/dev/null 2>&1 || true
+
+# Insert refactor changes into dev
+insert_from_view "refactor" "dev" >/dev/null 2>&1 || true
+
+# THE KEY TEST: dev should cleanly show both changes merged, no conflict markers
+assert_no_conflict_markers "no conflict markers on dev after insert (case 6)" "api.ts"
+assert_file_contains "dev has createUser" "api.ts" "createUser"
+
+# Switch to refactor — draft inherits dev (which now includes its own changes)
+switch_view "refactor" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no conflict markers on refactor after insert" "api.ts"
+assert_file_contains "refactor has async getUser" "api.ts" "async function getUser"
+# Refactor inherits dev's createUser since it's parented on dev
+assert_file_contains "refactor also has createUser (inherited)" "api.ts" "createUser"
+
+# Switch back to dev — must stay clean
+switch_view "dev" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no conflict markers on dev after round-trip (case 6)" "api.ts"
+assert_file_contains "dev still has createUser" "api.ts" "createUser"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Case 7: Multiple draft views, rapid switching"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Three draft views from the same shared parent, each editing the same
+# file.  Rapid-switch between all four views.  The shared view (dev)
+# must always show its original content with no conflict markers.
+
+make_temp_repo "switch-conflict-7"
+init_repo
+
+cat > index.html << 'EOF'
+<!DOCTYPE html>
+<html>
+<head>
+    <title>My App</title>
+    <meta charset="utf-8">
+</head>
+<body>
+    <h1>Welcome</h1>
+    <p>Hello, world!</p>
+    <footer>Copyright 2024</footer>
+</body>
+</html>
+EOF
+assert_success "add index.html" atomic add index.html
+record_change "Add index.html" >/dev/null 2>&1 || true
+
+ORIG_HTML="$(cat index.html)"
+
+# Create 3 drafts, each editing different parts
+for view_name in design content footer; do
+    new_view "$view_name" --draft --parent dev >/dev/null 2>&1 || true
+done
+
+# Design: change title
+switch_view "design" >/dev/null 2>&1 || true
+sed -i.bak 's/<title>My App<\/title>/<title>Awesome App<\/title>/' index.html && rm -f index.html.bak
+record_change "Design: update title" >/dev/null 2>&1 || true
+
+# Content: change paragraph
+switch_view "content" >/dev/null 2>&1 || true
+sed -i.bak 's/Hello, world!/Welcome to our platform!/' index.html && rm -f index.html.bak
+record_change "Content: update greeting" >/dev/null 2>&1 || true
+
+# Footer: change copyright
+switch_view "footer" >/dev/null 2>&1 || true
+sed -i.bak 's/Copyright 2024/Copyright 2025 Acme Inc/' index.html && rm -f index.html.bak
+record_change "Footer: update copyright" >/dev/null 2>&1 || true
+
+# Rapid switch cycle: dev must always show original
+for round in 1 2; do
+    switch_view "dev" >/dev/null 2>&1 || true
+    assert_no_conflict_markers "dev clean (round $round)" "index.html"
+    assert_file_content "dev has original (round $round)" "index.html" "$ORIG_HTML"
+
+    switch_view "design" >/dev/null 2>&1 || true
+    assert_no_conflict_markers "design clean (round $round)" "index.html"
+    assert_file_contains "design has Awesome App (round $round)" "index.html" "Awesome App"
+
+    switch_view "content" >/dev/null 2>&1 || true
+    assert_no_conflict_markers "content clean (round $round)" "index.html"
+    assert_file_contains "content has platform (round $round)" "index.html" "Welcome to our platform"
+
+    switch_view "footer" >/dev/null 2>&1 || true
+    assert_no_conflict_markers "footer clean (round $round)" "index.html"
+    assert_file_contains "footer has 2025 (round $round)" "index.html" "Copyright 2025"
+done
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Case 8: Git shadow — import, create draft, edit, switch"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Simulate the git+atomic coexistence scenario.  Create a git repo, import
+# into atomic, make edits on a draft view, then switch back to the shared
+# view that tracks the git branch.
+
+require_git
+
+make_temp_repo "switch-conflict-8"
+
+# Set up a git repo with several commits
+init_git_repo
+
+cat > main.py << 'PYEOF'
+"""Main application."""
+
+def greet(name: str) -> str:
+    return f"Hello, {name}!"
+
+def farewell(name: str) -> str:
+    return f"Goodbye, {name}!"
+
+if __name__ == "__main__":
+    print(greet("World"))
+    print(farewell("World"))
+PYEOF
+git add main.py
+git commit --quiet -m "Initial: add main.py"
+
+# Second commit: add a utility function
+cat > utils.py << 'PYEOF'
+"""Utility functions."""
+
+def format_name(first: str, last: str) -> str:
+    return f"{first} {last}"
+
+def validate_email(email: str) -> bool:
+    return "@" in email and "." in email
+PYEOF
+git add utils.py
+git commit --quiet -m "Add utils.py"
+
+# Detect the git default branch name (master vs main)
+GIT_BRANCH="$(git branch --show-current 2>/dev/null || git rev-parse --abbrev-ref HEAD)"
+
+# Import into atomic
+assert_success "atomic git import" atomic git import --branch "$GIT_BRANCH"
+assert_success "atomic status clean after import" atomic status
+
+# Save main.py content as the shared view's expected state
+SHARED_MAIN_PY="$(cat main.py)"
+
+# Create a draft view
+new_view "feature" --draft --parent "$GIT_BRANCH" >/dev/null 2>&1 || true
+switch_view "feature" >/dev/null 2>&1 || true
+
+# Edit main.py on feature
+sed -i.bak 's/Hello, {name}/Hi there, {name}/' main.py && rm -f main.py.bak
+assert_success "add modified main.py" atomic add main.py
+record_change "Feature: change greeting" >/dev/null 2>&1 || true
+
+# THE KEY TEST: Switch back to shared view — must show git's version
+switch_view "$GIT_BRANCH" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no conflict markers on shared after feature edits (git)" "main.py"
+assert_file_contains "shared has Hello" "main.py" "Hello, {name}"
+assert_file_not_contains "shared does NOT have Hi there" "main.py" "Hi there"
+# utils.py should be untouched
+assert_file_exists "utils.py exists on shared" "utils.py"
+assert_no_conflict_markers "no conflict markers in utils.py" "utils.py"
+
+# Switch back to feature
+switch_view "feature" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no markers on feature (round-trip)" "main.py"
+assert_file_contains "feature has Hi there" "main.py" "Hi there"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Case 9: Git shadow — import, git commit, incremental import, switch"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# After initial import: make a git commit on the shared branch, run
+# incremental import, then switch between draft and updated shared view.
+# The shared view should show the new git content, not merged content.
+
+require_git
+
+make_temp_repo "switch-conflict-9"
+
+# Set up git + initial import
+init_git_repo
+
+cat > config.yml << 'YEOF'
+app:
+  name: TestApp
+  version: "1.0"
+  debug: false
+
+database:
+  host: localhost
+  port: 5432
+YEOF
+git add config.yml
+git commit --quiet -m "Add config.yml"
+
+GIT_BRANCH="$(git branch --show-current 2>/dev/null || git rev-parse --abbrev-ref HEAD)"
+
+assert_success "import" atomic git import --branch "$GIT_BRANCH"
+
+# Create draft, edit config
+new_view "tweak" --draft --parent "$GIT_BRANCH" >/dev/null 2>&1 || true
+switch_view "tweak" >/dev/null 2>&1 || true
+
+sed -i.bak 's/debug: false/debug: true/' config.yml && rm -f config.yml.bak
+assert_success "add config" atomic add config.yml
+record_change "Enable debug mode" >/dev/null 2>&1 || true
+
+# Now make a git commit directly on the shared branch (simulating upstream change)
+switch_view "$GIT_BRANCH" >/dev/null 2>&1 || true
+sed -i.bak 's/port: 5432/port: 5433/' config.yml && rm -f config.yml.bak
+git add config.yml
+git commit --quiet -m "Change DB port to 5433"
+
+# Incremental import picks up the new git commit
+assert_success "incremental import" atomic git import --incremental --branch "$GIT_BRANCH"
+
+# THE KEY TEST: Shared view must show ONLY its own content (with new port)
+assert_no_conflict_markers "no markers on shared after import" "config.yml"
+assert_file_contains "shared has port 5433" "config.yml" "port: 5433"
+assert_file_contains "shared has debug false" "config.yml" "debug: false"
+
+# Switch to tweak — draft inherits the new port from shared
+switch_view "tweak" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no markers on tweak" "config.yml"
+assert_file_contains "tweak has debug true (own edit)" "config.yml" "debug: true"
+# Draft inherits updated port from shared
+assert_file_contains "tweak has port 5433 (inherited)" "config.yml" "port: 5433"
+
+# Switch back to shared — must be clean, no merge pollution
+switch_view "$GIT_BRANCH" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no markers on shared after round-trip" "config.yml"
+assert_file_contains "shared still has port 5433" "config.yml" "port: 5433"
+assert_file_contains "shared still has debug false" "config.yml" "debug: false"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Case 10: Large file with many lines — partial edits"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# A larger file (50+ lines) where the draft edits a few lines in the
+# middle.  Switch to shared must show all original values.
+
+make_temp_repo "switch-conflict-10"
+init_repo
+
+# Generate a 60-line file
+{
+    echo "# Configuration file"
+    echo ""
+    for i in $(seq 1 20); do
+        echo "setting_${i} = value_${i}"
+    done
+    echo ""
+    echo "# Section 2"
+    echo ""
+    for i in $(seq 21 40); do
+        echo "param_${i} = default_${i}"
+    done
+    echo ""
+    echo "# Section 3"
+    echo ""
+    for i in $(seq 41 50); do
+        echo "flag_${i} = false"
+    done
+} > big_config.txt
+
+assert_success "add big_config.txt" atomic add big_config.txt
+record_change "Add big_config.txt" >/dev/null 2>&1 || true
+
+ORIG_BIG="$(cat big_config.txt)"
+
+# Create draft
+new_view "tuning" --draft --parent dev >/dev/null 2>&1 || true
+switch_view "tuning" >/dev/null 2>&1 || true
+
+# Edit lines 10, 25, and 45 (spread across sections)
+sed -i.bak 's/setting_10 = value_10/setting_10 = TUNED_10/' big_config.txt && rm -f big_config.txt.bak
+sed -i.bak 's/param_25 = default_25/param_25 = TUNED_25/' big_config.txt && rm -f big_config.txt.bak
+sed -i.bak 's/flag_45 = false/flag_45 = true/' big_config.txt && rm -f big_config.txt.bak
+record_change "Tune settings" >/dev/null 2>&1 || true
+
+# Switch to dev — should show ALL original values
+switch_view "dev" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no markers on dev (large file)" "big_config.txt"
+assert_file_content "dev has original big_config" "big_config.txt" "$ORIG_BIG"
+assert_file_contains "dev has value_10" "big_config.txt" "setting_10 = value_10"
+assert_file_contains "dev has default_25" "big_config.txt" "param_25 = default_25"
+assert_file_contains "dev has flag_45 false" "big_config.txt" "flag_45 = false"
+
+# Switch to tuning — should show tuned values
+switch_view "tuning" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no markers on tuning (large file)" "big_config.txt"
+assert_file_contains "tuning has TUNED_10" "big_config.txt" "setting_10 = TUNED_10"
+assert_file_contains "tuning has TUNED_25" "big_config.txt" "param_25 = TUNED_25"
+assert_file_contains "tuning has flag_45 true" "big_config.txt" "flag_45 = true"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Case 11: Status clean after switch — no false Modified"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# After switching views, `atomic status` should report a clean working
+# copy — not show the switched-to files as Modified.
+
+make_temp_repo "switch-conflict-11"
+init_repo
+
+create_file "src/lib.rs" 'pub fn hello() -> &'"'"'static str { "hello" }'
+assert_success "add src/lib.rs" atomic add src/lib.rs
+record_change "Add lib.rs" >/dev/null 2>&1 || true
+
+new_view "experiment" --draft --parent dev >/dev/null 2>&1 || true
+switch_view "experiment" >/dev/null 2>&1 || true
+
+overwrite_file "src/lib.rs" 'pub fn hello() -> &'"'"'static str { "hi there" }'
+record_change "Experiment: change greeting" >/dev/null 2>&1 || true
+
+# Switch to dev
+switch_view "dev" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no markers" "src/lib.rs"
+assert_clean "dev is clean after switch"
+
+# Switch to experiment
+switch_view "experiment" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no markers on experiment" "src/lib.rs"
+assert_clean "experiment is clean after switch"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Case 12: Multiple files — some shared, some view-specific"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# A mix of files: some only on dev, some only on draft, some on both.
+# After switching, no file should have conflict markers.
+
+make_temp_repo "switch-conflict-12"
+init_repo
+
+create_file "shared.txt" "Shared content"
+create_file "dev-only.txt" "Dev-only content"
+assert_success "add shared and dev-only" atomic add shared.txt dev-only.txt
+record_change "Add shared and dev-only files" >/dev/null 2>&1 || true
+
+new_view "draft" --draft --parent dev >/dev/null 2>&1 || true
+switch_view "draft" >/dev/null 2>&1 || true
+
+# Create a draft-only file
+create_file "draft-only.txt" "Draft-only content"
+assert_success "add draft-only" atomic add draft-only.txt
+# Modify the shared file on draft
+overwrite_file "shared.txt" "Shared content (modified by draft)"
+record_change "Draft: add file and modify shared" >/dev/null 2>&1 || true
+
+# Switch to dev — check all files
+switch_view "dev" >/dev/null 2>&1 || true
+assert_file_exists "shared.txt exists on dev" "shared.txt"
+assert_file_exists "dev-only.txt exists on dev" "dev-only.txt"
+assert_file_not_exists "draft-only.txt NOT on dev" "draft-only.txt"
+assert_no_conflict_markers "no markers in shared.txt" "shared.txt"
+assert_no_conflict_markers "no markers in dev-only.txt" "dev-only.txt"
+assert_file_content "shared.txt has original" "shared.txt" "Shared content"
+
+# Switch to draft — check all files
+switch_view "draft" >/dev/null 2>&1 || true
+assert_file_exists "shared.txt exists on draft" "shared.txt"
+assert_file_exists "draft-only.txt exists on draft" "draft-only.txt"
+assert_no_conflict_markers "no markers in shared.txt on draft" "shared.txt"
+assert_no_conflict_markers "no markers in draft-only.txt" "draft-only.txt"
+assert_file_content "shared.txt has draft version" "shared.txt" "Shared content (modified by draft)"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Case 13: Insert conflicting changes from two drafts into shared"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Two separate draft views each modify the same line of the same file.
+# Insert both into the shared view.  After insert, the shared view should
+# handle the conflict via CRDT resolution (auto-merge or markers) — but
+# the key test is that switching BACK from a draft does not produce
+# ADDITIONAL conflict markers or duplicate content.
+
+make_temp_repo "switch-conflict-13"
+init_repo
+
+cat > data.json << 'EOF'
+{
+  "name": "TestProject",
+  "version": "1.0.0",
+  "description": "A test project"
+}
+EOF
+assert_success "add data.json" atomic add data.json
+record_change "Add data.json" >/dev/null 2>&1 || true
+
+# Create two drafts
+new_view "alpha" --draft --parent dev >/dev/null 2>&1 || true
+new_view "beta" --draft --parent dev >/dev/null 2>&1 || true
+
+# Alpha edits name
+switch_view "alpha" >/dev/null 2>&1 || true
+sed -i.bak 's/"TestProject"/"AlphaProject"/' data.json && rm -f data.json.bak
+record_change "Alpha: rename project" >/dev/null 2>&1 || true
+
+# Beta edits description (different line, clean merge expected)
+switch_view "beta" >/dev/null 2>&1 || true
+sed -i.bak 's/"A test project"/"Beta description"/' data.json && rm -f data.json.bak
+record_change "Beta: update description" >/dev/null 2>&1 || true
+
+# Switch to dev — clean before any inserts
+switch_view "dev" >/dev/null 2>&1 || true
+assert_no_conflict_markers "dev clean before inserts" "data.json"
+
+# Insert alpha's changes into dev
+insert_from_view "alpha" "dev" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no markers after alpha insert" "data.json"
+assert_file_contains "dev has AlphaProject" "data.json" "AlphaProject"
+
+# Insert beta's changes into dev
+insert_from_view "beta" "dev" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no markers after beta insert (different lines)" "data.json"
+assert_file_contains "dev has AlphaProject (still)" "data.json" "AlphaProject"
+assert_file_contains "dev has Beta description" "data.json" "Beta description"
+
+# Save dev's merged state
+DEV_AFTER_INSERTS="$(cat data.json)"
+
+# Now switch to alpha, then back to dev — dev must stay clean
+switch_view "alpha" >/dev/null 2>&1 || true
+switch_view "dev" >/dev/null 2>&1 || true
+assert_no_conflict_markers "dev clean after alpha round-trip" "data.json"
+assert_file_content "dev state preserved after round-trip" "data.json" "$DEV_AFTER_INSERTS"
+
+# Switch to beta, then back to dev — dev must stay clean
+switch_view "beta" >/dev/null 2>&1 || true
+switch_view "dev" >/dev/null 2>&1 || true
+assert_no_conflict_markers "dev clean after beta round-trip" "data.json"
+assert_file_content "dev state preserved (round 2)" "data.json" "$DEV_AFTER_INSERTS"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Case 14: Dev edits AFTER draft creation, switch to dev"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# This is the exact scenario from the bug report:
+#   1. Create draft from dev
+#   2. Make changes on draft
+#   3. Switch to dev (which hasn't changed since draft was created)
+#   4. Make changes on dev
+#   5. Switch FROM dev TO draft (draft inherits dev's new changes)
+#   6. Switch BACK to dev — dev must be clean
+#
+# Step 6 is where the bug was reported: after visiting the draft (which
+# has a merged/conflicted state), switching to dev should produce a
+# clean build, not carry over the merged state.
+
+make_temp_repo "switch-conflict-14"
+init_repo
+
+cat > module.ts << 'EOF'
+interface Config {
+  host: string;
+  port: number;
+  timeout: number;
+  retries: number;
+}
+
+export function createConfig(): Config {
+  return {
+    host: "localhost",
+    port: 3000,
+    timeout: 5000,
+    retries: 3,
+  };
+}
+
+export function validateConfig(config: Config): boolean {
+  return config.port > 0 && config.timeout > 0;
+}
+EOF
+assert_success "add module.ts" atomic add module.ts
+record_change "Add module.ts" >/dev/null 2>&1 || true
+
+# Step 1: Create draft
+new_view "agent-session" --draft --parent dev >/dev/null 2>&1 || true
+switch_view "agent-session" >/dev/null 2>&1 || true
+
+# Step 2: Draft changes port
+sed -i.bak 's/port: 3000/port: 8080/' module.ts && rm -f module.ts.bak
+record_change "Agent: change port to 8080" >/dev/null 2>&1 || true
+
+# Step 3: Switch to dev (unchanged since draft creation)
+switch_view "dev" >/dev/null 2>&1 || true
+assert_no_conflict_markers "dev clean (step 3)" "module.ts"
+assert_file_contains "dev has port 3000" "module.ts" "port: 3000"
+
+# Step 4: Dev changes timeout
+sed -i.bak 's/timeout: 5000/timeout: 10000/' module.ts && rm -f module.ts.bak
+record_change "Dev: change timeout to 10000" >/dev/null 2>&1 || true
+
+# Step 5: Switch to draft — draft inherits dev's timeout change
+switch_view "agent-session" >/dev/null 2>&1 || true
+# Draft sees merged state (its own port + dev's timeout) — different lines, clean
+assert_no_conflict_markers "draft merged cleanly (step 5)" "module.ts"
+assert_file_contains "draft has port 8080 (own edit)" "module.ts" "port: 8080"
+assert_file_contains "draft has timeout 10000 (inherited)" "module.ts" "timeout: 10000"
+
+# Step 6: THE BUG TEST — switch back to dev, must be CLEAN
+switch_view "dev" >/dev/null 2>&1 || true
+assert_no_conflict_markers "dev clean after visiting draft (step 6)" "module.ts"
+assert_file_contains "dev has port 3000 (own, not draft's 8080)" "module.ts" "port: 3000"
+assert_file_contains "dev has timeout 10000 (own edit)" "module.ts" "timeout: 10000"
+assert_file_not_contains "dev does NOT have port 8080" "module.ts" "port: 8080"
+
+# Extra: multiple round-trips to stress the cache
+for i in 1 2 3; do
+    switch_view "agent-session" >/dev/null 2>&1 || true
+    switch_view "dev" >/dev/null 2>&1 || true
+    assert_no_conflict_markers "dev clean after round-trip $i" "module.ts"
+    assert_file_contains "dev has port 3000 (round $i)" "module.ts" "port: 3000"
+    assert_file_not_contains "dev no 8080 (round $i)" "module.ts" "port: 8080"
+done
+
+# ═══════════════════════════════════════════════════════════════════════════
+
+print_summary

--- a/tests/harness/23_shared_view_parent_chain.sh
+++ b/tests/harness/23_shared_view_parent_chain.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# 23_shared_view_parent_chain.sh — Shared view parent chain filter tests.
+#
+# Validates that shared views with parent chains properly include
+# all ancestor changes in their change filter during materialization.
+#
+# Bug: collect_visible_change_ids only walks parent chain for draft views.
+# Shared views with parents (e.g. staging → dev) only see their own
+# VIEW_CHANGES, missing ancestor changes.  This could produce incomplete
+# content or conflict markers.
+
+HARNESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$HARNESS_DIR/helpers.sh"
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+assert_no_conflict_markers() {
+    local desc="$1"
+    local path="$2"
+    if [[ ! -f "$path" ]]; then
+        _fail "$desc" "file does not exist: $path"
+        return
+    fi
+    if grep -qE '>>>>>>|<<<<<<|=======' "$path" 2>/dev/null; then
+        local content
+        content="$(cat "$path")"
+        _fail "$desc" "conflict markers found in $path. Content: $(echo "$content" | head -20)"
+    else
+        _pass "$desc"
+    fi
+}
+
+assert_file_contains() {
+    local desc="$1"
+    local path="$2"
+    local needle="$3"
+    if [[ ! -f "$path" ]]; then
+        _fail "$desc" "file does not exist: $path"
+        return
+    fi
+    if grep -qF "$needle" "$path"; then
+        _pass "$desc"
+    else
+        _fail "$desc" "'$needle' not found in $path. Content: $(cat "$path" | head -10)"
+    fi
+}
+
+assert_file_not_contains() {
+    local desc="$1"
+    local path="$2"
+    local needle="$3"
+    if [[ ! -f "$path" ]]; then
+        _pass "$desc"
+        return
+    fi
+    if grep -qF "$needle" "$path"; then
+        _fail "$desc" "'$needle' should not be in $path but was found"
+    else
+        _pass "$desc"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Case 1: Shared chain dev → staging"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Build a two-level shared view hierarchy:
+#   dev (root shared, created by init)
+#   └── staging (shared, parent=dev)
+#
+# Record a file on dev, insert to staging, record on staging.
+# Switch between them.  Each view should show only its own content.
+
+make_temp_repo "shared-parent-1"
+init_repo
+
+# Record file on dev (root shared)
+create_file "base.txt" "I am the base file from dev"
+assert_success "add base.txt" atomic add base.txt
+record_change "Add base.txt on dev" >/dev/null 2>&1 || true
+
+# Create staging (shared, parent=dev)
+new_view "staging" --parent dev >/dev/null 2>&1 || true
+insert_from_view "dev" "staging" >/dev/null 2>&1 || true
+
+# Switch to staging — must see base.txt
+switch_view "staging" >/dev/null 2>&1 || true
+assert_file_exists "base.txt visible on staging" "base.txt"
+assert_file_content "base.txt has dev content on staging" "base.txt" "I am the base file from dev"
+assert_no_conflict_markers "no markers on staging" "base.txt"
+
+# Record something extra on staging
+create_file "staging-feature.txt" "staging feature"
+assert_success "add staging-feature.txt" atomic add staging-feature.txt
+record_change "Add staging-feature on staging" >/dev/null 2>&1 || true
+
+# Switch to dev — should see base.txt but NOT staging-feature.txt
+switch_view "dev" >/dev/null 2>&1 || true
+assert_file_exists "base.txt on dev" "base.txt"
+assert_file_content "base.txt content on dev" "base.txt" "I am the base file from dev"
+assert_no_conflict_markers "no markers on dev" "base.txt"
+assert_file_not_exists "staging-feature.txt NOT on dev" "staging-feature.txt"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Case 2: Shared chain — file edited at each level"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# dev has a file, staging adds to it.
+# Each level should show only its own accumulated content.
+# Dev must NOT show staging's additions.
+
+make_temp_repo "shared-parent-2"
+init_repo
+
+# Create multi-line file on dev
+cat > config.ini << 'EOF'
+[dev]
+setting = base
+EOF
+assert_success "add config.ini" atomic add config.ini
+record_change "Add config on dev" >/dev/null 2>&1 || true
+
+# Create staging (shared, parent=dev), insert dev's changes, add a section
+new_view "staging" --parent dev >/dev/null 2>&1 || true
+insert_from_view "dev" "staging" >/dev/null 2>&1 || true
+switch_view "staging" >/dev/null 2>&1 || true
+
+cat >> config.ini << 'EOF'
+
+[staging]
+version = 1.0
+EOF
+record_change "Add staging section" >/dev/null 2>&1 || true
+
+# Staging should see both sections
+assert_no_conflict_markers "no markers on staging" "config.ini"
+assert_file_contains "staging has dev section" "config.ini" "[dev]"
+assert_file_contains "staging has staging section" "config.ini" "[staging]"
+
+# Switch to dev — should see ONLY dev section
+switch_view "dev" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no markers on dev" "config.ini"
+assert_file_contains "dev has dev section" "config.ini" "[dev]"
+assert_file_not_contains "dev lacks staging section" "config.ini" "[staging]"
+
+# Round-trip: switch staging → dev → staging
+switch_view "staging" >/dev/null 2>&1 || true
+assert_no_conflict_markers "staging clean after round-trip" "config.ini"
+assert_file_contains "staging still has both" "config.ini" "[staging]"
+
+switch_view "dev" >/dev/null 2>&1 || true
+assert_no_conflict_markers "dev clean after round-trip" "config.ini"
+assert_file_not_contains "dev still lacks staging" "config.ini" "[staging]"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Case 3: Draft from shared child — inherits full chain"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# A draft view parented on staging (which is parented on dev) should
+# see all ancestor changes transitively.  Switching between views
+# should never produce conflict markers.
+
+make_temp_repo "shared-parent-3"
+init_repo
+
+# Dev creates a file
+create_file "library.rs" 'pub fn core_fn() -> i32 { 42 }'
+assert_success "add library.rs" atomic add library.rs
+record_change "Add library on dev" >/dev/null 2>&1 || true
+
+# Chain: dev → staging (shared)
+new_view "staging" --parent dev >/dev/null 2>&1 || true
+insert_from_view "dev" "staging" >/dev/null 2>&1 || true
+
+# Draft from staging
+new_view "feature" --draft --parent staging >/dev/null 2>&1 || true
+switch_view "feature" >/dev/null 2>&1 || true
+
+# Feature should see the file from dev (via staging → dev chain)
+assert_file_exists "library.rs on feature" "library.rs"
+assert_file_contains "feature sees core_fn" "library.rs" "core_fn"
+assert_no_conflict_markers "no markers on feature" "library.rs"
+
+# Edit on feature
+overwrite_file "library.rs" 'pub fn core_fn() -> i32 { 99 }'
+record_change "Feature: return 99" >/dev/null 2>&1 || true
+
+# Switch to staging — must see dev's original
+switch_view "staging" >/dev/null 2>&1 || true
+assert_file_exists "library.rs on staging" "library.rs"
+assert_file_contains "staging has 42" "library.rs" "42"
+assert_no_conflict_markers "no markers on staging" "library.rs"
+
+# Switch to dev — must see dev's original
+switch_view "dev" >/dev/null 2>&1 || true
+assert_file_exists "library.rs on dev" "library.rs"
+assert_file_contains "dev has 42" "library.rs" "42"
+assert_no_conflict_markers "no markers on dev" "library.rs"
+
+# ═══════════════════════════════════════════════════════════════════════════
+
+print_summary

--- a/tests/harness/24_concurrent_insert_conflict.sh
+++ b/tests/harness/24_concurrent_insert_conflict.sh
@@ -1,0 +1,449 @@
+#!/usr/bin/env bash
+# chmod +x tests/harness/24_concurrent_insert_conflict.sh
+#
+# 24_concurrent_insert_conflict.sh — Concurrent insert fork conflict resolution.
+#
+# Tests the specific scenario where multiple draft views independently modify
+# the same file (or same position within a file) and are then inserted into
+# a shared view.  This exercises the CRDT fork resolution path.
+#
+# Key questions answered by these tests:
+#   1. Do identical concurrent edits deduplicate cleanly?
+#   2. Do conflicting concurrent edits produce well-formed conflict markers?
+#   3. Does the graph remain stable across view switches after conflicts?
+#   4. Can a superseding change on the shared view resolve a prior fork?
+#
+# Each case creates a fresh repo to avoid cross-contamination.
+
+HARNESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$HARNESS_DIR/helpers.sh"
+
+# ── Local helpers (not in helpers.sh) ──────────────────────────────────────
+
+assert_no_conflict_markers() {
+    local desc="$1" path="$2"
+    if [[ ! -f "$path" ]]; then _fail "$desc" "file does not exist: $path"; return; fi
+    if grep -qE '>>>>>>|<<<<<<|=======' "$path" 2>/dev/null; then
+        _fail "$desc" "conflict markers found in $path. Content: $(cat "$path" | head -20)"
+    else
+        _pass "$desc"
+    fi
+}
+
+assert_file_contains() {
+    local desc="$1" path="$2" needle="$3"
+    if [[ ! -f "$path" ]]; then _fail "$desc" "file does not exist: $path"; return; fi
+    if grep -qF "$needle" "$path"; then _pass "$desc"
+    else _fail "$desc" "'$needle' not found in $path. Content: $(cat "$path" | head -10)"; fi
+}
+
+# Check for conflict markers — returns 0 if found, 1 if clean.
+has_conflict_markers() {
+    local path="$1"
+    grep -qE '>>>>>>|<<<<<<|=======' "$path" 2>/dev/null
+}
+
+# Assert that conflict markers are well-formed (both sides present).
+assert_well_formed_conflict() {
+    local desc="$1" path="$2"
+    if [[ ! -f "$path" ]]; then _fail "$desc" "file does not exist: $path"; return; fi
+    local has_open has_mid has_close
+    has_open=$(grep -cE '<<<<<<' "$path" 2>/dev/null || true)
+    has_mid=$(grep -cE '=======' "$path" 2>/dev/null || true)
+    has_close=$(grep -cE '>>>>>>' "$path" 2>/dev/null || true)
+    if [[ "$has_open" -gt 0 && "$has_mid" -gt 0 && "$has_close" -gt 0 ]]; then
+        _pass "$desc"
+    else
+        _fail "$desc" "malformed conflict: <<<<<<=$has_open, =======$has_mid, >>>>>>=$has_close in $path"
+    fi
+}
+
+# Snapshot a file's content for later comparison.
+snapshot_file() {
+    local path="$1"
+    if [[ -f "$path" ]]; then cat "$path"; else echo "__MISSING__"; fi
+}
+
+# Assert that a file's content is identical to a saved snapshot.
+assert_file_stable() {
+    local desc="$1" path="$2" expected_snapshot="$3"
+    if [[ ! -f "$path" ]]; then _fail "$desc" "file does not exist: $path"; return; fi
+    local actual
+    actual="$(cat "$path")"
+    if [[ "$actual" == "$expected_snapshot" ]]; then
+        _pass "$desc"
+    else
+        _fail "$desc" "content changed. Expected $(echo "$expected_snapshot" | wc -c | tr -d ' ') bytes, got $(echo "$actual" | wc -c | tr -d ' ') bytes"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Case 1: Identical edits from two drafts — should deduplicate"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Two drafts (alpha, beta) both add an identical empty line at the same
+# position.  When both are inserted into dev, the CRDT should recognise
+# identical content and deduplicate — no conflict markers.
+
+make_temp_repo "concurrent-1"
+init_repo
+
+# Create multi-line file on dev
+cat > imports.py << 'PYEOF'
+import os
+import sys
+import json
+
+def main():
+    pass
+PYEOF
+assert_success "add imports.py" atomic add imports.py
+record_change "Add imports.py on dev" >/dev/null 2>&1 || true
+
+# Create two draft views parented on dev
+new_view "alpha" --draft --parent dev >/dev/null 2>&1 || true
+new_view "beta"  --draft --parent dev >/dev/null 2>&1 || true
+
+# On alpha: add an empty line after the imports section (after 'import json')
+switch_view "alpha" >/dev/null 2>&1 || true
+cat > imports.py << 'PYEOF'
+import os
+import sys
+import json
+
+def main():
+    pass
+PYEOF
+# The file already has the blank line from the original — add a second one
+# to create a distinct edit (extra whitespace line after imports).
+cat > imports.py << 'PYEOF'
+import os
+import sys
+import json
+
+
+def main():
+    pass
+PYEOF
+record_change "Alpha: add blank line after imports" >/dev/null 2>&1 || true
+
+# On beta: add the same empty line at the same position
+switch_view "beta" >/dev/null 2>&1 || true
+cat > imports.py << 'PYEOF'
+import os
+import sys
+import json
+
+
+def main():
+    pass
+PYEOF
+record_change "Beta: add blank line after imports" >/dev/null 2>&1 || true
+
+# Switch to dev, insert from alpha, then beta
+switch_view "dev" >/dev/null 2>&1 || true
+insert_from_view "alpha" "dev" >/dev/null 2>&1 || true
+insert_from_view "beta" "dev" >/dev/null 2>&1 || true
+
+# Re-materialize: switch away and back
+switch_view "alpha" >/dev/null 2>&1 || true
+switch_view "dev" >/dev/null 2>&1 || true
+
+assert_file_exists "imports.py exists on dev after inserts" "imports.py"
+assert_no_conflict_markers "no conflict markers on dev (identical edits)" "imports.py"
+assert_file_contains "dev has import os" "imports.py" "import os"
+assert_file_contains "dev has import json" "imports.py" "import json"
+assert_file_contains "dev has def main" "imports.py" "def main():"
+
+# Verify content is stable across switches
+DEV_SNAPSHOT_1="$(snapshot_file "imports.py")"
+switch_view "alpha" >/dev/null 2>&1 || true
+switch_view "dev" >/dev/null 2>&1 || true
+assert_file_stable "dev content stable after round-trip (case 1)" "imports.py" "$DEV_SNAPSHOT_1"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Case 2: Different imports at same position — conflicting edits"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Alpha changes a line to add 'use bar;', beta changes the same line to
+# add 'use baz;'.  These are genuinely conflicting edits at the same
+# position.  After inserting both into dev, either the CRDT resolves
+# cleanly (both present) or conflict markers appear.
+
+make_temp_repo "concurrent-2"
+init_repo
+
+# Create file with a single import line
+create_file "lib.rs" "use foo;"
+assert_success "add lib.rs" atomic add lib.rs
+record_change "Add lib.rs with use foo" >/dev/null 2>&1 || true
+
+# Create two draft views
+new_view "alpha" --draft --parent dev >/dev/null 2>&1 || true
+new_view "beta"  --draft --parent dev >/dev/null 2>&1 || true
+
+# Alpha: change line to include bar
+switch_view "alpha" >/dev/null 2>&1 || true
+overwrite_file "lib.rs" "use foo;
+use bar;"
+record_change "Alpha: add use bar" >/dev/null 2>&1 || true
+
+# Beta: change line to include baz
+switch_view "beta" >/dev/null 2>&1 || true
+overwrite_file "lib.rs" "use foo;
+use baz;"
+record_change "Beta: add use baz" >/dev/null 2>&1 || true
+
+# Switch to dev, insert both
+switch_view "dev" >/dev/null 2>&1 || true
+insert_from_view "alpha" "dev" >/dev/null 2>&1 || true
+insert_from_view "beta" "dev" >/dev/null 2>&1 || true
+
+# Re-materialize
+switch_view "alpha" >/dev/null 2>&1 || true
+switch_view "dev" >/dev/null 2>&1 || true
+
+assert_file_exists "lib.rs exists on dev after both inserts" "lib.rs"
+
+# Check if conflict markers appeared
+if has_conflict_markers "lib.rs"; then
+    # If there are conflict markers, they must be well-formed
+    assert_well_formed_conflict "conflict markers are well-formed (case 2)" "lib.rs"
+    assert_file_contains "conflict contains bar side" "lib.rs" "bar"
+    assert_file_contains "conflict contains baz side" "lib.rs" "baz"
+else
+    # CRDT resolved cleanly — both additions should be present
+    assert_file_contains "dev has use foo" "lib.rs" "use foo;"
+    # At least one of bar/baz should be present
+    if grep -qF "bar" "lib.rs" || grep -qF "baz" "lib.rs"; then
+        _pass "CRDT resolved cleanly — content present"
+    else
+        _fail "CRDT resolved but content missing" "neither bar nor baz found"
+    fi
+fi
+
+# Stability check: switch to alpha and back — dev content must not change
+DEV_SNAPSHOT_2="$(snapshot_file "lib.rs")"
+switch_view "alpha" >/dev/null 2>&1 || true
+switch_view "dev" >/dev/null 2>&1 || true
+assert_file_stable "dev content stable after switch (case 2)" "lib.rs" "$DEV_SNAPSHOT_2"
+
+# Additional stability: switch to beta and back
+switch_view "beta" >/dev/null 2>&1 || true
+switch_view "dev" >/dev/null 2>&1 || true
+assert_file_stable "dev content stable after second switch (case 2)" "lib.rs" "$DEV_SNAPSHOT_2"
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Case 3: Three-way fork — three drafts modify same position"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Three drafts (a, b, c) each edit the same line differently.
+# After inserting all three into dev, either the CRDT resolves cleanly
+# or conflict markers are present and well-formed.  The graph must be
+# stable across view switches.
+
+make_temp_repo "concurrent-3"
+init_repo
+
+# Create base file
+create_file "config.toml" '[server]
+host = "localhost"
+port = 8080'
+assert_success "add config.toml" atomic add config.toml
+record_change "Add config.toml" >/dev/null 2>&1 || true
+
+# Create three draft views
+new_view "fork-a" --draft --parent dev >/dev/null 2>&1 || true
+new_view "fork-b" --draft --parent dev >/dev/null 2>&1 || true
+new_view "fork-c" --draft --parent dev >/dev/null 2>&1 || true
+
+# Fork A: change port to 3000
+switch_view "fork-a" >/dev/null 2>&1 || true
+overwrite_file "config.toml" '[server]
+host = "localhost"
+port = 3000'
+record_change "Fork A: port 3000" >/dev/null 2>&1 || true
+
+# Fork B: change port to 4000
+switch_view "fork-b" >/dev/null 2>&1 || true
+overwrite_file "config.toml" '[server]
+host = "localhost"
+port = 4000'
+record_change "Fork B: port 4000" >/dev/null 2>&1 || true
+
+# Fork C: change port to 5000
+switch_view "fork-c" >/dev/null 2>&1 || true
+overwrite_file "config.toml" '[server]
+host = "localhost"
+port = 5000'
+record_change "Fork C: port 5000" >/dev/null 2>&1 || true
+
+# Switch to dev and insert all three
+switch_view "dev" >/dev/null 2>&1 || true
+insert_from_view "fork-a" "dev" >/dev/null 2>&1 || true
+insert_from_view "fork-b" "dev" >/dev/null 2>&1 || true
+insert_from_view "fork-c" "dev" >/dev/null 2>&1 || true
+
+# Re-materialize
+switch_view "fork-a" >/dev/null 2>&1 || true
+switch_view "dev" >/dev/null 2>&1 || true
+
+assert_file_exists "config.toml exists on dev after 3 inserts" "config.toml"
+
+# The shared header should always be present
+assert_file_contains "dev has [server] header" "config.toml" "[server]"
+assert_file_contains "dev has host line" "config.toml" 'host = "localhost"'
+
+# Check conflict or clean resolution
+if has_conflict_markers "config.toml"; then
+    assert_well_formed_conflict "3-way conflict markers are well-formed" "config.toml"
+else
+    # CRDT resolved — at least one of the port values should be present
+    if grep -qE 'port = (3000|4000|5000)' "config.toml"; then
+        _pass "CRDT resolved 3-way fork — a port value is present"
+    else
+        _fail "CRDT resolved but no port value found" "$(cat "config.toml" | head -10)"
+    fi
+fi
+
+# Stability: switch through each fork and back to dev, content must not drift
+DEV_SNAPSHOT_3="$(snapshot_file "config.toml")"
+
+switch_view "fork-a" >/dev/null 2>&1 || true
+switch_view "dev" >/dev/null 2>&1 || true
+assert_file_stable "dev stable after switch to fork-a (case 3)" "config.toml" "$DEV_SNAPSHOT_3"
+
+switch_view "fork-b" >/dev/null 2>&1 || true
+switch_view "dev" >/dev/null 2>&1 || true
+assert_file_stable "dev stable after switch to fork-b (case 3)" "config.toml" "$DEV_SNAPSHOT_3"
+
+switch_view "fork-c" >/dev/null 2>&1 || true
+switch_view "dev" >/dev/null 2>&1 || true
+assert_file_stable "dev stable after switch to fork-c (case 3)" "config.toml" "$DEV_SNAPSHOT_3"
+
+# Each draft is a live perspective on its parent (dev).  Since dev now has
+# all three conflicting changes, each draft inherits them.  Drafts are NOT
+# snapshots — they see everything their parent sees plus their own changes.
+# Therefore drafts will show conflict markers if their parent has conflicts.
+
+switch_view "fork-a" >/dev/null 2>&1 || true
+assert_file_contains "fork-a still has port 3000" "config.toml" "port = 3000"
+if has_conflict_markers "config.toml"; then
+    _pass "fork-a inherits parent conflict markers (expected — draft = live perspective)"
+else
+    _pass "fork-a has no conflict markers (CRDT resolved cleanly on parent)"
+fi
+
+switch_view "fork-b" >/dev/null 2>&1 || true
+assert_file_contains "fork-b still has port 4000" "config.toml" "port = 4000"
+if has_conflict_markers "config.toml"; then
+    _pass "fork-b inherits parent conflict markers (expected — draft = live perspective)"
+else
+    _pass "fork-b has no conflict markers (CRDT resolved cleanly on parent)"
+fi
+
+switch_view "fork-c" >/dev/null 2>&1 || true
+assert_file_contains "fork-c still has port 5000" "config.toml" "port = 5000"
+if has_conflict_markers "config.toml"; then
+    _pass "fork-c inherits parent conflict markers (expected — draft = live perspective)"
+else
+    _pass "fork-c has no conflict markers (CRDT resolved cleanly on parent)"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Case 4: Superseding change resolves fork conflict"
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Two drafts edit the same line to different values, creating a fork on dev
+# when both are inserted.  Then a new change is recorded directly on dev
+# that sets the value to something else entirely — this superseding change
+# should resolve the fork cleanly (no conflict markers remain).
+
+make_temp_repo "concurrent-4"
+init_repo
+
+# Create base file
+create_file "setting.conf" "x = 1"
+assert_success "add setting.conf" atomic add setting.conf
+record_change "Add setting.conf with x=1" >/dev/null 2>&1 || true
+
+# Create draft alpha: x = 2
+new_view "alpha" --draft --parent dev >/dev/null 2>&1 || true
+switch_view "alpha" >/dev/null 2>&1 || true
+overwrite_file "setting.conf" "x = 2"
+record_change "Alpha: x = 2" >/dev/null 2>&1 || true
+
+# Create draft beta: x = 3
+switch_view "dev" >/dev/null 2>&1 || true
+new_view "beta" --draft --parent dev >/dev/null 2>&1 || true
+switch_view "beta" >/dev/null 2>&1 || true
+overwrite_file "setting.conf" "x = 3"
+record_change "Beta: x = 3" >/dev/null 2>&1 || true
+
+# Insert both into dev (creates a fork)
+switch_view "dev" >/dev/null 2>&1 || true
+insert_from_view "alpha" "dev" >/dev/null 2>&1 || true
+insert_from_view "beta" "dev" >/dev/null 2>&1 || true
+
+# Re-materialize
+switch_view "alpha" >/dev/null 2>&1 || true
+switch_view "dev" >/dev/null 2>&1 || true
+
+# At this point dev may have conflict markers from the fork
+# Record a note about the state before superseding
+PRE_SUPERSEDE="$(snapshot_file "setting.conf")"
+if has_conflict_markers "setting.conf"; then
+    _pass "fork created conflict markers (expected for divergent edits)"
+else
+    _pass "CRDT resolved fork without markers (also valid)"
+fi
+
+# Now record a superseding change directly on dev: x = 4
+overwrite_file "setting.conf" "x = 4"
+record_change "Dev: supersede to x = 4" >/dev/null 2>&1 || true
+
+# After the superseding change, there should be no conflict markers
+assert_file_exists "setting.conf exists after supersede" "setting.conf"
+assert_file_content "dev has x = 4 after supersede" "setting.conf" "x = 4"
+assert_no_conflict_markers "no conflict markers after supersede (case 4)" "setting.conf"
+
+# Stability: switch to each draft and back — dev should remain clean
+DEV_SNAPSHOT_4="$(snapshot_file "setting.conf")"
+
+switch_view "alpha" >/dev/null 2>&1 || true
+switch_view "dev" >/dev/null 2>&1 || true
+assert_file_stable "dev stable after switch to alpha (case 4)" "setting.conf" "$DEV_SNAPSHOT_4"
+assert_no_conflict_markers "no markers after alpha round-trip (case 4)" "setting.conf"
+
+switch_view "beta" >/dev/null 2>&1 || true
+switch_view "dev" >/dev/null 2>&1 || true
+assert_file_stable "dev stable after switch to beta (case 4)" "setting.conf" "$DEV_SNAPSHOT_4"
+assert_no_conflict_markers "no markers after beta round-trip (case 4)" "setting.conf"
+
+# Drafts are live perspectives on dev (their parent).  After inserting their
+# changes into dev and then recording a supersede on dev, the drafts inherit
+# the supersede change via the parent chain.  The supersede resolves the
+# fork, so drafts should show x = 4 and no conflict markers.
+switch_view "alpha" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no markers on alpha after supersede" "setting.conf"
+if grep -qF "x = 4" "setting.conf"; then
+    _pass "alpha inherits supersede (x = 4) from dev parent (expected — draft = live perspective)"
+elif grep -qF "x = 2" "setting.conf"; then
+    _pass "alpha shows own value x = 2 (draft isolated from parent supersede)"
+else
+    _fail "alpha has unexpected content" "$(cat "setting.conf" | head -5)"
+fi
+
+switch_view "beta" >/dev/null 2>&1 || true
+assert_no_conflict_markers "no markers on beta after supersede" "setting.conf"
+if grep -qF "x = 4" "setting.conf"; then
+    _pass "beta inherits supersede (x = 4) from dev parent (expected — draft = live perspective)"
+elif grep -qF "x = 3" "setting.conf"; then
+    _pass "beta shows own value x = 3 (draft isolated from parent supersede)"
+else
+    _fail "beta has unexpected content" "$(cat "setting.conf" | head -5)"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+
+print_summary


### PR DESCRIPTION
This pull request introduces several improvements to the view listing command and enhances the merge engine's ability to resolve multi-way and concurrent insertion conflicts more intelligently. The main changes include a new `--short` option for concise view listings, improved metadata display, and a more robust semantic merge strategy that deduplicates identical changes and resolves concurrent insertions where possible.

**View Listing Command Improvements:**
- Added a new `--short` (`-s`) option to the `atomic view list` command, allowing users to display only view names without metadata. The default output now includes metadata, and the old `--verbose` option is hidden but retained for backward compatibility. [[1]](diffhunk://#diff-47af24f4e52da7746c0c6b924ff40192be547eafc6dab177602a5421cb976e4cL12-R29) [[2]](diffhunk://#diff-47af24f4e52da7746c0c6b924ff40192be547eafc6dab177602a5421cb976e4cL50-R70)
- Enhanced the default output to show view metadata such as scope, change counts (including a breakdown of own vs. inherited changes for draft views), state hash, and parent view.
- Updated help text, examples, and tests to reflect the new behavior and options. [[1]](diffhunk://#diff-47af24f4e52da7746c0c6b924ff40192be547eafc6dab177602a5421cb976e4cL12-R29) [[2]](diffhunk://#diff-47af24f4e52da7746c0c6b924ff40192be547eafc6dab177602a5421cb976e4cR201-R208) [[3]](diffhunk://#diff-47af24f4e52da7746c0c6b924ff40192be547eafc6dab177602a5421cb976e4cL224-R238) [[4]](diffhunk://#diff-47af24f4e52da7746c0c6b924ff40192be547eafc6dab177602a5421cb976e4cL274-R288)

**Semantic Merge Engine Enhancements:**
- The merge engine now deduplicates vertices with identical content in conflict groups, automatically resolving N-way forks where possible. If all sides are identical, the conflict is resolved without user intervention.
- For concurrent insertions, the engine checks if one side's tokens are a subsequence of the other's (i.e., one side subsumes the other); if so, it auto-merges in favor of the superset. [[1]](diffhunk://#diff-a58bfd7a6460a6f18f437c322f7482c0faff585782bb884a6df870121cd781bfL90-L182) [[2]](diffhunk://#diff-a58bfd7a6460a6f18f437c322f7482c0faff585782bb884a6df870121cd781bfR380-R406)
- Refactored the merge logic for clarity, including a dedicated `run_three_way` method and improved logging for merge outcomes. [[1]](diffhunk://#diff-a58bfd7a6460a6f18f437c322f7482c0faff585782bb884a6df870121cd781bfL90-L182) [[2]](diffhunk://#diff-a58bfd7a6460a6f18f437c322f7482c0faff585782bb884a6df870121cd781bfL193) [[3]](diffhunk://#diff-a58bfd7a6460a6f18f437c322f7482c0faff585782bb884a6df870121cd781bfL203-R296)

**Repository Metadata:**
- The `ViewInfo` struct now distinguishes between total change count and the number of changes unique to a view (`own_change_count`), supporting more informative listings.

**Output Consistency:**
- Updated handling of unresolved forks to clarify that markers are emitted for all children when no CRDT data is available after deduplication.