### PR TITLE
feat(cli): configure single-tenant servers from the register response

### DIFF
--- a/atomic-cli/src/commands/identity/register.rs
+++ b/atomic-cli/src/commands/identity/register.rs
@@ -203,6 +203,12 @@ impl Register {
                 .get("base_url")
                 .and_then(|v| v.as_str())
                 .unwrap_or("(unknown)");
+            // Single-tenant deployments report `mode: "single"` (field added
+            // server-side in v1.4.0; absent on older servers = multi-tenant).
+            // On a single-tenant server the typed URL IS the tenant URL —
+            // no `{org}.` prefixing — so the profile must keep it verbatim
+            // and mark the server single-tenant.
+            let (single_tenant, role) = parse_tenancy_mode(data);
 
             let clean_server_url = self.server_url.trim_end_matches('/').to_string();
             let mut config = GlobalConfig::load().map_err(|e| {
@@ -223,6 +229,7 @@ impl Register {
                     default_org: Some(slug.to_string()),
                     default_workspaces: std::collections::BTreeMap::new(),
                     identity: Some(identity.name.clone()),
+                    single_tenant,
                 };
 
                 config.servers.insert(profile_name.clone(), profile);
@@ -248,6 +255,7 @@ impl Register {
                 // Default path: update the legacy [server] block.
                 config.server.url = Some(clean_server_url.clone());
                 config.server.default_org = Some(slug.to_string());
+                config.server.single_tenant = single_tenant;
             }
 
             config.save().map_err(|e| {
@@ -260,6 +268,12 @@ impl Register {
             println!("  Slug:      {slug}");
             println!("  URL:       {base_url}");
             println!("  Identity:  {} ({})", identity.name, identity.id.short());
+            if single_tenant {
+                println!(
+                    "  Mode:      single-tenant (role: {})",
+                    role.unwrap_or("member")
+                );
+            }
 
             if slug != username {
                 println!();
@@ -356,6 +370,18 @@ fn derive_profile_name(server_url: &str) -> Option<String> {
     }
 }
 
+/// Interpret the registration response's tenancy signal.
+///
+/// `mode: "single"` (server v1.4.0+) marks a single-tenant deployment and
+/// carries the org `role` the identity received; anything else — `"multi"`
+/// or a missing field (older servers) — keeps multi-tenant URL semantics.
+/// Returns `(single_tenant, role)`.
+fn parse_tenancy_mode(data: &serde_json::Value) -> (bool, Option<&str>) {
+    let single = data.get("mode").and_then(|v| v.as_str()) == Some("single");
+    let role = data.get("role").and_then(|v| v.as_str());
+    (single, role)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -383,6 +409,32 @@ mod tests {
 
         assert_eq!(endpoint_a, "https://atomic.storage/register");
         assert_eq!(endpoint_b, "https://atomic.storage/register");
+    }
+
+    #[test]
+    fn tenancy_mode_single_with_role() {
+        let data = serde_json::json!({"mode": "single", "role": "owner"});
+        let (single, role) = parse_tenancy_mode(&data);
+        assert!(single);
+        assert_eq!(role, Some("owner"));
+    }
+
+    #[test]
+    fn tenancy_mode_multi() {
+        let data = serde_json::json!({"mode": "multi"});
+        let (single, role) = parse_tenancy_mode(&data);
+        assert!(!single);
+        assert_eq!(role, None);
+    }
+
+    #[test]
+    fn tenancy_mode_missing_field_defaults_multi() {
+        // Legacy server responses (pre-mode field) must not flip profile
+        // semantics — they keep org-prefixed URLs.
+        let data = serde_json::json!({"slug": "alice", "base_url": "https://alice.atomic.storage"});
+        let (single, role) = parse_tenancy_mode(&data);
+        assert!(!single);
+        assert_eq!(role, None);
     }
 
     #[test]

--- a/atomic-cli/src/commands/server/mod.rs
+++ b/atomic-cli/src/commands/server/mod.rs
@@ -253,6 +253,9 @@ impl ServerCmd {
             default_org: add.org.clone(),
             default_workspaces: std::collections::BTreeMap::new(),
             identity: add.identity.clone(),
+            // Auto-detected at registration; manual profiles default to
+            // multi-tenant URL semantics.
+            single_tenant: false,
         };
 
         config.servers.insert(add.name.clone(), profile);

--- a/atomic-config/src/lib.rs
+++ b/atomic-config/src/lib.rs
@@ -108,6 +108,15 @@ pub struct ServerConfig {
     /// Example: `identity = "alice-staging"`
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identity: Option<String>,
+
+    /// Whether the server is a single-tenant deployment.
+    ///
+    /// Single-tenant servers (reported by the registration response's
+    /// `mode = "single"`) serve exactly one organization at their bare host:
+    /// org-scoped URLs are NOT prefixed with the org slug — every path is
+    /// already scoped to the single tenant server-side.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub single_tenant: bool,
 }
 
 impl ServerConfig {
@@ -123,8 +132,17 @@ impl ServerConfig {
     ///
     /// Given `url = "http://localhost:8080"` and `org = "alice"`,
     /// returns `"http://alice.localhost:8080"`.
+    ///
+    /// For single-tenant servers the org is already implied by the server
+    /// itself, so the URL is returned unchanged (no `{org}.` prefix).
     pub fn org_base_url(&self, org_slug: &str) -> Option<String> {
         let url = self.url.as_ref()?;
+
+        // Single-tenant: the bare host is already tenant-scoped server-side;
+        // prefixing would produce bogus hosts like `org.org.org.example.com`.
+        if self.single_tenant {
+            return Some(url.trim_end_matches('/').to_string());
+        }
 
         // Parse the URL to extract scheme, host, port
         let url_parsed = url::Url::parse(url).ok()?;
@@ -465,6 +483,7 @@ mod tests {
             default_org: Some("alice".to_string()),
             default_workspaces: BTreeMap::new(),
             identity: None,
+            single_tenant: false,
         };
         assert!(config.is_configured());
 
@@ -474,6 +493,7 @@ mod tests {
             default_org: None,
             default_workspaces: BTreeMap::new(),
             identity: None,
+            single_tenant: false,
         };
         assert!(!partial.is_configured());
 
@@ -483,6 +503,7 @@ mod tests {
             default_org: Some("alice".to_string()),
             default_workspaces: BTreeMap::new(),
             identity: None,
+            single_tenant: false,
         };
         assert!(!partial.is_configured());
     }
@@ -494,6 +515,7 @@ mod tests {
             default_org: Some("alice".to_string()),
             default_workspaces: BTreeMap::new(),
             identity: None,
+            single_tenant: false,
         };
         assert_eq!(
             config.org_base_url("alice"),
@@ -512,6 +534,7 @@ mod tests {
             default_org: None,
             default_workspaces: BTreeMap::new(),
             identity: None,
+            single_tenant: false,
         };
         assert_eq!(
             config.org_base_url("alice"),
@@ -526,6 +549,7 @@ mod tests {
             default_org: Some("alice".to_string()),
             default_workspaces: BTreeMap::new(),
             identity: None,
+            single_tenant: false,
         };
         assert_eq!(
             config.default_org_base_url(),
@@ -538,6 +562,7 @@ mod tests {
             default_org: None,
             default_workspaces: BTreeMap::new(),
             identity: None,
+            single_tenant: false,
         };
         assert!(config.default_org_base_url().is_none());
     }
@@ -549,6 +574,7 @@ mod tests {
             default_org: Some("alice".to_string()),
             default_workspaces: BTreeMap::new(),
             identity: None,
+            single_tenant: false,
         };
 
         let toml_str = toml::to_string_pretty(&config).unwrap();
@@ -573,6 +599,7 @@ mod tests {
                 default_org: Some("alice".to_string()),
                 default_workspaces: BTreeMap::new(),
                 identity: None,
+                single_tenant: false,
             },
             ..GlobalConfig::default()
         };
@@ -597,6 +624,7 @@ mod tests {
             default_org: Some("alice".to_string()),
             default_workspaces: BTreeMap::new(),
             identity: None,
+            single_tenant: false,
         };
         let toml_str = toml::to_string_pretty(&config).unwrap();
         assert!(!toml_str.contains("default_workspaces"));
@@ -613,6 +641,7 @@ mod tests {
             default_org: Some("alice".to_string()),
             default_workspaces: workspaces,
             identity: None,
+            single_tenant: false,
         };
 
         let toml_str = toml::to_string_pretty(&config).unwrap();
@@ -664,5 +693,60 @@ email = "test@example.com"
         assert!(!parsed.server.is_configured());
         assert!(parsed.server.url.is_none());
         assert!(parsed.server.default_org.is_none());
+    }
+
+    #[test]
+    fn test_org_base_url_single_tenant_not_prefixed() {
+        let config = ServerConfig {
+            url: Some("https://storage.acme.com".to_string()),
+            default_org: Some("acme".to_string()),
+            default_workspaces: BTreeMap::new(),
+            identity: None,
+            single_tenant: true,
+        };
+        // Single-tenant: the bare host is already tenant-scoped — no org prefix.
+        assert_eq!(
+            config.org_base_url("acme").as_deref(),
+            Some("https://storage.acme.com")
+        );
+        // Any org slug returns the bare host unchanged.
+        assert_eq!(
+            config.org_base_url("anything-else").as_deref(),
+            Some("https://storage.acme.com")
+        );
+        assert_eq!(
+            config.default_org_base_url().as_deref(),
+            Some("https://storage.acme.com")
+        );
+    }
+
+    #[test]
+    fn test_org_base_url_single_tenant_strips_trailing_slash() {
+        let config = ServerConfig {
+            url: Some("https://storage.acme.com/".to_string()),
+            default_org: Some("acme".to_string()),
+            default_workspaces: BTreeMap::new(),
+            identity: None,
+            single_tenant: true,
+        };
+        assert_eq!(
+            config.org_base_url("acme").as_deref(),
+            Some("https://storage.acme.com")
+        );
+    }
+
+    #[test]
+    fn test_single_tenant_defaults_false_for_legacy_configs() {
+        // Configs written before the field existed must deserialize as
+        // multi-tenant (org-prefixed) — no migration needed.
+        let legacy = r#"url = "https://atomic.storage"
+default_org = "alice"
+"#;
+        let config: ServerConfig = toml::from_str(legacy).unwrap();
+        assert!(!config.single_tenant);
+        assert_eq!(
+            config.org_base_url("alice").as_deref(),
+            Some("https://alice.atomic.storage")
+        );
     }
 }


### PR DESCRIPTION
## What

Companion to atomicdotdev/atomic-storage#78 (single-tenant mode). Registration
responses now carry `mode`/`role`; when `mode == "single"` the CLI configures
itself correctly from the response alone — no manual URL/org fixups.

- **`ServerConfig.single_tenant`** (serde-default `false`, skipped when false).
  Existing configs and pre-`mode` servers keep multi-tenant semantics — no
  migration, no config churn.
- **`org_base_url()`** returns the bare host unchanged for single-tenant
  servers. They're already tenant-scoped server-side, so the `{org}.` prefix
  would produce bogus hosts like `org.org.example.com`.
- **`identity register`** writes a correct profile straight from the response:
  typed URL kept verbatim, `default_org` from the response slug, identity
  bound, `single_tenant` set — including the default-identity (legacy
  `[server]`) path.

## Usage

### Register with a single-tenant server

```bash
atomic identity new alice --email alice@customer.com --set-default
atomic identity register https://storage.customer.com --identity alice --server-name customer
```

The server responds `mode: "single"`, and the CLI writes a ready-to-use
profile (URLs are used as-is, no `{org}.` prefix):

```toml
[servers.customer]
url = "https://storage.customer.com"
default_org = "customer"     # from the response slug
identity = "alice"
single_tenant = true
default_server = "customer"  # activated automatically when it's your first server
```

> Tip: pass `--server-name` — the auto-derived name is the first host label
> (`storage.customer.com` → `storage`), which is rarely what you want.

### Already on multi-tenant `atomic.storage`, adding a single-tenant server

Existing multi-tenant setup is left untouched. Registering a single-tenant
server **adds** a profile but does not silently switch your active server:

```bash
atomic identity register https://storage.customer.com --identity alice-customer --server-name customer
#   Profile:   'customer' added (activate with: atomic server set customer)
```

```toml
[server]                       # unchanged — still multi-tenant
url = "https://atomic.storage"
default_org = "alice"

[servers.customer]             # new — single-tenant
url = "https://storage.customer.com"
default_org = "customer"
identity = "alice-customer"
single_tenant = true
```

Switch between them:

```bash
atomic server list             # shows both; marks the active one
atomic server set customer     # activate the single-tenant server
atomic server unset            # revert to the legacy [server] (atomic.storage)
atomic <cmd> --server customer # or target per-command without switching
```

## Backwards compatibility

Multi-tenant is the default on both axes, so nothing changes for existing users:

- **Config**: `single_tenant` deserializes to `false` for configs written
  before the field existed; it's omitted from output when false. No migration.
- **Server**: a missing `mode` field (older servers) is treated as multi-tenant,
  preserving org-prefixed URLs.

## Test plan

- `atomic-config`: `org_base_url` single-tenant (no prefix, trailing slash
  stripped); legacy TOML deserialization defaults to multi.
- `atomic-cli`: tenancy parsing for single / multi / missing-field responses.
- Full suites green, clippy `-D warnings`, fmt.

Verified end-to-end against a live single-tenant deployment on GKE (push/pull as
owner; member joins with zero implicit access).
