### PR TITLE
fix(cli): correct behavior found by the command harness

### DIFF
--- a/atomic-cli/src/commands/agent/disable.rs
+++ b/atomic-cli/src/commands/agent/disable.rs
@@ -210,10 +210,12 @@ impl Disable {
     /// - `claude-code` → `~/.claude/settings.json`
     /// - `gemini-cli` → `~/.gemini/settings.json`
     /// - `agy` → `~/.gemini/config/plugins/atomic/` (plugin)
+    /// - `codex` → `~/.codex/hooks.json`
     /// - No `--agent` flag → removes from all agents that have global hooks
     fn run_global(&self) -> CliResult<()> {
         use atomic_agent::hooks::agy::AgyHook;
         use atomic_agent::hooks::claude_code::ClaudeCodeHook;
+        use atomic_agent::hooks::codex::CodexHook;
         use atomic_agent::hooks::gemini_cli::GeminiCliHook;
 
         let agents: Vec<&str> = if let Some(ref name) = self.agent {
@@ -229,6 +231,9 @@ impl Disable {
             }
             if AgyHook::new().is_installed_global() {
                 found.push("agy");
+            }
+            if CodexHook::new().is_installed_global() {
+                found.push("codex");
             }
             found
         };
@@ -295,6 +300,21 @@ impl Disable {
                         }
                     }
                 }
