### PR TITLE
fix(diff): honor positional file filter with --change

### DIFF
--- a/atomic-cli/src/commands/diff/helpers.rs
+++ b/atomic-cli/src/commands/diff/helpers.rs
@@ -21,6 +21,48 @@ impl Diff {
         print_info("No changes detected");
     }
 
+    /// Check whether a repository-relative path passes the positional
+    /// file filter (`atomic diff --change <hash> <file>...`).
+    ///
+    /// Returns `true` when no files were specified (no filtering) or when
+    /// the path exactly matches one of the given files. A leading `./` on
+    /// either side is tolerated.
+    pub(super) fn file_matches_filter(&self, path: &str) -> bool {
+        if self.files.is_empty() {
+            return true;
+        }
+        let path = path.strip_prefix("./").unwrap_or(path);
+        self.files.iter().any(|f| {
+            let f = f.strip_prefix("./").unwrap_or(f.as_str());
+            f == path
+        })
+    }
+
+    /// Filter computed file diffs down to the paths given on the command
+    /// line, rebuilding the aggregate stats from the surviving entries.
+    ///
+    /// This is a no-op when no positional files were specified.
+    pub(super) fn filter_file_diffs(
+        &self,
+        file_diffs: Vec<FileDiff>,
+        stats: DiffStats,
+    ) -> (Vec<FileDiff>, DiffStats) {
+        if self.files.is_empty() {
+            return (file_diffs, stats);
+        }
+        let file_diffs: Vec<FileDiff> = file_diffs
+            .into_iter()
+            .filter(|d| {
+                self.file_matches_filter(&d.old_path) || self.file_matches_filter(&d.new_path)
+            })
+            .collect();
+        let mut stats = DiffStats::new();
+        for d in &file_diffs {
+            stats.add_file(d.stats.clone());
+        }
+        (file_diffs, stats)
+    }
+
     /// Show the diff for a specific change by hash or prefix.
     ///
     /// This displays the content introduced by the change using state-based
