### PR TITLE
fix(diff): emit true hunk offsets and context lines for --change

### DIFF
--- a/atomic-cli/src/commands/diff/helpers.rs
+++ b/atomic-cli/src/commands/diff/helpers.rs
@@ -15,6 +15,56 @@ struct GitMetadataDiffFile {
     lines: Vec<GitDiffLine>,
 }
 
+/// A changed line paired with the insert/delete offset preceding it.
+///
+/// `net_before` is (insertions - deletions) before this line, which is what
+/// maps the line between old-file and new-file coordinates: an added line
+/// `n` was inserted after old line `n - 1 - net_before`, and a removed line
+/// `l` sat at new-file boundary `l - 1 + net_before`.
+#[derive(Debug, Clone)]
+pub(super) struct NumberedLine {
+    line: HunkLine,
+    net_before: isize,
+}
+
+impl NumberedLine {
+    pub(super) fn added(content: impl Into<String>, new_num: usize, net_before: isize) -> Self {
+        Self {
+            line: HunkLine::added(content, new_num),
+            net_before,
+        }
+    }
+
+    pub(super) fn removed(content: impl Into<String>, old_num: usize, net_before: isize) -> Self {
+        Self {
+            line: HunkLine::removed(content, old_num),
+            net_before,
+        }
+    }
+
+    /// Old-file position: the line number for removals, or the insertion
+    /// boundary (the number of the preceding old line) for additions.
+    fn old_pos(&self) -> usize {
+        match self.line.status {
+            LineStatus::Removed => self.line.old_line_num.unwrap_or(1),
+            _ => {
+                (self.line.new_line_num.unwrap_or(1) as isize - 1 - self.net_before).max(0) as usize
+            }
+        }
+    }
+
+    /// New-file position: the line number for additions, or the deletion
+    /// boundary (the number of the preceding new line) for removals.
+    fn new_pos(&self) -> usize {
+        match self.line.status {
+            LineStatus::Added => self.line.new_line_num.unwrap_or(1),
+            _ => {
+                (self.line.old_line_num.unwrap_or(1) as isize - 1 + self.net_before).max(0) as usize
+            }
+        }
+    }
+}
+
 impl Diff {
     /// Print a message when there are no changes.
     pub(super) fn print_no_changes(&self) {
@@ -63,6 +113,173 @@ impl Diff {
         (file_diffs, stats)
     }
 
+    /// Group numbered changed lines into diff hunks with true file offsets.
+    ///
+    /// `changed` must be in file order. Changes separated by more than
+    /// `2 * context` unchanged lines become separate hunks; closer changes
+    /// merge with the gap emitted as context. Context line content is taken
+    /// from `before_lines` (the file's recorded before-content); when it is
+    /// `None`, hunks are emitted with zero context but still carry true
+    /// offsets derived from the stored line numbers.
+    ///
+    /// Hunk headers follow git's unified-diff conventions: a pure insertion
+    /// at boundary `p` is `@@ -p,0 +n,k @@`, a pure deletion is
+    /// `@@ -l,k +p,0 @@`, and context lines count toward both sides.
+    pub(super) fn hunks_from_changed_lines(
+        changed: &[NumberedLine],
+        before_lines: Option<&[Vec<u8>]>,
+        context: usize,
+    ) -> Vec<DiffHunk> {
+        let mut hunks = Vec::new();
+        if changed.is_empty() {
+            return hunks;
+        }
+
+        let old_len = before_lines.map(|l| l.len()).unwrap_or(0);
+        let ctx = if before_lines.is_some() { context } else { 0 };
+        let merge_gap = 2 * ctx as isize;
+
+        // 1. Group into runs of nearby changes, measured in old-file
+        //    coordinates.
+        let mut runs: Vec<(usize, usize)> = Vec::new();
+        let mut run_start = 0usize;
+        let mut run_hi = changed[0].old_pos();
+        for (i, nl) in changed.iter().enumerate().skip(1) {
+            let lo = nl.old_pos();
+            // Unchanged lines between the run and this change. An addition
+            // sits at a boundary, so the gap is measured from the boundary
+            // itself; a removal occupies a line, hence the extra -1.
+            let gap = match nl.line.status {
+                LineStatus::Removed => lo as isize - run_hi as isize - 1,
+                _ => lo as isize - run_hi as isize,
+            };
+            if gap > merge_gap {
+                runs.push((run_start, i));
+                run_start = i;
+            }
+            run_hi = run_hi.max(nl.old_pos());
+        }
+        runs.push((run_start, changed.len()));
+
+        // 2. Emit one hunk per run.
+        for (start, end) in runs {
+            let lines = &changed[start..end];
+
+            let removed_count = lines.iter().filter(|l| l.line.is_removed()).count();
+            let added_count = lines.len() - removed_count;
+
+            let old_lo = lines.iter().map(|l| l.old_pos()).min().unwrap_or(0);
+            let old_hi = lines.iter().map(|l| l.old_pos()).max().unwrap_or(0);
+            let new_lo = lines.iter().map(|l| l.new_pos()).min().unwrap_or(0);
+
+            // Old-file range covered by the hunk, including context.
+            let (old_start, old_end, old_count) = if removed_count > 0 {
+                let s = old_lo.saturating_sub(ctx).max(1);
+                let e = if ctx > 0 {
+                    old_hi.saturating_add(ctx).min(old_len)
+                } else {
+                    old_hi
+                };
+                let e = e.max(s);
+                (s, e, e - s + 1)
+            } else {
+                // Pure insertion at boundary old_lo. With context, the old
+                // side covers the surviving lines around the boundary;
+                // without, it is the boundary itself with a count of 0.
+                let s = (old_lo + 1).saturating_sub(ctx).max(1);
+                let e = if ctx > 0 {
+                    old_hi.saturating_add(ctx).min(old_len)
+                } else {
+                    0
+                };
+                if ctx > 0 && s <= e {
+                    (s, e, e - s + 1)
+                } else {
+                    (old_lo, old_lo, 0)
+                }
+            };
+
+            // Emit context and changed lines in file order. `offset` is the
+            // running old→new line shift used to number context lines.
+            let mut hunk_lines: Vec<HunkLine> = Vec::new();
+            let mut offset: isize = lines[0].net_before;
+            let mut ctx_cursor = old_start;
+            let mut pre_ctx = 0usize;
+
+            for (idx, nl) in lines.iter().enumerate() {
+                if ctx > 0 {
+                    let fill_end = match nl.line.status {
+                        LineStatus::Removed => nl.old_pos().saturating_sub(1),
+                        _ => nl.old_pos(),
+                    };
+                    while ctx_cursor <= fill_end && ctx_cursor <= old_end {
+                        if let Some(content) = before_lines.and_then(|l| l.get(ctx_cursor - 1)) {
+                            let new_num = (ctx_cursor as isize + offset).max(1) as usize;
+                            hunk_lines.push(HunkLine::context(
+                                String::from_utf8_lossy(content).into_owned(),
+                                ctx_cursor,
+                                new_num,
+                            ));
+                            if idx == 0 {
+                                pre_ctx += 1;
+                            }
+                        }
+                        ctx_cursor += 1;
+                    }
+                }
+
+                hunk_lines.push(nl.line.clone());
+                match nl.line.status {
+                    LineStatus::Removed => {
+                        offset -= 1;
+                        ctx_cursor = ctx_cursor.max(nl.old_pos() + 1);
+                    }
+                    _ => {
+                        offset += 1;
+                    }
+                }
+            }
+
+            // Trailing context.
+            if ctx > 0 {
+                while ctx_cursor <= old_end {
+                    if let Some(content) = before_lines.and_then(|l| l.get(ctx_cursor - 1)) {
+                        let new_num = (ctx_cursor as isize + offset).max(1) as usize;
+                        hunk_lines.push(HunkLine::context(
+                            String::from_utf8_lossy(content).into_owned(),
+                            ctx_cursor,
+                            new_num,
+                        ));
+                    }
+                    ctx_cursor += 1;
+                }
+            }
+
+            let context_count = hunk_lines.iter().filter(|l| l.is_context()).count();
+            let new_count = context_count + added_count;
+            let new_start = if new_count == 0 {
+                // Pure deletion: anchor at the new-file boundary preceding
+                // the deleted lines.
+                new_lo
+            } else {
+                // New-file position of the first changed line, minus the
+                // context lines emitted before it.
+                let first = &lines[0];
+                let anchor = match first.line.status {
+                    LineStatus::Removed => first.new_pos() + 1,
+                    _ => first.line.new_line_num.unwrap_or(1),
+                };
+                anchor.saturating_sub(pre_ctx).max(1)
+            };
+
+            let mut hunk = DiffHunk::new(old_start, old_count, new_start, new_count);
+            hunk.lines = hunk_lines;
+            hunks.push(hunk);
+        }
+
+        hunks
+    }
+
     /// Show the diff for a specific change by hash or prefix.
     ///
     /// This displays the content introduced by the change using state-based
@@ -101,7 +318,7 @@ impl Diff {
         // Check if change has semantic layer (file_ops)
         if change.has_file_ops() {
             // Use the semantic layer for human-readable diff
-            return self.show_change_diff_from_file_ops(&change, &hash, config);
+            return self.show_change_diff_from_file_ops(repo, &change, &hash, config);
         }
 
         // Fallback: compute diff from content (legacy path)
@@ -112,8 +329,14 @@ impl Diff {
     ///
     /// This is the preferred path - it displays line-level and token-level
     /// changes directly from the stored CRDT operations, without recomputing.
+    ///
+    /// Hunks are anchored at their true file offsets (derived from the line
+    /// numbers stored on each operation at record time) and padded with
+    /// context lines from the file's recorded before-content, so downstream
+    /// renderers see standard unified-diff hunk headers.
     fn show_change_diff_from_file_ops(
         &self,
+        repo: &Repository,
         change: &Change,
         change_hash: &Hash,
         config: &DiffOutputConfig,
@@ -174,118 +397,145 @@ impl Diff {
                 _ => FileDiff::modified(file_path),
             };
 
-            // Build hunks from line operations
+            // Pass 1: flatten line operations into numbered changed lines.
+            //
+            // `net` tracks (insertions - deletions) so far, which is what
+            // lets each line be mapped between old-file and new-file
+            // coordinates when computing true hunk offsets.
             let mut insertions = 0usize;
             let mut deletions = 0usize;
             let mut new_line_num = 1usize;
             let mut old_line_num = 1usize;
+            let mut net: isize = 0;
+            let mut changed: Vec<NumberedLine> = Vec::new();
 
-            // Group consecutive operations into hunks
-            if !line_ops.is_empty() {
-                let mut current_hunk = DiffHunk::new(old_line_num, 0, new_line_num, 0);
+            for line_op in line_ops {
+                match line_op.operation() {
+                    BranchOp::Insert { content, .. } => {
+                        // Reconstruct line content from leaf operations
+                        let line_content = Self::reconstruct_line_from_leaf_ops(content);
+                        // Use stored line number if available, otherwise use counter
+                        let line_num = line_op.new_line_num().unwrap_or(new_line_num);
+                        changed.push(NumberedLine::added(line_content, line_num, net));
+                        new_line_num = line_num + 1;
+                        insertions += 1;
+                        net += 1;
+                    }
+                    BranchOp::Delete { content, .. } => {
+                        // Reconstruct deleted line content from stored leaf operations
+                        let line_content = if content.is_empty() {
+                            String::from("<deleted line>")
+                        } else {
+                            Self::reconstruct_line_from_leaf_ops(content)
+                        };
+                        // Use stored line number if available, otherwise use counter
+                        let line_num = line_op.old_line_num().unwrap_or(old_line_num);
+                        changed.push(NumberedLine::removed(line_content, line_num, net));
+                        old_line_num = line_num + 1;
+                        deletions += 1;
+                        net -= 1;
+                    }
+                    BranchOp::Modify {
+                        old_content,
+                        new_content,
+                        ..
+                    } => {
+                        // A Modify carries both old and new content.
+                        // Emit them as adjacent removed + added lines
+                        // so print_unified can pair them for word-level
+                        // highlighting.
+                        let old_line_content = if old_content.is_empty() {
+                            String::from("<modified line>")
+                        } else {
+                            Self::reconstruct_line_from_leaf_ops(old_content)
+                        };
+                        let new_line_content = Self::reconstruct_line_from_leaf_ops(new_content);
 
-                for line_op in line_ops {
-                    match line_op.operation() {
-                        BranchOp::Insert { content, .. } => {
-                            // Reconstruct line content from leaf operations
-                            let line_content = Self::reconstruct_line_from_leaf_ops(content);
-                            // Use stored line number if available, otherwise use counter
-                            let line_num = line_op.new_line_num().unwrap_or(new_line_num);
-                            current_hunk.add_line(HunkLine::added(line_content, line_num));
-                            new_line_num = line_num + 1;
-                            insertions += 1;
-                            current_hunk.new_count += 1;
-                        }
-                        BranchOp::Delete { content, .. } => {
-                            // Reconstruct deleted line content from stored leaf operations
-                            let line_content = if content.is_empty() {
-                                String::from("<deleted line>")
-                            } else {
-                                Self::reconstruct_line_from_leaf_ops(content)
-                            };
-                            // Use stored line number if available, otherwise use counter
-                            let line_num = line_op.old_line_num().unwrap_or(old_line_num);
-                            current_hunk.add_line(HunkLine::removed(line_content, line_num));
-                            old_line_num = line_num + 1;
-                            deletions += 1;
-                            current_hunk.old_count += 1;
-                        }
-                        BranchOp::Modify {
-                            old_content,
-                            new_content,
-                            ..
-                        } => {
-                            // A Modify carries both old and new content.
-                            // Emit them as adjacent removed + added lines
-                            // so print_unified can pair them for word-level
-                            // highlighting.
-                            let old_line_content = if old_content.is_empty() {
-                                String::from("<modified line>")
-                            } else {
-                                Self::reconstruct_line_from_leaf_ops(old_content)
-                            };
-                            let new_line_content =
-                                Self::reconstruct_line_from_leaf_ops(new_content);
+                        let old_ln = line_op.old_line_num().unwrap_or(old_line_num);
+                        let new_ln = line_op.new_line_num().unwrap_or(new_line_num);
 
-                            let old_ln = line_op.old_line_num().unwrap_or(old_line_num);
-                            let new_ln = line_op.new_line_num().unwrap_or(new_line_num);
+                        changed.push(NumberedLine::removed(old_line_content, old_ln, net));
+                        net -= 1;
+                        changed.push(NumberedLine::added(new_line_content, new_ln, net));
+                        net += 1;
 
-                            current_hunk.add_line(HunkLine::removed(old_line_content, old_ln));
-                            current_hunk.add_line(HunkLine::added(new_line_content, new_ln));
-
-                            old_line_num = old_ln + 1;
-                            new_line_num = new_ln + 1;
-                            deletions += 1;
-                            insertions += 1;
-                            current_hunk.old_count += 1;
-                            current_hunk.new_count += 1;
-                        }
-                        BranchOp::Restore { .. } => {
-                            // Restore is like an add for display purposes
-                            let line_num = line_op.new_line_num().unwrap_or(new_line_num);
-                            current_hunk.add_line(HunkLine::added(
-                                String::from("<restored line>"),
-                                line_num,
-                            ));
-                            new_line_num = line_num + 1;
-                            insertions += 1;
-                            current_hunk.new_count += 1;
-                        }
-                        BranchOp::Reparent { .. } => {
-                            // Position-only change — no visible delta in
-                            // unified diff output.  A future "blame-aware"
-                            // diff might render these explicitly; for now
-                            // they're silent.
-                        }
+                        old_line_num = old_ln + 1;
+                        new_line_num = new_ln + 1;
+                        deletions += 1;
+                        insertions += 1;
+                    }
+                    BranchOp::Restore { .. } => {
+                        // Restore is like an add for display purposes
+                        let line_num = line_op.new_line_num().unwrap_or(new_line_num);
+                        changed.push(NumberedLine::added(
+                            String::from("<restored line>"),
+                            line_num,
+                            net,
+                        ));
+                        new_line_num = line_num + 1;
+                        insertions += 1;
+                        net += 1;
+                    }
+                    BranchOp::Reparent { .. } => {
+                        // Position-only change — no visible delta in
+                        // unified diff output.  A future "blame-aware"
+                        // diff might render these explicitly; for now
+                        // they're silent.
                     }
                 }
+            }
 
-                if current_hunk.has_changes() {
-                    // Re-pair Delete+Insert lines by content similarity.
-                    //
-                    // The CRDT builder emits all Deletes before all Inserts
-                    // for unequal-count Replace blocks (to preserve correct
-                    // BRANCH_AFTER chain ordering).  This is correct for
-                    // the graph, but produces poor diff output because
-                    // modified lines appear as scattered -/+ pairs instead
-                    // of adjacent ones.
-                    //
-                    // This post-pass identifies contiguous runs of Removed
-                    // lines followed by Added lines and re-interleaves
-                    // them: each Removed line is paired with its best-
-                    // matching Added line (by bigram Jaccard similarity)
-                    // and emitted adjacently (-/+).  Unpaired lines keep
-                    // their original position.
-                    //
-                    // Git-imported changes already carry Git's authoritative
-                    // line ordering in their stored FileOps. Running the
-                    // heuristic re-pairing pass on top of that can scramble
-                    // the exact +/- sequence and break diff parity.
-                    if !Self::is_git_import_change(change) {
-                        current_hunk.lines = Self::repair_diff_lines(current_hunk.lines);
+            // Fetch the file's recorded before-content so hunks can be
+            // padded with context lines. Only needed for unified output
+            // with a non-zero --context; failures degrade to zero context.
+            let before_lines: Option<Vec<Vec<u8>>> =
+                if config.format == DiffFormat::Unified && config.context_lines > 0 {
+                    match repo.get_file_content_before_change(file_path, change_hash) {
+                        Ok(Some(content)) => {
+                            Some(content.split(|&b| b == b'\n').map(|l| l.to_vec()).collect())
+                        }
+                        _ => None,
                     }
-                    file_diff.add_hunk(current_hunk);
+                } else {
+                    None
+                };
+
+            // Pass 2: group changed lines into hunks at their true file
+            // offsets, padded with context lines.
+            let mut hunks = Self::hunks_from_changed_lines(
+                &changed,
+                before_lines.as_deref(),
+                config.context_lines,
+            );
+
+            for hunk in &mut hunks {
+                // Re-pair Delete+Insert lines by content similarity.
+                //
+                // The CRDT builder emits all Deletes before all Inserts
+                // for unequal-count Replace blocks (to preserve correct
+                // BRANCH_AFTER chain ordering).  This is correct for
+                // the graph, but produces poor diff output because
+                // modified lines appear as scattered -/+ pairs instead
+                // of adjacent ones.
+                //
+                // This post-pass identifies contiguous runs of Removed
+                // lines followed by Added lines and re-interleaves
+                // them: each Removed line is paired with its best-
+                // matching Added line (by bigram Jaccard similarity)
+                // and emitted adjacently (-/+).  Unpaired lines keep
+                // their original position.
+                //
+                // Git-imported changes already carry Git's authoritative
+                // line ordering in their stored FileOps. Running the
+                // heuristic re-pairing pass on top of that can scramble
+                // the exact +/- sequence and break diff parity.
+                if !Self::is_git_import_change(change) {
+                    hunk.lines = Self::repair_diff_lines(std::mem::take(&mut hunk.lines));
                 }
+            }
+
+            for hunk in hunks {
+                file_diff.add_hunk(hunk);
             }
 
             // Set stats based on change type

--- a/atomic-cli/src/commands/diff/tests.rs
+++ b/atomic-cli/src/commands/diff/tests.rs
@@ -709,6 +709,160 @@ mod tests {
         assert!(!stats.has_changes());
     }
 
+    // Hunk grouping tests (true offsets + context from FileOps line numbers)
+
+    use super::super::helpers::NumberedLine;
+
+    /// Build before-content lines "l1".."lN".
+    fn before_lines(n: usize) -> Vec<Vec<u8>> {
+        (1..=n).map(|i| format!("l{}", i).into_bytes()).collect()
+    }
+
+    #[test]
+    fn test_hunks_pure_insertion_zero_context_header() {
+        // Insert two lines after old line 15 (new lines 17,18; one prior
+        // insertion nets +1).
+        let changed = vec![
+            NumberedLine::added("x", 17, 1),
+            NumberedLine::added("y", 18, 2),
+        ];
+        let hunks = Diff::hunks_from_changed_lines(&changed, None, 3);
+        assert_eq!(hunks.len(), 1);
+        assert_eq!(hunks[0].header(), "@@ -15,0 +17,2 @@");
+        assert_eq!(hunks[0].lines.len(), 2);
+        assert!(hunks[0].lines.iter().all(|l| l.is_added()));
+    }
+
+    #[test]
+    fn test_hunks_pure_insertion_with_context() {
+        let before = before_lines(30);
+        let changed = vec![
+            NumberedLine::added("x", 17, 1),
+            NumberedLine::added("y", 18, 2),
+        ];
+        let hunks = Diff::hunks_from_changed_lines(&changed, Some(&before), 3);
+        assert_eq!(hunks.len(), 1);
+        assert_eq!(hunks[0].header(), "@@ -13,6 +14,8 @@");
+
+        let lines = &hunks[0].lines;
+        assert_eq!(lines.len(), 8);
+        // 3 context before (old 13-15 / new 14-16), 2 added, 3 context after
+        assert!(lines[0].is_context() && lines[0].content == "l13");
+        assert!(lines[1].is_context() && lines[1].content == "l14");
+        assert!(lines[2].is_context() && lines[2].content == "l15");
+        assert_eq!(lines[2].new_line_num, Some(16));
+        assert!(lines[3].is_added() && lines[3].new_line_num == Some(17));
+        assert!(lines[4].is_added() && lines[4].new_line_num == Some(18));
+        assert!(lines[5].is_context() && lines[5].content == "l16");
+        assert_eq!(lines[5].new_line_num, Some(19));
+        assert!(lines[7].is_context() && lines[7].content == "l18");
+    }
+
+    #[test]
+    fn test_hunks_pure_deletion_with_context() {
+        let before = before_lines(40);
+        let changed = vec![
+            NumberedLine::removed("a", 30, 0),
+            NumberedLine::removed("b", 31, -1),
+        ];
+        let hunks = Diff::hunks_from_changed_lines(&changed, Some(&before), 3);
+        assert_eq!(hunks.len(), 1);
+        assert_eq!(hunks[0].header(), "@@ -27,8 +27,6 @@");
+
+        let lines = &hunks[0].lines;
+        // 3 context, 2 removed, 3 context
+        assert_eq!(lines.len(), 8);
+        assert!(lines[0].is_context() && lines[0].content == "l27");
+        assert!(lines[3].is_removed() && lines[3].old_line_num == Some(30));
+        assert!(lines[4].is_removed() && lines[4].old_line_num == Some(31));
+        assert!(lines[5].is_context() && lines[5].content == "l32");
+        assert_eq!(lines[5].new_line_num, Some(30));
+    }
+
+    #[test]
+    fn test_hunks_full_file_deletion_zero_context() {
+        // Entire 3-line file deleted: git convention is @@ -1,3 +0,0 @@
+        let changed = vec![
+            NumberedLine::removed("a", 1, 0),
+            NumberedLine::removed("b", 2, -1),
+            NumberedLine::removed("c", 3, -2),
+        ];
+        let hunks = Diff::hunks_from_changed_lines(&changed, None, 3);
+        assert_eq!(hunks.len(), 1);
+        assert_eq!(hunks[0].header(), "@@ -1,3 +0,0 @@");
+    }
+
+    #[test]
+    fn test_hunks_new_file_header() {
+        // Brand-new file: git convention is @@ -0,0 +1,N @@
+        let changed = vec![
+            NumberedLine::added("a", 1, 0),
+            NumberedLine::added("b", 2, 1),
+            NumberedLine::added("c", 3, 2),
+        ];
+        let hunks = Diff::hunks_from_changed_lines(&changed, None, 3);
+        assert_eq!(hunks.len(), 1);
+        assert_eq!(hunks[0].header(), "@@ -0,0 +1,3 @@");
+    }
+
+    #[test]
+    fn test_hunks_split_on_gap_beyond_double_context() {
+        // Insertions after old lines 10 and 15: 5 unchanged lines between
+        // them, so with context 0 they form separate hunks.
+        let changed = vec![
+            NumberedLine::added("x", 11, 0),
+            NumberedLine::added("y", 17, 1),
+        ];
+        let hunks = Diff::hunks_from_changed_lines(&changed, None, 0);
+        assert_eq!(hunks.len(), 2);
+        assert_eq!(hunks[0].header(), "@@ -10,0 +11,1 @@");
+        assert_eq!(hunks[1].header(), "@@ -15,0 +17,1 @@");
+    }
+
+    #[test]
+    fn test_hunks_merge_within_double_context() {
+        // Same two insertions (boundaries 10 and 15) merge when context 3
+        // bridges the 5 unchanged lines between them.
+        let before = before_lines(30);
+        let changed = vec![
+            NumberedLine::added("x", 11, 0),
+            NumberedLine::added("y", 17, 1),
+        ];
+        let hunks = Diff::hunks_from_changed_lines(&changed, Some(&before), 3);
+        assert_eq!(hunks.len(), 1);
+        assert_eq!(hunks[0].header(), "@@ -8,11 +8,13 @@");
+
+        let lines = &hunks[0].lines;
+        // ctx 8,9,10 | +11 | ctx old 11-15 (new 12-16) | +17 | ctx old 16-18
+        assert_eq!(lines.len(), 13);
+        assert!(lines[3].is_added() && lines[3].new_line_num == Some(11));
+        assert!(lines[4].is_context() && lines[4].content == "l11");
+        assert_eq!(lines[4].new_line_num, Some(12));
+        assert!(lines[9].is_added() && lines[9].new_line_num == Some(17));
+        assert!(lines[10].is_context() && lines[10].content == "l16");
+        assert_eq!(lines[10].new_line_num, Some(18));
+    }
+
+    #[test]
+    fn test_hunks_modify_pair_offsets() {
+        // A Modify emits adjacent removed+added at line 5.
+        let changed = vec![
+            NumberedLine::removed("old", 5, 0),
+            NumberedLine::added("new", 5, -1),
+        ];
+        let hunks = Diff::hunks_from_changed_lines(&changed, None, 3);
+        assert_eq!(hunks.len(), 1);
+        assert_eq!(hunks[0].header(), "@@ -5,1 +5,1 @@");
+        assert!(hunks[0].lines[0].is_removed());
+        assert!(hunks[0].lines[1].is_added());
+    }
+
+    #[test]
+    fn test_hunks_empty_input() {
+        let hunks = Diff::hunks_from_changed_lines(&[], None, 3);
+        assert!(hunks.is_empty());
+    }
+
     #[test]
     fn test_git_import_diff_metadata_without_file_ops_builds_file_diff() {
         use atomic_core::change::ChangeHeader;


### PR DESCRIPTION
## Problem

`atomic diff --change <hash>` renders modifications to existing files as a **single all-add hunk anchored at line 1 with zero context**:

```
diff --atomic a/internal/store/store.go b/internal/store/store.go (+67)
@@ -1,0 +1,67 @@      ← 0 old lines, 67 new lines starting at line 1
```

Downstream renderers faithfully number the added lines 1…N per that header — but the numbers don't match where the changed code actually lives in the file. (Reported by a renderer author who verified the bug is in atomic's emitted diff, not their numbering logic.)

Follow-up to #120 (same command, related file-filter fix).

## Root cause

The record side already stores accurate old/new line numbers on every branch operation — I dumped the FileOps for a real change and found correct values (first insert at new line 11, exact old↔new mappings via Reparent ops). The display layer (`show_change_diff_from_file_ops`) simply:

1. Created one `DiffHunk::new(1, 0, 1, 0)` and stuffed every changed line into it, so the header always read `@@ -1,X +1,Y @@`
2. Never split hunks on gaps
3. Never emitted context lines (FileOps alone don't carry unchanged content)

## Fix

Reworked the FileOps path into two passes:

1. **Flatten** line ops into `NumberedLine`s, tracking the running insert/delete offset (`net`) that maps each line between old-file and new-file coordinates (an added line `n` was inserted after old line `n - 1 - net`; a removed line `l` sat at new boundary `l - 1 + net`).
2. **Group** via `hunks_from_changed_lines`: changes more than `2 * context` apart (old-file coordinates) split into separate hunks, closer ones merge. Headers follow git conventions (`@@ -p,0 +n,k @@` pure insertion, `@@ -l,k +p,0 @@` pure deletion, context counted on both sides). Context content comes from the file's recorded before-content, fetched lazily only for unified output with `--context > 0`; failures degrade gracefully to zero context with correct offsets.

## Verification

Real change (`internal/store/store.go`, +60 -4, edits mid-file):

```
# Before
@@ -1,4 +1,60 @@          ← one hunk at line 1, no context

# After
@@ -8,11 +8,14 @@           ← import block, 3 context lines each side
@@ -27,15 +30,29 @@         ← New(), with context
@@ -44,13 +61,52 @@        ← backupCorrupt/maxSeq, with context
```

Emitted lines verified line-for-line against the actual file content. `--context 0` yields exact zero-context headers (`@@ -10,0 +11,1 @@`, `@@ -52,1 +75,1 @@` — the latter matching `s.seq = maxSeq(links)` at real line 75). New files now get git's `@@ -0,0 +1,N @@`; full-file deletions get `@@ -1,N +0,0 @@`.

9 new unit tests (insertion/deletion/modify offsets, hunk split/merge, new-file and full-deletion conventions). Full `atomic-cli` suite passes (1640 tests), fmt + clippy clean. No frontend change needed — renderers that handle arbitrary hunk offsets, multiple hunks, and context lines will just work.