### PR TITLE
fix session indexing, intent lookup, and memory show

### DIFF
--- a/atomic-cli/src/commands/memory/bridge.rs
+++ b/atomic-cli/src/commands/memory/bridge.rs
@@ -115,6 +115,17 @@ pub fn lift(inputs: &MemLiftInputs) -> CliResult<MemoryNode> {
     })
 }
 
+/// Whether this is a freeform memory rather than a malformed canonical one.
+///
+/// `memory write` and the default `MEMORY.md` have only simple metadata. Once
+/// any canonical identity/kind field is present, lift errors stay visible
+/// instead of silently falling back to raw output.
+pub fn is_freeform_memory(inputs: &MemLiftInputs) -> bool {
+    ["@id", "uid", "id", "memoryKind", "kind"]
+        .iter()
+        .all(|key| !inputs.frontmatter.contains_key(*key))
+}
+
 /// Sanitize a memory id for use as a directory name in the sidecar/vault path.
 /// Keeps ASCII alphanumerics, `-` and `_`; everything else becomes `_`.
 /// Copied verbatim from `intent/bridge.rs::sanitize_id`.
@@ -290,6 +301,46 @@ mod tests {
             frontmatter,
             body: ":::memory\nThe durable fact.\n:::".to_string(),
         }
+    }
+
+    #[test]
+    fn freeform_memory_detection_does_not_hide_partial_canonical_records() {
+        let freeform = MemLiftInputs {
+            frontmatter: serde_json::json!({
+                "name": "notes",
+                "type": "project",
+            })
+            .as_object()
+            .unwrap()
+            .clone(),
+            body: "Raw notes".into(),
+        };
+        assert!(is_freeform_memory(&freeform));
+
+        let partial = MemLiftInputs {
+            frontmatter: serde_json::json!({
+                "uid": "01J8ZC4R8T",
+                "type": "project",
+            })
+            .as_object()
+            .unwrap()
+            .clone(),
+            body: "Missing memoryKind".into(),
+        };
+        assert!(!is_freeform_memory(&partial));
+        assert!(lift(&partial).is_err());
+
+        let partial_at_id = MemLiftInputs {
+            frontmatter: serde_json::json!({
+                "@id": "urn:atomic:memory:01J8ZC4R8T",
+                "type": "project",
+            })
+            .as_object()
+            .unwrap()
+            .clone(),
+            body: "Missing canonical fields".into(),
+        };
+        assert!(!is_freeform_memory(&partial_at_id));
     }
 
     fn attested_node(inputs: &MemLiftInputs) -> (MemoryNode, KeyPair) {

--- a/atomic-cli/src/commands/memory/mod.rs
+++ b/atomic-cli/src/commands/memory/mod.rs
@@ -10,7 +10,7 @@
 //!
 //! ```text
 //! atomic memory new --kind <k>       Scaffold a directive/frontmatter memory
-//! atomic memory show <id>            Render a memory as a read-time projection
+//! atomic memory show <id>            Show a canonical or freeform memory
 //! atomic memory validate <id|path>   Gate a memory against the canonical shapes
 //! atomic memory attest <id>          Sign a memory into a tracked attestation
 //! atomic memory verify <id>          Verify a signed memory's attestation
@@ -61,7 +61,7 @@ pub enum MemoryCommands {
     /// Scaffold a new directive-based memory into the vault.
     New(MemoryNew),
 
-    /// Show a memory as a rendered read-time projection.
+    /// Show a canonical or freeform memory.
     Show(MemoryShow),
 
     /// Validate a memory against the canonical shapes (the authoring gate).

--- a/atomic-cli/src/commands/memory/show.rs
+++ b/atomic-cli/src/commands/memory/show.rs
@@ -1,4 +1,4 @@
-//! `atomic memory show <ID>` — render a memory as a read-time projection.
+//! `atomic memory show <ID>` — show canonical and freeform memories.
 
 use clap::Parser;
 
@@ -9,17 +9,15 @@ use crate::commands::memory::bridge;
 use crate::commands::{find_repository_root, Command};
 use crate::error::{CliError, CliResult};
 
-/// Show a memory as a rendered read-time projection.
-///
-/// Unlike the retired raw `vault memory show` (which dumped the stored body),
-/// this projects the lifted canonical node.
+/// Show a canonical memory as a rendered projection, or a freeform memory as
+/// its stored body.
 #[derive(Parser, Debug)]
 #[command(name = "show")]
 pub struct MemoryShow {
     /// Memory id (or `memory/<id>.md` path).
     pub id: String,
 
-    /// Output the canonical node as JSON-LD instead of the rendered view.
+    /// Output JSON instead of the rendered view or raw body.
     #[arg(long)]
     pub json: bool,
 }
@@ -35,6 +33,23 @@ impl Command for MemoryShow {
         // attested author/proof); a stale one warns and falls back to the raw
         // node.
         let inputs = bridge::read_memory(&repo, &self.id)?;
+        if bridge::is_freeform_memory(&inputs) {
+            if self.json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "path": bridge::normalize_memory_path(&self.id),
+                        "content": inputs.body,
+                        "frontmatter": inputs.frontmatter,
+                    }))
+                    .unwrap()
+                );
+            } else {
+                print!("{}", inputs.body);
+            }
+            return Ok(());
+        }
+
         let node = match bridge::load_attestation(&repo, &self.id, &inputs)? {
             bridge::Attestation::Fresh(node) => *node,
             bridge::Attestation::Stale(_) => {

--- a/atomic-cli/tests/memory_compatibility_test.rs
+++ b/atomic-cli/tests/memory_compatibility_test.rs
@@ -1,0 +1,85 @@
+//! Compatibility coverage for freeform memories.
+#![cfg(not(windows))]
+
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+
+use tempfile::TempDir;
+
+const ATOMIC_BIN: &str = env!("CARGO_BIN_EXE_atomic");
+
+fn atomic(repo_dir: &Path, home_dir: &Path, args: &[&str]) -> Output {
+    Command::new(ATOMIC_BIN)
+        .args(args)
+        .current_dir(repo_dir)
+        .env("HOME", home_dir)
+        .output()
+        .expect("run atomic")
+}
+
+#[test]
+fn memory_show_reads_written_and_default_freeform_memories() {
+    let repo_tmp = TempDir::new().unwrap();
+    let home_tmp = TempDir::new().unwrap();
+    let repo_dir = repo_tmp.path();
+    let home_dir = home_tmp.path();
+
+    let init = atomic(repo_dir, home_dir, &["init"]);
+    assert!(
+        init.status.success(),
+        "init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let mut child = Command::new(ATOMIC_BIN)
+        .args(["memory", "write", "notes", "--type", "reference"])
+        .current_dir(repo_dir)
+        .env("HOME", home_dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn memory write");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"# Notes\nKeep this context.\n")
+        .unwrap();
+    let write = child.wait_with_output().unwrap();
+    assert!(
+        write.status.success(),
+        "memory write failed: {}",
+        String::from_utf8_lossy(&write.stderr)
+    );
+
+    let show = atomic(repo_dir, home_dir, &["memory", "show", "notes"]);
+    assert!(
+        show.status.success(),
+        "memory show failed: {}",
+        String::from_utf8_lossy(&show.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(show.stdout).unwrap(),
+        "# Notes\nKeep this context.\n"
+    );
+
+    let show_json = atomic(repo_dir, home_dir, &["memory", "show", "notes", "--json"]);
+    assert!(show_json.status.success());
+    let value: serde_json::Value = serde_json::from_slice(&show_json.stdout).unwrap();
+    assert_eq!(value["path"], "memory/notes.md");
+    assert_eq!(value["content"], "# Notes\nKeep this context.\n");
+    assert_eq!(value["frontmatter"]["name"], "notes");
+    assert_eq!(value["frontmatter"]["type"], "reference");
+
+    let default = atomic(repo_dir, home_dir, &["memory", "show", "MEMORY"]);
+    assert!(
+        default.status.success(),
+        "default memory show failed: {}",
+        String::from_utf8_lossy(&default.stderr)
+    );
+    assert!(String::from_utf8(default.stdout)
+        .unwrap()
+        .contains("# Project Memory"));
+}

--- a/atomic-cli/tests/session_integration_test.rs
+++ b/atomic-cli/tests/session_integration_test.rs
@@ -18,8 +18,10 @@ use atomic_core::change::provenance_graph::{ProvenanceNode, ProvenanceNodeKind};
 use atomic_core::change::session::SessionTodo;
 use atomic_core::change::ProvenanceGraph;
 use atomic_core::pristine::ontology::{edge_kind, entity_type, predicate};
-use atomic_core::pristine::KgTxnT;
+use atomic_core::pristine::vault::{KgEdge, KgNode};
+use atomic_core::pristine::{KgMutTxnT, KgTxnT};
 use atomic_core::types::{Base32, Hash};
+use atomic_core::MutTxnT;
 use atomic_repository::Repository;
 use tempfile::TempDir;
 
@@ -113,6 +115,102 @@ fn session_manifest_is_content_addressed_and_ingestible() {
 }
 
 #[test]
+fn session_order_and_manifest_do_not_depend_on_ingestion_order() {
+    let a_tmp = TempDir::new().unwrap();
+    let b_tmp = TempDir::new().unwrap();
+    let home_tmp = TempDir::new().unwrap();
+    init_repo(a_tmp.path(), home_tmp.path());
+    init_repo(b_tmp.path(), home_tmp.path());
+
+    let parent = ProvenanceGraph::builder("ordered-session", "opencode")
+        .timestamp(100)
+        .add_node(goal_node("parent-goal", "parent"))
+        .build();
+    let parent_hash = Hash::of(&parent.serialize().unwrap());
+    let child = ProvenanceGraph::builder("ordered-session", "opencode")
+        .timestamp(200)
+        .previous(parent_hash)
+        .add_node(goal_node("child-goal", "child"))
+        .build();
+    let child_hash = Hash::of(&child.serialize().unwrap());
+
+    let repo_a = Repository::open(a_tmp.path()).unwrap();
+    repo_a.save_provenance_graph(&parent).unwrap();
+    repo_a.save_provenance_graph(&child).unwrap();
+
+    let repo_b = Repository::open(b_tmp.path()).unwrap();
+    repo_b.save_provenance_graph(&child).unwrap();
+    {
+        let mut txn = repo_b.pristine().write_txn().unwrap();
+        txn.upsert_kg_node(&KgNode::new(
+            "memory:incoming-link",
+            "memory",
+            "incoming",
+            "vault",
+        ))
+        .unwrap();
+        txn.upsert_kg_node(&KgNode::new(
+            "memory:outgoing-link",
+            "memory",
+            "outgoing",
+            "vault",
+        ))
+        .unwrap();
+        txn.upsert_kg_edge(&KgEdge::new(
+            "memory:incoming-link",
+            "session:ordered-session/turn:0",
+            "extension:references",
+        ))
+        .unwrap();
+        txn.upsert_kg_edge(&KgEdge::new(
+            "session:ordered-session/turn:0",
+            "memory:outgoing-link",
+            "extension:produced",
+        ))
+        .unwrap();
+        txn.commit().unwrap();
+    }
+    repo_b.save_provenance_graph(&parent).unwrap();
+
+    let head_a = repo_a.get_session_head("ordered-session").unwrap();
+    let head_b = repo_b.get_session_head("ordered-session").unwrap();
+    assert_eq!(head_a, head_b, "manifest hash changed with ingestion order");
+
+    let (_, turns_b) = repo_b
+        .get_session_ledger("ordered-session")
+        .unwrap()
+        .unwrap();
+    assert_eq!(turns_b[0].provenance_hash, parent_hash);
+    assert_eq!(turns_b[1].provenance_hash, child_hash);
+
+    let txn = repo_b.pristine().read_txn().unwrap();
+    let child_edges = txn
+        .get_kg_edges_from("session:ordered-session/turn:1")
+        .unwrap();
+    assert!(child_edges.iter().any(|edge| {
+        edge.kind == predicate::WAS_INFORMED_BY && edge.to_id == "session:ordered-session/turn:0"
+    }));
+    let parent_edges = txn
+        .get_kg_edges_from("session:ordered-session/turn:0")
+        .unwrap();
+    assert!(!parent_edges
+        .iter()
+        .any(|edge| edge.kind == predicate::WAS_INFORMED_BY));
+    assert!(child_edges
+        .iter()
+        .any(|edge| { edge.kind == "extension:produced" && edge.to_id == "memory:outgoing-link" }));
+    let child_incoming = txn
+        .get_kg_edges_to("session:ordered-session/turn:1")
+        .unwrap();
+    assert!(child_incoming.iter().any(|edge| {
+        edge.kind == "extension:references" && edge.from_id == "memory:incoming-link"
+    }));
+    assert!(!parent_edges
+        .iter()
+        .any(|edge| edge.kind.starts_with("extension:")));
+}
+
+#[test]
 fn session_fork_inherits_prefix_and_links_parent_manifest() {
     let repo_tmp = TempDir::new().unwrap();
     let home_tmp = TempDir::new().unwrap();
@@ -166,6 +264,10 @@ fn session_fork_inherits_prefix_and_links_parent_manifest() {
     assert_eq!(child_turns_after[2].turn_number, 2);
     assert_eq!(child_turns_after[2].provenance_hash, c2);
     assert_eq!(child_turns_after[2].previous_provenance, Some(child_latest));
+    let child_head = repo.get_session_head("child").unwrap().unwrap();
+    let child_head = repo.get_session_manifest(&child_head).unwrap().unwrap();
+    assert_eq!(child_head.parent_session, Some(parent_manifest));
+    assert_eq!(child_head.fork_turn, Some(1));
 
     // Forking beyond the parent's last turn is rejected.
     assert!(repo.fork_session("parent", 42, "child2").is_err());
@@ -195,6 +297,26 @@ fn session_rebuild_is_idempotent_and_tolerates_corruption() {
             .expect("ledger query")
             .expect("ledger exists");
         assert_eq!(turns.len(), 2, "rebuild must not duplicate turns");
+
+        let mut txn = repo.pristine().write_txn().unwrap();
+        txn.del_kg_edge(
+            "session:rebuild/turn:1",
+            "session:rebuild/turn:0",
+            predicate::WAS_INFORMED_BY,
+        )
+        .unwrap();
+        txn.commit().unwrap();
+
+        let (indexed, skipped, corrupt) = repo.rebuild_session_index().expect("repair rebuild");
+        assert_eq!((indexed, skipped, corrupt), (0, 2, 0));
+        let txn = repo.pristine().read_txn().unwrap();
+        assert!(txn
+            .get_kg_edges_from("session:rebuild/turn:1")
+            .unwrap()
+            .iter()
+            .any(|edge| {
+                edge.kind == predicate::WAS_INFORMED_BY && edge.to_id == "session:rebuild/turn:0"
+            }));
     }
 
     // A corrupt provenance file is reported, not fatal.
@@ -314,6 +436,75 @@ fn session_cross_repo_sync_rebuilds_ledger_from_provenance() {
 }
 
 #[test]
+fn session_rebuild_restores_a_fork_from_its_manifest() {
+    let a_tmp = TempDir::new().unwrap();
+    let b_tmp = TempDir::new().unwrap();
+    let home_tmp = TempDir::new().unwrap();
+    init_repo(a_tmp.path(), home_tmp.path());
+    init_repo(b_tmp.path(), home_tmp.path());
+
+    let repo_a = Repository::open(a_tmp.path()).unwrap();
+    let p0 = save_turn_graph(&repo_a, "manifest-parent", "turn zero", 1, None);
+    save_turn_graph(&repo_a, "manifest-parent", "turn one", 2, Some(p0));
+    let (parent_manifest, child_manifest) = repo_a
+        .fork_session("manifest-parent", 1, "manifest-child")
+        .unwrap();
+    let child = repo_a
+        .get_session_manifest(&child_manifest)
+        .unwrap()
+        .unwrap();
+    repo_a
+        .upsert_session_lifecycle("empty-parent", None, None, None)
+        .unwrap();
+    let (empty_parent_manifest, empty_child_manifest) = repo_a
+        .fork_session("empty-parent", 0, "empty-child")
+        .unwrap();
+    let empty_child = repo_a
+        .get_session_manifest(&empty_child_manifest)
+        .unwrap()
+        .unwrap();
+
+    let repo_b = Repository::open(b_tmp.path()).unwrap();
+    repo_b.ingest_session_manifest(&child).unwrap();
+    repo_b.ingest_session_manifest(&empty_child).unwrap();
+    assert!(repo_b
+        .get_session_ledger("manifest-child")
+        .unwrap()
+        .is_none());
+    assert!(repo_b.get_session_ledger("empty-child").unwrap().is_none());
+
+    let (indexed, skipped, corrupt) = repo_b.rebuild_session_index().unwrap();
+    assert_eq!((indexed, skipped, corrupt), (2, 0, 0));
+
+    let (_, turns) = repo_b
+        .get_session_ledger("manifest-child")
+        .unwrap()
+        .expect("child ledger rebuilt from manifest");
+    assert_eq!(turns.len(), 2);
+    assert_eq!(turns[0].provenance_hash, child.turns[0].provenance_hash);
+    assert_eq!(turns[1].provenance_hash, child.turns[1].provenance_hash);
+
+    let rebuilt_head = repo_b.get_session_head("manifest-child").unwrap().unwrap();
+    let rebuilt = repo_b.get_session_manifest(&rebuilt_head).unwrap().unwrap();
+    assert_eq!(rebuilt.parent_session, Some(parent_manifest));
+    assert_eq!(rebuilt.fork_turn, Some(1));
+
+    let (empty_record, empty_turns) = repo_b
+        .get_session_ledger("empty-child")
+        .unwrap()
+        .expect("empty child ledger rebuilt from manifest");
+    assert_eq!(empty_record.turn_count, 0);
+    assert!(empty_turns.is_empty());
+    let txn = repo_b.pristine().read_txn().unwrap();
+    assert!(txn.get_kg_node("session:empty-child").unwrap().is_some());
+    drop(txn);
+    let empty_head = repo_b.get_session_head("empty-child").unwrap().unwrap();
+    let empty_rebuilt = repo_b.get_session_manifest(&empty_head).unwrap().unwrap();
+    assert_eq!(empty_rebuilt.parent_session, Some(empty_parent_manifest));
+    assert_eq!(empty_rebuilt.fork_turn, Some(0));
+}
+
+#[test]
 fn session_reregistration_is_idempotent() {
     let repo_tmp = TempDir::new().unwrap();
     let home_tmp = TempDir::new().unwrap();
@@ -420,12 +611,20 @@ fn session_ledger_emits_rdf_taxonomy() {
         .save_provenance_graph(
             &ProvenanceGraph::builder("kg-session", "opencode")
                 .plan_id("ATOM-20")
-                .todos(vec![SessionTodo {
-                    id: "todo-rdf".into(),
-                    content: "Emit RDF plan and todo links".into(),
-                    status: "completed".into(),
-                    priority: "high".into(),
-                }])
+                .todos(vec![
+                    SessionTodo {
+                        id: "todo-rdf".into(),
+                        content: "Emit RDF plan and todo links".into(),
+                        status: "completed".into(),
+                        priority: "high".into(),
+                    },
+                    SessionTodo {
+                        id: "external-collision".into(),
+                        content: "Keep an unrelated global node".into(),
+                        status: "pending".into(),
+                        priority: "normal".into(),
+                    },
+                ])
                 .add_node(goal_node("kg-goal", "kg turn zero"))
                 .add_change_explained(change0)
                 .build(),
@@ -489,11 +688,11 @@ fn session_ledger_emits_rdf_taxonomy() {
     assert!(turn0_edges
         .iter()
         .any(|e| e.kind == predicate::HAD_PLAN && e.to_id == "intent:ATOM-20"));
-    assert!(turn0_edges
-        .iter()
-        .any(|e| e.kind == predicate::HAS_TODO && e.to_id == "todo:todo-rdf"));
+    assert!(turn0_edges.iter().any(|e| {
+        e.kind == predicate::HAS_TODO && e.to_id == "session:kg-session/todo:todo-rdf"
+    }));
     let todo = txn
-        .get_kg_node("todo:todo-rdf")
+        .get_kg_node("session:kg-session/todo:todo-rdf")
         .expect("kg read")
         .expect("todo node");
     assert_eq!(
@@ -534,6 +733,88 @@ fn session_ledger_emits_rdf_taxonomy() {
         .get_kg_node("session:kg-child/turn:1")
         .expect("kg read")
         .is_some());
+    drop(txn);
+
+    // Simulate the old global todo representation on an inherited-only child.
+    let mut txn = repo.pristine().write_txn().expect("write txn");
+    txn.del_kg_node("session:kg-child/todo:todo-rdf").unwrap();
+    txn.upsert_kg_node(&KgNode::new(
+        "todo:todo-rdf",
+        "todo",
+        "Emit RDF plan and todo links",
+        "session_ledger",
+    ))
+    .unwrap();
+    txn.upsert_kg_edge(&KgEdge::new(
+        "session:kg-child/turn:0",
+        "todo:todo-rdf",
+        predicate::HAS_TODO,
+    ))
+    .unwrap();
+    txn.upsert_kg_node(&KgNode::new(
+        "todo:external-collision",
+        "todo",
+        "Owned by another index",
+        "external_index",
+    ))
+    .unwrap();
+    txn.commit().unwrap();
+
+    repo.rebuild_session_index().expect("rebuild");
+    let txn = repo.pristine().read_txn().expect("read txn");
+    assert!(txn.get_kg_node("todo:todo-rdf").unwrap().is_none());
+    assert!(txn
+        .get_kg_node("session:kg-child/todo:todo-rdf")
+        .unwrap()
+        .is_some());
+    let unrelated = txn
+        .get_kg_node("todo:external-collision")
+        .unwrap()
+        .expect("unrelated colliding node must survive");
+    assert_eq!(unrelated.source, "external_index");
+    drop(txn);
+
+    let child_head = repo.get_session_head("kg-child").unwrap().unwrap();
+    let child_manifest = repo.get_session_manifest(&child_head).unwrap().unwrap();
+    assert_eq!(child_manifest.parent_session, Some(parent_manifest));
+    assert_eq!(child_manifest.fork_turn, Some(1));
+}
+
+#[test]
+fn todo_ids_are_scoped_to_their_session() {
+    let repo_tmp = TempDir::new().unwrap();
+    let home_tmp = TempDir::new().unwrap();
+    init_repo(repo_tmp.path(), home_tmp.path());
+    let repo = Repository::open(repo_tmp.path()).unwrap();
+
+    for (session_id, content) in [("todo-a", "First session"), ("todo-b", "Second session")] {
+        repo.save_provenance_graph(
+            &ProvenanceGraph::builder(session_id, "opencode")
+                .todos(vec![SessionTodo {
+                    id: "t-1".into(),
+                    content: content.into(),
+                    status: "pending".into(),
+                    priority: "normal".into(),
+                }])
+                .build(),
+        )
+        .unwrap();
+    }
+
+    let txn = repo.pristine().read_txn().unwrap();
+    let first = txn
+        .get_kg_node("session:todo-a/todo:t-1")
+        .unwrap()
+        .expect("first session todo");
+    let second = txn
+        .get_kg_node("session:todo-b/todo:t-1")
+        .unwrap()
+        .expect("second session todo");
+    assert_eq!(first.label, "First session");
+    assert_eq!(second.label, "Second session");
+    assert_eq!(first.metadata.unwrap()["session_id"], "todo-a");
+    assert_eq!(second.metadata.unwrap()["session_id"], "todo-b");
+    assert!(txn.get_kg_node("todo:t-1").unwrap().is_none());
 }
 
 #[test]

--- a/atomic-core/src/change/session.rs
+++ b/atomic-core/src/change/session.rs
@@ -65,6 +65,76 @@ pub struct SessionTurn {
     pub todos: Vec<SessionTodo>,
 }
 
+/// Return a deterministic, causality-aware ordering for a session's turns.
+///
+/// Stored provenance can arrive in any order (for example during pull). A
+/// timestamp plus full provenance hash provides a stable tie-break, while the
+/// `previous_provenance` link keeps a child after its parent when both are
+/// present. Turn numbers are reassigned from zero after ordering.
+pub fn canonicalize_session_turns(turns: Vec<SessionTurn>) -> Vec<SessionTurn> {
+    type SortKey = (i64, [u8; 32], usize);
+
+    let count = turns.len();
+    let positions: std::collections::HashMap<Hash, usize> = turns
+        .iter()
+        .enumerate()
+        .map(|(index, turn)| (turn.provenance_hash, index))
+        .collect();
+    let sort_keys: Vec<SortKey> = turns
+        .iter()
+        .enumerate()
+        .map(|(index, turn)| (turn.timestamp, *turn.provenance_hash.as_bytes(), index))
+        .collect();
+    let mut children = vec![Vec::new(); count];
+    let mut blocked = vec![false; count];
+
+    for (index, turn) in turns.iter().enumerate() {
+        if let Some(parent) = turn
+            .previous_provenance
+            .and_then(|hash| positions.get(&hash).copied())
+        {
+            blocked[index] = true;
+            children[parent].push(index);
+        }
+    }
+
+    let mut remaining: std::collections::BTreeSet<SortKey> = sort_keys.iter().copied().collect();
+    let mut ready: std::collections::BTreeSet<SortKey> = sort_keys
+        .iter()
+        .copied()
+        .filter(|key| !blocked[key.2])
+        .collect();
+    let mut slots: Vec<Option<SessionTurn>> = turns.into_iter().map(Some).collect();
+    let mut ordered = Vec::with_capacity(count);
+
+    while ordered.len() < count {
+        // If malformed provenance contains a cycle, break it at the same
+        // timestamp/hash point in every repository.
+        let key = ready
+            .pop_first()
+            .or_else(|| remaining.first().copied())
+            .expect("remaining turn while canonicalizing");
+        remaining.remove(&key);
+        let index = key.2;
+        let Some(turn) = slots[index].take() else {
+            continue;
+        };
+        ordered.push(turn);
+
+        for child in &children[index] {
+            if blocked[*child] {
+                blocked[*child] = false;
+                ready.insert(sort_keys[*child]);
+            }
+        }
+    }
+
+    for (turn_number, turn) in ordered.iter_mut().enumerate() {
+        turn.turn_number = turn_number as u32;
+    }
+    ordered
+}
+
 /// Generic todo snapshot carried by provenance and the session ledger.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionTodo {
@@ -878,6 +948,78 @@ mod tests {
         let later = encode_session_turn_key(namespace, 2);
         assert!(earlier < later);
         assert_eq!(decode_session_turn_key(&later), (namespace, 2));
+    }
+
+    #[test]
+    fn test_session_turn_order_is_independent_of_ingestion_order() {
+        let parent_hash = Hash::of(b"parent");
+        let child_hash = Hash::of(b"child");
+        let make_turns = || {
+            vec![
+                SessionTurn {
+                    session_id: "sess-1".into(),
+                    turn_number: 0,
+                    goal: None,
+                    provenance_hash: parent_hash,
+                    change_hashes: Vec::new(),
+                    previous_provenance: None,
+                    timestamp: 100,
+                    plan_id: None,
+                    todos: Vec::new(),
+                },
+                SessionTurn {
+                    session_id: "sess-1".into(),
+                    turn_number: 1,
+                    goal: None,
+                    provenance_hash: child_hash,
+                    change_hashes: Vec::new(),
+                    previous_provenance: Some(parent_hash),
+                    // Clock skew must not place a child before its parent.
+                    timestamp: 50,
+                    plan_id: None,
+                    todos: Vec::new(),
+                },
+            ]
+        };
+
+        let forward = canonicalize_session_turns(make_turns());
+        let mut reverse_input = make_turns();
+        reverse_input.reverse();
+        let reverse = canonicalize_session_turns(reverse_input);
+
+        assert_eq!(forward, reverse);
+        assert_eq!(forward[0].provenance_hash, parent_hash);
+        assert_eq!(forward[1].previous_provenance, Some(parent_hash));
+        assert_eq!(
+            forward
+                .iter()
+                .map(|turn| turn.turn_number)
+                .collect::<Vec<_>>(),
+            vec![0, 1]
+        );
+    }
+
+    #[test]
+    fn test_session_turn_order_uses_hash_to_break_timestamp_ties() {
+        let make_turn = |hash: Hash| SessionTurn {
+            session_id: "sess-1".into(),
+            turn_number: 99,
+            goal: None,
+            provenance_hash: hash,
+            change_hashes: Vec::new(),
+            previous_provenance: None,
+            timestamp: 100,
+            plan_id: None,
+            todos: Vec::new(),
+        };
+        let a = make_turn(Hash::of(b"a"));
+        let b = make_turn(Hash::of(b"b"));
+
+        let forward = canonicalize_session_turns(vec![a.clone(), b.clone()]);
+        let reverse = canonicalize_session_turns(vec![b, a]);
+
+        assert_eq!(forward, reverse);
+        assert!(forward[0].provenance_hash.as_bytes() < forward[1].provenance_hash.as_bytes());
     }
 
     #[test]

--- a/atomic-core/src/pristine/txn/read.rs
+++ b/atomic-core/src/pristine/txn/read.rs
@@ -638,6 +638,20 @@ impl ReadTxn {
             .map(|value| crate::types::Hash::from_bytes(*value.value())))
     }
 
+    /// Read every mutable session head for index rebuilds.
+    pub fn list_session_heads(&self) -> PristineResult<Vec<(String, crate::types::Hash)>> {
+        let table = self.txn.open_table(SESSION_HEADS)?;
+        let mut heads = Vec::new();
+        for result in table.iter()? {
+            let (session_id, hash) = result?;
+            heads.push((
+                session_id.value().to_string(),
+                crate::types::Hash::from_bytes(*hash.value()),
+            ));
+        }
+        Ok(heads)
+    }
+
     /// Get all session events for a provenance graph.
     ///
     /// Returns events in sequence order (one per provenance node, for any

--- a/atomic-core/src/pristine/txn/write/mod.rs
+++ b/atomic-core/src/pristine/txn/write/mod.rs
@@ -22,12 +22,15 @@ use crate::types::{
 use crate::pristine::error::{PristineError, PristineResult};
 use crate::pristine::tables::*;
 use crate::pristine::traits::{
-    FileIndexEntry, FileIndexMetadata, GraphTxnT, MutTxnT, TreeTxnT, ViewScope, ViewState, ViewTxnT,
+    FileIndexEntry, FileIndexMetadata, GraphTxnT, KgMutTxnT, MutTxnT, TreeTxnT, ViewScope,
+    ViewState, ViewTxnT,
 };
 
 use super::helpers::{
     deserialize_edge, deserialize_view_state, serialize_edge, serialize_view_state, AdjIterator,
 };
+
+const SESSION_LEDGER_SCHEMA_VERSION: u32 = 1;
 
 /// Read-write transaction
 ///
@@ -285,6 +288,255 @@ impl<'a> WriteTxn<'a> {
         Ok(())
     }
 
+    fn load_session_record_for_write(
+        &self,
+        session_id: &str,
+    ) -> PristineResult<Option<crate::change::session::SessionRecord>> {
+        use crate::change::session::SessionRecord;
+
+        let sessions = self.txn.open_table(SESSIONS)?;
+        let existing = sessions.get(session_id)?;
+        match existing {
+            Some(value) => SessionRecord::from_bytes(value.value())
+                .map(Some)
+                .map_err(|e| PristineError::Serialization {
+                    message: format!("session record decode: {}", e),
+                }),
+            None => Ok(None),
+        }
+    }
+
+    fn load_session_turns_for_write(
+        &self,
+        session_id: &str,
+    ) -> PristineResult<Vec<crate::change::session::SessionTurn>> {
+        use crate::change::session::{
+            encode_session_turn_key, session_turn_namespace, SessionTurn,
+        };
+
+        let turns = self.txn.open_table(SESSION_TURNS)?;
+        let namespace = session_turn_namespace(session_id);
+        let scan_start = encode_session_turn_key(namespace, 0);
+        let scan_end = encode_session_turn_key(namespace, u32::MAX);
+        let mut result = Vec::new();
+
+        for row in turns.range::<&[u8; 40]>(&scan_start..=&scan_end)? {
+            let (_key, value) = row?;
+            let turn = SessionTurn::from_bytes(value.value()).map_err(|e| {
+                PristineError::Serialization {
+                    message: format!("session turn decode: {}", e),
+                }
+            })?;
+            if turn.session_id == session_id {
+                result.push(turn);
+            }
+        }
+        result.sort_by_key(|turn| turn.turn_number);
+        Ok(result)
+    }
+
+    fn session_ledger_schema_key(session_id: &str) -> String {
+        format!(
+            "session_ledger_schema:{}",
+            blake3::hash(session_id.as_bytes()).to_hex()
+        )
+    }
+
+    fn has_current_session_ledger_schema(&self, session_id: &str) -> PristineResult<bool> {
+        let metadata = self.txn.open_table(KG_INDEX_META)?;
+        let key = Self::session_ledger_schema_key(session_id);
+        let is_current = metadata
+            .get(key.as_str())?
+            .is_some_and(|value| value.value() >= SESSION_LEDGER_SCHEMA_VERSION);
+        Ok(is_current)
+    }
+
+    fn mark_current_session_ledger_schema(&mut self, session_id: &str) -> PristineResult<()> {
+        let mut metadata = self.txn.open_table(KG_INDEX_META)?;
+        let key = Self::session_ledger_schema_key(session_id);
+        metadata.insert(key.as_str(), SESSION_LEDGER_SCHEMA_VERSION)?;
+        Ok(())
+    }
+
+    /// Append a turn without touching prior rows when the existing session was
+    /// already written with the current canonical schema.
+    fn append_session_turn(
+        &mut self,
+        mut record: crate::change::session::SessionRecord,
+        turn: crate::change::session::SessionTurn,
+        existing_turns: &[crate::change::session::SessionTurn],
+    ) -> PristineResult<()> {
+        use crate::change::session::{encode_session_turn_key, session_turn_namespace};
+
+        let key =
+            encode_session_turn_key(session_turn_namespace(&record.session_id), turn.turn_number);
+        {
+            let mut turns = self.txn.open_table(SESSION_TURNS)?;
+            let mut reverse = self.txn.open_table(SESSION_PROVENANCE)?;
+            let bytes = turn.to_bytes();
+            turns.insert(&key, bytes.as_slice())?;
+            reverse.insert(turn.provenance_hash.as_bytes(), &key)?;
+        }
+
+        if record.first_provenance.is_none() {
+            record.first_provenance = Some(turn.provenance_hash);
+        }
+        record.latest_provenance = Some(turn.provenance_hash);
+        record.turn_count = turn.turn_number.saturating_add(1);
+        record.started_at = record.started_at.min(turn.timestamp);
+        {
+            let mut sessions = self.txn.open_table(SESSIONS)?;
+            let bytes = record.to_bytes();
+            sessions.insert(record.session_id.as_str(), bytes.as_slice())?;
+        }
+
+        let previous_turn_number = turn.previous_provenance.and_then(|hash| {
+            existing_turns
+                .iter()
+                .find(|existing| existing.provenance_hash == hash)
+                .map(|existing| existing.turn_number)
+                .or_else(|| (hash == turn.provenance_hash).then_some(turn.turn_number))
+        });
+        self.emit_turn_kg(&record, &turn, previous_turn_number)
+    }
+
+    fn index_session_turn_candidate(
+        &mut self,
+        record: crate::change::session::SessionRecord,
+        existing_turns: Vec<crate::change::session::SessionTurn>,
+        mut candidate: crate::change::session::SessionTurn,
+    ) -> PristineResult<()> {
+        use crate::change::session::canonicalize_session_turns;
+
+        let current_schema = self.has_current_session_ledger_schema(&record.session_id)?;
+        candidate.turn_number = existing_turns.len() as u32;
+
+        // The common chained append cannot sort before an existing turn:
+        // causality keeps it blocked until the current last turn is emitted.
+        let chained_append = existing_turns.is_empty()
+            || candidate.previous_provenance
+                == existing_turns.last().map(|turn| turn.provenance_hash);
+        if current_schema && chained_append {
+            return self.append_session_turn(record, candidate, &existing_turns);
+        }
+
+        let mut all_turns = existing_turns.clone();
+        all_turns.push(candidate);
+        let canonical = canonicalize_session_turns(all_turns);
+
+        // Independent roots may also sort at the end. Keep the append-only
+        // write path when canonicalization leaves every prior row untouched.
+        if current_schema
+            && canonical.get(..existing_turns.len()) == Some(existing_turns.as_slice())
+        {
+            if let Some(last) = canonical.last() {
+                if !existing_turns
+                    .iter()
+                    .any(|turn| turn.provenance_hash == last.provenance_hash)
+                {
+                    return self.append_session_turn(record, last.clone(), &existing_turns);
+                }
+            }
+        }
+
+        self.rewrite_session_turns(record, canonical)
+    }
+
+    /// Rewrite one session's derived index from its complete immutable turn
+    /// set. This keeps local keys, manifest order, lifecycle pointers, and KG
+    /// turn numbers consistent even when provenance arrives out of order.
+    fn rewrite_session_turns(
+        &mut self,
+        mut record: crate::change::session::SessionRecord,
+        turns: Vec<crate::change::session::SessionTurn>,
+    ) -> PristineResult<()> {
+        use crate::change::session::{
+            canonicalize_session_turns, encode_session_turn_key, session_turn_namespace,
+        };
+
+        let old_turns = self.load_session_turns_for_write(&record.session_id)?;
+        let turns = canonicalize_session_turns(turns);
+        let preserved_edges = self.clear_session_turn_kg(&old_turns, &turns)?;
+
+        let namespace = session_turn_namespace(&record.session_id);
+        let scan_start = encode_session_turn_key(namespace, 0);
+        let scan_end = encode_session_turn_key(namespace, u32::MAX);
+        let existing_keys = {
+            let table = self.txn.open_table(SESSION_TURNS)?;
+            let mut keys = Vec::new();
+            for row in table.range::<&[u8; 40]>(&scan_start..=&scan_end)? {
+                let (key, _value) = row?;
+                keys.push(*key.value());
+            }
+            keys
+        };
+        {
+            let mut table = self.txn.open_table(SESSION_TURNS)?;
+            for key in existing_keys {
+                table.remove(&key)?;
+            }
+        }
+        {
+            let mut table = self.txn.open_table(SESSION_TURNS)?;
+            let mut reverse = self.txn.open_table(SESSION_PROVENANCE)?;
+            for turn in &turns {
+                let key = encode_session_turn_key(namespace, turn.turn_number);
+                let bytes = turn.to_bytes();
+                table.insert(&key, bytes.as_slice())?;
+                reverse.insert(turn.provenance_hash.as_bytes(), &key)?;
+            }
+        }
+
+        record.first_provenance = turns.first().map(|turn| turn.provenance_hash);
+        record.latest_provenance = turns.last().map(|turn| turn.provenance_hash);
+        record.turn_count = turns.len() as u32;
+        if let Some(first) = turns.first() {
+            record.started_at = record.started_at.min(first.timestamp);
+        }
+        {
+            let mut sessions = self.txn.open_table(SESSIONS)?;
+            let bytes = record.to_bytes();
+            sessions.insert(record.session_id.as_str(), bytes.as_slice())?;
+        }
+
+        let turn_numbers: std::collections::HashMap<Hash, u32> = turns
+            .iter()
+            .map(|turn| (turn.provenance_hash, turn.turn_number))
+            .collect();
+        if turns.is_empty() {
+            self.emit_session_node(&record)?;
+        }
+        for turn in &turns {
+            let previous_turn_number = turn
+                .previous_provenance
+                .and_then(|hash| turn_numbers.get(&hash).copied());
+            self.emit_turn_kg(&record, turn, previous_turn_number)?;
+        }
+        for edge in preserved_edges {
+            self.upsert_kg_edge(&edge)?;
+        }
+        self.mark_current_session_ledger_schema(&record.session_id)?;
+
+        Ok(())
+    }
+
+    /// Re-derive a stored session's canonical order and KG without adding a
+    /// turn. Used by rebuild to repair indexes created by older versions.
+    pub fn normalize_session_turn_order(&mut self, session_id: &str) -> PristineResult<()> {
+        let Some(record) = self.load_session_record_for_write(session_id)? else {
+            return Ok(());
+        };
+        let turns = self.load_session_turns_for_write(session_id)?;
+        let canonical = crate::change::session::canonicalize_session_turns(turns.clone());
+        if self.has_current_session_ledger_schema(session_id)?
+            && canonical == turns
+            && self.session_turn_kg_is_current(session_id, &turns)?
+        {
+            return Ok(());
+        }
+        self.rewrite_session_turns(record, canonical)
+    }
+
     /// Index an immutable provenance graph as the next turn of its session.
     ///
     /// The session ID is the portable external identity. The turn key uses the
@@ -297,41 +549,21 @@ impl<'a> WriteTxn<'a> {
         provenance_hash: &Hash,
         graph: &crate::change::ProvenanceGraph,
     ) -> PristineResult<()> {
-        use crate::change::session::{
-            encode_session_turn_key, session_turn_namespace, SessionRecord, SessionTurn,
-        };
+        use crate::change::session::{SessionRecord, SessionTurn};
 
-        let mut sessions = self.txn.open_table(SESSIONS)?;
-        let mut turns = self.txn.open_table(SESSION_TURNS)?;
-        let mut reverse = self.txn.open_table(SESSION_PROVENANCE)?;
-
-        // Idempotency guard: the same provenance graph must never index twice
-        // IN THE SAME SESSION. Registration can race or repeat across
-        // ingestion paths (a second `save_provenance_graph` for the same
-        // graph, a geodist listener re-registering after a snapshot restore,
-        // a retried pull). The check is a namespace scan rather than the
-        // reverse index because forked sessions legitimately share provenance
-        // hashes — only same-session duplicates are dropped.
-        let namespace = session_turn_namespace(session_id);
-        let scan_start = encode_session_turn_key(namespace, 0);
-        let scan_end = encode_session_turn_key(namespace, u32::MAX);
-        for result in turns.range::<&[u8; 40]>(&scan_start..=&scan_end)? {
-            let (_key, value) = result?;
-            if let Ok(existing) = SessionTurn::from_bytes(value.value()) {
-                if existing.session_id == session_id && existing.provenance_hash == *provenance_hash
-                {
-                    return Ok(());
-                }
-            }
+        // Idempotency is session-local because forked sessions legitimately
+        // share provenance hashes.
+        let turns = self.load_session_turns_for_write(session_id)?;
+        if turns
+            .iter()
+            .any(|turn| turn.provenance_hash == *provenance_hash)
+        {
+            return Ok(());
         }
 
-        let mut record = match sessions.get(session_id)? {
-            Some(value) => SessionRecord::from_bytes(value.value()).map_err(|e| {
-                PristineError::Serialization {
-                    message: format!("session record decode: {}", e),
-                }
-            })?,
-            None => SessionRecord {
+        let mut record = self
+            .load_session_record_for_write(session_id)?
+            .unwrap_or_else(|| SessionRecord {
                 session_id: session_id.to_string(),
                 json_path: json_path.to_string(),
                 view_name: None,
@@ -341,17 +573,16 @@ impl<'a> WriteTxn<'a> {
                 turn_count: 0,
                 started_at: graph.timestamp,
                 ended_at: None,
-            },
-        };
+            });
 
         if record.json_path.is_empty() {
             record.json_path = json_path.to_string();
         }
 
-        let turn_number = record.turn_count;
-        let turn = SessionTurn {
+        let candidate = SessionTurn {
             session_id: session_id.to_string(),
-            turn_number,
+            // Canonical numbering is assigned from the complete turn set.
+            turn_number: 0,
             goal: graph
                 .nodes
                 .iter()
@@ -369,57 +600,33 @@ impl<'a> WriteTxn<'a> {
             plan_id: graph.plan_id.clone(),
             todos: graph.todos.clone(),
         };
-        let key = encode_session_turn_key(session_turn_namespace(session_id), turn_number);
-        let bytes = turn.to_bytes();
-        turns.insert(&key, bytes.as_slice())?;
-        reverse.insert(provenance_hash.as_bytes(), &key)?;
 
-        if record.first_provenance.is_none() {
-            record.first_provenance = Some(*provenance_hash);
-        }
-        record.latest_provenance = Some(*provenance_hash);
-        record.turn_count = record.turn_count.saturating_add(1);
-        let record_bytes = record.to_bytes();
-        sessions.insert(session_id, record_bytes.as_slice())?;
-
-        // Taxonomy emission (ATOM-16): the ledger row becomes KG triples in
-        // the same transaction — session/turn/provenance nodes, hadMember,
-        // explainedBy, generated, wasInformedBy.
-        drop(sessions);
-        drop(turns);
-        drop(reverse);
-        self.emit_turn_kg(&record, &turn)?;
-
-        Ok(())
+        self.index_session_turn_candidate(record, turns, candidate)
     }
 
     /// Index an inherited turn row for a forked session.
     ///
-    /// Unlike `index_session_turn`, the turn number and provenance hash come
-    /// from the parent's immutable ledger entry. The session record's turn
-    /// count advances to max(current, turn_number + 1) so later turns append
-    /// after the inherited prefix.
+    /// The immutable turn data comes from the parent; the child derives its
+    /// own canonical numbering from the complete inherited prefix.
     pub fn index_inherited_turn(
         &mut self,
         child_session_id: &str,
         json_path: &str,
         turn: &crate::change::session::SessionTurn,
     ) -> PristineResult<()> {
-        use crate::change::session::{
-            encode_session_turn_key, session_turn_namespace, SessionRecord,
-        };
+        use crate::change::session::SessionRecord;
 
-        let mut sessions = self.txn.open_table(SESSIONS)?;
-        let mut turns = self.txn.open_table(SESSION_TURNS)?;
-        let mut reverse = self.txn.open_table(SESSION_PROVENANCE)?;
+        let turns = self.load_session_turns_for_write(child_session_id)?;
+        if turns
+            .iter()
+            .any(|existing| existing.provenance_hash == turn.provenance_hash)
+        {
+            return Ok(());
+        }
 
-        let mut record = match sessions.get(child_session_id)? {
-            Some(value) => SessionRecord::from_bytes(value.value()).map_err(|e| {
-                PristineError::Serialization {
-                    message: format!("session record decode: {}", e),
-                }
-            })?,
-            None => SessionRecord {
+        let mut record = self
+            .load_session_record_for_write(child_session_id)?
+            .unwrap_or_else(|| SessionRecord {
                 session_id: child_session_id.to_string(),
                 json_path: json_path.to_string(),
                 view_name: None,
@@ -429,35 +636,17 @@ impl<'a> WriteTxn<'a> {
                 turn_count: 0,
                 started_at: turn.timestamp,
                 ended_at: None,
-            },
-        };
+            });
 
         if record.json_path.is_empty() {
             record.json_path = json_path.to_string();
         }
 
-        let key =
-            encode_session_turn_key(session_turn_namespace(child_session_id), turn.turn_number);
-        let bytes = turn.to_bytes();
-        turns.insert(&key, bytes.as_slice())?;
-        reverse.insert(turn.provenance_hash.as_bytes(), &key)?;
+        let mut inherited = turn.clone();
+        inherited.session_id = child_session_id.to_string();
+        inherited.turn_number = 0;
 
-        if record.first_provenance.is_none() {
-            record.first_provenance = Some(turn.provenance_hash);
-        }
-        record.latest_provenance = Some(turn.provenance_hash);
-        record.turn_count = record.turn_count.max(turn.turn_number.saturating_add(1));
-        let record_bytes = record.to_bytes();
-        sessions.insert(child_session_id, record_bytes.as_slice())?;
-
-        // Taxonomy emission for the inherited row (ATOM-16): the child's
-        // ledger prefix is semantically identical to natively indexed turns.
-        drop(sessions);
-        drop(turns);
-        drop(reverse);
-        self.emit_turn_kg(&record, turn)?;
-
-        Ok(())
+        self.index_session_turn_candidate(record, turns, inherited)
     }
 
     /// Create an empty session record (e.g., a fork with no inherited turns).
@@ -487,99 +676,8 @@ impl<'a> WriteTxn<'a> {
         };
         let bytes = record.to_bytes();
         sessions.insert(session_id, bytes.as_slice())?;
-        Ok(())
-    }
-
-    /// Count indexed turns under a session namespace (for rebuild assignment).
-    pub fn count_session_turns(&self, namespace: &[u8; 32]) -> PristineResult<usize> {
-        let table = self.txn.open_table(SESSION_TURNS)?;
-        let start = crate::change::session::encode_session_turn_key(*namespace, 0);
-        let end = crate::change::session::encode_session_turn_key(*namespace, u32::MAX);
-        let mut count = 0usize;
-        for result in table.range::<&[u8; 40]>(&start..=&end)? {
-            result?;
-            count += 1;
-        }
-        Ok(count)
-    }
-
-    /// Index a turn at an explicit position (rebuild/backfill path).
-    pub fn index_turn_at(
-        &mut self,
-        session_id: &str,
-        json_path: &str,
-        provenance_hash: &Hash,
-        graph: &crate::change::ProvenanceGraph,
-        turn_number: u32,
-        key: &[u8; 40],
-    ) -> PristineResult<()> {
-        use crate::change::session::{SessionRecord, SessionTurn};
-
-        let mut sessions = self.txn.open_table(SESSIONS)?;
-        let mut turns = self.txn.open_table(SESSION_TURNS)?;
-        let mut reverse = self.txn.open_table(SESSION_PROVENANCE)?;
-
-        let turn = SessionTurn {
-            session_id: session_id.to_string(),
-            turn_number,
-            goal: graph
-                .nodes
-                .iter()
-                .find(|node| {
-                    matches!(
-                        node.kind,
-                        crate::change::provenance_graph::ProvenanceNodeKind::Goal
-                    )
-                })
-                .map(|node| node.summary.clone()),
-            provenance_hash: *provenance_hash,
-            change_hashes: graph.changes_explained.clone(),
-            previous_provenance: graph.previous,
-            timestamp: graph.timestamp,
-            plan_id: graph.plan_id.clone(),
-            todos: graph.todos.clone(),
-        };
-        let bytes = turn.to_bytes();
-        turns.insert(key, bytes.as_slice())?;
-        reverse.insert(provenance_hash.as_bytes(), key)?;
-
-        let mut record = match sessions.get(session_id)? {
-            Some(value) => SessionRecord::from_bytes(value.value()).map_err(|e| {
-                PristineError::Serialization {
-                    message: format!("session record decode: {}", e),
-                }
-            })?,
-            None => SessionRecord {
-                session_id: session_id.to_string(),
-                json_path: json_path.to_string(),
-                view_name: None,
-                parent_view: None,
-                first_provenance: None,
-                latest_provenance: None,
-                turn_count: 0,
-                started_at: graph.timestamp,
-                ended_at: None,
-            },
-        };
-        if record.json_path.is_empty() {
-            record.json_path = json_path.to_string();
-        }
-        if record.first_provenance.is_none() {
-            record.first_provenance = Some(*provenance_hash);
-        }
-        record.latest_provenance = Some(*provenance_hash);
-        record.turn_count = record.turn_count.max(turn_number.saturating_add(1));
-        let record_bytes = record.to_bytes();
-        sessions.insert(session_id, record_bytes.as_slice())?;
-
-        // Taxonomy emission for the rebuilt row (ATOM-16): a rebuild must
-        // reproduce the same KG a native registration would have written.
         drop(sessions);
-        drop(turns);
-        drop(reverse);
-        self.emit_turn_kg(&record, &turn)?;
-
-        Ok(())
+        self.emit_session_node(&record)
     }
 
     /// Reconcile lifecycle metadata for a session record.

--- a/atomic-core/src/pristine/txn/write/session_kg.rs
+++ b/atomic-core/src/pristine/txn/write/session_kg.rs
@@ -21,7 +21,7 @@
 use crate::change::session::{SessionRecord, SessionTurn};
 use crate::pristine::error::PristineResult;
 use crate::pristine::ontology::{edge_kind, entity_type, predicate};
-use crate::pristine::traits::KgMutTxnT;
+use crate::pristine::traits::{KgMutTxnT, KgTxnT};
 use crate::pristine::vault::{KgEdge, KgNode};
 use crate::types::{Base32, Hash};
 
@@ -48,17 +48,254 @@ pub(crate) fn change_node_id(hash: &Hash) -> String {
     format!("change:{}", &b32[..12.min(b32.len())])
 }
 
-/// Node id for a todo. Upstream IDs are global todo nodes; generated
-/// turn-local snapshot IDs are already fully qualified session IDs.
-pub(crate) fn todo_node_id(todo_id: &str) -> String {
-    if todo_id.starts_with("session:") {
+/// Node id for a todo. Agent-provided IDs are only stable within their
+/// session, so qualify them with that session. Generated turn-local IDs are
+/// already fully qualified and pass through unchanged.
+pub(crate) fn todo_node_id(session_id: &str, todo_id: &str) -> String {
+    if todo_id.starts_with(&format!("session:{session_id}/")) {
         todo_id.to_string()
     } else {
-        format!("todo:{}", todo_id)
+        format!("session:{session_id}/todo:{todo_id}")
     }
 }
 
+fn legacy_todo_node_id(todo_id: &str) -> String {
+    if todo_id.starts_with("session:") {
+        todo_id.to_string()
+    } else {
+        format!("todo:{todo_id}")
+    }
+}
+
+fn is_session_owned_turn_edge(edge: &KgEdge, turn: &SessionTurn) -> bool {
+    let turn_id = turn_node_id(&turn.session_id, turn.turn_number);
+    let session_turn_prefix = format!("session:{}/turn:", turn.session_id);
+    if edge.from_id == turn_id {
+        return (edge.kind == predicate::EXPLAINED_BY
+            && edge.to_id == provenance_node_id(&turn.provenance_hash))
+            || (edge.kind == predicate::HAD_PLAN
+                && turn.plan_id.as_ref().is_some_and(|plan_id| {
+                    edge.to_id == format!("intent:{}", plan_id.to_uppercase())
+                }))
+            || (edge.kind == predicate::HAS_TODO
+                && turn.todos.iter().any(|todo| {
+                    edge.to_id == todo_node_id(&turn.session_id, &todo.id)
+                        || edge.to_id == legacy_todo_node_id(&todo.id)
+                }))
+            || (edge.kind == predicate::GENERATED
+                && turn
+                    .change_hashes
+                    .iter()
+                    .any(|hash| edge.to_id == change_node_id(hash)))
+            || (edge.kind == predicate::WAS_INFORMED_BY
+                && edge.to_id.starts_with(&session_turn_prefix));
+    }
+
+    edge.to_id == turn_id
+        && ((edge.kind == predicate::HAD_MEMBER
+            && edge.from_id == session_node_id(&turn.session_id))
+            || (edge.kind == predicate::WAS_INFORMED_BY
+                && edge.from_id.starts_with(&session_turn_prefix)))
+}
+
 impl WriteTxn<'_> {
+    /// Remove derived turn/todo KG state before a session ledger is
+    /// re-numbered. Edges not owned by the session index are returned with
+    /// their turn endpoints remapped so callers can restore them afterward.
+    pub(crate) fn clear_session_turn_kg(
+        &mut self,
+        old_turns: &[SessionTurn],
+        new_turns: &[SessionTurn],
+    ) -> PristineResult<Vec<KgEdge>> {
+        let mut todo_ids = std::collections::BTreeSet::new();
+        let old_turn_ids: std::collections::BTreeSet<String> = old_turns
+            .iter()
+            .map(|turn| turn_node_id(&turn.session_id, turn.turn_number))
+            .collect();
+        let new_turn_ids: std::collections::HashMap<Hash, String> = new_turns
+            .iter()
+            .map(|turn| {
+                (
+                    turn.provenance_hash,
+                    turn_node_id(&turn.session_id, turn.turn_number),
+                )
+            })
+            .collect();
+        let mut remapped_turn_ids = std::collections::HashMap::new();
+        let mut preserved = std::collections::BTreeMap::new();
+
+        for turn in old_turns {
+            let old_turn_id = turn_node_id(&turn.session_id, turn.turn_number);
+            if let Some(new_turn_id) = new_turn_ids.get(&turn.provenance_hash) {
+                remapped_turn_ids.insert(old_turn_id.clone(), new_turn_id.clone());
+            }
+            for todo in &turn.todos {
+                // Current namespaced form.
+                todo_ids.insert(todo_node_id(&turn.session_id, &todo.id));
+                // Pre-fix global form, for safe migration during a rewrite.
+                todo_ids.insert(legacy_todo_node_id(&todo.id));
+            }
+
+            let edges = self
+                .get_kg_edges_from(&old_turn_id)?
+                .into_iter()
+                .chain(self.get_kg_edges_to(&old_turn_id)?);
+            for edge in edges {
+                if !is_session_owned_turn_edge(&edge, turn) {
+                    preserved.insert(
+                        (edge.from_id.clone(), edge.to_id.clone(), edge.kind.clone()),
+                        edge,
+                    );
+                }
+            }
+        }
+
+        for turn_id in &old_turn_ids {
+            self.del_kg_node(turn_id)?;
+        }
+
+        for todo_id in todo_ids {
+            let is_session_todo = self
+                .get_kg_node(&todo_id)?
+                .is_some_and(|node| node.kind == "todo" && node.source == "session_ledger");
+            if is_session_todo
+                && self.get_kg_edges_from(&todo_id)?.is_empty()
+                && self.get_kg_edges_to(&todo_id)?.is_empty()
+            {
+                self.del_kg_node(&todo_id)?;
+            }
+        }
+
+        Ok(preserved
+            .into_values()
+            .map(|mut edge| {
+                if let Some(new_id) = remapped_turn_ids.get(&edge.from_id) {
+                    edge.from_id = new_id.clone();
+                }
+                if let Some(new_id) = remapped_turn_ids.get(&edge.to_id) {
+                    edge.to_id = new_id.clone();
+                }
+                edge
+            })
+            .collect())
+    }
+
+    /// Check the derived nodes and edges covered by the session-ledger schema
+    /// marker before an idempotent rebuild skips a full rewrite.
+    pub(crate) fn session_turn_kg_is_current(
+        &self,
+        session_id: &str,
+        turns: &[SessionTurn],
+    ) -> PristineResult<bool> {
+        let session_node = session_node_id(session_id);
+        let is_current_session = self
+            .get_kg_node(&session_node)?
+            .is_some_and(|node| node.kind == "session" && node.source == "session_ledger");
+        if !is_current_session {
+            return Ok(false);
+        }
+
+        let session_edges = self.get_kg_edges_from(&session_node)?;
+        let turn_numbers: std::collections::HashMap<Hash, u32> = turns
+            .iter()
+            .map(|turn| (turn.provenance_hash, turn.turn_number))
+            .collect();
+        let turn_prefix = format!("session:{session_id}/turn:");
+
+        for turn in turns {
+            if turn.session_id != session_id {
+                return Ok(false);
+            }
+
+            let turn_id = turn_node_id(&turn.session_id, turn.turn_number);
+            let is_current_turn = self
+                .get_kg_node(&turn_id)?
+                .is_some_and(|node| node.kind == "session_turn" && node.source == "session_ledger");
+            if !is_current_turn
+                || !session_edges
+                    .iter()
+                    .any(|edge| edge.kind == predicate::HAD_MEMBER && edge.to_id == turn_id)
+            {
+                return Ok(false);
+            }
+
+            let turn_edges = self.get_kg_edges_from(&turn_id)?;
+            if !turn_edges.iter().any(|edge| {
+                edge.kind == predicate::EXPLAINED_BY
+                    && edge.to_id == provenance_node_id(&turn.provenance_hash)
+            }) {
+                return Ok(false);
+            }
+
+            let expected_previous = turn.previous_provenance.and_then(|hash| {
+                turn_numbers
+                    .get(&hash)
+                    .map(|number| turn_node_id(session_id, *number))
+            });
+            let actual_previous: Vec<&str> = turn_edges
+                .iter()
+                .filter(|edge| {
+                    edge.kind == predicate::WAS_INFORMED_BY && edge.to_id.starts_with(&turn_prefix)
+                })
+                .map(|edge| edge.to_id.as_str())
+                .collect();
+            match expected_previous {
+                Some(expected)
+                    if actual_previous.len() == 1 && actual_previous[0] == expected.as_str() => {}
+                None if actual_previous.is_empty() => {}
+                _ => return Ok(false),
+            }
+
+            if let Some(plan_id) = &turn.plan_id {
+                let intent_id = format!("intent:{}", plan_id.to_uppercase());
+                if !turn_edges
+                    .iter()
+                    .any(|edge| edge.kind == predicate::HAD_PLAN && edge.to_id == intent_id)
+                    || !session_edges
+                        .iter()
+                        .any(|edge| edge.kind == predicate::HAD_PLAN && edge.to_id == intent_id)
+                {
+                    return Ok(false);
+                }
+            }
+
+            for todo in &turn.todos {
+                let current_id = todo_node_id(&turn.session_id, &todo.id);
+                let is_current_todo = self
+                    .get_kg_node(&current_id)?
+                    .is_some_and(|node| node.kind == "todo" && node.source == "session_ledger");
+                if !is_current_todo
+                    || !turn_edges
+                        .iter()
+                        .any(|edge| edge.kind == predicate::HAS_TODO && edge.to_id == current_id)
+                {
+                    return Ok(false);
+                }
+
+                let legacy_id = legacy_todo_node_id(&todo.id);
+                if legacy_id != current_id
+                    && self
+                        .get_kg_node(&legacy_id)?
+                        .is_some_and(|node| node.kind == "todo" && node.source == "session_ledger")
+                {
+                    return Ok(false);
+                }
+            }
+
+            for change_hash in &turn.change_hashes {
+                let change_id = change_node_id(change_hash);
+                if !turn_edges
+                    .iter()
+                    .any(|edge| edge.kind == predicate::GENERATED && edge.to_id == change_id)
+                {
+                    return Ok(false);
+                }
+            }
+        }
+
+        Ok(true)
+    }
+
     /// Upsert the session node with its current lifecycle metadata.
     pub(crate) fn emit_session_node(&mut self, record: &SessionRecord) -> PristineResult<()> {
         let node = KgNode::new(
@@ -98,11 +335,12 @@ impl WriteTxn<'_> {
     /// - session `prov:hadMember` turn
     /// - turn `vault:explainedBy` provenance
     /// - turn `prov:generated` change (per explained change; full hash in edge metadata)
-    /// - turn `prov:wasInformedBy` previous turn (when turn_number > 0)
+    /// - turn `prov:wasInformedBy` the turn named by `previous_provenance`
     pub(crate) fn emit_turn_kg(
         &mut self,
         record: &SessionRecord,
         turn: &SessionTurn,
+        previous_turn_number: Option<u32>,
     ) -> PristineResult<()> {
         self.emit_session_node(record)?;
 
@@ -159,7 +397,7 @@ impl WriteTxn<'_> {
         }
 
         for todo in &turn.todos {
-            let todo_id = todo_node_id(&todo.id);
+            let todo_id = todo_node_id(&turn.session_id, &todo.id);
             let todo_node = KgNode::new(&todo_id, "todo", &todo.content, "session_ledger")
                 .with_summary(&todo.content)
                 .with_metadata(serde_json::json!({
@@ -190,10 +428,10 @@ impl WriteTxn<'_> {
             )?;
         }
 
-        if turn.turn_number > 0 {
+        if let Some(previous_turn_number) = previous_turn_number {
             self.upsert_kg_edge(&KgEdge::new(
                 &turn_id,
-                turn_node_id(&turn.session_id, turn.turn_number - 1),
+                turn_node_id(&turn.session_id, previous_turn_number),
                 predicate::WAS_INFORMED_BY,
             ))?;
         }

--- a/atomic-repository/src/error.rs
+++ b/atomic-repository/src/error.rs
@@ -78,6 +78,13 @@ pub enum RepositoryError {
         matches: Vec<String>,
     },
 
+    /// Ambiguous intent UID prefix (multiple matches)
+    #[error("Ambiguous intent reference '{prefix}': matches {}", matches.join(", "))]
+    AmbiguousIntent {
+        prefix: String,
+        matches: Vec<String>,
+    },
+
     /// Change already applied
     #[error("Change already applied: {hash}")]
     ChangeAlreadyApplied { hash: String },

--- a/atomic-repository/src/repository/changes.rs
+++ b/atomic-repository/src/repository/changes.rs
@@ -335,9 +335,17 @@ impl Repository {
         Ok(hash)
     }
 
-    /// Build and persist the latest content-addressed manifest for a session.
+    /// Build and persist the latest content-addressed manifest for a session,
+    /// preserving fork lineage from the current head.
     pub fn publish_session_manifest(&self, session_id: &str) -> Result<Hash, RepositoryError> {
-        self.publish_session_manifest_with_fork(session_id, None, None)
+        let (parent_session, fork_turn) = match self.get_session_head(session_id)? {
+            Some(head) => match self.get_session_manifest(&head)? {
+                Some(manifest) => (manifest.parent_session, manifest.fork_turn),
+                None => (None, None),
+            },
+            None => (None, None),
+        };
+        self.publish_session_manifest_with_fork(session_id, parent_session, fork_turn)
     }
 
     /// Load an immutable session manifest by content hash.
@@ -390,8 +398,6 @@ impl Repository {
     /// files are reported in the result rather than aborting the rebuild.
     /// Returns `(indexed_count, skipped_existing, corrupt_count)`.
     pub fn rebuild_session_index(&self) -> Result<(usize, usize, usize), RepositoryError> {
-        use atomic_core::change::session::{encode_session_turn_key, session_turn_namespace};
-
         let mut indexed = 0usize;
         let mut skipped = 0usize;
         let mut corrupt = 0usize;
@@ -408,25 +414,88 @@ impl Repository {
             }
         }
 
-        // Group by session and sort each group by timestamp so turn numbers
-        // are deterministic even for graphs indexed out of order.
+        // Group by session. The core index derives canonical turn order from
+        // the complete set, independent of this ingestion order.
         let mut by_session: std::collections::BTreeMap<
             String,
             Vec<(Hash, atomic_core::change::ProvenanceGraph)>,
         > = std::collections::BTreeMap::new();
+        let mut head_manifests = std::collections::BTreeMap::new();
+        let mut fork_parents = std::collections::BTreeMap::new();
         for (hash, graph) in graphs {
             by_session
                 .entry(graph.session_id.clone())
                 .or_default()
                 .push((hash, graph));
         }
+        // Forked children can contain only inherited turns, whose provenance
+        // files still name the parent session. Include both existing ledgers
+        // and portable manifests so rebuild can create or migrate the child.
+        {
+            let txn = self
+                .pristine
+                .read_txn()
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+            for record in txn
+                .list_session_records()
+                .map_err(|e| RepositoryError::Database(e.to_string()))?
+            {
+                if record.turn_count > 0 {
+                    by_session.entry(record.session_id).or_default();
+                }
+            }
+            for (head_session_id, head) in txn
+                .list_session_heads()
+                .map_err(|e| RepositoryError::Database(e.to_string()))?
+            {
+                match txn.get_session_manifest(&head) {
+                    Ok(Some(manifest)) if manifest.session_id == head_session_id => {
+                        if let (Some(parent_hash), Some(fork_turn)) =
+                            (manifest.parent_session, manifest.fork_turn)
+                        {
+                            if let Ok(Some(parent)) = txn.get_session_manifest(&parent_hash) {
+                                fork_parents.insert(
+                                    head_session_id.clone(),
+                                    (parent.session_id, parent_hash, fork_turn),
+                                );
+                            }
+                        }
+                        by_session.entry(head_session_id.clone()).or_default();
+                        head_manifests.insert(head_session_id, manifest);
+                    }
+                    Ok(Some(_)) => {
+                        log::warn!(
+                            "Skipping session head {} because its manifest names another session",
+                            head_session_id
+                        );
+                    }
+                    Ok(None) => {
+                        log::warn!(
+                            "Session head {} points to a missing manifest",
+                            head_session_id
+                        );
+                    }
+                    Err(error) => {
+                        log::warn!(
+                            "Skipping unreadable session manifest for {}: {}",
+                            head_session_id,
+                            error
+                        );
+                    }
+                }
+            }
+        }
 
         for (session_id, mut session_graphs) in by_session {
-            session_graphs.sort_by_key(|(_, g)| g.timestamp);
+            session_graphs.sort_by(|(a_hash, a), (b_hash, b)| {
+                a.timestamp
+                    .cmp(&b.timestamp)
+                    .then_with(|| a_hash.as_bytes().cmp(b_hash.as_bytes()))
+            });
 
             // Read existing reverse entries once to detect already-indexed
             // provenance hashes.
-            let existing: std::collections::HashSet<Hash> = {
+            let (mut existing, had_record): (std::collections::HashSet<Hash>, bool) = {
                 let txn = self
                     .pristine
                     .read_txn()
@@ -443,7 +512,7 @@ impl Repository {
                         set.insert(turn.provenance_hash);
                     }
                 }
-                set
+                (set, record.is_some())
             };
 
             let json_path = self
@@ -457,34 +526,49 @@ impl Repository {
                 .pristine
                 .write_txn()
                 .map_err(|e| RepositoryError::Database(e.to_string()))?;
-            let mut any_new = false;
             for (hash, graph) in &session_graphs {
                 if existing.contains(hash) {
                     skipped += 1;
                     continue;
                 }
-                // Determine the turn number: existing count if present,
-                // otherwise position in the sorted group.
-                let turn_number = {
-                    let ns = session_turn_namespace(&session_id);
-                    let current = txn
-                        .count_session_turns(&ns)
-                        .map_err(|e| RepositoryError::Database(e.to_string()))?;
-                    current as u32
-                };
-                let key = encode_session_turn_key(session_turn_namespace(&session_id), turn_number);
-                txn.index_turn_at(&session_id, &json_path, hash, graph, turn_number, &key)
+                txn.index_session_turn(&session_id, &json_path, hash, graph)
                     .map_err(|e| RepositoryError::Database(e.to_string()))?;
-                any_new = true;
+                existing.insert(*hash);
                 indexed += 1;
+            }
+            if let Some(manifest) = head_manifests.get(&session_id) {
+                for turn in &manifest.turns {
+                    if existing.insert(turn.provenance_hash) {
+                        txn.index_inherited_turn(&session_id, &json_path, turn)
+                            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+                        indexed += 1;
+                    }
+                }
+                if manifest.turns.is_empty() && !had_record {
+                    txn.index_empty_session(&session_id, &json_path, None, None)
+                        .map_err(|e| RepositoryError::Database(e.to_string()))?;
+                }
+            }
+            // Also repairs turn numbers, causal edges, and legacy todo IDs
+            // when every provenance graph was already indexed.
+            txn.normalize_session_turn_order(&session_id)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+            if let Some((parent_session_id, parent_manifest, fork_turn)) =
+                fork_parents.get(&session_id)
+            {
+                txn.emit_session_fork_kg(
+                    &session_id,
+                    parent_session_id,
+                    *fork_turn,
+                    parent_manifest,
+                )
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
             }
             txn.commit()
                 .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
-            if any_new {
-                if let Err(e) = self.publish_session_manifest(&session_id) {
-                    log::warn!("Manifest publication failed for {}: {}", session_id, e);
-                }
+            if let Err(e) = self.publish_session_manifest(&session_id) {
+                log::warn!("Manifest publication failed for {}: {}", session_id, e);
             }
         }
 

--- a/atomic-repository/src/repository/vault_intent.rs
+++ b/atomic-repository/src/repository/vault_intent.rs
@@ -820,15 +820,38 @@ impl Repository {
                 Ok(key)
             }
             IntentRef::Uid(uid) => {
-                // Match a stored ULID exactly or by prefix; return its human key.
-                let mut matches = manifest.intents.values().filter(|s| {
-                    s.uid == uid || s.uid.starts_with(&uid) || s.uid.eq_ignore_ascii_case(&uid)
-                });
-                if let Some(summary) = matches.next() {
+                // Prefer an exact UID. A prefix is accepted only when it
+                // identifies exactly one intent.
+                let mut matches: Vec<_> = manifest
+                    .intents
+                    .values()
+                    .filter(|summary| summary.uid.eq_ignore_ascii_case(&uid))
+                    .collect();
+                if matches.is_empty() {
+                    let prefix = uid.to_ascii_uppercase();
+                    matches = manifest
+                        .intents
+                        .values()
+                        .filter(|summary| summary.uid.to_ascii_uppercase().starts_with(&prefix))
+                        .collect();
+                }
+                matches.sort_by(|a, b| a.uid.cmp(&b.uid));
+
+                if matches.len() == 1 {
+                    let summary = matches[0];
                     return Ok(if summary.human_key.is_empty() {
-                        uid
+                        summary.uid.clone()
                     } else {
                         summary.human_key.clone()
+                    });
+                }
+                if matches.len() > 1 {
+                    return Err(RepositoryError::AmbiguousIntent {
+                        prefix: id.to_string(),
+                        matches: matches
+                            .into_iter()
+                            .map(|summary| summary.uid.clone())
+                            .collect(),
                     });
                 }
                 Err(RepositoryError::InvalidOperation {
@@ -1551,6 +1574,36 @@ The authentication module has no rate limiting.
             repo.normalize_intent_id(&created.uid[..8]).unwrap(),
             human_key
         );
+    }
+
+    #[test]
+    fn test_normalize_intent_id_rejects_ambiguous_prefix() {
+        let dir = tempdir().unwrap();
+        let repo = init_repo_with_vault(dir.path());
+        let first = repo.vault_intent_create(create_opts("First")).unwrap();
+        let second = repo.vault_intent_create(create_opts("Second")).unwrap();
+        let first_uid = "01KTEST0000000000000000001";
+        let second_uid = "01KTEST0000000000000000002";
+
+        let mut txn = repo.pristine.write_txn().unwrap();
+        let mut manifest = txn.get_vault_manifest().unwrap();
+        manifest.intents.get_mut(&first.id).unwrap().uid = first_uid.into();
+        manifest.intents.get_mut(&second.id).unwrap().uid = second_uid.into();
+        txn.put_vault_manifest(&manifest).unwrap();
+        txn.commit().unwrap();
+
+        // A complete UID remains exact.
+        assert_eq!(repo.normalize_intent_id(first_uid).unwrap(), first.id);
+
+        // A shared prefix must never pick whichever HashMap entry appears first.
+        let error = repo.normalize_intent_id("01KTEST").unwrap_err();
+        match error {
+            RepositoryError::AmbiguousIntent { prefix, matches } => {
+                assert_eq!(prefix, "01KTEST");
+                assert_eq!(matches, vec![first_uid.to_string(), second_uid.to_string()]);
+            }
+            other => panic!("expected ambiguous intent error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/docs/intent-identity.md
+++ b/docs/intent-identity.md
@@ -91,7 +91,7 @@ rarely type the author. Resolution fills in the current project and identity:
 | `3` | `PROJECT::<current-author>::3` |
 | `alice::3` | `PROJECT::alice::3` (a teammate's intent) |
 | `PIMO::lee-faus::3` | exact (project case-normalized) |
-| `01J8ZE…` | the intent whose ULID matches (a **prefix** works too) |
+| `01J8ZE…` | the intent whose ULID matches (a **unique prefix** works too) |
 
 ```bash
 atomic intent show 3                      # my third intent, this project
@@ -99,6 +99,9 @@ atomic intent show alice::3               # alice's third intent
 atomic intent show PIMO::lee-faus::3      # fully qualified
 atomic intent show 01J8ZE7G2W             # by ULID prefix
 ```
+
+If a prefix matches more than one intent, Atomic asks for a longer prefix
+instead of choosing one arbitrarily.
 
 All of these flow through a single resolver
 (`Repository::resolve_intent_key`), shared by the CLI and the attestation


### PR DESCRIPTION
## What

- Make session turn order deterministic and keep `wasInformedBy` links correct.
- Scope todo IDs to each session.
- Reject ambiguous intent ULID prefixes.
- Let `memory show` read freeform and default memories.

## Why

Pull order and reused todo IDs could change or overwrite session data. A short intent prefix could select the wrong intent, and `memory show` could not read memories created by `memory write` or `init`.

## Test

- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
