### PR TITLE
refactor(agent): agy — canonical AGENTS.md + atomic-vcs skill via vault files

### DIFF
--- a/atomic-agent/src/hooks/agy.rs
+++ b/atomic-agent/src/hooks/agy.rs
@@ -39,15 +39,16 @@
 //! reading whole files. Antigravity imports plugin skills and exposes them
 //! to the agent for task-based selection.
 //!
-//! # AGENTS.md Managed Section
+//! # Agent Instruction File
 //!
-//! Skills are on-demand — nothing forces the agent to read them. So
-//! project-level install additionally writes a small managed section into
-//! the repo's `AGENTS.md` (between `<!-- atomic:tools:start/end -->`
-//! markers) with the KG-first discovery rules. agy reads `AGENTS.md` as
-//! workspace context, making the workflow always-on for that repo. User
-//! content outside the markers is preserved; `uninstall` removes the
-//! section.
+//! The agent-facing instruction file (VCS rules, intent workflow, recording
+//! rules) is **required** for the integration to work as designed — without
+//! it the agent falls back to grep-and-read and git. Its canonical copy is
+//! `atomic-repository/vault/AGENTS.md`, a plain markdown file mirrored as
+//! `AGENTS.md` in the atomic-agy integration repository. On install, this
+//! adapter writes it into the project's `AGENTS.md` as a managed section
+//! (`<!-- atomic:tools:start/end -->` markers) and refreshes it on rerun
+//! when the canonical content changes; `uninstall` removes it.
 //!
 //! # Hook Execution Environment (Important)
 //!
@@ -171,45 +172,17 @@ const SECTION_START: &str = "<!-- atomic:tools:start -->";
 /// End marker for the managed Atomic section in `AGENTS.md`.
 const SECTION_END: &str = "<!-- atomic:tools:end -->";
 
-/// The managed section teaching the agent Atomic's code discovery workflow.
+/// The agent instruction file — VCS rules, intent workflow, recording
+/// rules, skills list.
 ///
