### PR TITLE
fix: resolve legacy dash-style intent ids after the ULID migration

### DIFF
--- a/atomic-repository/src/repository/vault_intent.rs
+++ b/atomic-repository/src/repository/vault_intent.rs
@@ -842,6 +842,11 @@ impl Repository {
     /// - `PIMO::alice::3`  -> exact (project uppercased)
     /// - a ULID or prefix  -> resolved to the matching intent's human key
     /// - a legacy `PIMO-1` -> matched case-insensitively against manifest keys
+    ///
+    /// Note that a legacy dash-style id reaches the manifest-key match through
+    /// the `Uid` arm, not the `HumanKey` arm: `parse_intent_reference` only
+    /// produces a `HumanKey` for `::`-separated or all-digit input, so anything
+    /// else — including `PIMO-1` — arrives here classified as a ULID.
     fn normalize_intent_id(&self, id: &str) -> Result<String, RepositoryError> {
         use atomic_core::pristine::vault::{parse_intent_reference, IntentRef};
 
@@ -901,6 +906,36 @@ impl Repository {
                             .collect(),
                     });
                 }
+
+                // Legacy fallback: a pre-ULID intent is keyed in the manifest by
+                // its dash-style id (`TEST-1`), which `parse_intent_reference`
+                // classifies as a Uid because it has neither `::` nor an
+                // all-digit form. Such summaries carry no ULID (`uid` is
+                // documented as empty on legacy entries), so neither lookup
+                // above can match and the intent would be unaddressable even
+                // though `vault_intent_list` still reports it.
+                //
+                // Fall back to the manifest key itself — the same
+                // case-insensitive match the `HumanKey` arm performs — so
+                // intents created before the ULID migration stay resolvable by
+                // `show` / `update` / `attest` / `link`. Ambiguity is reported
+                // rather than silently picking one, matching how a colliding
+                // ULID prefix is handled.
+                let legacy: Vec<&String> = manifest
+                    .intents
+                    .keys()
+                    .filter(|key| key.eq_ignore_ascii_case(id))
+                    .collect();
+                if legacy.len() == 1 {
+                    return Ok(legacy[0].clone());
+                }
+                if legacy.len() > 1 {
+                    return Err(RepositoryError::AmbiguousIntent {
+                        prefix: id.to_string(),
+                        matches: legacy.into_iter().cloned().collect(),
+                    });
+                }
+
                 Err(RepositoryError::InvalidOperation {
                     message: format!("No intent matches reference '{}'", id),
                 })
@@ -1749,6 +1784,57 @@ Login attempts are rate-limited.\n:::\n\n\
             repo.vault_intent_path(&intent.id).unwrap(),
             Some(intent.intent_file)
         );
+    }
+
+    /// A pre-ULID intent is keyed in the manifest by its dash-style id and has
+    /// no `uid`. `parse_intent_reference` classifies such a reference as a ULID
+    /// (no `::`, not all digits), so resolution must fall back to the manifest
+    /// key or the intent becomes unaddressable while still being listed.
+    #[test]
+    fn test_resolve_legacy_dash_id_without_uid() {
+        let dir = tempdir().unwrap();
+        let repo = init_repo_with_vault(dir.path());
+        let intent = repo
+            .vault_intent_create(create_opts("Legacy dash id"))
+            .unwrap();
+
+        // Rewrite the manifest to look like a pre-ULID entry: keyed `TEST-1`,
+        // with no uid and no human key.
+        let mut txn = repo.pristine.write_txn().unwrap();
+        let mut manifest = txn.get_vault_manifest().unwrap();
+        let mut summary = manifest.intents.remove(&intent.id).unwrap();
+        summary.uid.clear();
+        summary.human_key.clear();
+        manifest.intents.insert("TEST-1".to_string(), summary);
+        txn.put_vault_manifest(&manifest).unwrap();
+        txn.commit().unwrap();
+
+        assert_eq!(repo.resolve_intent_key("TEST-1").unwrap(), "TEST-1");
+        // Case-insensitively too, matching the `HumanKey` arm's behavior.
+        assert_eq!(repo.resolve_intent_key("test-1").unwrap(), "TEST-1");
+        // A genuinely absent reference must still fail rather than resolve.
+        assert!(repo.resolve_intent_key("NOPE-9").is_err());
+    }
+
+    /// The legacy fallback must not shadow ULID resolution: a modern intent is
+    /// still resolvable by full key, bare sequence, and ULID prefix.
+    #[test]
+    fn test_resolve_modern_intent_unaffected_by_legacy_fallback() {
+        let dir = tempdir().unwrap();
+        let repo = init_repo_with_vault(dir.path());
+        let intent = repo
+            .vault_intent_create(create_opts("Modern identity"))
+            .unwrap();
+
+        let uid = {
+            let manifest = repo.vault_manifest().unwrap();
+            manifest.intents[&intent.id].uid.clone()
+        };
+        assert!(!uid.is_empty(), "a new intent must have a ULID");
+
+        assert_eq!(repo.resolve_intent_key(&intent.id).unwrap(), intent.id);
+        assert_eq!(repo.resolve_intent_key(&uid).unwrap(), intent.id);
+        assert_eq!(repo.resolve_intent_key(&uid[..10]).unwrap(), intent.id);
     }
 
     #[test]


