### PR TITLE
fix: read pre-widening attestations instead of discarding them

### DIFF
--- a/atomic-canonical/src/gate.rs
+++ b/atomic-canonical/src/gate.rs
@@ -183,7 +183,9 @@ pub fn validate_intent(node: &CanonicalNode) -> ValidationReport {
                 ),
             });
         }
-        for target in &task.satisfies {
+        // `as_slice` so the gate holds a legacy scalar `satisfies` to the same
+        // rule as a list — a dangling criterion reference is a violation either way.
+        for target in task.satisfies.as_slice() {
             if !ac_ids.contains(target.as_str()) {
                 out.push(Violation {
                     focus_node: task.id.clone(),
@@ -350,7 +352,11 @@ mod tests {
             text: "a work item".to_string(),
             task_status: "open".to_string(),
             touches_file: Vec::new(),
-            satisfies: satisfies.iter().map(|s| s.to_string()).collect(),
+            satisfies: satisfies
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>()
+                .into(),
         }
     }
 

--- a/atomic-canonical/src/lift.rs
+++ b/atomic-canonical/src/lift.rs
@@ -191,7 +191,10 @@ fn lift_task(d: &Directive, id_base: &str, n: usize) -> Task {
         text: d.body.clone(),
         task_status: d.attr("status").unwrap_or("open").to_string(),
         touches_file: touches,
-        satisfies,
+        // `.into()` yields `Satisfies::Many`, so freshly lifted tasks always
+        // serialize as a list. The scalar variant is reachable only by
+        // deserializing a pre-widening attestation; nothing here mints one.
+        satisfies: satisfies.into(),
     }
 }
 
@@ -407,7 +410,7 @@ Do not touch the global keyboard handler.
         let node = lift_intent(&fm(), body).unwrap();
         assert_eq!(node.has_task.len(), 1);
         assert_eq!(
-            node.has_task[0].satisfies,
+            node.has_task[0].satisfies.as_slice(),
             vec!["urn:atomic:ac:WORD-5-ac-1".to_string()]
         );
     }
@@ -419,7 +422,7 @@ Do not touch the global keyboard handler.
         let body = ":::task{#demo-2-1 status=met criteria=demo-2-ac-1,demo-2-ac-2,demo-2-ac-3}\nDo the thing.\n:::";
         let node = lift_intent(&fm(), body).unwrap();
         assert_eq!(
-            node.has_task[0].satisfies,
+            node.has_task[0].satisfies.as_slice(),
             vec![
                 "urn:atomic:ac:demo-2-ac-1".to_string(),
                 "urn:atomic:ac:demo-2-ac-2".to_string(),
@@ -436,7 +439,7 @@ Do not touch the global keyboard handler.
         let body = ":::task{#t1 status=open criteria=\"WORD-5-ac-1, WORD-5-ac-2 ,\"}\nWork.\n:::";
         let node = lift_intent(&fm(), body).unwrap();
         assert_eq!(
-            node.has_task[0].satisfies,
+            node.has_task[0].satisfies.as_slice(),
             vec![
                 "urn:atomic:ac:WORD-5-ac-1".to_string(),
                 "urn:atomic:ac:WORD-5-ac-2".to_string(),

--- a/atomic-canonical/src/node.rs
+++ b/atomic-canonical/src/node.rs
@@ -75,6 +75,82 @@ pub struct Ref {
     pub edge: String,
 }
 
+/// The acceptance criteria a task fulfills, in whichever JSON shape it was read.
+///
+/// # Why this is not just `Vec<String>`
+///
+/// `satisfies` was a scalar `Option<String>` until it was widened to a list (a
+/// task may satisfy more than one criterion). Attestations signed before that
+/// change therefore carry a bare string:
+///
+/// ```json
+/// { "@id": "urn:atomic:task:t-1", "satisfies": "urn:atomic:ac:t-1-ac-1" }
+/// ```
+///
+/// A plain `Vec<String>` cannot deserialize that, so every pre-widening
+/// attestation was rejected outright and its intent silently fell back to
+/// "unattested" — discarding signatures that are in fact perfectly valid.
+///
+/// The tempting fix — normalize `"x"` into `vec!["x"]` on read — is **wrong, and
+/// worse than the bug**. Signatures here cover *re-serialized* bytes, not the
+/// bytes on disk: [`crate::proof::verify`] calls `to_value()`, recomputes the
+/// content hash over `hashing_view`, and checks the signature over
+/// `jcs(signing_view)`. Rewriting a scalar into a one-element array changes those
+/// bytes, so the hash stops matching. And because a verification error surfaces
+/// as "signature invalid" rather than "unreadable", normalizing would convert an
+/// honest *unknown* into a **false accusation of tampering** against
+/// cryptographically sound data.
+///
+/// So this type is deliberately *representation-preserving*: it remembers which
+/// shape it was read in and serializes back into that same shape, leaving the
+/// signed bytes byte-for-byte intact. Readers use [`Satisfies::as_slice`] and
+/// never learn which variant they hold.
+///
+/// Newly lifted tasks are always [`Satisfies::Many`] — see the
+/// `From<Vec<String>>` impl, the only construction path in the codebase. Do not
+/// construct [`Satisfies::One`] elsewhere: it exists solely to round-trip
+/// history, and minting a fresh scalar would propagate the old shape forward.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Satisfies {
+    /// A single criterion, as pre-widening attestations stored it. Effectively
+    /// read-only: preserved across a round-trip, never newly minted.
+    One(String),
+    /// Zero or more criteria — the current shape, used by every new task.
+    Many(Vec<String>),
+}
+
+impl Satisfies {
+    /// The criteria as a slice, whatever the shape on disk. Callers use this
+    /// instead of matching, so the legacy variant stays invisible to them.
+    pub fn as_slice(&self) -> &[String] {
+        match self {
+            // `from_ref` lets a scalar masquerade as a one-element slice without
+            // allocating — and, crucially, without rewriting the stored form.
+            Self::One(one) => std::slice::from_ref(one),
+            Self::Many(many) => many,
+        }
+    }
+
+    /// True when no criteria are referenced. Drives `skip_serializing_if`, so an
+    /// empty list is omitted exactly as it was under the plain `Vec`.
+    pub fn is_empty(&self) -> bool {
+        self.as_slice().is_empty()
+    }
+}
+
+impl Default for Satisfies {
+    fn default() -> Self {
+        Self::Many(Vec::new())
+    }
+}
+
+impl From<Vec<String>> for Satisfies {
+    fn from(many: Vec<String>) -> Self {
+        Self::Many(many)
+    }
+}
+
 /// A decomposed task, lifted from a `:::task` directive.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -88,10 +164,11 @@ pub struct Task {
     pub task_status: String,
     #[serde(rename = "touchesFile", default, skip_serializing_if = "Vec::is_empty")]
     pub touches_file: Vec<String>,
-    /// The acceptance criteria this task fulfills. A task may satisfy more than
-    /// one criterion, so this is a list of `urn:atomic:ac:*` ids, not a scalar.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub satisfies: Vec<String>,
+    /// The acceptance criteria this task fulfills — a list on new tasks, but
+    /// possibly a bare string on attestations signed before the field was
+    /// widened. See [`Satisfies`] for why the shape is preserved, not normalized.
+    #[serde(default, skip_serializing_if = "Satisfies::is_empty")]
+    pub satisfies: Satisfies,
 }
 
 /// A Data Integrity proof (`eddsa-jcs-2022`).

--- a/atomic-canonical/src/proof.rs
+++ b/atomic-canonical/src/proof.rs
@@ -310,4 +310,118 @@ mod tests {
             via_core.proof.as_ref().map(|p| &p.proof_value)
         );
     }
+
+    /// A node shaped the way pre-widening attestations were: `satisfies` is a
+    /// bare string, not a list. Built at the Value level so the fixture is
+    /// genuinely scalar on the wire — which is exactly how the old typed struct
+    /// (`satisfies: Option<String>`) serialized it.
+    fn legacy_scalar_satisfies_value() -> Value {
+        json!({
+            "@context": CONTEXT_URL,
+            "@type": "Intent",
+            "@id": "urn:atomic:intent:legacy-1",
+            "humanKey": "LEG-1",
+            "title": "A pre-widening intent",
+            "status": "backlog",
+            "createdAt": "2026-07-20T14:50:41Z",
+            "hasAcceptanceCriterion": [{
+                "@type": "AcceptanceCriterion",
+                "@id": "urn:atomic:ac:leg-1-ac-1",
+                "text": "It works.",
+                "acStatus": "open"
+            }],
+            "hasTask": [{
+                "@type": "Task",
+                "@id": "urn:atomic:task:leg-1-1",
+                "text": "Do the thing.",
+                "taskStatus": "open",
+                "satisfies": "urn:atomic:ac:leg-1-ac-1"
+            }]
+        })
+    }
+
+    #[test]
+    fn legacy_scalar_satisfies_deserializes_and_still_verifies() {
+        // The regression this locks down: `satisfies` was widened from
+        // `Option<String>` to a list, which made every attestation signed before
+        // that change fail to deserialize — so valid signatures were reported as
+        // absent and the intent showed as unattested.
+        let (id, kp) = dev_identity();
+        let attested = attest_value(legacy_scalar_satisfies_value(), &id, &kp);
+
+        // Sanity: the fixture really is scalar on the wire, or this test proves
+        // nothing about the shape we care about.
+        assert!(attested["hasTask"][0]["satisfies"].is_string());
+
+        // 1. It deserializes at all — this is what used to fail outright.
+        let node: CanonicalNode =
+            serde_json::from_value(attested.clone()).expect("legacy scalar must deserialize");
+        assert_eq!(
+            node.has_task[0].satisfies.as_slice(),
+            vec!["urn:atomic:ac:leg-1-ac-1".to_string()],
+            "a scalar must read as a one-element slice"
+        );
+
+        // 2. Re-serializing reproduces the signed bytes EXACTLY. This is the
+        //    property that rules out the tempting `"x"` -> `["x"]` shim: the
+        //    signature covers `to_value()` output, so any normalization would
+        //    change the content hash and turn a valid signature into a reported
+        //    forgery.
+        assert_eq!(
+            node.to_value(),
+            attested,
+            "round-trip must preserve the scalar shape byte-for-byte"
+        );
+        assert_eq!(
+            jcs::canonicalize(&node.signing_value()),
+            jcs::canonicalize(&signing_view(&attested)),
+            "canonical signing bytes must be unchanged by the round-trip"
+        );
+
+        // 3. And therefore the original signature verifies through the typed path.
+        verify(&node, &kp.public).expect("legacy attestation must still verify");
+    }
+
+    #[test]
+    fn normalizing_a_legacy_scalar_would_break_verification() {
+        // Guards the reasoning above rather than the code: it demonstrates why
+        // `Satisfies` preserves representation. If someone later "simplifies" the
+        // enum back to a plain `Vec`, this test documents the cost — verification
+        // fails on data that is cryptographically sound.
+        let (id, kp) = dev_identity();
+        let attested = attest_value(legacy_scalar_satisfies_value(), &id, &kp);
+
+        let mut normalized = attested.clone();
+        normalized["hasTask"][0]["satisfies"] =
+            json!([attested["hasTask"][0]["satisfies"].as_str().unwrap()]);
+
+        let err = verify_value(&normalized, &kp.public)
+            .expect_err("normalizing the shape must break the content hash");
+        assert!(
+            matches!(err, CanonicalError::HashMismatch { .. }),
+            "expected a hash mismatch, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn newly_lifted_tasks_never_mint_the_scalar_shape() {
+        // The scalar variant exists only to round-trip history. Anything we
+        // author must serialize as a list, so the old shape does not spread.
+        let node = crate::lift::lift_intent(
+            &serde_json::from_value(json!({
+                "id": "NEW-1",
+                "uid": "01KYWH0XDVKKYE4PX0ZENJYB5G",
+                "title": "A new intent",
+                "status": "backlog"
+            }))
+            .unwrap(),
+            ":::task{#t-1 status=open satisfies=new-1-ac-1}\nWork.\n:::",
+        )
+        .expect("lift must succeed");
+
+        assert!(
+            node.to_value()["hasTask"][0]["satisfies"].is_array(),
+            "a freshly lifted task must serialize `satisfies` as an array"
+        );
+    }
 }

--- a/atomic-canonical/src/render.rs
+++ b/atomic-canonical/src/render.rs
@@ -88,7 +88,11 @@ fn render_cli(node: &CanonicalNode) -> String {
             let mark = if t.task_status == "done" { "x" } else { " " };
             s.push_str(&format!("  [{mark}] {}\n", t.text));
             if !t.satisfies.is_empty() {
-                s.push_str(&format!("        satisfies: {}\n", t.satisfies.join(", ")));
+                // `as_slice` so a legacy scalar renders identically to a list.
+                s.push_str(&format!(
+                    "        satisfies: {}\n",
+                    t.satisfies.as_slice().join(", ")
+                ));
             }
             if !t.touches_file.is_empty() {
                 s.push_str(&format!("        touches: {}\n", t.touches_file.join(", ")));

--- a/atomic-repository/src/repository/vault_triples.rs
+++ b/atomic-repository/src/repository/vault_triples.rs
@@ -1095,7 +1095,10 @@ fn project_intent_semantics(
                 .with_metadata(serde_json::json!({ "status": t.task_status })),
         );
         edges.push(KgEdge::new(intent_subject, &id, edge_kind::HAS_TASK));
-        for ac_urn in &t.satisfies {
+        // `as_slice` so a legacy scalar `satisfies` still produces its SATISFIES
+        // edge — otherwise pre-widening intents would silently lose the
+        // task→criterion links in the knowledge graph.
+        for ac_urn in t.satisfies.as_slice() {
             edges.push(KgEdge::new(&id, child_kg_id(ac_urn), edge_kind::SATISFIES));
         }
         for file in &t.touches_file {


### PR DESCRIPTION
Stacks on #142 (legacy id *resolution*); this fixes legacy attestation *reading*. Together they restore what `docs/intent-identity.md` already promises. Merge or drop as you see fit.

## The bug

`Task.satisfies` was widened from `Option<String>` to `Vec<String>` in this branch's own implementation commit (`ce42c2f`), with no back-compat on the read side. Every attestation signed before that carries a bare string:

```json
{ "@id": "urn:atomic:task:test-1-1", "satisfies": "urn:atomic:ac:test-1-ac-1" }
```

which a plain `Vec<String>` cannot deserialize. `load_attestation` warned and skipped, the intent fell back to `Attestation::None`, and the `attested` / `verifies` columns were dead for **all** pre-widening data. Measured before the fix, in a real pre-migration project:

```
  humanKey  status   attested  verifies
  TEST-1    icebox   –         –
  TEST-6    done     –         –          ← its signature is valid and fresh
```

## The signatures were never broken

All five attestations in that project verify against the original signer's key with their stored bytes untouched. There is nothing to migrate — there was a reader to fix. (A re-key migration is not merely expensive but impossible in general: `@id`, `humanKey`, and `view` are all inside the signed payload, so re-keying requires re-signing, which requires the original signer's private key. A teammate's attestation could never be preserved.)

## Why the obvious fix is worse than the bug

Signatures cover **re-serialized** bytes, not the bytes on disk: `verify` calls `to_value()`, recomputes the content hash over `hashing_view`, and checks the signature over `jcs(signing_view)`.

So normalizing `"x"` into `["x"]` on read changes those bytes and the content hash stops matching. And because `compute_verifies` maps `Err` to `Verifies::No`, that would flip the column from `–` ("unknown", honest) to `✗` ("signature invalid") — **a false accusation of tampering against cryptographically sound data.** Measured: hash mismatch on all five.

There is a test asserting exactly this (`normalizing_a_legacy_scalar_would_break_verification`), so the cost is documented in-repo if anyone later simplifies the enum back to a `Vec`.

## The fix

`Satisfies` — an untagged enum that remembers which shape it was read in and serializes back into that shape, leaving signed bytes byte-for-byte intact:

- Readers call `as_slice()` and never learn which variant they hold, so the legacy form is invisible to `render`, `gate`, and the KG builder.
- `From<Vec<String>>` is the only construction path in the codebase, so freshly lifted tasks are always the list form and the scalar shape cannot spread forward. Pinned by a test.
- `skip_serializing_if = "Satisfies::is_empty"` keeps the empty case omitted exactly as the plain `Vec` did.

Four mechanical call sites: `render.rs`, `gate.rs`, `vault_triples.rs`, `lift.rs`. The `gate` and KG changes matter beyond compiling — without them a legacy scalar would evade the dangling-criterion check and lose its `SATISFIES` edge.

## Verification

Against the same real pre-migration project, after:

```
  humanKey  status   attested  verifies        (--identity bradley, the signer)
  TEST-1    icebox   stale     –
  TEST-2    planned  stale     –
  TEST-3    done     stale     –
  TEST-4    backlog  –         –               (no attestation entry)
  TEST-5    backlog  stale     –
  TEST-6    done     fresh     ✓
```

The deserialization warnings are gone. The four `stale` rows are stale for an unrelated reason — those intents were edited after signing — which is now reported accurately instead of as "unattested". `TEST-6` verifies.

Note the default-identity nuance: `verifies` is `–` unless the resolving identity is the signer, which is deliberate (`compute_verifies`'s DID-match-then-verify rule), so `--identity bradley` is needed to see the `✓` in that project.

Tests: 72 `atomic-canonical` lib tests (3 new) and 777 `atomic-repository` lib tests pass.

## Memory attestations: checked, clear

The memory bridge (`atomic-cli/src/commands/memory/bridge.rs:226,263`) has the identical warn-and-skip pair, so it was the obvious place for the same bug. It does not have it:

- **No `MemoryNode` field was ever narrowed.** `about` and `derived_from` are its only `Vec<String>` fields and both were `Vec<String>` from introduction — `git log -S 'about: Option<String>'` and the `derived_from` equivalent return nothing across all history. `ce42c2f` does not touch `memory.rs` at all.
- **The one real risk — `derived_from` being *added* in #117 — is provably safe.** Signing a memory node shaped as a pre-#117 attestation (no `derivedFrom` key) and reading it with today's type: deserializes (`derived_from = []`), round-trips byte-identically, canonical signing bytes unchanged, `verify` passes. The `default` + `skip_serializing_if = "Vec::is_empty"` pair is what saves it — an absent key reads as empty and serializes back to absent. That is the discipline `satisfies` broke by changing a field's *shape* instead of adding one.
- A scalar `about` *would* be rejected with the identical error, but no version of atomic ever wrote one, and authoring cannot introduce one either: `str_array` normalizes a scalar frontmatter string into a `Vec` at lift time, before anything is signed.

## Not addressed here

- The **silent degradation itself** is worth a look, independent of this fix: `load_attestation` warns to stderr and falls back to `Attestation::None` in both bridges, which is precisely why the intent case went unnoticed for so long. Distinguishing "unreadable" from "unattested" in the `attested` column would have surfaced it immediately. Left out deliberately — it is a design change, not a fix.
- `atomic intent show TEST-1` prints each acceptance criterion and task twice in that project. Unrelated to attestations and **unverified** whether it is bad data or a `lift`/directive-parse duplication.