-/// Written into the repo's `AGENTS.md` between the markers — agy reads that
-/// file as workspace context, which is how the agent learns to prefer the
-/// vault knowledge graph over grep-and-read, and `atomic` commands over
-/// `git`. Everything between the markers is Atomic-managed; user content
-/// outside them is preserved.
-const SECTION_BODY: &str = r#"## Atomic Code Intelligence
-
-This repository uses Atomic for version control. Its vault knowledge graph
-indexes every function, struct, trait, enum, and module, plus recorded
-changes — **search the KG first for code discovery, before grep or reading
-whole files**.
-
-1. `atomic vault query search "term"` — find entities, files, and changes by
-   keyword (use 1–2 specific words, not natural language)
-2. `atomic vault query neighbors <node-id>` — explore callers, definitions,
-   and changes; copy node IDs verbatim from search results
-3. Read files only after the KG tells you where to look
-
-Use grep only for literal strings and error messages the KG does not index.
-The KG is populated from recorded changes — unrecorded work will not appear
-in it.
-
-## Atomic, not git
-
-Atomic is the source of truth for this repository's history. **Use `atomic`
-commands, not `git`**, even if a `.git/` directory is present:
-
-- History: `atomic log` (not `git log`); inspect one change with
-  `atomic change <hash>`
-- Working copy: `atomic status` and `atomic diff` (not `git status` /
-  `git diff`)
-- Save work: `atomic record -m "..."` (not `git commit` — git commits
-  bypass Atomic's graph and provenance)
-- Parallel work: `atomic view` manages views, not branches
-
-Never run `git checkout`, `git reset`, or `git restore` — they fight the
-working copy Atomic materializes from its graph."#;
+/// The canonical copy lives at `atomic-repository/vault/AGENTS.md` (and is
+/// mirrored as `AGENTS.md` in the atomic-agy integration repository) —
+/// a plain markdown file, not embedded prose. It is written into the
+/// project's `AGENTS.md` between the markers above so the agent gets the
+/// standard workflow on `atomic agent enable`, and refreshed on rerun when
+/// the canonical content changes. User content outside the markers is
+/// preserved.
+const SECTION_BODY: &str = include_str!("../../../atomic-repository/vault/AGENTS.md");
 
 /// The plugin manifest written alongside `hooks.json`.
 const PLUGIN_MANIFEST: &str = r#"{
@@ -234,6 +207,10 @@ const PLUGIN_SKILLS: &[(&str, &str)] = &[
     (
         "atomic-vault.md",
         include_str!("../../../atomic-repository/vault/skills/atomic-vault.md"),
+    ),
+    (
+        "atomic-vcs.md",
+        include_str!("../../../atomic-repository/vault/skills/atomic-vcs.md"),
     ),
 ];
 
@@ -778,7 +755,9 @@ impl AgyHook {
     // AGENTS.md managed section
 
     /// Insert or replace the managed Atomic section in the repo's
-    /// `AGENTS.md`, creating the file if needed. Returns `true` if the file
+    /// `AGENTS.md`, creating the file if needed. The section content comes
+    /// from the canonical `atomic-repository/vault/AGENTS.md` (mirrored by
+    /// the atomic-agy integration repository). Returns `true` if the file
     /// was written.
     fn upsert_agents_md_section(repo_root: &Path) -> AgentResult<bool> {
         let path = repo_root.join(AGENTS_MD_FILE);
@@ -827,9 +806,10 @@ impl AgyHook {
         Ok(true)
     }
 
-    /// Remove the managed Atomic section from the repo's `AGENTS.md`,
-    /// preserving everything else. Deletes the file only if nothing else
-    /// remains. Returns `true` if the file was changed.
+    /// Remove a managed Atomic section from the repo's `AGENTS.md`, if one
+    /// exists from an older Atomic release that wrote it on install.
+    /// Preserves everything else in the file and deletes the file only if
+    /// nothing else remains. Returns `true` if the file was changed.
     fn remove_agents_md_section(repo_root: &Path) -> AgentResult<bool> {
         let path = repo_root.join(AGENTS_MD_FILE);
         if !path.exists() {
@@ -992,8 +972,9 @@ impl AgentHook for AgyHook {
     fn install(&self, repo_root: &Path) -> AgentResult<usize> {
         // Two-part install:
         // 1. Global plugin (hooks + skills) — the only mechanism agy fires.
-        // 2. Managed AGENTS.md section in the repo — teaches the agent the
-        //    KG-first discovery workflow.
+        // 2. Managed AGENTS.md section in the repo — the standard agent
+        //    instruction file, required for the agent to follow Atomic's
+        //    workflow (KG-first discovery, intent turns, recording rules).
         let count = self.install_global(false)?;
         Self::upsert_agents_md_section(repo_root)?;
         Ok(count)
@@ -1009,8 +990,8 @@ impl AgentHook for AgyHook {
     fn is_installed(&self, repo_root: &Path) -> bool {
         // Installed means both halves are present *and current*: the global
         // plugin and the repo's AGENTS.md section. Checking the section
-        // content (not just its markers) means an Atomic upgrade with
-        // revised guidance is picked up by a plain `agent enable` rerun.
+        // content (not just its markers) means an update to the canonical
+        // instruction file is picked up by a plain `agent enable` rerun.
         if !self.is_installed_global() {
             return false;
         }
@@ -1831,10 +1812,10 @@ mod tests {
         let content = std::fs::read_to_string(repo.path().join("AGENTS.md")).unwrap();
         assert!(content.contains(SECTION_START));
         assert!(content.contains(SECTION_END));
+        // Content comes from the canonical atomic-repository/vault/AGENTS.md.
+        assert!(content.contains("Atomic VCS Agent"));
+        assert!(content.contains("Do NOT run `atomic add` or `atomic record`"));
         assert!(content.contains("atomic vault query search"));
-        // VCS preference guidance: atomic commands over git.
-        assert!(content.contains("atomic log"));
-        assert!(content.contains("not `git log`"));
     }
 
     #[test]
@@ -1875,7 +1856,7 @@ mod tests {
 
         let content = std::fs::read_to_string(repo.path().join("AGENTS.md")).unwrap();
         assert!(!content.contains("old stale content"));
-        assert!(content.contains("atomic vault query search"));
+        assert!(content.contains("Atomic VCS Agent"));
         assert!(content.starts_with("# Project\n\n"));
     }
 
@@ -1894,7 +1875,6 @@ mod tests {
 
         let content = std::fs::read_to_string(repo.path().join("AGENTS.md")).unwrap();
         assert!(!content.contains(SECTION_START));
-        assert!(!content.contains("atomic vault query"));
         assert!(content.contains("# My Project"));
         assert!(content.contains("Custom rules here."));
         // No trailing blank-line debris.

--- a/atomic-repository/vault/AGENTS.md
+++ b/atomic-repository/vault/AGENTS.md
@@ -1,0 +1,107 @@
+# Atomic VCS Agent
+
+You use **Atomic VCS** (not git). A draft view is created for each session automatically.
+
+## Version control rules
+
+- **Never use `git` for repository operations** — no `git status`,
+  `git diff`, `git log`, `git add`, `git commit`, `git checkout`,
+  `git branch`, `git merge`, `git pull`, or `git push`. They bypass Atomic's
+  graph and provenance, and `git checkout` / `git reset` / `git restore`
+  fight the working copy Atomic materializes.
+- Use the **Atomic CLI** instead:
+  - `atomic status` instead of `git status`
+  - `atomic diff` instead of `git diff`
+  - `atomic log` instead of `git log`
+  - `atomic change <hash>` instead of `git show <hash>`
+  - `atomic view list` instead of `git branch`
+  - `atomic pull` / `atomic push` instead of `git pull` / `git push`
+- **Do NOT run `atomic add` or `atomic record`.** The Antigravity plugin
+  records your changes automatically with full AI provenance (session,
+  timing, decision graph) when the turn ends — running them yourself
+  pre-empts the plugin's recording and loses the provenance graph.
+
+## Code discovery: knowledge graph first
+
+The vault knowledge graph indexes every function, struct, trait, enum, and
+module, plus recorded changes. Search it before grep or reading whole files:
+
+1. `atomic vault query search "term"` — find entities, files, and changes by
+   keyword (use 1–2 specific words, not natural language)
+2. `atomic vault query neighbors <node-id>` — explore callers, definitions,
+   and changes; copy node IDs verbatim from search results
+3. Read files only after the KG tells you where to look
+
+Use grep only for literal strings the KG does not index. The KG is populated
+from recorded changes — unrecorded work will not appear in it.
+
+## Every prompt is a turn. Every turn follows this sequence.
+
+### 1. Create an intent
+
+Check `atomic vault intent list` first (do not duplicate an existing intent), then:
+
+```bash
+atomic vault intent create --title "<short title>"
+```
+
+This gives you an intent ID (e.g., HELL-4) and a file path.
+
+### 2. Define the problem
+
+The user's prompt is usually a **solution** ("build me X"). Reframe it as a **problem statement**.
+
+Ask clarifying questions if the problem is ambiguous. Do not guess — ask.
+
+Once the problem is clear, define:
+
+- **Problem statement** — what problem are we solving and why
+- **Success criteria** — concrete, testable conditions that mean "done"
+- **Tasks** — ordered list of work items
+
+Write all of this into the intent file, then run `atomic vault sync` to
+persist the file into the vault database. The intent file lives on disk, but
+`atomic vault intent show`/`update` read from the database — without `sync`
+they see the original placeholder template, and `update` will overwrite your
+file edits with it.
+
+### 3. Execute the tasks
+
+Work through the tasks in order. After completing each one:
+
+1. **Verify** it meets its criteria — run the commands or checks specified.
+2. **Edit the intent file** using your file editing tool to mark it done
+   (`- [ ]` → `- [x]`), and check off any satisfied acceptance criteria.
+   Use your file editing tool — not bash, not Python, not sed. Raw file
+   manipulation bypasses the vault.
+3. **Sync** so the database stays current:
+   ```bash
+   atomic vault sync
+   ```
+
+### 4. Update the intent
+
+```bash
+atomic vault sync                          # persist file edits to the database first
+atomic vault intent update <ID> --status done
+```
+
+## Rules
+
+- **One intent per turn.** Every prompt gets its own intent.
+- **Problem first.** Reframe solution-requests as problems. Ask questions if unclear.
+- **Write the intent file before coding.** The plan goes in the file, not just in chat.
+- **Do run `atomic vault sync` after editing any `.vault/` file** — it moves
+  your edits into the vault database; it is not `atomic record`, and hooks
+  do not do it for you mid-turn.
+- **Do not run `atomic add` or `atomic record`.** Hooks handle this with provenance.
+- **Do not create or switch views.** The session view is created automatically.
+- **Do not run `atomic agent enable`.** The integration is already configured.
+
+## Skills
+
+Use these for detailed reference when needed:
+
+- `/code-intelligence` — knowledge graph queries for code exploration
+- `/atomic-vault` — intent and goal lifecycle, memory operations
+- `/atomic-vcs` — inspect repository state and history: `status`, `log`, `change`, `diff`

--- a/atomic-repository/vault/skills/atomic-vcs.md
+++ b/atomic-repository/vault/skills/atomic-vcs.md
@@ -1,0 +1,193 @@
+---
+name: atomic-vcs
+description: Inspect repository state and history with the Atomic VCS CLI — status, log, change (including -p provenance and -a AI attestation), and diff. Use this whenever you need to see what changed, review your own recorded work, audit AI provenance, understand a teammate's change, or check the working copy before acting. These are read-only commands, safe to run anytime.
+---
+
+# Working with Atomic VCS
+
+Atomic is the version control system for this repository — not Git. You and Atomic
+are a pair: **hooks record your work automatically with full AI provenance** (model,
+tokens, cost, session, the decision graph), and these commands let you **read that
+history back**. Use them to ground yourself in reality instead of guessing.
+
+You do **not** run `atomic add` or `atomic record` — the hook system does that at turn
+end. Everything in this skill is **read-only inspection**, safe to run at any point in
+a turn, as often as you like.
+
+## The four commands
+
+| Command | Answers |
+|---------|---------|
+| `atomic status` | What's different in the working copy right now? |
+| `atomic log`    | What's the recent history of this view? |
+| `atomic change` | What exactly is in one change? (deps, hunks, provenance, AI attestation) |
+| `atomic diff`   | What are the precise line/token edits, working copy vs. recorded? |
+
+Start with `status` to orient, `log` to scan history, `change`/`diff` to drill in.
+
+## `atomic status` — working copy state
+
+```bash
+atomic status                  # full, human-readable
+atomic status -s               # short/porcelain: one line per file, machine-parseable
+atomic status src/             # restrict to a path
+atomic status --no-untracked   # hide untracked files (only tracked changes)
+atomic status --reindex        # rebuild FILE_INDEX first (use after git import / reset mtimes)
+```
+
+Short-format status codes (first column):
+
+| Code | Meaning | Code | Meaning |
+|------|---------|------|---------|
+| `A ` | Added (new tracked) | `R ` | Renamed |
+| `M ` | Modified | `C ` | Conflicted |
+| `D ` | Deleted | `T ` | Type changed |
+| `P ` | Permissions changed | `??` | Untracked |
+
+Run `status` **before you start editing** (to see the starting point) and **before the
+turn ends** (to confirm what your changes will record as).
+
+## `atomic log` — change history
+
+```bash
+atomic log                     # full history of the current view, newest first
+atomic log -n 10               # last 10 changes
+atomic log -f oneline          # compact: one line per change
+atomic log -f short            # hash + first line of message
+atomic log -f json             # machine-readable array (for parsing)
+atomic log --view dev          # another view's history without switching
+atomic log --path src/auth.rs  # only changes that touched this path
+atomic log --tags-only         # only tagged changes (release history)
+atomic log --reverse           # oldest first
+atomic log --from 42           # start at sequence 42
+atomic log --full-hash         # full 52-char Base32 hashes (default is abbreviated)
+```
+
+`log` is your replacement for `git log`. Use `-f oneline` to scan quickly, then copy a
+hash into `atomic change` to inspect one in detail.
+
+## `atomic change` — inspect a single change
+
+```bash
+atomic change                  # the most recent change on the current view
+atomic change R4YQUAS2UZV5     # by full hash
+atomic change R4YQ             # by hash prefix
+atomic change '#42'            # by sequence number (quote the # so the shell ignores it)
+atomic change --view dev '#3'  # sequence lookup against another view
+```
+
+Detail flags:
+
+```bash
+atomic change <id> --show-deps     # show each dependency change's message
+atomic change <id> --show-hunks    # show per-hunk graph-op details
+atomic change <id> --full-hash     # full hashes
+atomic change <id> -f json         # machine-readable
+atomic change <id> -a              # AI attestation  (see below)
+atomic change <id> -p              # provenance graph (see below)
+```
+
+### `change -a` — AI attestation (`--attest`)
+
+Shows the AI metadata recorded inline in the change header:
+
+- **vendor / model / model version** — which model authored the change
+- **token usage** — input / output / total
+- **cost** — what the change cost to produce
+- **session info** — the session/request it came from
+
+Use this to **audit authorship**: was a change human-written, AI-assisted, or fully
+AI-authored, and at what cost? This is the trust layer that makes AI commits reviewable.
+
+### `change -p` — provenance decision graph (`--provenance`)
+
+Shows the causal decision DAG stored in the change's `.provenance` file — the *why*
+behind the *what*:
+
+- **goals** — what the turn was trying to achieve
+- **tool executions** — the commands/searches that were run
+- **explorations** — what was investigated
+- **commitments** — the TODOs/decisions made
+- **patch proposals** — the edits that became this change
+
+This is uniquely powerful for collaboration: instead of reverse-engineering intent from
+a diff, you read the actual reasoning chain. Use `change -p` to **understand why a prior
+change was made before building on or modifying it** — including your own earlier turns.
+
+Combine them: `atomic change <id> -a -p --show-deps` gives the full picture — what it
+depends on, who/what authored it, what it cost, and the reasoning that produced it.
+
+## `atomic diff` — precise edits
+
+```bash
+atomic diff                    # working copy vs. recorded state, all modified tracked files
+atomic diff src/auth.rs        # one or more specific files
+atomic diff -c R4YQ            # compare against a specific change
+atomic diff --stat             # summary: files + line counts
+atomic diff --name-only        # just the changed paths
+atomic diff --name-status      # paths with M/A/D indicators
+atomic diff --untracked        # include untracked files
+atomic diff --view dev         # compare against another view
+atomic diff --word-diff        # token-level highlighting (CRDT-powered)
+atomic diff --algorithm patience   # better for moved blocks (default: myers)
+```
+
+`--word-diff` is special to Atomic: it shows exactly which **tokens** changed within a
+line, not just that the line changed. Reach for it during code review when a line was
+edited subtly.
+
+## Collaboration playbook
+
+**Orient at the start of a turn**
+```bash
+atomic status -s            # what's dirty?
+atomic log -n 5 -f oneline  # what happened recently?
+```
+
+**Review your own last recorded change**
+```bash
+atomic change -a -p         # what did I just do, and is the provenance correct?
+```
+
+**Understand a change before modifying its code**
+```bash
+atomic log --path src/auth.rs -f oneline   # find the change that introduced it
+atomic change <hash> -p --show-deps        # read the reasoning + dependencies
+```
+
+**Audit AI authorship across recent history**
+```bash
+atomic log -n 20 -f json    # then inspect interesting ones:
+atomic change <hash> -a
+```
+
+**Verify before the turn ends**
+```bash
+atomic status -s            # confirm the set of files that will record
+atomic diff --stat          # confirm the size/shape of the change
+```
+
+## When to use what
+
+| Goal | Command | Not this |
+|------|---------|----------|
+| See uncommitted changes | `atomic status` / `atomic diff` | ~~git status / git diff~~ |
+| Scan recent history | `atomic log -f oneline` | ~~git log~~ |
+| Inspect one change in full | `atomic change <id> --show-hunks` | ~~git show~~ |
+| See why a change was made | `atomic change <id> -p` | ~~guessing from the diff~~ |
+| Check model/tokens/cost of a change | `atomic change <id> -a` | ~~assuming~~ |
+| Token-level review of an edit | `atomic diff --word-diff` | ~~eyeballing the line~~ |
+| Find changes touching a file | `atomic log --path <file>` | ~~grep through history~~ |
+| Feed history to a script | add `-f json` / `--name-status` | ~~parsing human output~~ |
+
+## Tips
+
+- These commands are read-only — run them freely; they never modify the repo.
+- You don't record (`atomic add`/`record`) — hooks do, with provenance. These commands
+  let you read that provenance back.
+- Quote sequence references so the shell doesn't treat `#` as a comment: `atomic change '#42'`.
+- Add `-f json` (log/change) or `--name-status` (diff) when you need to parse output.
+- For *code structure and content* search (functions, definitions, text), use the
+  `code-intelligence` skill (`atomic vault query ...`). This skill is for *version
+  history and working-copy state*.
+- For the goals/intents/memory and recording workflow, see the `atomic-vault` skill.


### PR DESCRIPTION
> **Context:** the agy integration's content home is the atomic-agy repo (https://github.com/atomicdotdev/atomic-agy). This PR fixes *how* the binary distributes that content: plain canonical markdown files in `atomic-repository/vault/` — the same mechanism the vault skills already use — never as prose embedded in Rust string literals.

## Why

Two review findings, reconciled:

1. The agy adapter embedded the agent instruction file as a **~100-line string const in Rust source** — weird and release-gated.
2. But `AGENTS.md` is **required** for the integration to work as designed: without it the agent never learns the VCS rules, intent workflow, or recording rules, and `atomic agent enable --agent agy` must deliver it.

## What

**`atomic agent enable --agent agy` now yields a complete integration:**

```
~/.gemini/config/plugins/atomic/     ← global plugin (hooks, plugin.json, 3 skills, registry entry)
<project>/AGENTS.md                  ← managed section with the canonical instruction file
```

- **Canonical content as markdown files** — `atomic-repository/vault/AGENTS.md` (instruction file) and `atomic-repository/vault/skills/atomic-vcs.md` (the third skill, completing the standard set) are included via `include_str!`, exactly how the existing vault skills work. `atomic-agy/AGENTS.md` mirrors the instruction file — verified byte-identical.
- **Managed section with freshness** — install writes the instruction file into the project's `AGENTS.md` between `<!-- atomic:tools:start/end -->` markers, preserving user content; `is_installed` compares content so a canonical update is picked up by a plain `agent enable` rerun; `disable` removes the section.
- **Plugin unchanged** — hooks + `plugin.json` + 3 skills + `import_manifest.json` entry, as established in #118.

## Verified

- 42 adapter tests (section creation/refresh/removal, canonical content assertions); full `atomic-agent` suite green (1266); clippy/fmt clean.
- Live e2e: `atomic agent enable --agent agy` in a test project writes `AGENTS.md` containing the canonical `# Atomic VCS Agent` content between the markers.