### PR DESCRIPTION
Stacks on #136 (`feat/agent-native-help-contract`), which stacks on #126 — so this rides along rather than needing its own path to `dev`. Merge or drop as you see fit.

## The problem

On #126, intents created before the ULID migration are **listed but cannot be resolved**:

```
atomic intent list --json   ->  [{"id": "TEST-1", ...}, ...]   # lists fine
atomic intent show TEST-1   ->  ✗ No intent matches reference 'TEST-1'
atomic intent show 1        ->  ✗ Intent 'TEST::auditor::1' not found
```

Since `intent update`, `attest`, and `link` all resolve the id first, every write path fails too — so an existing project upgrading to #126 can see its intents but not open or change any of them.

## It is not a data-migration problem

The legacy entries are intact and correctly registered. `vault_intent_list` iterates `manifest.intents`, which is exactly how `intent list` finds them, so `TEST-1` is a live manifest key. No backfill or migration command is needed — only resolution is broken.

The break is three steps:

1. `parse_intent_reference` (`atomic-core/src/pristine/vault.rs`) yields a `HumanKey` only for `::`-separated or all-digit input. A dash-style `TEST-1` matches neither and falls through to the catch-all `IntentRef::Uid(t.to_uppercase())`.
2. The `Uid` arm of `normalize_intent_id` matches solely against `IntentSummary::uid` — documented as *"Empty on legacy pre-ULID entries"* — so neither the exact nor the prefix lookup can hit, and it returns `No intent matches reference '{id}'`.
3. The case-insensitive manifest-key fallback that *would* have matched (`k.eq_ignore_ascii_case(id)`) lives in the **`HumanKey`** arm, which a legacy id never reaches.

So `normalize_intent_id`'s documented contract — *"a legacy `PIMO-1` -> matched case-insensitively against manifest keys"* — is unreachable for the case it names. The fallback was written; the classifier routes past it.

## The fix

Add that same manifest-key fallback to the `Uid` arm, immediately before it errors. Deliberately narrow:

- Runs **only** after exact-uid and uid-prefix lookups both come up empty, so ULID resolution keeps priority and nothing changes for modern intents.
- Reports `AmbiguousIntent` when more than one key matches case-insensitively, rather than silently picking one — matching how a colliding ULID prefix is already handled.
- No change to `parse_intent_reference`'s classification semantics. Tightening that (only treat a token as a ULID when it is plausibly Crockford base32 — `-` is not) is the alternative fix, but it has a wider blast radius and this achieves the same result at the resolution layer.

The doc comment now also records which arm legacy ids actually travel through, since that was the trap.

## Verification

Against a **real pre-migration repository** (nested `intents/manual/<author>/<n>/intent.md`, frontmatter `id: TEST-6`, no `uid`):

- `intent show TEST-1`, `test-1`, and `TEST-6` all render in full — title, status, priority, view, why, acceptance criteria.
- `intent update TEST-4 --status todo` succeeds and persists.
- `NOPE-9` still fails, so absent references are not papered over.

Against a repo of **new-format** intents, unchanged: `LEDG::auditor::1`, bare `1`, and ULID prefix `01KYWH0XDV` all resolve; a bogus `01ZZZZZZZZ` still errors.

Two regression tests added — one for a legacy `uid`-less manifest entry (including the case-insensitive and not-found paths), one asserting modern resolution is unaffected by the new fallback. All 36 existing `vault_intent` tests pass.

Also noticed while testing, and **not** addressed here as it looks unrelated: pre-existing attestations emit `warning: ignoring malformed tracked attestation … invalid type: string "urn:atomic:ac:test-1-ac-1", expected a sequence`. Non-fatal and on stderr (stdout stays clean JSON), but the attestation reader may want a scalar-or-sequence shim.