+                "codex" => {
+                    let hook = CodexHook::new();
+                    if !hook.is_installed_global() {
+                        continue;
+                    }
+                    match hook.uninstall_global() {
+                        Ok(()) => {
+                            print_success("Removed global hooks from ~/.codex/hooks.json");
+                            total_removed += 1;
+                        }
+                        Err(e) => {
+                            print_error(&format!("Failed to remove Codex global hooks: {}", e));
+                        }
+                    }
+                }
                 "kiro" => {
                     print_success("Kiro hooks are configured through the IDE panel.");
                     println!(
@@ -309,7 +329,7 @@ impl Disable {
                 }
                 other => {
                     print_warning(&format!(
-                        "Global disable is not supported for '{}'. Supported agents: claude-code, gemini-cli, agy, kilo, kiro",
+                        "Global disable is not supported for '{}'. Supported agents: claude-code, gemini-cli, agy, codex, kilo, kiro",
                         other
                     ));
                 }

--- a/atomic-cli/src/commands/agent/enable.rs
+++ b/atomic-cli/src/commands/agent/enable.rs
@@ -130,7 +130,9 @@ impl Command for Enable {
             if detected.is_empty() {
                 // No agents detected — refuse rather than blanket-installing
                 // hooks for every registered agent into configs that don't exist.
-                print_error("No agents detected in this repository — nothing to enable with --all.");
+                print_error(
+                    "No agents detected in this repository — nothing to enable with --all.",
+                );
                 print_warning(
                     "Create a .claude/, .gemini/, or .agents/ directory first, or use --agent <name>.",
                 );

--- a/atomic-cli/src/commands/agent/enable.rs
+++ b/atomic-cli/src/commands/agent/enable.rs
@@ -128,8 +128,7 @@ impl Command for Enable {
             // Install for all detected agents
             let detected = registry.detect(&repo_root);
             if detected.is_empty() {
-                // No agents detected — refuse rather than blanket-installing
-                // hooks for every registered agent into configs that don't exist.
+                // Do not install hooks when no agent is detected.
                 print_error(
                     "No agents detected in this repository — nothing to enable with --all.",
                 );

--- a/atomic-cli/src/commands/agent/enable.rs
+++ b/atomic-cli/src/commands/agent/enable.rs
@@ -128,12 +128,17 @@ impl Command for Enable {
             // Install for all detected agents
             let detected = registry.detect(&repo_root);
             if detected.is_empty() {
-                // If none detected, try all registered agents
-                print_warning("No agents detected — installing hooks for all registered agents.");
-                registry.list()
-            } else {
-                detected
+                // No agents detected — refuse rather than blanket-installing
+                // hooks for every registered agent into configs that don't exist.
+                print_error("No agents detected in this repository — nothing to enable with --all.");
+                print_warning(
+                    "Create a .claude/, .gemini/, or .agents/ directory first, or use --agent <name>.",
+                );
+                return Err(crate::error::CliError::InvalidArgument {
+                    message: "no agents detected for --all".to_string(),
+                });
             }
+            detected
         } else if let Some(ref name) = self.agent {
             // Specific agent requested — validate it exists
             registry

--- a/atomic-cli/src/commands/clone/command.rs
+++ b/atomic-cli/src/commands/clone/command.rs
@@ -529,6 +529,7 @@ impl Clone {
         }
 
         // Apply downloaded changes to the local view
+        let mut apply_errors = Vec::new();
         if stats.changes_downloaded > 0 {
             print_blank();
             progress.phase = ClonePhase::Applying;
@@ -536,7 +537,6 @@ impl Clone {
 
             // Insert each downloaded change in order to build the graph
             let insert_options = atomic_repository::InsertOptions::default();
-            let mut apply_errors = Vec::new();
 
             for entry in &remote_entries {
                 let hash = match atomic_core::types::Hash::from_base32(entry.hash.as_bytes()) {
@@ -657,20 +657,40 @@ impl Clone {
 
         progress.phase = ClonePhase::Complete;
 
-        // Final summary
+        // Final summary. Download and apply failures were already printed
+        // above — exit non-zero so scripts don't mistake a partial clone for
+        // success (the partially-cloned repository is kept on disk).
         print_blank();
-        if stats.has_failures() {
+        if stats.has_failures() || !apply_errors.is_empty() {
             print_warning(&format!(
-                "Clone completed with errors: {} downloaded, {} failed",
-                stats.changes_downloaded, stats.changes_failed
+                "Clone completed with errors: {} downloaded, {} failed to download, {} failed to apply",
+                stats.changes_downloaded,
+                stats.changes_failed,
+                apply_errors.len(),
             ));
-        } else {
-            print_success(&format!(
-                "Clone complete: {} downloaded into {}/",
-                format_count(stats.changes_downloaded, "change"),
-                target_path.display()
-            ));
+
+            if self.into_existing {
+                print_hint(
+                    "Next: run 'atomic git import --incremental' to import the Git checkout.",
+                );
+            }
+
+            // Keep the partial clone: disable the cleanup guard before failing.
+            if let Some(guard) = guard {
+                guard.disable();
+            }
+            return Err(CliError::Internal(anyhow::anyhow!(
+                "clone completed with errors ({} download, {} apply)",
+                stats.changes_failed,
+                apply_errors.len(),
+            )));
         }
+
+        print_success(&format!(
+            "Clone complete: {} downloaded into {}/",
+            format_count(stats.changes_downloaded, "change"),
+            target_path.display()
+        ));
 
         if self.into_existing {
             print_hint("Next: run 'atomic git import --incremental' to import the Git checkout.");

--- a/atomic-cli/src/commands/clone/command.rs
+++ b/atomic-cli/src/commands/clone/command.rs
@@ -657,9 +657,7 @@ impl Clone {
 
         progress.phase = ClonePhase::Complete;
 
-        // Final summary. Download and apply failures were already printed
-        // above — exit non-zero so scripts don't mistake a partial clone for
-        // success (the partially-cloned repository is kept on disk).
+        // Keep partial output, but return failure when any step failed.
         print_blank();
         if stats.has_failures() || !apply_errors.is_empty() {
             print_warning(&format!(
@@ -675,7 +673,7 @@ impl Clone {
                 );
             }
 
-            // Keep the partial clone: disable the cleanup guard before failing.
+            // Preserve the partial clone before returning the error.
             if let Some(guard) = guard {
                 guard.disable();
             }

--- a/atomic-cli/src/commands/git/push.rs
+++ b/atomic-cli/src/commands/git/push.rs
@@ -160,10 +160,11 @@ impl Command for Push {
                     print_success(&format!("Pushed to {}/{}", self.remote, current_view));
                 }
                 Err(e) => {
-                    print_warning(&format!(
-                        "Commit created but push failed: {}. Run 'git push' manually.",
-                        e
-                    ));
+                    // The commit exists locally, but the push did not reach the
+                    // remote — surface that as a failure (non-zero exit) so
+                    // scripts and CI don't treat it as success.
+                    print_warning("Commit created locally. Run 'git push' manually to retry.");
+                    return Err(e);
                 }
             }
         }

--- a/atomic-cli/src/commands/git/push.rs
+++ b/atomic-cli/src/commands/git/push.rs
@@ -160,9 +160,7 @@ impl Command for Push {
                     print_success(&format!("Pushed to {}/{}", self.remote, current_view));
                 }
                 Err(e) => {
-                    // The commit exists locally, but the push did not reach the
-                    // remote — surface that as a failure (non-zero exit) so
-                    // scripts and CI don't treat it as success.
+                    // Keep the local commit, but report the failed push.
                     print_warning("Commit created locally. Run 'git push' manually to retry.");
                     return Err(e);
                 }

--- a/atomic-cli/src/commands/intent/delete.rs
+++ b/atomic-cli/src/commands/intent/delete.rs
@@ -37,6 +37,11 @@ impl Command for IntentDelete {
         let root = find_repository_root()?;
         let repo = Repository::open(&root).map_err(CliError::Repository)?;
 
+        // Verify the intent exists before asking for confirmation, so a
+        // typo'd ID fails fast instead of after the destructive prompt.
+        repo.vault_intent_show(&self.id)
+            .map_err(CliError::Repository)?;
+
         if !self.force {
             let prompt = format!(
                 "Discard intent '{}'? This removes the unstarted draft from the vault.",

--- a/atomic-cli/src/commands/intent/delete.rs
+++ b/atomic-cli/src/commands/intent/delete.rs
@@ -38,9 +38,7 @@ impl Command for IntentDelete {
         let repo = Repository::open(&root).map_err(CliError::Repository)?;
 
         if !self.force {
-            // Verify the intent exists before asking for confirmation, so a
-            // typo'd ID fails fast instead of after the destructive prompt.
-            // --force skips the precheck, matching the other delete commands.
+            // Check that the intent exists before prompting.
             repo.vault_intent_show(&self.id)
                 .map_err(CliError::Repository)?;
 

--- a/atomic-cli/src/commands/intent/delete.rs
+++ b/atomic-cli/src/commands/intent/delete.rs
@@ -37,12 +37,13 @@ impl Command for IntentDelete {
         let root = find_repository_root()?;
         let repo = Repository::open(&root).map_err(CliError::Repository)?;
 
-        // Verify the intent exists before asking for confirmation, so a
-        // typo'd ID fails fast instead of after the destructive prompt.
-        repo.vault_intent_show(&self.id)
-            .map_err(CliError::Repository)?;
-
         if !self.force {
+            // Verify the intent exists before asking for confirmation, so a
+            // typo'd ID fails fast instead of after the destructive prompt.
+            // --force skips the precheck, matching the other delete commands.
+            repo.vault_intent_show(&self.id)
+                .map_err(CliError::Repository)?;
+
             let prompt = format!(
                 "Discard intent '{}'? This removes the unstarted draft from the vault.",
                 self.id

--- a/atomic-cli/src/commands/org/delete.rs
+++ b/atomic-cli/src/commands/org/delete.rs
@@ -85,17 +85,18 @@ impl OrgDelete {
     async fn execute(&self) -> CliResult<()> {
         let client = build_client(self.org.as_deref(), None).await?;
 
-        // Verify the organization exists before asking for confirmation, so a
-        // typo'd slug fails fast instead of after the destructive prompt.
-        atomic_teams::org::get_org(&client, &self.slug)
-            .await
-            .map_err(|e| CliError::RemoteError {
-                message: e.to_string(),
-                url: None,
-            })?;
-
-        // Prompt for confirmation unless --force is set.
+        // Prompt for confirmation unless --force is set. --force skips the
+        // existence precheck too, keeping scripted deletes to a single request.
         if !self.force {
+            // Verify the organization exists before asking for confirmation,
+            // so a typo'd slug fails fast instead of after the prompt.
+            atomic_teams::org::get_org(&client, &self.slug)
+                .await
+                .map_err(|e| CliError::RemoteError {
+                    message: e.to_string(),
+                    url: None,
+                })?;
+
             print_warning(&format!(
                 "This will permanently delete organization '{}' and all its data.",
                 self.slug

--- a/atomic-cli/src/commands/org/delete.rs
+++ b/atomic-cli/src/commands/org/delete.rs
@@ -83,6 +83,17 @@ impl Command for OrgDelete {
 
 impl OrgDelete {
     async fn execute(&self) -> CliResult<()> {
+        let client = build_client(self.org.as_deref(), None).await?;
+
+        // Verify the organization exists before asking for confirmation, so a
+        // typo'd slug fails fast instead of after the destructive prompt.
+        atomic_teams::org::get_org(&client, &self.slug)
+            .await
+            .map_err(|e| CliError::RemoteError {
+                message: e.to_string(),
+                url: None,
+            })?;
+
         // Prompt for confirmation unless --force is set.
         if !self.force {
             print_warning(&format!(
@@ -102,8 +113,6 @@ impl OrgDelete {
                 return Err(CliError::Cancelled);
             }
         }
-
-        let client = build_client(self.org.as_deref(), None).await?;
 
         atomic_teams::org::delete_org(&client, &self.slug)
             .await

--- a/atomic-cli/src/commands/org/delete.rs
+++ b/atomic-cli/src/commands/org/delete.rs
@@ -85,11 +85,9 @@ impl OrgDelete {
     async fn execute(&self) -> CliResult<()> {
         let client = build_client(self.org.as_deref(), None).await?;
 
-        // Prompt for confirmation unless --force is set. --force skips the
-        // existence precheck too, keeping scripted deletes to a single request.
+        // `--force` skips both the precheck and confirmation.
         if !self.force {
-            // Verify the organization exists before asking for confirmation,
-            // so a typo'd slug fails fast instead of after the prompt.
+            // Check that the organization exists before prompting.
             atomic_teams::org::get_org(&client, &self.slug)
                 .await
                 .map_err(|e| CliError::RemoteError {

--- a/atomic-cli/src/commands/pull/command.rs
+++ b/atomic-cli/src/commands/pull/command.rs
@@ -106,10 +106,7 @@ pub struct Pull {
     ///
     /// Can be a configured remote name (like "origin") or a full URL.
     ///
-    /// If not specified, the remote is resolved in this order: the remote
-    /// marked default by `atomic remote default <name>`; then "origin" if
-    /// it is configured; then the sole configured remote if there is
-    /// exactly one; then the literal "origin".
+    /// Defaults to the configured remote, then `origin`.
     #[arg()]
     pub remote: Option<String>,
 
@@ -251,11 +248,7 @@ impl Pull {
 
     // Internal Helper Methods
 
-    /// Resolve the remote name to operate on.
-    ///
-    /// Explicit CLI argument wins; otherwise the remote configured with
-    /// `atomic remote default <name>` (which itself falls back to "origin"
-    /// or the only configured remote); otherwise the literal "origin".
+    /// Use the explicit remote first, then the repository default.
     fn resolve_remote_name(&self, repo: &Repository) -> String {
         match &self.remote {
             Some(name) => name.clone(),
@@ -266,12 +259,7 @@ impl Pull {
         }
     }
 
-    /// Resolve the remote name, URL, and any identity hint from the
-    /// `--identity` flag.
-    ///
-    /// Returns `(name, url, identity_hint)` where `identity_hint` comes
-    /// solely from the `--identity` CLI flag. If absent, `attach_identity`
-    /// falls back to URL-subdomain inference.
+    /// Resolve the remote and optional identity override.
     fn resolve_remote_url(&self, repo: &Repository) -> CliResult<(String, String, Option<String>)> {
         let remote_name = self.resolve_remote_name(repo);
 
@@ -726,9 +714,7 @@ impl Pull {
             }
         }
 
-        // Final summary. Download, apply, and materialize failures were
-        // already printed above — exit non-zero so scripts don't mistake a
-        // partial pull for success.
+        // Keep partial output, but return failure when any step failed.
         print_blank();
         if stats.has_failures() || !apply_errors.is_empty() || materialize_failed {
             print_warning(&format!(

--- a/atomic-cli/src/commands/pull/command.rs
+++ b/atomic-cli/src/commands/pull/command.rs
@@ -105,9 +105,10 @@ pub struct Pull {
     /// Remote name or URL to pull from.
     ///
     /// Can be a configured remote name (like "origin") or a full URL.
-    /// If not specified, uses the default remote "origin".
-    #[arg(default_value = DEFAULT_REMOTE)]
-    pub remote: String,
+    /// If not specified, uses the remote configured with
+    /// `atomic remote default <name>`, falling back to "origin".
+    #[arg()]
+    pub remote: Option<String>,
 
     /// Local view to pull into.
     ///
@@ -174,12 +175,12 @@ impl Pull {
     /// use atomic::commands::pull::Pull;
     ///
     /// let pull = Pull::new();
-    /// assert_eq!(pull.remote, "origin");
+    /// assert!(pull.remote.is_none());
     /// assert!(!pull.dry_run);
     /// ```
     pub fn new() -> Self {
         Self {
-            remote: DEFAULT_REMOTE.to_string(),
+            remote: None,
             to_view: None,
             from_view: None,
             dry_run: false,
@@ -193,7 +194,7 @@ impl Pull {
 
     /// Builder: set the remote name or URL.
     pub fn with_remote(mut self, remote: impl Into<String>) -> Self {
-        self.remote = remote.into();
+        self.remote = Some(remote.into());
         self
     }
 
@@ -247,24 +248,40 @@ impl Pull {
 
     // Internal Helper Methods
 
-    /// Resolve the remote URL and any identity hint from the `--identity` flag.
+    /// Resolve the remote name to operate on.
     ///
-    /// Returns `(url, identity_hint)` where `identity_hint` comes solely from
-    /// the `--identity` CLI flag. If absent, `attach_identity` falls back to
-    /// URL-subdomain inference.
-    fn resolve_remote_url(&self, repo: &Repository) -> CliResult<(String, Option<String>)> {
+    /// Explicit CLI argument wins; otherwise the remote configured with
+    /// `atomic remote default <name>` (which itself falls back to "origin"
+    /// or the only configured remote); otherwise the literal "origin".
+    fn resolve_remote_name(&self, repo: &Repository) -> String {
+        match &self.remote {
+            Some(name) => name.clone(),
+            None => repo
+                .get_default_remote()
+                .map(|(name, _entry)| name)
+                .unwrap_or_else(|_| DEFAULT_REMOTE.to_string()),
+        }
+    }
+
+    /// Resolve the remote name, URL, and any identity hint from the
+    /// `--identity` flag.
+    ///
+    /// Returns `(name, url, identity_hint)` where `identity_hint` comes
+    /// solely from the `--identity` CLI flag. If absent, `attach_identity`
+    /// falls back to URL-subdomain inference.
+    fn resolve_remote_url(&self, repo: &Repository) -> CliResult<(String, String, Option<String>)> {
+        let remote_name = self.resolve_remote_name(repo);
+
         // If it looks like a URL, use it directly
-        if self.remote.contains("://") {
-            return Ok((self.remote.clone(), self.identity.clone()));
+        if remote_name.contains("://") {
+            return Ok((remote_name.clone(), remote_name, self.identity.clone()));
         }
 
         // Look up named remote in repository configuration
-        match repo.get_remote(&self.remote) {
-            Ok(entry) => Ok((entry.url, self.identity.clone())),
+        match repo.get_remote(&remote_name) {
+            Ok(entry) => Ok((remote_name, entry.url, self.identity.clone())),
             Err(atomic_repository::RepositoryError::RemoteNotFound { .. }) => {
-                Err(CliError::RemoteNotFound {
-                    name: self.remote.clone(),
-                })
+                Err(CliError::RemoteNotFound { name: remote_name })
             }
             Err(e) => Err(CliError::Repository(e)),
         }
@@ -309,6 +326,7 @@ impl Pull {
     /// Shows what changes would be pulled without actually pulling them.
     fn display_dry_run(
         &self,
+        remote_name: &str,
         remote_url: &str,
         remote_view: &str,
         to_download: &[PullChange],
@@ -321,7 +339,7 @@ impl Pull {
         println!(
             "Would pull {} from {} (view: {}):",
             format_count(to_download.len(), "change"),
-            self.remote,
+            remote_name,
             remote_view
         );
         print_blank();
@@ -373,8 +391,8 @@ impl Pull {
         let repo_root = find_repository_root()?;
         let repo = Repository::open(&repo_root).map_err(CliError::Repository)?;
 
-        // Resolve remote URL and identity hint
-        let (remote_url, identity_hint) = self.resolve_remote_url(&repo)?;
+        // Resolve remote name, URL, and identity hint
+        let (remote_name, remote_url, identity_hint) = self.resolve_remote_url(&repo)?;
 
         // Determine views
         let local_view = self.get_local_view(&repo);
@@ -383,7 +401,7 @@ impl Pull {
         // Print header
         println!(
             "Pulling from {} ({})",
-            style_view(&self.remote),
+            style_view(&remote_name),
             hint(&remote_url)
         );
 
@@ -453,7 +471,7 @@ impl Pull {
 
         // Handle dry run
         if self.dry_run {
-            return self.display_dry_run(&remote_url, &remote_view, &to_download);
+            return self.display_dry_run(&remote_name, &remote_url, &remote_view, &to_download);
         }
 
         // Check for nothing to pull
@@ -594,6 +612,7 @@ impl Pull {
         }
 
         // Materialize the working copy so on-disk files reflect the new state
+        let mut materialize_failed = false;
         if stats.has_applied() {
             let mat_spinner = create_spinner("Updating working copy...");
             match repo.materialize() {
@@ -604,6 +623,7 @@ impl Pull {
                     );
                 }
                 Err(e) => {
+                    materialize_failed = true;
                     finish_error(&mat_spinner, "Failed to update working copy");
                     print_warning(&format!(
                         "Applied {} but failed to update working copy: {}",
@@ -703,20 +723,34 @@ impl Pull {
             }
         }
 
-        // Final summary
+        // Final summary. Download, apply, and materialize failures were
+        // already printed above — exit non-zero so scripts don't mistake a
+        // partial pull for success.
         print_blank();
-        if stats.has_failures() {
+        if stats.has_failures() || !apply_errors.is_empty() || materialize_failed {
             print_warning(&format!(
-                "Pull completed with errors: {} downloaded, {} failed",
-                stats.changes_downloaded, stats.changes_failed
+                "Pull completed with errors: {} downloaded, {} failed to download, {} failed to apply",
+                stats.changes_downloaded,
+                stats.changes_failed,
+                apply_errors.len(),
             ));
-        } else {
-            print_success(&format!(
-                "Pull complete: {} downloaded and applied to {}",
-                format_count(stats.changes_downloaded, "change"),
-                local_view
-            ));
+            return Err(CliError::Internal(anyhow::anyhow!(
+                "pull completed with errors ({} download, {} apply{})",
+                stats.changes_failed,
+                apply_errors.len(),
+                if materialize_failed {
+                    ", working copy not updated"
+                } else {
+                    ""
+                },
+            )));
         }
+
+        print_success(&format!(
+            "Pull complete: {} downloaded and applied to {}",
+            format_count(stats.changes_downloaded, "change"),
+            local_view
+        ));
 
         Ok(())
     }
@@ -765,7 +799,7 @@ mod tests {
     fn test_pull_new() {
         let pull = Pull::new();
 
-        assert_eq!(pull.remote, DEFAULT_REMOTE);
+        assert!(pull.remote.is_none());
         assert!(pull.to_view.is_none());
         assert!(pull.from_view.is_none());
         assert!(!pull.dry_run);
@@ -779,21 +813,21 @@ mod tests {
     #[test]
     fn test_pull_default() {
         let pull: Pull = Default::default();
-        assert_eq!(pull.remote, DEFAULT_REMOTE);
+        assert!(pull.remote.is_none());
     }
 
     /// Test with_remote builder method.
     #[test]
     fn test_pull_with_remote() {
         let pull = Pull::new().with_remote("upstream");
-        assert_eq!(pull.remote, "upstream");
+        assert_eq!(pull.remote.as_deref(), Some("upstream"));
     }
 
     /// Test with_remote with URL.
     #[test]
     fn test_pull_with_remote_url() {
         let pull = Pull::new().with_remote("https://example.com/repo");
-        assert_eq!(pull.remote, "https://example.com/repo");
+        assert_eq!(pull.remote.as_deref(), Some("https://example.com/repo"));
     }
 
     /// Test with_to_view builder method.
@@ -861,7 +895,7 @@ mod tests {
             .with_timeout(120)
             .with_download_only(true);
 
-        assert_eq!(pull.remote, "upstream");
+        assert_eq!(pull.remote.as_deref(), Some("upstream"));
         assert_eq!(pull.to_view, Some("feature".to_string()));
         assert_eq!(pull.from_view, Some("main".to_string()));
         assert!(pull.dry_run);
@@ -878,7 +912,7 @@ mod tests {
 
         let cloned = original.clone();
 
-        assert_eq!(cloned.remote, "test");
+        assert_eq!(cloned.remote.as_deref(), Some("test"));
         assert!(cloned.dry_run);
     }
 

--- a/atomic-cli/src/commands/pull/command.rs
+++ b/atomic-cli/src/commands/pull/command.rs
@@ -105,8 +105,11 @@ pub struct Pull {
     /// Remote name or URL to pull from.
     ///
     /// Can be a configured remote name (like "origin") or a full URL.
-    /// If not specified, uses the remote configured with
-    /// `atomic remote default <name>`, falling back to "origin".
+    ///
+    /// If not specified, the remote is resolved in this order: the remote
+    /// marked default by `atomic remote default <name>`; then "origin" if
+    /// it is configured; then the sole configured remote if there is
+    /// exactly one; then the literal "origin".
     #[arg()]
     pub remote: Option<String>,
 

--- a/atomic-cli/src/commands/pull/mod.rs
+++ b/atomic-cli/src/commands/pull/mod.rs
@@ -32,7 +32,7 @@
 //! atomic pull [OPTIONS] [REMOTE]
 //!
 //! Arguments:
-//!   [REMOTE]  Remote name or URL (default: "origin")
+//!   [REMOTE]  Remote name or URL (default: the configured default remote, or "origin")
 //!
 //! Options:
 //!       --to-channel <CHANNEL>    Local channel to pull into (default: current)
@@ -183,7 +183,7 @@ mod tests {
     #[test]
     fn test_pull_reexported() {
         let pull = Pull::new();
-        assert_eq!(pull.remote, DEFAULT_REMOTE);
+        assert!(pull.remote.is_none());
     }
 
     /// Verify that PullChange is properly re-exported.

--- a/atomic-cli/src/commands/push/command.rs
+++ b/atomic-cli/src/commands/push/command.rs
@@ -78,9 +78,10 @@ pub struct Push {
     /// Remote name or URL to push to.
     ///
     /// Can be a configured remote name (like "origin") or a full URL.
-    /// If not specified, uses the default remote "origin".
-    #[arg(default_value = DEFAULT_REMOTE)]
-    pub remote: String,
+    /// If not specified, uses the remote configured with
+    /// `atomic remote default <name>`, falling back to "origin".
+    #[arg()]
+    pub remote: Option<String>,
 
     /// Remote view to push to.
     ///
@@ -142,12 +143,12 @@ impl Push {
     /// use atomic::commands::push::Push;
     ///
     /// let push = Push::new();
-    /// assert_eq!(push.remote, "origin");
+    /// assert!(push.remote.is_none());
     /// assert!(!push.dry_run);
     /// ```
     pub fn new() -> Self {
         Self {
-            remote: DEFAULT_REMOTE.to_string(),
+            remote: None,
             to_view: None,
             from_view: None,
             dry_run: false,
@@ -161,7 +162,7 @@ impl Push {
 
     /// Builder: set the remote name or URL.
     pub fn with_remote(mut self, remote: impl Into<String>) -> Self {
-        self.remote = remote.into();
+        self.remote = Some(remote.into());
         self
     }
 
@@ -175,6 +176,21 @@ impl Push {
     pub fn with_from_view(mut self, view: impl Into<String>) -> Self {
         self.from_view = Some(view.into());
         self
+    }
+
+    /// Resolve the remote name to operate on.
+    ///
+    /// Explicit CLI argument wins; otherwise the remote configured with
+    /// `atomic remote default <name>` (which itself falls back to "origin"
+    /// or the only configured remote); otherwise the literal "origin".
+    fn resolve_remote_name(&self, repo: &Repository) -> String {
+        match &self.remote {
+            Some(name) => name.clone(),
+            None => repo
+                .get_default_remote()
+                .map(|(name, _entry)| name)
+                .unwrap_or_else(|_| DEFAULT_REMOTE.to_string()),
+        }
     }
 
     /// Builder: set the dry-run flag.
@@ -213,24 +229,25 @@ impl Push {
         self
     }
 
-    /// Resolve the remote URL and any identity hint from the `--identity` flag.
+    /// Resolve the remote name, URL, and any identity hint from the
+    /// `--identity` flag.
     ///
-    /// Returns `(url, identity_hint)` where `identity_hint` comes solely from
-    /// the `--identity` CLI flag. If absent, `attach_identity` falls back to
-    /// URL-subdomain inference.
-    fn resolve_remote_url(&self, repo: &Repository) -> CliResult<(String, Option<String>)> {
+    /// Returns `(name, url, identity_hint)` where `identity_hint` comes
+    /// solely from the `--identity` CLI flag. If absent, `attach_identity`
+    /// falls back to URL-subdomain inference.
+    fn resolve_remote_url(&self, repo: &Repository) -> CliResult<(String, String, Option<String>)> {
+        let remote_name = self.resolve_remote_name(repo);
+
         // If it looks like a URL, use it directly
-        if self.remote.contains("://") {
-            return Ok((self.remote.clone(), self.identity.clone()));
+        if remote_name.contains("://") {
+            return Ok((remote_name.clone(), remote_name, self.identity.clone()));
         }
 
         // Look up named remote in repository configuration
-        match repo.get_remote(&self.remote) {
-            Ok(entry) => Ok((entry.url, self.identity.clone())),
+        match repo.get_remote(&remote_name) {
+            Ok(entry) => Ok((remote_name, entry.url, self.identity.clone())),
             Err(atomic_repository::RepositoryError::RemoteNotFound { .. }) => {
-                Err(CliError::RemoteNotFound {
-                    name: self.remote.clone(),
-                })
+                Err(CliError::RemoteNotFound { name: remote_name })
             }
             Err(e) => Err(CliError::Repository(e)),
         }
@@ -273,6 +290,7 @@ impl Push {
     /// Display the dry run preview.
     fn display_dry_run(
         &self,
+        remote_name: &str,
         remote_url: &str,
         remote_view: &str,
         to_upload: &[PushChange],
@@ -285,7 +303,7 @@ impl Push {
         println!(
             "Would push {} to {} (view: {}):",
             format_count(to_upload.len(), "change"),
-            self.remote,
+            remote_name,
             remote_view
         );
         print_blank();
@@ -308,8 +326,8 @@ impl Push {
         let repo_root = find_repository_root()?;
         let repo = Repository::open(&repo_root).map_err(CliError::Repository)?;
 
-        // Resolve remote URL and identity hint
-        let (remote_url, identity_hint) = self.resolve_remote_url(&repo)?;
+        // Resolve remote name, URL, and identity hint
+        let (remote_name, remote_url, identity_hint) = self.resolve_remote_url(&repo)?;
 
         // Determine views
         let local_view = self.get_local_view(&repo);
@@ -319,7 +337,7 @@ impl Push {
         // Print header
         println!(
             "Pushing to {} ({})",
-            style_view(&self.remote),
+            style_view(&remote_name),
             hint(&remote_url)
         );
 
@@ -427,7 +445,7 @@ impl Push {
 
         // Handle dry run
         if self.dry_run {
-            return self.display_dry_run(&remote_url, &remote_view, &to_upload);
+            return self.display_dry_run(&remote_name, &remote_url, &remote_view, &to_upload);
         }
 
         // Check for nothing to push
@@ -484,7 +502,7 @@ impl Push {
             print_blank();
             print_success(&format!(
                 "Push complete: {} view created on {}",
-                remote_view, self.remote
+                remote_view, remote_name
             ));
             return Ok(());
         }
@@ -805,7 +823,7 @@ mod tests {
     #[test]
     fn test_push_new() {
         let push = Push::new();
-        assert_eq!(push.remote, "origin");
+        assert!(push.remote.is_none());
         assert!(push.to_view.is_none());
         assert!(push.from_view.is_none());
         assert!(!push.dry_run);
@@ -818,19 +836,19 @@ mod tests {
     #[test]
     fn test_push_default() {
         let push = Push::default();
-        assert_eq!(push.remote, "origin");
+        assert!(push.remote.is_none());
     }
 
     #[test]
     fn test_push_with_remote() {
         let push = Push::new().with_remote("upstream");
-        assert_eq!(push.remote, "upstream");
+        assert_eq!(push.remote.as_deref(), Some("upstream"));
     }
 
     #[test]
     fn test_push_with_remote_url() {
         let push = Push::new().with_remote("https://example.com/repo");
-        assert_eq!(push.remote, "https://example.com/repo");
+        assert_eq!(push.remote.as_deref(), Some("https://example.com/repo"));
     }
 
     #[test]
@@ -890,7 +908,7 @@ mod tests {
             .with_insecure(true)
             .with_timeout(120);
 
-        assert_eq!(push.remote, "upstream");
+        assert_eq!(push.remote.as_deref(), Some("upstream"));
         assert_eq!(push.to_view, Some("main".to_string()));
         assert_eq!(push.from_view, Some("feature".to_string()));
         assert!(push.dry_run);
@@ -911,7 +929,7 @@ mod tests {
 
     #[test]
     fn test_push_debug() {
-        let push = Push::new();
+        let push = Push::new().with_remote("origin");
         let debug_str = format!("{:?}", push);
 
         assert!(debug_str.contains("Push"));

--- a/atomic-cli/src/commands/push/command.rs
+++ b/atomic-cli/src/commands/push/command.rs
@@ -79,10 +79,7 @@ pub struct Push {
     ///
     /// Can be a configured remote name (like "origin") or a full URL.
     ///
-    /// If not specified, the remote is resolved in this order: the remote
-    /// marked default by `atomic remote default <name>`; then "origin" if
-    /// it is configured; then the sole configured remote if there is
-    /// exactly one; then the literal "origin".
+    /// Defaults to the configured remote, then `origin`.
     #[arg()]
     pub remote: Option<String>,
 
@@ -181,11 +178,7 @@ impl Push {
         self
     }
 
-    /// Resolve the remote name to operate on.
-    ///
-    /// Explicit CLI argument wins; otherwise the remote configured with
-    /// `atomic remote default <name>` (which itself falls back to "origin"
-    /// or the only configured remote); otherwise the literal "origin".
+    /// Use the explicit remote first, then the repository default.
     fn resolve_remote_name(&self, repo: &Repository) -> String {
         match &self.remote {
             Some(name) => name.clone(),
@@ -232,12 +225,7 @@ impl Push {
         self
     }
 
-    /// Resolve the remote name, URL, and any identity hint from the
-    /// `--identity` flag.
-    ///
-    /// Returns `(name, url, identity_hint)` where `identity_hint` comes
-    /// solely from the `--identity` CLI flag. If absent, `attach_identity`
-    /// falls back to URL-subdomain inference.
+    /// Resolve the remote and optional identity override.
     fn resolve_remote_url(&self, repo: &Repository) -> CliResult<(String, String, Option<String>)> {
         let remote_name = self.resolve_remote_name(repo);
 

--- a/atomic-cli/src/commands/push/command.rs
+++ b/atomic-cli/src/commands/push/command.rs
@@ -78,8 +78,11 @@ pub struct Push {
     /// Remote name or URL to push to.
     ///
     /// Can be a configured remote name (like "origin") or a full URL.
-    /// If not specified, uses the remote configured with
-    /// `atomic remote default <name>`, falling back to "origin".
+    ///
+    /// If not specified, the remote is resolved in this order: the remote
+    /// marked default by `atomic remote default <name>`; then "origin" if
+    /// it is configured; then the sole configured remote if there is
+    /// exactly one; then the literal "origin".
     #[arg()]
     pub remote: Option<String>,
 

--- a/atomic-cli/src/commands/push/mod.rs
+++ b/atomic-cli/src/commands/push/mod.rs
@@ -31,7 +31,7 @@
 //! atomic push [OPTIONS] [REMOTE]
 //!
 //! Arguments:
-//!   [REMOTE]  Remote name or URL (default: "origin")
+//!   [REMOTE]  Remote name or URL (default: the configured default remote, or "origin")
 //!
 //! Options:
 //!       --to-channel <CHANNEL>    Remote channel to push to (default: same as local)
@@ -147,7 +147,7 @@ mod tests {
     #[test]
     fn test_push_reexported() {
         let push = Push::new();
-        assert_eq!(push.remote, DEFAULT_REMOTE);
+        assert!(push.remote.is_none());
     }
 
     #[test]

--- a/atomic-cli/src/commands/query/mod.rs
+++ b/atomic-cli/src/commands/query/mod.rs
@@ -1996,26 +1996,34 @@ mod tests {
     }
 
     #[test]
-    fn test_truncate_display_cjk_no_panic() {
+    fn test_truncate_display_three_byte_chars_no_panic() {
         // Regression: byte slicing (&s[..57]) panicked on multi-byte content
-        // when byte 57 fell inside a character (e.g. "x" + CJK text).
-        let s = format!("x{}", "修复认证模块中的关键安全漏洞并添加全面的单元测试覆盖率以确保长期稳定性和可维护性");
-        let out = truncate_display(&s, 60);
-        assert!(out.ends_with("...") || out == s);
-        // Result must be valid UTF-8 with at most 60 chars before the ellipsis
-        assert!(out.trim_end_matches("...").chars().count() <= 60);
+        // when byte 57 fell inside a character. "x" + 3-byte chars (U+20AC)
+        // shifts alignment so byte 57 is mid-char, while the char count (41)
+        // stays within the display limit.
+        let s = format!("x{}", "\u{20ac}".repeat(40));
+        assert!(s.len() > 60); // byte length exceeds the old byte-based check
+        assert_eq!(truncate_display(&s, 60), s); // 41 chars: no truncation
     }
 
     #[test]
-    fn test_truncate_display_emoji_within_limit_unchanged() {
-        let s = "🚀".repeat(40); // 4-byte chars: any byte index not divisible by 4 is mid-char
+    fn test_truncate_display_three_byte_chars_truncated() {
+        let s = format!("x{}", "\u{20ac}".repeat(80)); // 81 chars, 241 bytes
+        let out = truncate_display(&s, 60);
+        assert_eq!(out, format!("x{}...", "\u{20ac}".repeat(56)));
+    }
+
+    #[test]
+    fn test_truncate_display_four_byte_chars_within_limit_unchanged() {
+        // 4-byte chars (U+1F680): any byte index not divisible by 4 is mid-char
+        let s = "\u{1f680}".repeat(40);
         assert_eq!(truncate_display(&s, 50), s);
     }
 
     #[test]
-    fn test_truncate_display_emoji_truncated() {
-        let s = "🚀".repeat(80);
+    fn test_truncate_display_four_byte_chars_truncated() {
+        let s = "\u{1f680}".repeat(80);
         let out = truncate_display(&s, 50);
-        assert_eq!(out, format!("{}...", "🚀".repeat(47)));
+        assert_eq!(out, format!("{}...", "\u{1f680}".repeat(47)));
     }
 }

--- a/atomic-cli/src/commands/query/mod.rs
+++ b/atomic-cli/src/commands/query/mod.rs
@@ -1027,12 +1027,7 @@ fn emit_html(query: &str, nodes: &[KgNode], edges: &[KgEdge]) -> String {
     )
 }
 
-/// Truncate `s` to at most `max_chars` characters for display, appending
-/// `...` when content was removed.
-///
-/// Operates on char boundaries, so multi-byte content (CJK, emoji) never
-/// panics — unlike byte slicing (`&s[..n]`), which aborts with a
-/// char-boundary panic on such input.
+/// Truncate display text on character boundaries and append `...`.
 fn truncate_display(s: &str, max_chars: usize) -> String {
     if s.chars().count() <= max_chars {
         s.to_string()
@@ -1816,7 +1811,7 @@ impl Command for PlanExec {
                 for node in &result.nodes {
                     print!("  [{}] {}", node.kind, node.label);
                     if let Some(ref s) = node.summary {
-                        // Char-based truncation: byte slicing panics on CJK/emoji.
+                        // Truncate safely for Unicode text.
                         let short: String = s.chars().take(60).collect();
                         print!(": {}", short);
                     }
@@ -1837,7 +1832,7 @@ impl Command for PlanExec {
             if !result.content.is_empty() {
                 println!("\nContent ({} entries):", result.content.len());
                 for (path, text) in &result.content {
-                    // Char-based truncation: byte slicing panics on CJK/emoji.
+                    // Truncate safely for Unicode text.
                     let preview: String = text.chars().take(100).collect();
                     println!("  {}: {}...", path, preview.replace('\n', " "));
                 }
@@ -1997,10 +1992,7 @@ mod tests {
 
     #[test]
     fn test_truncate_display_three_byte_chars_no_panic() {
-        // Regression: byte slicing (&s[..57]) panicked on multi-byte content
-        // when byte 57 fell inside a character. "x" + 3-byte chars (U+20AC)
-        // shifts alignment so byte 57 is mid-char, while the char count (41)
-        // stays within the display limit.
+        // Regression test for three-byte characters.
         let s = format!("x{}", "\u{20ac}".repeat(40));
         assert!(s.len() > 60); // byte length exceeds the old byte-based check
         assert_eq!(truncate_display(&s, 60), s); // 41 chars: no truncation
@@ -2015,7 +2007,7 @@ mod tests {
 
     #[test]
     fn test_truncate_display_four_byte_chars_within_limit_unchanged() {
-        // 4-byte chars (U+1F680): any byte index not divisible by 4 is mid-char
+        // Regression test for four-byte characters.
         let s = "\u{1f680}".repeat(40);
         assert_eq!(truncate_display(&s, 50), s);
     }

--- a/atomic-cli/src/commands/query/mod.rs
+++ b/atomic-cli/src/commands/query/mod.rs
@@ -1027,6 +1027,21 @@ fn emit_html(query: &str, nodes: &[KgNode], edges: &[KgEdge]) -> String {
     )
 }
 
+/// Truncate `s` to at most `max_chars` characters for display, appending
+/// `...` when content was removed.
+///
+/// Operates on char boundaries, so multi-byte content (CJK, emoji) never
+/// panics — unlike byte slicing (`&s[..n]`), which aborts with a
+/// char-boundary panic on such input.
+fn truncate_display(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        s.to_string()
+    } else {
+        let kept: String = s.chars().take(max_chars.saturating_sub(3)).collect();
+        format!("{}...", kept)
+    }
+}
+
 /// Search the knowledge graph.
 #[derive(Parser, Debug)]
 pub struct QueryNodes {
@@ -1099,12 +1114,7 @@ impl Command for QueryNodes {
                 let summary_display = if summary.is_empty() {
                     String::new()
                 } else {
-                    let truncated = if summary.len() > 60 {
-                        format!("{}...", &summary[..57])
-                    } else {
-                        summary.to_string()
-                    };
-                    format!("  {}", truncated)
+                    format!("  {}", truncate_display(summary, 60))
                 };
                 println!("  [{}] {}{}", node.kind, node.id, summary_display);
             }
@@ -1150,12 +1160,7 @@ impl Command for QueryNeighbors {
                 let summary_display = if summary.is_empty() {
                     String::new()
                 } else {
-                    let truncated = if summary.len() > 50 {
-                        format!("{}...", &summary[..47])
-                    } else {
-                        summary.to_string()
-                    };
-                    format!("  {}", truncated)
+                    format!("  {}", truncate_display(summary, 50))
                 };
                 println!("  [{}] {}{}", node.kind, node.id, summary_display);
             }
@@ -1811,7 +1816,8 @@ impl Command for PlanExec {
                 for node in &result.nodes {
                     print!("  [{}] {}", node.kind, node.label);
                     if let Some(ref s) = node.summary {
-                        let short = if s.len() > 60 { &s[..60] } else { s };
+                        // Char-based truncation: byte slicing panics on CJK/emoji.
+                        let short: String = s.chars().take(60).collect();
                         print!(": {}", short);
                     }
                     println!();
@@ -1831,7 +1837,8 @@ impl Command for PlanExec {
             if !result.content.is_empty() {
                 println!("\nContent ({} entries):", result.content.len());
                 for (path, text) in &result.content {
-                    let preview = if text.len() > 100 { &text[..100] } else { text };
+                    // Char-based truncation: byte slicing panics on CJK/emoji.
+                    let preview: String = text.chars().take(100).collect();
                     println!("  {}: {}...", path, preview.replace('\n', " "));
                 }
             }
@@ -1963,5 +1970,52 @@ impl Command for QueryAsk {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_display;
+
+    #[test]
+    fn test_truncate_display_short_ascii_unchanged() {
+        assert_eq!(truncate_display("hello", 60), "hello");
+    }
+
+    #[test]
+    fn test_truncate_display_long_ascii_truncated() {
+        let s = "a".repeat(80);
+        let out = truncate_display(&s, 60);
+        assert_eq!(out, format!("{}...", "a".repeat(57)));
+    }
+
+    #[test]
+    fn test_truncate_display_exact_limit_unchanged() {
+        let s = "b".repeat(60);
+        assert_eq!(truncate_display(&s, 60), s);
+    }
+
+    #[test]
+    fn test_truncate_display_cjk_no_panic() {
+        // Regression: byte slicing (&s[..57]) panicked on multi-byte content
+        // when byte 57 fell inside a character (e.g. "x" + CJK text).
+        let s = format!("x{}", "修复认证模块中的关键安全漏洞并添加全面的单元测试覆盖率以确保长期稳定性和可维护性");
+        let out = truncate_display(&s, 60);
+        assert!(out.ends_with("...") || out == s);
+        // Result must be valid UTF-8 with at most 60 chars before the ellipsis
+        assert!(out.trim_end_matches("...").chars().count() <= 60);
+    }
+
+    #[test]
+    fn test_truncate_display_emoji_within_limit_unchanged() {
+        let s = "🚀".repeat(40); // 4-byte chars: any byte index not divisible by 4 is mid-char
+        assert_eq!(truncate_display(&s, 50), s);
+    }
+
+    #[test]
+    fn test_truncate_display_emoji_truncated() {
+        let s = "🚀".repeat(80);
+        let out = truncate_display(&s, 50);
+        assert_eq!(out, format!("{}...", "🚀".repeat(47)));
     }
 }

--- a/atomic-cli/src/commands/team/delete.rs
+++ b/atomic-cli/src/commands/team/delete.rs
@@ -88,17 +88,18 @@ impl TeamDelete {
         let client = build_client(self.org.as_deref(), None).await?;
         let org_slug = client.org_slug().to_string();
 
-        // Verify the team exists before asking for confirmation, so a typo'd
-        // slug fails fast instead of after the destructive prompt.
-        atomic_teams::team::get_team(&client, &org_slug, &self.slug)
-            .await
-            .map_err(|e| CliError::RemoteError {
-                message: e.to_string(),
-                url: None,
-            })?;
-
-        // Prompt for confirmation unless --force is set.
+        // Prompt for confirmation unless --force is set. --force skips the
+        // existence precheck too, keeping scripted deletes to a single request.
         if !self.force {
+            // Verify the team exists before asking for confirmation, so a
+            // typo'd slug fails fast instead of after the prompt.
+            atomic_teams::team::get_team(&client, &org_slug, &self.slug)
+                .await
+                .map_err(|e| CliError::RemoteError {
+                    message: e.to_string(),
+                    url: None,
+                })?;
+
             print_warning(&format!(
                 "This will permanently delete team '{}' and all its memberships and grants.",
                 self.slug

--- a/atomic-cli/src/commands/team/delete.rs
+++ b/atomic-cli/src/commands/team/delete.rs
@@ -88,11 +88,9 @@ impl TeamDelete {
         let client = build_client(self.org.as_deref(), None).await?;
         let org_slug = client.org_slug().to_string();
 
-        // Prompt for confirmation unless --force is set. --force skips the
-        // existence precheck too, keeping scripted deletes to a single request.
+        // `--force` skips both the precheck and confirmation.
         if !self.force {
-            // Verify the team exists before asking for confirmation, so a
-            // typo'd slug fails fast instead of after the prompt.
+            // Check that the team exists before prompting.
             atomic_teams::team::get_team(&client, &org_slug, &self.slug)
                 .await
                 .map_err(|e| CliError::RemoteError {

--- a/atomic-cli/src/commands/team/delete.rs
+++ b/atomic-cli/src/commands/team/delete.rs
@@ -85,6 +85,18 @@ impl Command for TeamDelete {
 
 impl TeamDelete {
     async fn execute(&self) -> CliResult<()> {
+        let client = build_client(self.org.as_deref(), None).await?;
+        let org_slug = client.org_slug().to_string();
+
+        // Verify the team exists before asking for confirmation, so a typo'd
+        // slug fails fast instead of after the destructive prompt.
+        atomic_teams::team::get_team(&client, &org_slug, &self.slug)
+            .await
+            .map_err(|e| CliError::RemoteError {
+                message: e.to_string(),
+                url: None,
+            })?;
+
         // Prompt for confirmation unless --force is set.
         if !self.force {
             print_warning(&format!(
@@ -104,9 +116,6 @@ impl TeamDelete {
                 return Err(CliError::Cancelled);
             }
         }
-
-        let client = build_client(self.org.as_deref(), None).await?;
-        let org_slug = client.org_slug().to_string();
 
         atomic_teams::team::delete_team(&client, &org_slug, &self.slug)
             .await

--- a/atomic-cli/src/commands/workspace/delete.rs
+++ b/atomic-cli/src/commands/workspace/delete.rs
@@ -73,11 +73,9 @@ impl Command for WorkspaceDelete {
         rt.block_on(async {
             let (client, org_slug) = build_client_with_org(self.org.as_deref(), None).await?;
 
-            // Confirm unless --force is set. --force skips the existence
-            // precheck too, keeping scripted deletes to a single request.
+            // `--force` skips both the precheck and confirmation.
             if !self.force {
-                // Verify the workspace exists before asking for confirmation,
-                // so a typo'd slug fails fast instead of after the prompt.
+                // Check that the workspace exists before prompting.
                 client.get_workspace(&self.slug).await.map_err(remote_err)?;
 
                 print_warning(&format!(

--- a/atomic-cli/src/commands/workspace/delete.rs
+++ b/atomic-cli/src/commands/workspace/delete.rs
@@ -73,15 +73,13 @@ impl Command for WorkspaceDelete {
         rt.block_on(async {
             let (client, org_slug) = build_client_with_org(self.org.as_deref(), None).await?;
 
-            // Verify the workspace exists before asking for confirmation, so a
-            // typo'd slug fails fast instead of after the destructive prompt.
-            client
-                .get_workspace(&self.slug)
-                .await
-                .map_err(remote_err)?;
-
-            // Confirm unless --force is set.
+            // Confirm unless --force is set. --force skips the existence
+            // precheck too, keeping scripted deletes to a single request.
             if !self.force {
+                // Verify the workspace exists before asking for confirmation,
+                // so a typo'd slug fails fast instead of after the prompt.
+                client.get_workspace(&self.slug).await.map_err(remote_err)?;
+
                 print_warning(&format!(
                     "This will permanently delete workspace '{}' and all its projects.",
                     self.slug

--- a/atomic-cli/src/commands/workspace/delete.rs
+++ b/atomic-cli/src/commands/workspace/delete.rs
@@ -71,6 +71,15 @@ impl Command for WorkspaceDelete {
             .map_err(|e| CliError::Internal(anyhow::anyhow!("{}", e)))?;
 
         rt.block_on(async {
+            let (client, org_slug) = build_client_with_org(self.org.as_deref(), None).await?;
+
+            // Verify the workspace exists before asking for confirmation, so a
+            // typo'd slug fails fast instead of after the destructive prompt.
+            client
+                .get_workspace(&self.slug)
+                .await
+                .map_err(remote_err)?;
+
             // Confirm unless --force is set.
             if !self.force {
                 print_warning(&format!(
@@ -89,8 +98,6 @@ impl Command for WorkspaceDelete {
                     return Err(CliError::Cancelled);
                 }
             }
-
-            let (client, org_slug) = build_client_with_org(self.org.as_deref(), None).await?;
 
             client
                 .delete_workspace(&self.slug)


### PR DESCRIPTION
## What

- Prevented Unicode text from crashing query output.
- Made push, pull, and clone return failure when any step fails.
- Made push and pull honor the configured default remote.
- Fixed agent hook edge cases for `enable --all` and `disable --global codex`.
- Made delete commands check that the target exists before prompting.

## Why

The command harness found cases where the CLI crashed, ignored configuration, or returned success after a failure. These fixes make the CLI match its documented behavior and work reliably in scripts and CI.

## Test

- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- Manually verified Unicode output, failure exit codes, remote selection, and delete prompt order.

Depends on #128.