### PR TITLE
fix(cli): not-found on a vault entity exits 3, not 2

### DIFF
--- a/atomic-cli/src/commands/vault/context.rs
+++ b/atomic-cli/src/commands/vault/context.rs
@@ -308,8 +308,9 @@ impl Context {
             .intents
             .iter()
             .find(|(id, _)| id.eq_ignore_ascii_case(intent_id))
-            .ok_or_else(|| CliError::InvalidArgument {
-                message: format!("Intent not found: {}", intent_id),
+            .ok_or_else(|| CliError::VaultEntityNotFound {
+                kind: "intent",
+                id: intent_id.to_string(),
             })?;
 
         seed_terms.push(summary.title.clone());
@@ -320,8 +321,9 @@ impl Context {
         let intent_path = repo
             .vault_intent_path(resolved_id)
             .map_err(CliError::Repository)?
-            .ok_or_else(|| CliError::InvalidArgument {
-                message: format!("Intent not found: {}", intent_id),
+            .ok_or_else(|| CliError::VaultEntityNotFound {
+                kind: "intent",
+                id: intent_id.to_string(),
             })?;
 
         if let Some(entry) = repo

--- a/atomic-cli/src/commands/vault/memory.rs
+++ b/atomic-cli/src/commands/vault/memory.rs
@@ -177,8 +177,9 @@ impl Command for MemoryShow {
         let entry = repo
             .vault_retrieve(&path)
             .map_err(CliError::Repository)?
-            .ok_or_else(|| CliError::InvalidArgument {
-                message: format!("Memory file not found: {}", self.name),
+            .ok_or_else(|| CliError::VaultEntityNotFound {
+                kind: "memory",
+                id: self.name.clone(),
             })?;
 
         if self.json {

--- a/atomic-cli/src/commands/vault/show.rs
+++ b/atomic-cli/src/commands/vault/show.rs
@@ -41,8 +41,9 @@ impl Command for Show {
         let entry = repo
             .vault_retrieve(&self.path)
             .map_err(CliError::Repository)?
-            .ok_or_else(|| CliError::InvalidArgument {
-                message: format!("Vault entry not found: {}", self.path),
+            .ok_or_else(|| CliError::VaultEntityNotFound {
+                kind: "vault entry",
+                id: self.path.clone(),
             })?;
 
         if self.json {

--- a/atomic-cli/src/error.rs
+++ b/atomic-cli/src/error.rs
@@ -197,6 +197,23 @@ pub enum CliError {
         hash: String,
     },
 
+    /// A vault entity (memory, intent, session, …) with the given id wasn't
+    /// found.
+    ///
+    /// The sibling of [`Self::ChangeNotFound`] for the vault's own entities.
+    /// Before this existed these sites reached for [`Self::InvalidArgument`],
+    /// which exits 2 — the code reserved for "usage error, the command did not
+    /// run". The command parses fine and runs; the id simply is not there, and
+    /// the two cases call for opposite recoveries: fix the command line, versus
+    /// create the entity or look up the right id.
+    #[error("{kind} not found: {id}")]
+    VaultEntityNotFound {
+        /// The kind of entity, lowercase and singular: `memory`, `intent`, …
+        kind: &'static str,
+        /// The id (or partial id) that did not resolve
+        id: String,
+    },
+
     /// The change hash is ambiguous (matches multiple changes).
     ///
     /// This occurs when a partial hash matches more than one change.
@@ -391,6 +408,7 @@ impl CliError {
                 | Self::ViewNotFound { .. }
                 | Self::FileNotFound { .. }
                 | Self::ChangeNotFound { .. }
+                | Self::VaultEntityNotFound { .. }
                 | Self::RemoteNotFound { .. }
         )
     }
@@ -590,6 +608,7 @@ impl CliError {
             | Self::PathOutsideRepository { .. }
             | Self::PathIgnored { .. }
             | Self::ChangeNotFound { .. }
+            | Self::VaultEntityNotFound { .. }
             | Self::AmbiguousHash { .. }
             | Self::MissingDependency { .. }
             | Self::Conflict { .. }


### PR DESCRIPTION
Closes #137 for the sites that exist on `dev`.

## The problem

`atomic vault memory show <missing>` parses fine, runs to completion, and exits **2** — the code reserved for *"usage error, the command did not run."* The id simply isn't there.

These call sites reached for `CliError::InvalidArgument` because there was nothing better to hand, and that maps to 2 (`error.rs:579`). Meanwhile every other not-found in the taxonomy already maps to 3:

```
ChangeNotFound | FileNotFound | ViewNotFound | IdentityNotFound | RemoteNotFound => 3
```

So the code you got depended on which variant happened to be closest, not on what went wrong:

```
atomic vault memory show nosuch     ->  2    InvalidArgument
atomic vault show nosuch/path.md    ->  2    InvalidArgument
atomic change nosuchhash            ->  3    ChangeNotFound
```

## The change

Adds `VaultEntityNotFound { kind, id }` next to `ChangeNotFound`, wired into **both** `exit_code()` and the `is_not_found()` predicate, then switches the four sites that were reporting a missing entity as a usage error — `vault/show.rs`, `vault/memory.rs`, and `vault/context.rs` (×2).

After:

```
atomic vault memory show nosuch     ->  3    memory not found: nosuch
atomic vault show nosuch/path.md    ->  3    vault entry not found: …
atomic vault context --intent X     ->  3    intent not found: X
```

## Why it's worth a variant rather than a doc note

An agent driving the CLI branches on the exit code before it reads the message.

Exit 2 tells it *"you called this wrong — re-read `--help` and try a different invocation."* But the invocation was fine, and no amount of re-reading help will produce an id that doesn't exist. The recoveries are opposite: fix your command line, versus create the thing or look up the right id.

## Scope

Deliberately limited to what exists on `dev`. The root-level `memory` and `session` commands on `feat/store-session-in-graph` (#126) carry the same pattern — `memory show|validate|attest|verify` and `session show` all exit 2 on an unknown id — and should follow once that lands. I didn't want to touch an in-flight branch from here.

`vault memory show` on a *path*-shaped argument already returned `FileNotFound` → 3, so the argument-shape split closes on its own.

## Verification

```
cargo test -p atomic-cli    1640 + 2 + 9 passed, 0 failed
```

Exit codes checked by running, not reading — all three commands above confirmed at 3 in a scratch repo.

Naming is the one thing I'd push back on myself: `VaultEntityNotFound` with a `&'static str` kind is the least invasive shape I could find, but if you'd rather have separate `MemoryNotFound` / `IntentNotFound` variants, say so and I'll split it.