@@ -52,6 +94,7 @@ impl Diff {
         // FileOps or the expensive graph reconstruction fallback. Graph-first
         // imported changes may intentionally have no FileOps yet.
         if let Some((file_diffs, stats)) = Self::build_git_import_file_diffs(&change) {
+            let (file_diffs, stats) = self.filter_file_diffs(file_diffs, stats);
             return self.print_change_file_diffs(&change, &hash, config, file_diffs, stats);
         }
 
@@ -76,6 +119,7 @@ impl Diff {
         config: &DiffOutputConfig,
     ) -> CliResult<()> {
         if let Some((file_diffs, stats)) = Self::build_git_import_file_diffs(change) {
+            let (file_diffs, stats) = self.filter_file_diffs(file_diffs, stats);
             if file_diffs.is_empty() {
                 self.print_no_changes();
                 return Ok(());
@@ -105,6 +149,12 @@ impl Diff {
 
         for ops in file_ops {
             let file_path = ops.path();
+
+            // Honor the positional file filter (`diff --change <hash> <file>`)
+            if !self.file_matches_filter(file_path) {
+                continue;
+            }
+
             let trunk_op = ops.trunk_op();
             let line_ops = ops.line_ops();
 
@@ -553,8 +603,12 @@ impl Diff {
     ) -> CliResult<()> {
         use atomic_repository::get_files_in_change;
 
-        // Get all files modified by this change
-        let modified_files = get_files_in_change(change);
+        // Get all files modified by this change, honoring the positional
+        // file filter (`diff --change <hash> <file>`)
+        let modified_files: Vec<_> = get_files_in_change(change)
+            .into_iter()
+            .filter(|path| self.file_matches_filter(path))
+            .collect();
 
         if modified_files.is_empty() {
             self.print_no_changes();

--- a/atomic-cli/src/commands/diff/tests.rs
+++ b/atomic-cli/src/commands/diff/tests.rs
@@ -625,6 +625,90 @@ mod tests {
         assert_eq!(diff.change, Some("abc123".to_string()));
     }
 
+    // File filter tests (`diff --change <hash> <file>`)
+
+    #[test]
+    fn test_file_matches_filter_empty_matches_everything() {
+        let diff = Diff::new();
+        assert!(diff.file_matches_filter("src/lib.rs"));
+        assert!(diff.file_matches_filter("a.txt"));
+    }
+
+    #[test]
+    fn test_file_matches_filter_exact_match() {
+        let diff = Diff::new().with_files(vec!["a.txt"]);
+        assert!(diff.file_matches_filter("a.txt"));
+        assert!(!diff.file_matches_filter("b.txt"));
+        assert!(!diff.file_matches_filter("dir/a.txt"));
+    }
+
+    #[test]
+    fn test_file_matches_filter_tolerates_dot_slash_prefix() {
+        let diff = Diff::new().with_files(vec!["./a.txt"]);
+        assert!(diff.file_matches_filter("a.txt"));
+
+        let diff = Diff::new().with_files(vec!["b.txt"]);
+        assert!(diff.file_matches_filter("./b.txt"));
+    }
+
+    #[test]
+    fn test_filter_file_diffs_no_files_is_noop() {
+        let diff = Diff::new();
+        let mut stats = DiffStats::new();
+        let d = FileDiff::modified("a.txt");
+        stats.add_file(d.stats.clone());
+        let (diffs, stats) = diff.filter_file_diffs(vec![d], stats);
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(stats.file_count(), 1);
+    }
+
+    #[test]
+    fn test_filter_file_diffs_keeps_only_matching_files() {
+        let diff = Diff::new().with_files(vec!["a.txt"]);
+
+        let mut a = FileDiff::modified("a.txt");
+        a.stats = FileDiffStats::modified("a.txt", 2, 1);
+        let mut b = FileDiff::modified("b.txt");
+        b.stats = FileDiffStats::modified("b.txt", 5, 5);
+
+        let mut stats = DiffStats::new();
+        stats.add_file(a.stats.clone());
+        stats.add_file(b.stats.clone());
+
+        let (diffs, stats) = diff.filter_file_diffs(vec![a, b], stats);
+
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].new_path, "a.txt");
+        // Stats are rebuilt from the surviving entries only
+        assert_eq!(stats.file_count(), 1);
+        assert_eq!(stats.total_insertions(), 2);
+        assert_eq!(stats.total_deletions(), 1);
+    }
+
+    #[test]
+    fn test_filter_file_diffs_added_file_matches_new_path() {
+        // Added files have old_path == "/dev/null"; the filter must match
+        // against new_path.
+        let diff = Diff::new().with_files(vec!["new.txt"]);
+
+        let mut added = FileDiff::added("new.txt");
+        added.stats = FileDiffStats::added("new.txt", 3);
+
+        let (diffs, stats) = diff.filter_file_diffs(vec![added], DiffStats::new());
+
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(stats.total_insertions(), 3);
+    }
+
+    #[test]
+    fn test_filter_file_diffs_no_match_yields_empty() {
+        let diff = Diff::new().with_files(vec!["nonexistent.txt"]);
+        let d = FileDiff::modified("a.txt");
+        let (diffs, stats) = diff.filter_file_diffs(vec![d], DiffStats::new());
+        assert!(diffs.is_empty());
+        assert!(!stats.has_changes());
+    }
+
     #[test]
     fn test_git_import_diff_metadata_without_file_ops_builds_file_diff() {
         use atomic_core::change::ChangeHeader;


### PR DESCRIPTION
## Problem

`atomic diff --change <hash> <file>` silently ignored the trailing file filter and always showed every file touched by the change.

## Root cause

`Diff::run` short-circuits into `show_change_diff` when `--change` is set (`command.rs`), and none of the three change-diff code paths in `helpers.rs` ever consulted `self.files`:

1. Git-import metadata path (`build_git_import_file_diffs`)
2. Semantic FileOps path (`show_change_diff_from_file_ops`)
3. Legacy computed fallback (`show_change_diff_computed`)

## Fix

- Added `file_matches_filter()` — exact repo-relative match, tolerating a leading `./`
- Added `filter_file_diffs()` — prunes computed `FileDiff`s and rebuilds aggregate stats from surviving entries
- Wired filtering into all three paths; the legacy computed path filters the file list up front to avoid expensive before/after content retrieval for filtered-out files

## Verification

Reproduced against a change touching two files:

```
# Before: both files shown despite filter
$ atomic diff --change NPA4BUIJFNAO .vault/intents/manual/auditor/5/intent.md --name-only
.vault/attestations/LINK-5/attested.md
.vault/intents/manual/auditor/5/intent.md

# After: only the filtered file
$ atomic diff --change NPA4BUIJFNAO .vault/intents/manual/auditor/5/intent.md --name-only
.vault/intents/manual/auditor/5/intent.md
```

Also verified: no filter still shows all files, non-matching filter prints "No changes detected", `--stat` totals reflect only filtered files.

Added 7 unit tests covering the filter helpers. Full `atomic-cli` diff test suite passes (135 tests), `cargo fmt --check` and `clippy` clean.