### PR TITLE
fix(agent): close the four agent-provenance gaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +142,7 @@ dependencies = [
  "ignore",
  "log",
  "postcard",
+ "rusqlite",
  "semver",
  "serde",
  "serde_json",
@@ -929,6 +942,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastcdc"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,9 +1240,27 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heapless"
@@ -1506,7 +1549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1632,6 +1675,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2309,6 +2363,20 @@ checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.13.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,9 @@ zstd = "0.13"
 
 # Database
 redb = "2.1"
+# Read-only access to OpenCode's session store (transcript recovery);
+# bundled so no system SQLite is required.
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 # CLI
 clap = { version = "4.5", features = ["derive", "env", "wrap_help"] }

--- a/atomic-agent/Cargo.toml
+++ b/atomic-agent/Cargo.toml
@@ -53,6 +53,9 @@ fs2 = "0.4"
 # Home directory resolution (for ~/.atomic/identities/)
 dirs = { workspace = true }
 
+# Read-only access to OpenCode's session store (transcript recovery)
+rusqlite = { workspace = true }
+
 [dev-dependencies]
 tempfile = { workspace = true }
 serial_test = { workspace = true }

--- a/atomic-agent/src/hooks/cline.rs
+++ b/atomic-agent/src/hooks/cline.rs
@@ -178,8 +178,9 @@ struct ClineInput {
 /// Cline hook adapter.
 ///
 /// Cline uses executable script files for hooks rather than a JSON config file.
-/// Installation and uninstallation are managed by the `atomic-cline` sub-project,
-/// so the Rust adapter only handles JSON parsing from stdin and presence detection.
+/// Installation and uninstallation are managed by the `atomic-cline` package
+/// via the integrations engine, so the Rust adapter only handles JSON parsing
+/// from stdin and presence detection.
 ///
 /// # Differences from Other Adapters
 ///
@@ -418,15 +419,17 @@ impl AgentHook for ClineHook {
     }
 
     fn install(&self, _repo_root: &Path) -> AgentResult<usize> {
-        Ok(0) // Installation handled by atomic-cline project
+        // Installation is owned by the integrations engine (the atomic-cline
+        // package on Atomic storage); this adapter installs nothing.
+        Ok(0)
     }
 
     fn uninstall(&self, _repo_root: &Path) -> AgentResult<()> {
-        Ok(()) // Uninstallation handled by atomic-cline project
+        Ok(()) // Uninstallation is receipt-driven via the integrations engine.
     }
 
     fn is_installed(&self, _repo_root: &Path) -> bool {
-        false // Managed by atomic-cline project
+        false // Managed by the integrations engine (atomic-cline package)
     }
 
     fn supported_hooks(&self) -> Vec<HookType> {
@@ -982,7 +985,7 @@ mod tests {
         assert!(!hook.detect_presence(tmp.path()));
     }
 
-    // ── Installation is a no-op (managed by atomic-cline project) ───
+    // ── Installation is a no-op (owned by the integrations engine) ──
 
     #[test]
     fn test_install_is_noop() {

--- a/atomic-agent/src/hooks/copilot.rs
+++ b/atomic-agent/src/hooks/copilot.rs
@@ -411,15 +411,17 @@ impl AgentHook for CopilotHook {
     }
 
     fn install(&self, _repo_root: &Path) -> AgentResult<usize> {
-        Ok(0) // Installation handled by atomic-copilot package
+        // Installation is owned by the integrations engine (the atomic-copilot
+        // package on Atomic storage); this adapter installs nothing.
+        Ok(0)
     }
 
     fn uninstall(&self, _repo_root: &Path) -> AgentResult<()> {
-        Ok(()) // Uninstallation handled by atomic-copilot package
+        Ok(()) // Uninstallation is receipt-driven via the integrations engine.
     }
 
     fn is_installed(&self, _repo_root: &Path) -> bool {
-        false // Managed by atomic-copilot package
+        false // Managed by the integrations engine (atomic-copilot package)
     }
 
     fn supported_hooks(&self) -> Vec<HookType> {
@@ -829,7 +831,7 @@ mod tests {
         assert!(!hook.detect_presence(tmp.path()));
     }
 
-    // ── Installation is a no-op (managed by atomic-copilot package) ──
+    // ── Installation is a no-op (owned by the integrations engine) ──
 
     #[test]
     fn test_install_is_noop() {

--- a/atomic-agent/src/hooks/cursor.rs
+++ b/atomic-agent/src/hooks/cursor.rs
@@ -705,15 +705,17 @@ impl AgentHook for CursorHook {
     }
 
     fn install(&self, _repo_root: &Path) -> AgentResult<usize> {
-        Ok(0) // Installation handled by atomic-cursor package
+        // Installation is owned by the integrations engine (the atomic-cursor
+        // package on Atomic storage); this adapter installs nothing.
+        Ok(0)
     }
 
     fn uninstall(&self, _repo_root: &Path) -> AgentResult<()> {
-        Ok(()) // Uninstallation handled by atomic-cursor package
+        Ok(()) // Uninstallation is receipt-driven via the integrations engine.
     }
 
     fn is_installed(&self, _repo_root: &Path) -> bool {
-        false // Managed by atomic-cursor package
+        false // Managed by the integrations engine (atomic-cursor package)
     }
 
     fn supported_hooks(&self) -> Vec<HookType> {
@@ -1145,7 +1147,7 @@ mod tests {
         assert!(!hook.detect_presence(tmp.path()));
     }
 
-    // install / uninstall / is_installed are no-ops (managed by atomic-cursor package)
+    // install / uninstall / is_installed are no-ops (owned by the integrations engine)
 
     #[test]
     fn test_install_is_noop() {

--- a/atomic-agent/src/hooks/devin.rs
+++ b/atomic-agent/src/hooks/devin.rs
@@ -48,8 +48,8 @@
 //!
 //! # Installation
 //!
-//! Devin Desktop hook installation is handled by the standalone `atomic-devin`
-//! package. This adapter only parses hook events.
+//! Devin Desktop hook installation is handled by the `atomic-devin` package
+//! via the integrations engine. This adapter only parses hook events.
 
 use std::path::Path;
 
@@ -170,7 +170,8 @@ struct PostToolInput {
 /// Devin Desktop agent hook adapter.
 ///
 /// Parses hook JSON from the Devin Desktop (Cascade) bridge scripts.
-/// Hook installation is handled by the standalone `atomic-devin` package.
+/// Hook installation is handled by the `atomic-devin` package via the
+/// integrations engine.
 #[derive(Debug)]
 pub struct DevinHook {
     _private: (),

--- a/atomic-agent/src/hooks/grok.rs
+++ b/atomic-agent/src/hooks/grok.rs
@@ -1,9 +1,9 @@
 //! Grok Build hook adapter for Atomic Agent.
 //!
 //! Grok fires Claude-compatible lifecycle hooks with a camelCase JSON
-//! envelope on stdin. Installation is handled by the standalone
-//! `atomic-grok` package (hooks file + skills + rules); this adapter only
-//! parses events from the installed hooks.
+//! envelope on stdin. Installation is handled by the `atomic-grok` package
+//! via the integrations engine (hooks file + skills + rules); this adapter
+//! only parses events from the installed hooks.
 //!
 //! # Hook Events
 //!

--- a/atomic-agent/src/hooks/kilo.rs
+++ b/atomic-agent/src/hooks/kilo.rs
@@ -8,8 +8,8 @@
 //!
 //! Kilo Code hooks are configured through kilo.jsonc or agent definitions.
 //! Each hook uses a shell command that invokes the Atomic CLI.
-//! The `atomic-kilo` npm package provides the shell scripts that bridge
-//! Kilo's hook triggers to `atomic agent hooks kilo <verb>`.
+//! The `atomic-kilo` package provides the shell scripts that bridge Kilo's
+//! hook triggers to `atomic agent hooks kilo <verb>`.
 //!
 //! ```text
 //! ┌─────────────────────────────────────────────────────────────────────────┐
@@ -46,9 +46,9 @@
 //!
 //! # Installation
 //!
-//! Kilo hook configuration is managed through `kilo.jsonc` and the
-//! `atomic-kilo` npm package. This adapter only parses hook events —
-//! `install()` and `uninstall()` are no-ops.
+//! Kilo hook configuration is managed through `kilo.jsonc` and installed by
+//! the `atomic-kilo` package via the integrations engine. This adapter only
+//! parses hook events — `install()` and `uninstall()` are no-ops.
 //!
 //! # Detection
 //!
@@ -151,7 +151,8 @@ struct ToolUseInput {
 /// Kilo Code agent hook adapter.
 ///
 /// Parses hook JSON from Kilo Code's shell command hooks. Hook configuration
-/// is managed through `kilo.jsonc` and the `atomic-kilo` npm package.
+/// is managed through `kilo.jsonc` and the `atomic-kilo` package via the
+/// integrations engine.
 #[derive(Debug)]
 pub struct KiloHook {
     _private: (),
@@ -335,15 +336,17 @@ impl AgentHook for KiloHook {
     }
 
     fn install(&self, _repo_root: &Path) -> AgentResult<usize> {
-        Ok(0) // Installation handled by atomic-kilo package
+        // Installation is owned by the integrations engine (the atomic-kilo
+        // package on Atomic storage); this adapter installs nothing.
+        Ok(0)
     }
 
     fn uninstall(&self, _repo_root: &Path) -> AgentResult<()> {
-        Ok(()) // Uninstallation handled by atomic-kilo package
+        Ok(()) // Uninstallation is receipt-driven via the integrations engine.
     }
 
     fn is_installed(&self, _repo_root: &Path) -> bool {
-        false // Managed by atomic-kilo npm package
+        false // Managed by the integrations engine (atomic-kilo package)
     }
 
     fn supported_hooks(&self) -> Vec<HookType> {

--- a/atomic-agent/src/hooks/kiro.rs
+++ b/atomic-agent/src/hooks/kiro.rs
@@ -8,8 +8,8 @@
 //!
 //! Kiro IDE hooks are configured through the IDE's Agent Steering & Skills
 //! panel. Each hook uses a "Shell Command" action that invokes the Atomic CLI.
-//! The `atomic-kiro` npm package provides the shell scripts that bridge
-//! Kiro's hook triggers to `atomic agent hooks kiro <verb>`.
+//! The `atomic-kiro` package provides the shell scripts that bridge Kiro's
+//! hook triggers to `atomic agent hooks kiro <verb>`.
 //!
 //! ```text
 //! ┌─────────────────────────────────────────────────────────────────────────┐
@@ -48,9 +48,9 @@
 //!
 //! # Installation
 //!
-//! Kiro hook configuration is managed through the IDE panel and the
-//! `atomic-kiro` npm package. This adapter only parses hook events —
-//! `install()` and `uninstall()` are no-ops.
+//! Kiro hook configuration is managed through the IDE panel and installed by
+//! the `atomic-kiro` package via the integrations engine. This adapter only
+//! parses hook events — `install()` and `uninstall()` are no-ops.
 //!
 //! # Detection
 //!
@@ -180,7 +180,8 @@ struct PostTaskInput {
 /// Kiro IDE agent hook adapter.
 ///
 /// Parses hook JSON from Kiro IDE's shell command hooks. Hook configuration
-/// is managed through the IDE panel and the `atomic-kiro` npm package.
+/// is managed through the IDE panel and the `atomic-kiro` package via the
+/// integrations engine.
 #[derive(Debug)]
 pub struct KiroHook {
     _private: (),
@@ -365,15 +366,17 @@ impl AgentHook for KiroHook {
     }
 
     fn install(&self, _repo_root: &Path) -> AgentResult<usize> {
-        Ok(0) // Installation handled by atomic-kiro package via IDE panel
+        // Installation is owned by the integrations engine (the atomic-kiro
+        // package on Atomic storage); this adapter installs nothing.
+        Ok(0)
     }
 
     fn uninstall(&self, _repo_root: &Path) -> AgentResult<()> {
-        Ok(()) // Uninstallation handled by atomic-kiro package
+        Ok(()) // Uninstallation is receipt-driven via the integrations engine.
     }
 
     fn is_installed(&self, _repo_root: &Path) -> bool {
-        false // Managed by atomic-kiro npm package
+        false // Managed by the integrations engine (atomic-kiro package)
     }
 
     fn supported_hooks(&self) -> Vec<HookType> {

--- a/atomic-agent/src/hooks/opencode.rs
+++ b/atomic-agent/src/hooks/opencode.rs
@@ -51,9 +51,13 @@
 //!
 //! # Installation
 //!
-//! Plugin installation is handled by the standalone `atomic-opencode` package,
-//! which places the `atomic-hooks.ts` plugin file in `.opencode/plugins/`.
-//! This adapter only handles parsing hook events from the installed plugin.
+//! Installation is handled by the `atomic-opencode` package via the
+//! integrations engine (`crate::integrations`): `atomic agent enable
+//! --agent opencode` syncs the package from Atomic storage, stages
+//! `atomic-hooks.ts` at `~/.config/opencode/plugins/` (plus agent and
+//! skills files), and registers the plugin in `opencode.json` via the
+//! settings manifest. This adapter only parses hook events from the
+//! installed plugin.
 
 use std::path::Path;
 
@@ -325,7 +329,8 @@ struct AfterToolInput {
 /// OpenCode agent hook adapter.
 ///
 /// Handles hook JSON parsing from the OpenCode hooks plugin.
-/// Plugin installation is managed by the standalone `atomic-opencode` package.
+/// Plugin installation is handled by the `atomic-opencode` package via the
+/// integrations engine.
 ///
 /// # Differences from Claude Code / Gemini CLI
 ///
@@ -577,9 +582,9 @@ impl AgentHook for OpenCodeHook {
     }
 
     fn install(&self, _repo_root: &Path) -> AgentResult<usize> {
-        // OpenCode hooks are managed by the atomic-opencode package, not
-        // by writing files into the repo.  Report 1 if the plugin is
-        // already present so that `enable` shows a success message.
+        // Installation is owned by the integrations engine (the
+        // atomic-opencode package on Atomic storage). Report 1 when the
+        // plugin is already staged so `enable` shows a success message.
         if Self::is_plugin_installed() {
             Ok(1)
         } else {
@@ -588,7 +593,7 @@ impl AgentHook for OpenCodeHook {
     }
 
     fn uninstall(&self, _repo_root: &Path) -> AgentResult<()> {
-        Ok(()) // Uninstallation handled by atomic-opencode package
+        Ok(()) // Uninstallation is receipt-driven via the integrations engine.
     }
 
     fn is_installed(&self, _repo_root: &Path) -> bool {
@@ -608,7 +613,7 @@ impl AgentHook for OpenCodeHook {
 
     fn detect_presence(&self, repo_root: &Path) -> bool {
         // OpenCode is present if the repo has a .opencode directory OR if
-        // the atomic-opencode plugin is installed globally.
+        // the atomic-hooks.ts plugin is staged under ~/.config/opencode/.
         repo_root.join(OPENCODE_DIR).is_dir() || Self::is_plugin_installed()
     }
 

--- a/atomic-agent/src/hooks/pi.rs
+++ b/atomic-agent/src/hooks/pi.rs
@@ -51,8 +51,8 @@
 //!
 //! # Installation
 //!
-//! Pi extension installation is handled by the standalone `atomic-pi`
-//! package. This adapter only parses hook events.
+//! Pi extension installation is handled by the `atomic-pi` package via the
+//! integrations engine. This adapter only parses hook events.
 
 use std::path::Path;
 
@@ -282,7 +282,7 @@ struct AfterToolInput {
 /// Pi agent hook adapter.
 ///
 /// Parses hook JSON from the Pi extensions system. Extension installation
-/// is handled by the standalone `atomic-pi` package.
+/// is handled by the `atomic-pi` package via the integrations engine.
 #[derive(Debug)]
 pub struct PiHook {
     _private: (),

--- a/atomic-agent/src/provenance/accumulator/append.rs
+++ b/atomic-agent/src/provenance/accumulator/append.rs
@@ -1,5 +1,5 @@
 use super::helpers::{build_tool_detail, short_hash, truncate_prompt};
-use super::{ProvenanceAccumulator, MAX_GOAL_PROMPT_LEN};
+use super::{ProvenanceAccumulator, MAX_GOAL_PROMPT_LEN, MAX_RESPONSE_TEXT_LEN};
 use crate::provenance::classify::{classify_tool_call, summarize_tool_call};
 use crate::provenance::types::{EdgeKind, GraphEdge, GraphNode, NodeKind};
 
@@ -163,7 +163,59 @@ impl ProvenanceAccumulator {
             }
         }
 
-        self.stats.decision_count += 1;
+        self.push_node(node);
+        node_id
+    }
+
+    /// Append an LLM response node — the agent's final answer for the turn.
+    ///
+    /// Created at turn end from the agent's closing message: the stop
+    /// payload's response field (`last_assistant_message`,
+    /// `prompt_response`, …) or, failing that, the last assistant entry of
+    /// the session transcript. This is the durable record of what the agent
+    /// *concluded*, complementing the tool-derived nodes that record what it
+    /// *did*.
+    ///
+    /// Returns the new node's ID.
+    pub fn append_llm_response(&mut self, text: &str, timestamp: i64) -> String {
+        let summary = truncate_prompt(text, 200);
+        let mut node =
+            GraphNode::new(self.next_id(), NodeKind::LlmResponse, timestamp, &summary);
+
+        let stored: String = text.chars().take(MAX_RESPONSE_TEXT_LEN).collect();
+        node.detail = Some(serde_json::json!({
+            "response_text": stored,
+            "text_length": text.len(),
+        }));
+
+        // Mark as classified so the Phase 3 consolidator doesn't touch it
+        node.classified = true;
+        node.confidence = Some(1.0);
+
+        let node_id = node.id.clone();
+
+        // Edge: goal --led_to-→ response (the answer serves the prompt)
+        if let Some(goal) = &self.current_goal {
+            self.edges.push(GraphEdge::new(
+                goal.clone(),
+                node_id.clone(),
+                EdgeKind::LedTo,
+            ));
+            self.stats.edge_count += 1;
+        }
+
+        // Also chain from the previous node for temporal ordering
+        if let Some(prev) = &self.last_node {
+            if self.current_goal.as_ref() != Some(prev) {
+                self.edges.push(GraphEdge::new(
+                    prev.clone(),
+                    node_id.clone(),
+                    EdgeKind::LedTo,
+                ));
+                self.stats.edge_count += 1;
+            }
+        }
+
         self.push_node(node);
         node_id
     }

--- a/atomic-agent/src/provenance/accumulator/mod.rs
+++ b/atomic-agent/src/provenance/accumulator/mod.rs
@@ -90,6 +90,10 @@ const GRAPH_FILENAME: &str = "graph.json";
 /// Maximum number of characters for a goal node's prompt text.
 const MAX_GOAL_PROMPT_LEN: usize = 500;
 
+/// Maximum number of characters of response text kept in an
+/// `llm_response` node's detail (the summary is truncated separately).
+const MAX_RESPONSE_TEXT_LEN: usize = 8_000;
+
 // =============================================================================
 // ProvenanceAccumulator
 // =============================================================================

--- a/atomic-agent/src/provenance/accumulator/mod.rs
+++ b/atomic-agent/src/provenance/accumulator/mod.rs
@@ -70,6 +70,8 @@ mod append;
 mod convert;
 mod helpers;
 
+pub(crate) use helpers::build_tool_detail;
+
 #[cfg(test)]
 mod tests;
 

--- a/atomic-agent/src/provenance/accumulator/tests.rs
+++ b/atomic-agent/src/provenance/accumulator/tests.rs
@@ -929,3 +929,55 @@ fn test_stats_match_nodes() {
     assert_eq!(stats.total_nodes(), acc.node_count() as u32);
     assert_eq!(stats.edge_count, acc.edge_count() as u32);
 }
+
+// ---- append_llm_response ----
+
+#[test]
+fn test_append_llm_response_links_goal_and_last_node() {
+    let mut acc = ProvenanceAccumulator::new("s1");
+    let goal = acc.append_goal("Fix bug", 1000);
+    let read_id = acc.append_tool_call("read", Some("c1"), None, None, None, None, 1001);
+    let resp = acc.append_llm_response("Fixed it — tests pass.", 1002);
+
+    let node = acc.nodes().iter().find(|n| n.id == resp).unwrap();
+    assert_eq!(node.kind, NodeKind::LlmResponse);
+    assert_eq!(node.summary, "Fixed it — tests pass.");
+    assert!(node.classified);
+    let detail = node.detail.as_ref().unwrap();
+    assert_eq!(detail["response_text"], "Fixed it — tests pass.");
+    assert_eq!(detail["text_length"], "Fixed it — tests pass.".len());
+
+    // goal --led_to-→ response and last_node --led_to-→ response
+    assert!(acc
+        .edges()
+        .iter()
+        .any(|e| e.from == goal && e.to == resp && e.kind == EdgeKind::LedTo));
+    assert!(acc
+        .edges()
+        .iter()
+        .any(|e| e.from == read_id && e.to == resp && e.kind == EdgeKind::LedTo));
+    assert_eq!(acc.stats().llm_response_count, 1);
+}
+
+#[test]
+fn test_append_llm_response_without_goal_or_history() {
+    let mut acc = ProvenanceAccumulator::new("s1");
+    let resp = acc.append_llm_response("Done.", 1000);
+
+    assert_eq!(acc.node_count(), 1);
+    assert_eq!(acc.nodes()[0].id, resp);
+    assert!(acc.edges().is_empty());
+    assert_eq!(acc.stats().llm_response_count, 1);
+}
+
+#[test]
+fn test_append_llm_response_truncates_stored_text() {
+    let mut acc = ProvenanceAccumulator::new("s1");
+    let long = "x".repeat(20_000);
+    let resp = acc.append_llm_response(&long, 1000);
+
+    let node = acc.nodes().iter().find(|n| n.id == resp).unwrap();
+    let detail = node.detail.as_ref().unwrap();
+    assert_eq!(detail["response_text"].as_str().unwrap().len(), 8_000);
+    assert_eq!(detail["text_length"], 20_000);
+}

--- a/atomic-agent/src/record/mod.rs
+++ b/atomic-agent/src/record/mod.rs
@@ -65,6 +65,7 @@ mod tests;
 use std::path::Path;
 
 use atomic_core::change::ChangeHeader;
+use atomic_core::types::Base32;
 
 use atomic_repository::status::RepositoryStatus;
 
@@ -414,6 +415,47 @@ pub fn record_turn(
                     if has_reasoning { " + reasoning" } else { "" },
                     options.turn_number,
                 );
+
+                // The store wrote the change file during record(), before
+                // this unhashed data existed. Re-save so the file on disk
+                // carries the transcript. The unhashed section is outside
+                // the hash, so the content hash is unchanged and the file
+                match atomic_repository::Repository::canonical_dot_dir(repo_root)
+                    .map(|dot| dot.join("changes"))
+                    .map_err(|e| e.to_string())
+                    .and_then(|dir| {
+                        atomic_repository::ChangeStore::new(
+                            dir,
+                            atomic_repository::DEFAULT_CACHE_CAPACITY,
+                        )
+                        .map_err(|e| e.to_string())
+                    }) {
+                    Ok(store) => match store.save_change(outcome.change()) {
+                        Ok(saved) if saved == *outcome.hash() => {}
+                        Ok(saved) => {
+                            log::warn!(
+                                "Re-saved change hash {} differs from recorded {} — \
+                                 unhashed data may be orphaned",
+                                saved.to_base32(),
+                                outcome.hash().to_base32(),
+                            );
+                        }
+                        Err(e) => {
+                            log::warn!(
+                                "Failed to persist transcript on change {} (non-fatal): {}",
+                                outcome.hash().to_base32(),
+                                e
+                            );
+                        }
+                    },
+                    Err(e) => {
+                        log::warn!(
+                            "Could not open change store to persist transcript \
+                             (non-fatal): {}",
+                            e
+                        );
+                    }
+                }
             }
             Err(e) => {
                 log::warn!(

--- a/atomic-agent/src/record/provenance.rs
+++ b/atomic-agent/src/record/provenance.rs
@@ -101,14 +101,38 @@ pub(crate) fn build_turn_provenance(options: &TurnRecordOptions<'_>) -> Provenan
     // Reasoning signature — Anthropic cryptographic proof
     let reasoning_signature = raw_str("reasoning_signature");
 
-    // Reasoning text — concatenated chain-of-thought, truncated to 10KB
-    let reasoning_text = raw_str("reasoning_text").map(|t| {
-        if t.len() > 10_240 {
-            format!("{}...[truncated, {} chars total]", &t[..10_240], t.len())
-        } else {
-            t
-        }
-    });
+    // Reasoning text — concatenated chain-of-thought, truncated to 10KB.
+    // Stop payloads carry either the concatenated `reasoning_text`
+    // (claude-style plugins) or structured `reasoning_blocks` (opencode);
+    // join the latter with the documented separator when the former is
+    // absent.
+    let reasoning_text = raw_str("reasoning_text")
+        .or_else(|| {
+            raw.and_then(|r| r.get("reasoning_blocks"))
+                .and_then(|v| v.as_array())
+                .map(|blocks| {
+                    blocks
+                        .iter()
+                        .filter_map(|b| b.get("text").and_then(|v| v.as_str()))
+                        .map(|t| t.trim())
+                        .filter(|t| !t.is_empty())
+                        .collect::<Vec<_>>()
+                        .join("\n---\n")
+                })
+                .filter(|s| !s.is_empty())
+        })
+        .map(|t| {
+            if t.len() > 10_240 {
+                // Never slice mid-codepoint.
+                let mut end = 10_240;
+                while !t.is_char_boundary(end) {
+                    end -= 1;
+                }
+                format!("{}...[truncated, {} chars total]", &t[..end], t.len())
+            } else {
+                t
+            }
+        });
 
     // Task plan — agent's todo list serialized as JSON string
     let task_plan = raw
@@ -259,11 +283,7 @@ pub(crate) fn build_unhashed_turn_data(
     }
 
     // Determine format from agent name
-    let format = if options.session.agent_name.contains("gemini") {
-        "json"
-    } else {
-        "jsonl"
-    };
+    let format = transcript::format_for_agent(&options.session.agent_name);
 
     // Condense into structured entries
     let entries = transcript::condense_transcript(&raw, format);

--- a/atomic-agent/src/transcript/condense.rs
+++ b/atomic-agent/src/transcript/condense.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use super::types::{AssistantMessage, CondensedEntry, ToolInput, ToolUseSummary, TranscriptLine};
+use super::types::{AssistantMessage, CondensedEntry, EntryType, ToolInput, ToolUseSummary, TranscriptLine};
 
 // Transcript Parsing (Claude Code JSONL)
 
@@ -79,11 +79,90 @@ pub fn condense_claude_transcript(raw: &[u8]) -> Vec<CondensedEntry> {
 pub fn condense_transcript(raw: &[u8], format: &str) -> Vec<CondensedEntry> {
     match format {
         "jsonl" => condense_claude_transcript(raw),
+        "opencode" => condense_opencode_transcript(raw),
         // Future: "json" => condense_gemini_transcript(raw),
         _ => {
             log::warn!("Unknown transcript format '{}', returning empty", format);
             Vec::new()
         }
+    }
+}
+
+/// Parse a synthesized OpenCode JSONL transcript into condensed entries.
+///
+/// The line shape is produced by [`crate::transcript::opencode`] from
+/// OpenCode's SQLite store: `user`/`assistant` lines carry `text`, `tool`
+/// lines carry the tool name and an optional title. `reasoning` lines are
+/// skipped — reasoning is carried separately by the change provenance and
+/// the session graph's Decision nodes.
+pub fn condense_opencode_transcript(raw: &[u8]) -> Vec<CondensedEntry> {
+    let mut entries = Vec::new();
+
+    for line in raw.split(|&b| b == b'\n') {
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(line) else {
+            continue;
+        };
+
+        match parsed.get("type").and_then(|v| v.as_str()) {
+            Some("user") | Some("assistant") => {
+                let Some(text) = parsed.get("text").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                if text.trim().is_empty() {
+                    continue;
+                }
+                if parsed["type"] == "user" {
+                    entries.push(CondensedEntry::user(text));
+                } else {
+                    entries.push(CondensedEntry::assistant(text));
+                }
+            }
+            Some("tool") => {
+                let name = parsed.get("tool").and_then(|v| v.as_str()).unwrap_or("tool");
+                let title = parsed
+                    .get("title")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                entries.push(CondensedEntry::tool(name, title));
+            }
+            _ => {}
+        }
+    }
+
+    entries
+}
+
+/// Extract the agent's final response text from a transcript.
+///
+/// Condenses the transcript and returns the text of the last assistant
+/// entry — what the agent said last. This is the fallback source for the
+/// session graph's `llm_response` node when the agent's stop payload does
+/// not carry the response itself.
+///
+/// Returns `None` when the transcript has no assistant text.
+pub fn last_assistant_text(raw: &[u8], format: &str) -> Option<String> {
+    condense_transcript(raw, format)
+        .into_iter()
+        .rev()
+        .find(|e| matches!(e.entry_type, EntryType::Assistant))
+        .and_then(|e| e.content)
+        .filter(|t| !t.trim().is_empty())
+}
+
+/// The transcript format produced by an agent's transcript file.
+///
+/// Used both when condensing a transcript for `agent_turn` data and when
+/// deriving the agent's final response from it.
+pub fn format_for_agent(agent_name: &str) -> &'static str {
+    if agent_name.contains("gemini") {
+        "json"
+    } else if agent_name == "opencode" {
+        "opencode"
+    } else {
+        "jsonl"
     }
 }
 

--- a/atomic-agent/src/transcript/mod.rs
+++ b/atomic-agent/src/transcript/mod.rs
@@ -84,6 +84,7 @@
 
 mod condense;
 mod generator;
+pub(crate) mod opencode;
 mod reasoning;
 mod storage;
 mod types;
@@ -92,10 +93,9 @@ mod types;
 mod tests;
 
 // Re-export all public types and functions
-
 pub use condense::{
-    aggregate_tool_usage, condense_claude_transcript, condense_transcript, extract_prompts,
-    format_condensed,
+    aggregate_tool_usage, condense_claude_transcript, condense_opencode_transcript,
+    condense_transcript, extract_prompts, format_condensed, format_for_agent, last_assistant_text,
 };
 pub use generator::{
     generate_reasoning, truncate_for_display, try_generate_reasoning, ClaudeCliGenerator,

--- a/atomic-agent/src/transcript/opencode.rs
+++ b/atomic-agent/src/transcript/opencode.rs
@@ -42,8 +42,20 @@ pub(crate) struct ReasoningBlock {
     pub duration_ms: Option<u64>,
 }
 
+/// A tool part recovered from the store, keyed by the same call id the
+/// plugin puts in the hook payload (`tool_call_id` on graph nodes).
+#[derive(Debug)]
+pub(crate) struct ToolPart {
+    pub call_id: String,
+    pub tool: String,
+    pub input: Option<Value>,
+    pub output: Option<String>,
+    pub status: Option<String>,
+}
+
 /// Turn data recovered from OpenCode's SQLite store.
 #[derive(Debug)]
+
 pub(crate) struct TurnData {
     /// JSONL transcript of the whole session, one line per content part.
     pub transcript_jsonl: String,
@@ -64,6 +76,9 @@ pub(crate) struct TurnData {
     pub finish_reason: Option<String>,
     /// Number of model steps in the current turn.
     pub step_count: u32,
+    /// Tool parts for the session, so graph tool nodes recorded from thin
+    /// payloads can be enriched with their commands, files and outputs.
+    pub tool_parts: Vec<ToolPart>,
 }
 
 /// Locate the OpenCode database, if present.
@@ -247,6 +262,7 @@ fn assemble(messages: &[(String, String)], parts: &[(String, Value)]) -> TurnDat
         cost_usd: 0.0,
         finish_reason: None,
         step_count: 0,
+        tool_parts: Vec::new(),
     };
 
     let push_line = |line: Value, out: &mut TurnData| {
@@ -313,6 +329,21 @@ fn assemble(messages: &[(String, String)], parts: &[(String, Value)]) -> TurnDat
                     line["status"] = serde_json::Value::from(status.to_string());
                 }
                 push_line(line, &mut data);
+                // Recover the full tool record so graph nodes recorded from
+                // thin payloads can be enriched with commands/files/outputs.
+                if let Some(call_id) = part.get("callID").and_then(Value::as_str) {
+                    let output = state
+                        .and_then(|s| s.get("output"))
+                        .and_then(Value::as_str)
+                        .map(|o| o.chars().take(2_000).collect());
+                    data.tool_parts.push(ToolPart {
+                        call_id: call_id.to_string(),
+                        tool: tool.to_string(),
+                        input: state.and_then(|s| s.get("input")).cloned(),
+                        output,
+                        status: status.map(|s| s.to_string()),
+                    });
+                }
             }
             "step-start" => {
                 if in_turn {

--- a/atomic-agent/src/transcript/opencode.rs
+++ b/atomic-agent/src/transcript/opencode.rs
@@ -1,0 +1,429 @@
+//! OpenCode session recovery from its local SQLite store.
+//!
+//! OpenCode does not write transcript files — sessions, messages, and
+//! parts live in a SQLite database (`opencode.db` in OpenCode's data
+//! directory). Its hooks therefore have no `transcript_path` to point at,
+//! and thin plugin versions forward only session/model metadata in the
+//! stop payload. Without help, an OpenCode turn records with none of:
+//!
+//! - the unhashed `agent_turn` data (gated on `session.transcript_path`),
+//! - reasoning text (only recent plugins forward `reasoning_blocks`),
+//! - the agent's response (no plugin puts it in the stop payload).
+//!
+//! This module reads the session back from OpenCode's own store at turn
+//! end and synthesizes what other agents' hooks provide natively: a
+//! session transcript (JSONL, one line per content part) plus the current
+//! turn's reasoning blocks, response text, token usage, cost, finish
+//! reason, and step count. The orchestrator folds them into the session
+//! and the stop payload before recording.
+//!
+//! Everything here is best-effort: OpenCode owns the database and its
+//! schema, so every failure is logged and swallowed — the turn records
+//! with whatever the plugin sent.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use rusqlite::{Connection, OpenFlags};
+use serde_json::Value;
+
+/// Name of the OpenCode SQLite database inside its data directory.
+const DB_FILENAME: &str = "opencode.db";
+
+/// How long to wait on a database lock before giving up. OpenCode runs
+/// WAL in practice, where readers do not block on the writer; the cap
+/// guarantees the agent's stop hook is never stalled by this read.
+const DB_BUSY_TIMEOUT_MS: u64 = 100;
+
+/// A reasoning block recovered for the current turn.
+#[derive(Debug)]
+pub(crate) struct ReasoningBlock {
+    pub text: String,
+    pub duration_ms: Option<u64>,
+}
+
+/// Turn data recovered from OpenCode's SQLite store.
+#[derive(Debug)]
+pub(crate) struct TurnData {
+    /// JSONL transcript of the whole session, one line per content part.
+    pub transcript_jsonl: String,
+    /// Reasoning blocks belonging to the current turn.
+    pub reasoning_blocks: Vec<ReasoningBlock>,
+    /// The last assistant text part of the current turn.
+    pub response: Option<String>,
+    /// Token usage summed over the current turn's steps.
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub reasoning_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_write_tokens: u64,
+    /// USD cost summed over the current turn's steps.
+    pub cost_usd: f64,
+    /// Finish reason of the turn's last step ("stop", "tool-calls",
+    /// "length").
+    pub finish_reason: Option<String>,
+    /// Number of model steps in the current turn.
+    pub step_count: u32,
+}
+
+/// Locate the OpenCode database, if present.
+///
+/// Checks `$OPENCODE_HOME`, then `$XDG_DATA_HOME/opencode`, then
+/// `~/.local/share/opencode` (OpenCode's default data directory on both
+/// Linux and macOS), then the platform data dir as a last resort.
+fn locate_db() -> Option<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Some(home) = std::env::var_os("OPENCODE_HOME") {
+        candidates.push(PathBuf::from(home));
+    }
+    if let Some(xdg) = std::env::var_os("XDG_DATA_HOME") {
+        candidates.push(PathBuf::from(xdg).join("opencode"));
+    }
+    if let Some(home) = dirs::home_dir() {
+        candidates.push(home.join(".local").join("share").join("opencode"));
+    }
+    if let Some(data) = dirs::data_dir() {
+        candidates.push(data.join("opencode"));
+    }
+
+    candidates
+        .into_iter()
+        .map(|dir| dir.join(DB_FILENAME))
+        .find(|path| path.is_file())
+}
+
+/// Read the current turn's data for `session_id` from OpenCode's store.
+///
+/// Returns `None` when the database is missing or unreadable, the session
+/// is unknown, or the session belongs to a different directory than
+/// `expected_dir` (a guard against reading an unrelated project's session
+/// with a colliding ID).
+pub(crate) fn read_turn(session_id: &str, expected_dir: &Path) -> Option<TurnData> {
+    let db_path = locate_db()?;
+
+    let conn = match Connection::open_with_flags(
+        &db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    ) {
+        Ok(c) => c,
+        Err(e) => {
+            log::debug!("opencode store: cannot open {}: {}", db_path.display(), e);
+            return None;
+        }
+    };
+    let _ = conn.busy_timeout(std::time::Duration::from_millis(DB_BUSY_TIMEOUT_MS));
+
+    // The session row carries the project directory; refuse to read a
+    // session that belongs to a different checkout.
+    let directory: String = match conn.query_row(
+        "SELECT directory FROM session WHERE id = ?1",
+        [session_id],
+        |row| row.get(0),
+    ) {
+        Ok(d) => d,
+        Err(e) => {
+            log::debug!(
+                "opencode store: session {} not found in {}: {}",
+                session_id,
+                db_path.display(),
+                e
+            );
+            return None;
+        }
+    };
+    if !same_dir(Path::new(&directory), expected_dir) {
+        log::warn!(
+            "opencode store: session {} belongs to '{}', not '{}' — skipping",
+            session_id,
+            directory,
+            expected_dir.display()
+        );
+        return None;
+    }
+
+    let messages = read_messages(&conn, session_id)?;
+    let parts = read_parts(&conn, session_id)?;
+    Some(assemble(&messages, &parts))
+}
+
+/// Compare two directories, canonicalizing when possible.
+fn same_dir(a: &Path, b: &Path) -> bool {
+    let ca = std::fs::canonicalize(a);
+    let cb = std::fs::canonicalize(b);
+    match (ca, cb) {
+        (Ok(ca), Ok(cb)) => ca == cb,
+        _ => a == b,
+    }
+}
+
+/// Messages of the session in chronological order: `(id, role)`.
+fn read_messages(conn: &Connection, session_id: &str) -> Option<Vec<(String, String)>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, json_extract(data, '$.role') FROM message \
+             WHERE session_id = ?1 ORDER BY time_created, id",
+        )
+        .ok()?;
+    let rows = stmt
+        .query_map([session_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .ok()?;
+
+    let mut out = Vec::new();
+    for row in rows {
+        match row {
+            Ok((id, role)) => out.push((id, role)),
+            Err(e) => {
+                log::debug!("opencode store: skipping message row: {}", e);
+            }
+        }
+    }
+    Some(out)
+}
+
+/// Content parts of the session in chronological order:
+/// `(message_id, data)`.
+fn read_parts(conn: &Connection, session_id: &str) -> Option<Vec<(String, Value)>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT message_id, data FROM part \
+             WHERE session_id = ?1 ORDER BY time_created, id",
+        )
+        .ok()?;
+    let rows = stmt
+        .query_map([session_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .ok()?;
+
+    let mut out = Vec::new();
+    for row in rows {
+        match row {
+            Ok((message_id, data)) => match serde_json::from_str::<Value>(&data) {
+                Ok(v) => out.push((message_id, v)),
+                Err(e) => log::debug!("opencode store: skipping unparseable part: {}", e),
+            },
+            Err(e) => {
+                log::debug!("opencode store: skipping part row: {}", e);
+            }
+        }
+    }
+    Some(out)
+}
+
+/// Fold messages and parts into [`TurnData`].
+///
+/// The current turn starts at the last user message; reasoning, response,
+/// and step statistics are scoped to that window, while the transcript
+/// covers the whole session (mirroring how Claude Code's transcript file
+/// is a full-session record).
+fn assemble(messages: &[(String, String)], parts: &[(String, Value)]) -> TurnData {
+    let role_of: HashMap<&str, &str> = messages
+        .iter()
+        .map(|(id, role)| (id.as_str(), role.as_str()))
+        .collect();
+
+    // Turn window: message indices from the last user message onward.
+    let turn_start = messages
+        .iter()
+        .rposition(|(_, role)| role == "user")
+        .unwrap_or(0);
+    let in_turn: HashMap<&str, bool> = messages
+        .iter()
+        .enumerate()
+        .map(|(i, (id, _))| (id.as_str(), i >= turn_start))
+        .collect();
+
+    let mut data = TurnData {
+        transcript_jsonl: String::new(),
+        reasoning_blocks: Vec::new(),
+        response: None,
+        input_tokens: 0,
+        output_tokens: 0,
+        reasoning_tokens: 0,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        cost_usd: 0.0,
+        finish_reason: None,
+        step_count: 0,
+    };
+
+    let push_line = |line: Value, out: &mut TurnData| {
+        if let Ok(s) = serde_json::to_string(&line) {
+            out.transcript_jsonl.push_str(&s);
+            out.transcript_jsonl.push('\n');
+        }
+    };
+
+    for (message_id, part) in parts {
+        let part_type = part.get("type").and_then(Value::as_str).unwrap_or("");
+        let in_turn = in_turn.get(message_id.as_str()).copied().unwrap_or(false);
+        let role = role_of.get(message_id.as_str()).copied().unwrap_or("assistant");
+
+        match part_type {
+            "text" => {
+                let Some(text) = part.get("text").and_then(Value::as_str) else {
+                    continue;
+                };
+                if text.trim().is_empty() {
+                    continue;
+                }
+                let line = serde_json::json!({ "type": role, "text": text });
+                push_line(line, &mut data);
+                if in_turn && role == "assistant" {
+                    data.response = Some(text.to_string());
+                }
+            }
+            "reasoning" => {
+                let Some(text) = part.get("text").and_then(Value::as_str) else {
+                    continue;
+                };
+                if text.trim().is_empty() {
+                    continue;
+                }
+                let duration_ms = part
+                    .get("time")
+                    .and_then(|t| t.get("start"))
+                    .and_then(Value::as_u64)
+                    .zip(part.get("time").and_then(|t| t.get("end")).and_then(Value::as_u64))
+                    .map(|(start, end)| end.saturating_sub(start));
+                let mut line = serde_json::json!({ "type": "reasoning", "text": text });
+                if let Some(ms) = duration_ms {
+                    line["duration_ms"] = serde_json::Value::from(ms);
+                }
+                push_line(line, &mut data);
+                if in_turn {
+                    data.reasoning_blocks.push(ReasoningBlock {
+                        text: text.to_string(),
+                        duration_ms,
+                    });
+                }
+            }
+            "tool" => {
+                let tool = part.get("tool").and_then(Value::as_str).unwrap_or("tool");
+                let state = part.get("state");
+                let title = state.and_then(|s| s.get("title")).and_then(Value::as_str);
+                let status = state.and_then(|s| s.get("status")).and_then(Value::as_str);
+                let mut line = serde_json::json!({ "type": "tool", "tool": tool });
+                if let Some(title) = title {
+                    line["title"] = serde_json::Value::from(title.to_string());
+                }
+                if let Some(status) = status {
+                    line["status"] = serde_json::Value::from(status.to_string());
+                }
+                push_line(line, &mut data);
+            }
+            "step-start" => {
+                if in_turn {
+                    data.step_count += 1;
+                }
+            }
+            "step-finish" => {
+                if !in_turn {
+                    continue;
+                }
+                if let Some(tokens) = part.get("tokens") {
+                    data.input_tokens += tokens.get("input").and_then(Value::as_u64).unwrap_or(0);
+                    data.output_tokens +=
+                        tokens.get("output").and_then(Value::as_u64).unwrap_or(0);
+                    data.reasoning_tokens += tokens
+                        .get("reasoning")
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0);
+                    if let Some(cache) = tokens.get("cache") {
+                        data.cache_read_tokens +=
+                            cache.get("read").and_then(Value::as_u64).unwrap_or(0);
+                        data.cache_write_tokens +=
+                            cache.get("write").and_then(Value::as_u64).unwrap_or(0);
+                    }
+                }
+                data.cost_usd += part.get("cost").and_then(Value::as_f64).unwrap_or(0.0);
+                if let Some(reason) = part.get("reason").and_then(Value::as_str) {
+                    data.finish_reason = Some(reason.to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    data
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn msg(id: &str, role: &str) -> (String, String) {
+        (id.to_string(), role.to_string())
+    }
+
+    fn part(message_id: &str, data: Value) -> (String, Value) {
+        (message_id.to_string(), data)
+    }
+
+    #[test]
+    fn turn_window_scopes_reasoning_and_response() {
+        let messages = vec![msg("m1", "user"), msg("m2", "assistant"), msg("m3", "user"), msg("m4", "assistant")];
+        let parts = vec![
+            part("m1", serde_json::json!({"type": "text", "text": "first question"})),
+            part("m2", serde_json::json!({"type": "reasoning", "text": "old thinking"})),
+            part("m2", serde_json::json!({"type": "text", "text": "old answer"})),
+            part("m3", serde_json::json!({"type": "text", "text": "second question"})),
+            part("m4", serde_json::json!({"type": "reasoning", "text": "new thinking", "time": {"start": 10, "end": 52}})),
+            part("m4", serde_json::json!({"type": "text", "text": "new answer"})),
+        ];
+
+        let data = assemble(&messages, &parts);
+
+        // Response and reasoning come from the last turn only.
+        assert_eq!(data.response.as_deref(), Some("new answer"));
+        assert_eq!(data.reasoning_blocks.len(), 1);
+        assert_eq!(data.reasoning_blocks[0].text, "new thinking");
+        assert_eq!(data.reasoning_blocks[0].duration_ms, Some(42));
+
+        // Transcript covers the whole session.
+        assert_eq!(data.transcript_jsonl.lines().count(), 6);
+        assert!(data.transcript_jsonl.contains("first question"));
+        assert!(data.transcript_jsonl.contains("old answer"));
+    }
+
+    #[test]
+    fn step_finish_sums_tokens_cost_and_reason() {
+        let messages = vec![msg("m1", "user"), msg("m2", "assistant")];
+        let parts = vec![
+            part("m2", serde_json::json!({"type": "step-start"})),
+            part(
+                "m2",
+                serde_json::json!({"type": "step-finish", "reason": "stop", "cost": 0.5,
+                    "tokens": {"input": 10, "output": 20, "reasoning": 5, "cache": {"read": 3, "write": 2}}}),
+            ),
+            part("m2", serde_json::json!({"type": "step-start"})),
+            part(
+                "m2",
+                serde_json::json!({"type": "step-finish", "reason": "tool-calls", "cost": 0.25,
+                    "tokens": {"input": 1, "output": 2}}),
+            ),
+        ];
+
+        let data = assemble(&messages, &parts);
+
+        assert_eq!(data.step_count, 2);
+        assert_eq!(data.input_tokens, 11);
+        assert_eq!(data.output_tokens, 22);
+        assert_eq!(data.reasoning_tokens, 5);
+        assert_eq!(data.cache_read_tokens, 3);
+        assert_eq!(data.cache_write_tokens, 2);
+        assert!((data.cost_usd - 0.75).abs() < f64::EPSILON);
+        assert_eq!(data.finish_reason.as_deref(), Some("tool-calls"));
+    }
+
+    #[test]
+    fn empty_parts_produce_empty_turn() {
+        let data = assemble(&[], &[]);
+        assert!(data.transcript_jsonl.is_empty());
+        assert!(data.response.is_none());
+        assert!(data.reasoning_blocks.is_empty());
+        assert_eq!(data.step_count, 0);
+    }
+}

--- a/atomic-agent/src/transcript/tests.rs
+++ b/atomic-agent/src/transcript/tests.rs
@@ -919,3 +919,81 @@ fn test_parse_claude_response_missing_optional_fields() {
     assert!(reasoning.learnings.code[0].function.is_none());
     assert!(reasoning.learnings.code[0].category.is_none());
 }
+
+// condense_opencode_transcript / format_for_agent / last_assistant_text
+
+#[test]
+fn test_condense_opencode_transcript() {
+    let jsonl = [
+        r#"{"type":"user","text":"fix the bug"}"#,
+        r#"{"type":"reasoning","text":"thinking about it"}"#,
+        r#"{"type":"tool","tool":"bash","title":"cargo test","status":"completed"}"#,
+        r#"{"type":"assistant","text":"fixed"}"#,
+    ]
+    .join("\n");
+
+    let entries = condense_opencode_transcript(jsonl.as_bytes());
+
+    // Reasoning lines stay out of the condensed view.
+    assert_eq!(entries.len(), 3);
+    assert!(entries[0].is_user());
+    assert_eq!(entries[0].content.as_deref(), Some("fix the bug"));
+    assert!(entries[1].is_tool());
+    assert_eq!(entries[1].tool_name.as_deref(), Some("bash"));
+    assert_eq!(entries[1].tool_detail.as_deref(), Some("cargo test"));
+    assert!(entries[2].is_assistant());
+    assert_eq!(entries[2].content.as_deref(), Some("fixed"));
+}
+
+#[test]
+fn test_condense_opencode_transcript_skips_bad_lines() {
+    let jsonl = "not json\n{\"type\":\"assistant\",\"text\":\"ok\"}\n";
+    let entries = condense_opencode_transcript(jsonl.as_bytes());
+    assert_eq!(entries.len(), 1);
+    assert!(entries[0].is_assistant());
+}
+
+#[test]
+fn test_format_for_agent() {
+    assert_eq!(format_for_agent("claude-code"), "jsonl");
+    assert_eq!(format_for_agent("codex"), "jsonl");
+    assert_eq!(format_for_agent("gemini-cli"), "json");
+    assert_eq!(format_for_agent("opencode"), "opencode");
+}
+
+#[test]
+fn test_last_assistant_text_claude_jsonl() {
+    let jsonl = [
+        r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"q"}]}}"#,
+        r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"first"}]}}"#,
+        r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{}}]}}"#,
+        r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"final answer"}]}}"#,
+    ]
+    .join("\n");
+
+    assert_eq!(
+        last_assistant_text(jsonl.as_bytes(), "jsonl").as_deref(),
+        Some("final answer")
+    );
+}
+
+#[test]
+fn test_last_assistant_text_opencode() {
+    let jsonl = [
+        r#"{"type":"assistant","text":"one"}"#,
+        r#"{"type":"tool","tool":"bash"}"#,
+        r#"{"type":"assistant","text":"two"}"#,
+    ]
+    .join("\n");
+
+    assert_eq!(
+        last_assistant_text(jsonl.as_bytes(), "opencode").as_deref(),
+        Some("two")
+    );
+}
+
+#[test]
+fn test_last_assistant_text_none_when_no_assistant() {
+    let jsonl = r#"{"type":"user","text":"hello"}"#;
+    assert_eq!(last_assistant_text(jsonl.as_bytes(), "opencode"), None);
+}

--- a/atomic-agent/src/turn/orchestrator/provenance.rs
+++ b/atomic-agent/src/turn/orchestrator/provenance.rs
@@ -20,6 +20,7 @@ use std::path::{Path, PathBuf};
 use crate::event::TurnEvent;
 use crate::provenance::accumulator::ProvenanceAccumulator;
 use crate::record::TurnRecordOutcome;
+use crate::transcript;
 use crate::turn::session::AgentSession;
 use atomic_core::change::session::SessionTodo;
 
@@ -244,6 +245,193 @@ impl TurnOrchestrator {
 
             block_count > 0
         });
+    }
+
+    /// Inject an LLM response node into the ProvenanceAccumulator.
+    ///
+    /// The agent's closing message for the turn — what it *concluded*, as
+    /// opposed to the tool-derived nodes that capture what it *did*.
+    /// Sources, in priority order:
+    ///
+    /// 1. The stop payload, when the agent sends the response there
+    ///    (`last_assistant_message` for codex/grok, `prompt_response` for
+    ///    gemini-cli, `response` for plugins that supply it).
+    /// 2. The last assistant entry of the session transcript (claude-code:
+    ///    the Stop hook carries `transcript_path`, applied to the session
+    ///    before recording).
+    ///
+    /// Agents with neither source available get no node.
+    pub(crate) fn inject_response_node(
+        &mut self,
+        session_id: &str,
+        session: &AgentSession,
+        event: &TurnEvent,
+    ) {
+        let raw = event.raw_json.as_ref();
+        let from_payload = |key: &str| -> Option<String> {
+            raw.and_then(|r| r.get(key))
+                .and_then(|v| v.as_str())
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        };
+
+        let response = from_payload("last_assistant_message")
+            .or_else(|| from_payload("prompt_response"))
+            .or_else(|| from_payload("response"))
+            .or_else(|| {
+                let path = session.transcript_path.as_ref()?;
+                let data = std::fs::read(path).ok()?;
+                transcript::last_assistant_text(
+                    &data,
+                    transcript::format_for_agent(&session.agent_name),
+                )
+            });
+
+        let Some(response) = response else {
+            return;
+        };
+
+        let timestamp = event.timestamp.timestamp();
+        self.with_accumulator(session_id, |acc| {
+            acc.append_llm_response(&response, timestamp);
+            true
+        });
+    }
+
+    /// OpenCode: recover transcript, reasoning, and response from
+    /// OpenCode's local SQLite store and fold them into the session and
+    /// the stop payload before recording.
+    ///
+    /// OpenCode writes no transcript file, so its sessions never carry a
+    /// `transcript_path`, and thin plugin versions forward only
+    /// session/model metadata. Without this step an OpenCode turn could
+    /// never carry `agent_turn` data, reasoning, or an `llm_response`
+    /// node. The recovered data lands exactly where the existing pipeline
+    /// reads it:
+    ///
+    /// - the transcript is synthesized into the session directory and set
+    ///   as `session.transcript_path` (consumed by
+    ///   `build_unhashed_turn_data` via the `opencode` condense format);
+    /// - the turn's reasoning/response/token/cost fields are injected
+    ///   into `event.raw_json` only when the plugin didn't send them
+    ///   (consumed by `build_turn_provenance`, `inject_reasoning_nodes`,
+    ///   and `inject_response_node`).
+    ///
+    /// Best-effort: any failure leaves the turn recording what the plugin
+    /// sent.
+    pub(crate) fn enrich_opencode_turn(&self, session: &mut AgentSession, event: &mut TurnEvent) {
+        if session.agent_name != "opencode" {
+            return;
+        }
+
+        let Some(data) = transcript::opencode::read_turn(&session.session_id, &self.repo_root)
+        else {
+            return;
+        };
+
+        // 1. Transcript file → transcript_path (unblocks agent_turn).
+        // Rewritten on every turn (whole-session record); a plugin-supplied
+        // transcript path is never clobbered.
+        if !data.transcript_jsonl.is_empty() {
+            let dir = self.session_graph_dir(&session.session_id);
+            let synthesized = dir.join("opencode-transcript.jsonl");
+            let ours = session.transcript_path.is_none()
+                || session.transcript_path.as_deref() == Some(synthesized.as_path());
+            if ours {
+                let _ = std::fs::create_dir_all(&dir);
+                match std::fs::write(&synthesized, &data.transcript_jsonl) {
+                    Ok(()) => session.set_transcript_path(&synthesized),
+                    Err(e) => log::warn!(
+                        "Failed to write opencode transcript for session {}: {}",
+                        session.session_id,
+                        e
+                    ),
+                }
+            }
+        }
+
+        // 2. Stop-payload fields the plugin didn't send.
+        let Some(raw) = event.raw_json.as_mut() else {
+            return;
+        };
+        let Some(obj) = raw.as_object_mut() else {
+            return;
+        };
+
+        if !obj.contains_key("reasoning_blocks")
+            && !obj.contains_key("reasoning_text")
+            && !data.reasoning_blocks.is_empty()
+        {
+            let blocks: Vec<serde_json::Value> = data
+                .reasoning_blocks
+                .iter()
+                .map(|b| {
+                    serde_json::json!({
+                        "text": b.text,
+                        "duration_ms": b.duration_ms,
+                    })
+                })
+                .collect();
+            obj.insert(
+                "reasoning_blocks".to_string(),
+                serde_json::Value::Array(blocks),
+            );
+        }
+
+        if let Some(response) = &data.response {
+            if !obj.contains_key("last_assistant_message") && !obj.contains_key("response") {
+                obj.insert("response".to_string(), serde_json::json!(response));
+            }
+        }
+
+        let have_tokens = obj.contains_key("input_tokens") || obj.contains_key("output_tokens");
+        if !have_tokens
+            && (data.input_tokens > 0 || data.output_tokens > 0 || data.reasoning_tokens > 0)
+        {
+            obj.insert(
+                "input_tokens".to_string(),
+                serde_json::json!(data.input_tokens),
+            );
+            obj.insert(
+                "output_tokens".to_string(),
+                serde_json::json!(data.output_tokens),
+            );
+            obj.insert(
+                "reasoning_tokens".to_string(),
+                serde_json::json!(data.reasoning_tokens),
+            );
+            obj.insert(
+                "cache_read_tokens".to_string(),
+                serde_json::json!(data.cache_read_tokens),
+            );
+            obj.insert(
+                "cache_write_tokens".to_string(),
+                serde_json::json!(data.cache_write_tokens),
+            );
+        }
+
+        if !obj.contains_key("cost_usd") && data.cost_usd > 0.0 {
+            obj.insert("cost_usd".to_string(), serde_json::json!(data.cost_usd));
+        }
+        if !obj.contains_key("finish_reason") {
+            if let Some(reason) = &data.finish_reason {
+                obj.insert("finish_reason".to_string(), serde_json::json!(reason));
+            }
+        }
+        if !obj.contains_key("step_count") && data.step_count > 0 {
+            obj.insert("step_count".to_string(), serde_json::json!(data.step_count));
+        }
+
+        log::info!(
+            "Recovered opencode turn data from local store for session {} \
+             ({} reasoning block{}, response: {}, {} step{})",
+            session.session_id,
+            data.reasoning_blocks.len(),
+            if data.reasoning_blocks.len() == 1 { "" } else { "s" },
+            data.response.is_some(),
+            data.step_count,
+            if data.step_count == 1 { "" } else { "s" },
+        );
     }
 
     /// Read a Sherpa JSONL trace file and create provenance nodes for

--- a/atomic-agent/src/turn/orchestrator/provenance.rs
+++ b/atomic-agent/src/turn/orchestrator/provenance.rs
@@ -15,10 +15,12 @@
 //! load → mutate → save cycles are serialized through an advisory file
 //! lock (`{session_dir}/graph.lock`) to prevent corruption.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::event::TurnEvent;
-use crate::provenance::accumulator::ProvenanceAccumulator;
+use crate::provenance::accumulator::{build_tool_detail, ProvenanceAccumulator};
+use crate::provenance::classify::summarize_tool_call;
 use crate::record::TurnRecordOutcome;
 use crate::transcript;
 use crate::turn::session::AgentSession;
@@ -420,6 +422,49 @@ impl TurnOrchestrator {
         }
         if !obj.contains_key("step_count") && data.step_count > 0 {
             obj.insert("step_count".to_string(), serde_json::json!(data.step_count));
+        }
+
+        // 3. Enrich the session graph's tool nodes. Thin plugin payloads carry
+        //    no tool input/output, so nodes recorded at hook time hold bare
+        //    summaries ("Execute bash"). The store's tool parts carry the
+        //    command, file and output under the same call id — rewrite the
+        //    summary and detail so the graph reads as rich as the rich-plugin
+        //    path. Runs over ALL nodes, so one enriched turn repairs earlier
+        //    thin turns of the same session.
+        if !data.tool_parts.is_empty() {
+            let by_call: HashMap<&str, &transcript::opencode::ToolPart> = data
+                .tool_parts
+                .iter()
+                .map(|tp| (tp.call_id.as_str(), tp))
+                .collect();
+
+            self.with_accumulator(&session.session_id, |acc| {
+                let mut changed = false;
+                for node in acc.nodes.iter_mut() {
+                    let Some(call_id) = node.tool_call_id.as_deref() else {
+                        continue;
+                    };
+                    let Some(tp) = by_call.get(call_id) else {
+                        continue;
+                    };
+                    let tool_name = node.tool_name.as_deref().unwrap_or(tp.tool.as_str());
+                    let input = tp.input.as_ref();
+                    let output = tp.output.as_deref();
+                    let status = tp.status.as_deref();
+
+                    let summary =
+                        summarize_tool_call(tool_name, node.kind, input, output, status);
+                    if summary != node.summary {
+                        node.summary = summary;
+                        changed = true;
+                    }
+                    if let Some(detail) = build_tool_detail(node.kind, tool_name, input, output) {
+                        node.detail = Some(detail);
+                        changed = true;
+                    }
+                }
+                changed
+            });
         }
 
         log::info!(

--- a/atomic-agent/src/turn/orchestrator/turn.rs
+++ b/atomic-agent/src/turn/orchestrator/turn.rs
@@ -133,9 +133,12 @@ impl TurnOrchestrator {
     /// repository what changed since the last recorded state.
     pub(super) async fn handle_turn_end(
         &mut self,
-        event: TurnEvent,
+        mut event: TurnEvent,
     ) -> AgentResult<DispatchResult> {
-        let session_id = &event.session_id;
+        // Clone so `event` stays mutable for enrichment below while the
+        // id is borrowed throughout this function.
+        let session_id_owned = event.session_id.clone();
+        let session_id = session_id_owned.as_str();
         let _turn_end_lock = match self.try_turn_end_lock(session_id) {
             TurnEndLock::Acquired(guard) => Some(guard),
             TurnEndLock::Busy => {
@@ -184,6 +187,20 @@ impl TurnOrchestrator {
                 }
             }
         }
+
+        // Update the transcript path from the Stop event. Claude Code's Stop
+        // payload carries `transcript_path`, but a session created without one
+        // (transcript file not yet minted at SessionStart) would otherwise
+        // record with `transcript_path = None` and lose the unhashed
+        // `agent_turn` transcript data — the record below is the consumer.
+        if let Some(path) = &event.transcript_path {
+            session.set_transcript_path(path);
+        }
+
+        // OpenCode: recover transcript/reasoning/response from its local
+        // store before recording — thin plugins send none of these, and
+        // OpenCode writes no transcript file of its own.
+        self.enrich_opencode_turn(&mut session, &mut event);
 
         // Release the watcher if it was active (best-effort, ignore errors)
         if self.watcher.is_active() {
@@ -269,9 +286,11 @@ impl TurnOrchestrator {
                                 self.ingest_sherpa_trace(session_id, Path::new(trace_path));
                             }
 
-                            // Provenance: inject reasoning blocks as Decision nodes,
+                            // Provenance: inject reasoning blocks as Decision nodes
+                            // and the agent's closing message as an LlmResponse node,
                             // then append a patch proposal node and save the graph.
                             self.inject_reasoning_nodes(session_id, &event);
+                            self.inject_response_node(session_id, &session, &event);
                             self.save_turn_provenance(session_id, &session, &outcome, &event);
 
                             log::info!(

--- a/atomic-cli/src/commands/agent/disable.rs
+++ b/atomic-cli/src/commands/agent/disable.rs
@@ -380,8 +380,7 @@ impl Disable {
                 }
                 "kilo" => {
                     print_success("Kilo Code hooks are configured through kilo.jsonc.");
-                    println!("  Remove rules/agent from .kilo/ directory manually.");
-                    println!("  Uninstall: npx atomic-kilo --uninstall");
+                    println!("  Uninstall the integration: atomic agent disable --agent kilo");
                 }
                 other => {
                     print_warning(&format!(

--- a/atomic-cli/src/commands/change/tests.rs
+++ b/atomic-cli/src/commands/change/tests.rs
@@ -7,6 +7,7 @@ mod tests {
     use atomic_core::change::{Atom, Encoding, Insertion, Local};
     use atomic_core::types::{ChangePosition, Merkle, Position};
     use atomic_core::EdgeFlags;
+    use atomic_core::change::{AITool, AIVendor, PromptContent, Provenance, SuggestionType};
 
     // ChangeFormat Tests
 
@@ -843,5 +844,72 @@ mod tests {
 
         let result2 = truncate_string("Hello 世界!", 8);
         assert!(result2.ends_with("..."));
+    }
+
+    #[test]
+    fn test_json_provenance_surfaces_agent_context_fields() {
+        let prov = Provenance {
+            vendor: AIVendor::Anthropic,
+            model: "claude-sonnet-4".to_string(),
+            tool: AITool::Cli("claude-code".to_string()),
+            suggestion_type: SuggestionType::Complete,
+            prompt: PromptContent::hash_from("fix the bug"),
+            metadata: vec![("turn_number".to_string(), "2".to_string())],
+            agent_mode: Some("build".to_string()),
+            finish_reason: Some("stop".to_string()),
+            step_count: Some(3),
+            session_slug: Some("mighty-rocket".to_string()),
+            reasoning_signature: Some("sig-abc".to_string()),
+            reasoning_text: Some("thought hard about it".to_string()),
+            task_plan: Some("[{\"content\":\"fix\"}]".to_string()),
+            ..Default::default()
+        };
+
+        let json = JsonProvenance::from(&prov);
+
+        assert_eq!(json.agent_mode.as_deref(), Some("build"));
+        assert_eq!(json.finish_reason.as_deref(), Some("stop"));
+        assert_eq!(json.step_count, Some(3));
+        assert_eq!(json.session_slug.as_deref(), Some("mighty-rocket"));
+        assert_eq!(json.reasoning_signature.as_deref(), Some("sig-abc"));
+        assert_eq!(json.reasoning_text.as_deref(), Some("thought hard about it"));
+        assert!(json.prompt_hash.is_some());
+        assert!(json.metadata.is_some());
+
+        // The serialized form carries the keys the gap report measured.
+        let value = serde_json::to_value(&json).unwrap();
+        for key in [
+            "reasoning_text",
+            "reasoning_signature",
+            "agent_mode",
+            "finish_reason",
+            "step_count",
+            "session_slug",
+            "task_plan",
+            "prompt_hash",
+            "metadata",
+        ] {
+            assert!(value.get(key).is_some(), "missing key: {}", key);
+        }
+    }
+
+    #[test]
+    fn test_json_provenance_omits_absent_agent_fields() {
+        let prov = Provenance {
+            vendor: AIVendor::OpenAI,
+            model: "gpt-5".to_string(),
+            tool: AITool::Cli("codex".to_string()),
+            suggestion_type: SuggestionType::Complete,
+            ..Default::default()
+        };
+
+        let value = serde_json::to_value(JsonProvenance::from(&prov)).unwrap();
+        let obj = value.as_object().unwrap();
+
+        // Absent fields stay out of the output entirely.
+        for key in ["reasoning_text", "agent_mode", "step_count", "prompt_hash", "metadata"] {
+            assert!(!obj.contains_key(key), "unexpected key: {}", key);
+        }
+        assert_eq!(obj.get("vendor").and_then(|v| v.as_str()), Some("OpenAI"));
     }
 }

--- a/atomic-cli/src/commands/change/tests.rs
+++ b/atomic-cli/src/commands/change/tests.rs
@@ -408,6 +408,36 @@ mod tests {
         assert!(json.contains("\"description\": \"This is a description\""));
     }
 
+    #[test]
+    fn test_json_change_omits_unhashed_when_absent() {
+        let change = create_test_change();
+        let hash = Hash::of(b"test change");
+        let json_change = JsonChange::from_change(&change, &hash, None);
+
+        assert!(json_change.unhashed.is_none());
+        let json = serde_json::to_string(&json_change).unwrap();
+        assert!(!json.contains("unhashed"));
+    }
+
+    #[test]
+    fn test_json_change_surfaces_unhashed_agent_turn() {
+        let mut change = create_test_change();
+        change.unhashed = Some(serde_json::json!({
+            "agent_turn": {
+                "session_id": "sess-1",
+                "turn_number": 3,
+                "condensed_text": "[User] fix it\n[Assistant] fixed",
+            }
+        }));
+        let hash = Hash::of(b"test change");
+        let json_change = JsonChange::from_change(&change, &hash, None);
+
+        let value = serde_json::to_value(&json_change).unwrap();
+        let turn = &value["unhashed"]["agent_turn"];
+        assert_eq!(turn["session_id"], "sess-1");
+        assert_eq!(turn["turn_number"], 3);
+    }
+
     // Helper Function Tests
 
     #[test]

--- a/atomic-cli/src/commands/change/types.rs
+++ b/atomic-cli/src/commands/change/types.rs
@@ -236,6 +236,12 @@ pub struct JsonChange {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provenance: Option<JsonProvenance>,
 
+    /// Data stored outside the content hash — the agent turn transcript
+    /// (`agent_turn`) and anything else attached unhashed — when the change
+    /// carries it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unhashed: Option<serde_json::Value>,
+
     /// Sequence number in the current view (if known).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sequence: Option<u64>,
@@ -271,6 +277,7 @@ impl JsonChange {
             hunks: change.hashed.hunks.iter().map(hunk_to_summary).collect(),
             has_provenance: change.has_provenance(),
             provenance: None,
+            unhashed: change.unhashed.clone(),
             sequence,
         }
     }

--- a/atomic-cli/src/commands/change/types.rs
+++ b/atomic-cli/src/commands/change/types.rs
@@ -321,6 +321,34 @@ pub struct JsonProvenance {
     /// Session ID.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
+    /// Hash of the prompt (base32), when only the hash is stored.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_hash: Option<String>,
+    /// Additional metadata key-value pairs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+    /// Agent mode: "build", "code", "ask", etc.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_mode: Option<String>,
+    /// Why the model stopped on the final step ("stop", "tool-calls",
+    /// "length").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finish_reason: Option<String>,
+    /// Number of LLM roundtrips (steps) in the turn.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub step_count: Option<u32>,
+    /// Human-readable session slug (e.g., "mighty-rocket").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_slug: Option<String>,
+    /// Model-provider signature over the reasoning blocks.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_signature: Option<String>,
+    /// Concatenated reasoning/thinking text from the turn.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_text: Option<String>,
+    /// Agent's structured task plan at turn completion (JSON string).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_plan: Option<String>,
 }
 
 /// JSON representation of token usage.
@@ -362,6 +390,27 @@ impl From<&Provenance> for JsonProvenance {
             None
         };
 
+        let prompt_hash = match &prov.prompt {
+            atomic_core::change::PromptContent::Hashed(h) => {
+                use atomic_core::types::Base32;
+                Some(h.to_base32())
+            }
+            _ => None,
+        };
+
+        let metadata = if prov.metadata.is_empty() {
+            None
+        } else {
+            Some(serde_json::Value::Array(
+                prov.metadata
+                    .iter()
+                    .map(|(k, v)| {
+                        serde_json::json!({ "key": k, "value": v })
+                    })
+                    .collect(),
+            ))
+        };
+
         Self {
             vendor: format!("{:?}", prov.vendor),
             model: prov.model.clone(),
@@ -374,6 +423,15 @@ impl From<&Provenance> for JsonProvenance {
             timestamp: prov.timestamp,
             request_id: prov.request_id.clone(),
             session_id: prov.session_id.clone(),
+            prompt_hash,
+            metadata,
+            agent_mode: prov.agent_mode.clone(),
+            finish_reason: prov.finish_reason.clone(),
+            step_count: prov.step_count,
+            session_slug: prov.session_slug.clone(),
+            reasoning_signature: prov.reasoning_signature.clone(),
+            reasoning_text: prov.reasoning_text.clone(),
+            task_plan: prov.task_plan.clone(),
         }
     }
 }

--- a/tests/harness/25_agent_provenance.sh
+++ b/tests/harness/25_agent_provenance.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# 25_agent_provenance.sh — Agent provenance gap tests.
+#
+# End-to-end coverage for the four agent-provenance gaps (handoff doc:
+# noname/docs/agent-provenance-gaps.md), driving real hook invocations
+# against the CLI:
+#
+#   #1 llm_response nodes are emitted into the session graph
+#   #2 change.unhashed["agent_turn"] is populated AND persisted
+#   #3 opencode sessions get a transcript_path (synthesized from
+#      OpenCode's SQLite store; seeded fake store here)
+#   #4 reasoning_text lands on the change provenance (and tokens/cost/
+#      finish_reason/step_count come along)
+#
+# Two scenarios:
+#   A. opencode — thin stop payload (no reasoning/tokens/response),
+#      everything recovered from the fake OpenCode store.
+#   B. claude-code — session starts WITHOUT transcript_path; the Stop
+#      hook carries it (the timing fix), and the agent's response is
+#      derived from the transcript.
+#
+# Prerequisites: sqlite3, python3, zstd. Suite skips (exit 77) if absent.
+
+HARNESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$HARNESS_DIR/helpers.sh"
+
+for tool in sqlite3 python3 zstd; do
+    if ! command -v "$tool" &>/dev/null; then
+        skip_suite "$tool not installed"
+    fi
+done
+
+# Extract the last zstd frame of a change file (the UNHASHED section is
+# written last, before the 32-byte trailer) and print its JSON.
+last_section_json() {
+    local change_file="$1"
+    python3 - "$change_file" <<'EOF' >/tmp/_prov_last.zst
+import sys
+data = open(sys.argv[1], "rb").read()
+i = data.rfind(b"\x28\xb5\x2f\xfd")
+assert i >= 0, "no zstd frame in change file"
+sys.stdout.buffer.write(data[i:len(data) - 32])
+EOF
+    zstd -d -f /tmp/_prov_last.zst -o /tmp/_prov_last.json >/dev/null 2>&1
+    cat /tmp/_prov_last.json
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Agent provenance: opencode (thin payload + store recovery)"
+# ═══════════════════════════════════════════════════════════════════════════
+
+make_temp_repo "agent-prov-oc"
+init_repo
+# macOS: mktemp lands under /var → sessions record the canonical
+# /private/var path. Work with the physical path everywhere.
+REPO_DIR="$(pwd -P)"
+
+# Fake OpenCode data dir with a minimal schema — just what the reader
+# queries: session.directory, message(id, data), part(message_id, data).
+OC_HOME="$REPO_DIR/oc-home"
+mkdir -p "$OC_HOME"
+NOW_MS=$(( $(date +%s) * 1000 ))
+USER_MS=$NOW_MS
+ASST_MS=$(( NOW_MS + 5000 ))
+
+sqlite3 "$OC_HOME/opencode.db" <<EOF
+CREATE TABLE session (
+  id text PRIMARY KEY, project_id text, directory text NOT NULL,
+  time_created integer, time_updated integer);
+CREATE TABLE message (
+  id text PRIMARY KEY, session_id text,
+  time_created integer, time_updated integer, data text);
+CREATE TABLE part (
+  id text PRIMARY KEY, message_id text, session_id text,
+  time_created integer, time_updated integer, data text);
+INSERT INTO session VALUES ('ses_harness', 'prj_x', '$REPO_DIR', $USER_MS, $ASST_MS);
+INSERT INTO message VALUES ('msg_u', 'ses_harness', $USER_MS, $USER_MS, '{"role":"user"}');
+INSERT INTO message VALUES ('msg_a', 'ses_harness', $ASST_MS, $ASST_MS, '{"role":"assistant"}');
+INSERT INTO part VALUES
+ ('p1','msg_u','ses_harness',$USER_MS,$USER_MS,
+  '{"type":"text","text":"harness: fix the widget"}'),
+ ('p2','msg_a','ses_harness',$((ASST_MS+100)),$((ASST_MS+100)),
+  '{"type":"reasoning","text":"widget reasoning","time":{"start":10,"end":60}}'),
+ ('p3','msg_a','ses_harness',$((ASST_MS+200)),$((ASST_MS+200)),
+  '{"type":"step-start"}'),
+ ('p4','msg_a','ses_harness',$((ASST_MS+300)),$((ASST_MS+300)),
+  '{"type":"step-finish","reason":"stop","cost":0.02,"tokens":{"input":40,"output":50,"reasoning":10,"cache":{"write":5,"read":20}}}'),
+ ('p5','msg_a','ses_harness',$((ASST_MS+400)),$((ASST_MS+400)),
+  '{"type":"tool","tool":"bash","state":{"title":"ran tests","status":"completed"}}'),
+ ('p6','msg_a','ses_harness',$((ASST_MS+500)),$((ASST_MS+500)),
+  '{"type":"text","text":"The widget is fixed."}');
+EOF
+
+# Drive the hook sequence with a THIN stop payload — what the old plugin
+# sends: only session/model metadata.
+echo '{"session_id":"ses_harness","source":"startup","cwd":"'"$REPO_DIR"'"}' \
+    | OPENCODE_HOME="$OC_HOME" atomic agent hooks opencode session-start >/dev/null 2>&1
+echo '{"session_id":"ses_harness","prompt":"harness: fix the widget","cwd":"'"$REPO_DIR"'"}' \
+    | OPENCODE_HOME="$OC_HOME" atomic agent hooks opencode user-prompt >/dev/null 2>&1
+
+create_file "widget.txt" "widget v1"
+
+echo '{"session_id":"ses_harness","turn_number":1,"model":"test/model","provider":"testprovider","cwd":"'"$REPO_DIR"'"}' \
+    | OPENCODE_HOME="$OC_HOME" atomic agent hooks opencode stop >/dev/null 2>&1
+if [[ -f ".atomic/sessions/ses_harness.json" ]]; then
+    _pass "opencode turn recorded a session"
+else
+    _fail "opencode turn recorded a session" "no session file"
+fi
+
+# #3 — transcript synthesized from the store, path set on the session.
+assert_file_exists "synthesized opencode transcript exists" \
+    ".atomic/sessions/ses_harness/opencode-transcript.jsonl"
+tp="$(python3 -c "import json; print(json.load(open('.atomic/sessions/ses_harness.json')).get('transcript_path') or '')")"
+if [[ "$tp" == "$REPO_DIR/.atomic/sessions/ses_harness/opencode-transcript.jsonl" ]]; then
+    _pass "session transcript_path points at the synthesized transcript"
+else
+    _fail "session transcript_path points at the synthesized transcript" "got: $tp"
+fi
+
+# #1 + #4 (graph side) — llm_response and decision nodes present.
+graph=".atomic/sessions/ses_harness/graph.json"
+if python3 - "$graph" <<'EOF'
+import json, sys
+kinds = [n["kind"] for n in json.load(open(sys.argv[1]))["nodes"]]
+assert "llm_response" in kinds, kinds
+assert "decision" in kinds, kinds
+EOF
+then
+    _pass "graph has llm_response and decision nodes"
+else
+    _fail "graph has llm_response and decision nodes" "$(cat "$graph" 2>/dev/null | head -3)"
+fi
+if python3 - "$graph" <<'EOF'
+import json, sys
+nodes = json.load(open(sys.argv[1]))["nodes"]
+resp = next(n for n in nodes if n["kind"] == "llm_response")
+assert resp["summary"] == "The widget is fixed.", resp["summary"]
+EOF
+then
+    _pass "llm_response carries the store response text"
+else
+    _fail "llm_response carries the store response text"
+fi
+
+# #4 (change side) — reasoning_text, tokens, cost, steps on the provenance.
+HASH="$(atomic log -f json 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin)[0]['hash'])")"
+prov_json="$(atomic change "$HASH" -f json 2>/dev/null)"
+if echo "$prov_json" | python3 -c "
+import json, sys
+p = json.load(sys.stdin)['provenance']
+assert p.get('reasoning_text') == 'widget reasoning', p.get('reasoning_text')
+assert p.get('finish_reason') == 'stop'
+assert p.get('step_count') == 1
+assert (p.get('tokens') or {}).get('input') == 40
+assert (p.get('cost') or {}).get('amount_micros') == 20000
+"; then
+    _pass "change provenance carries reasoning_text/tokens/cost/steps"
+else
+    _fail "change provenance carries reasoning_text/tokens/cost/steps" \
+        "$(echo "$prov_json" | head -3)"
+fi
+
+# #2 — agent_turn persisted inside the change file (unhashed section).
+change_file="$(find .atomic/changes -name "$HASH.change" | head -1)"
+if last_section_json "$change_file" | python3 -c "
+import json, sys
+t = json.load(sys.stdin).get('agent_turn')
+assert t, 'no agent_turn key'
+types = [e['entry_type'] for e in t['condensed_transcript']]
+assert 'user' in types and 'assistant' in types and 'tool' in types, types
+"; then
+    _pass "agent_turn with condensed transcript persisted on the change"
+else
+    _fail "agent_turn with condensed transcript persisted on the change"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+begin_section "Agent provenance: claude-code (transcript_path timing + fallback)"
+# ═══════════════════════════════════════════════════════════════════════════
+
+make_temp_repo "agent-prov-cc"
+init_repo
+REPO_DIR="$(pwd -P)"
+
+TRANSCRIPT="$REPO_DIR/cc-transcript.jsonl"
+cat > "$TRANSCRIPT" <<'EOF'
+{"type":"user","uuid":"u1","message":{"role":"user","content":[{"type":"text","text":"patch the parser"}]}}
+{"type":"assistant","uuid":"a1","message":{"role":"assistant","content":[{"type":"text","text":"Patching now."},{"type":"tool_use","name":"Edit","input":{"file_path":"parser.rs"}}]}}
+{"type":"assistant","uuid":"a2","message":{"role":"assistant","content":[{"type":"text","text":"The parser is patched and verified."}]}}
+EOF
+
+# Deliberately NO transcript_path at session start / prompt — the timing
+# gap. The Stop hook carries it.
+echo '{"session_id":"cc-harness","cwd":"'"$REPO_DIR"'"}' \
+    | atomic agent hooks claude-code session-start >/dev/null 2>&1
+echo '{"session_id":"cc-harness","prompt":"patch the parser","cwd":"'"$REPO_DIR"'"}' \
+    | atomic agent hooks claude-code user-prompt-submit >/dev/null 2>&1
+
+before="$(python3 -c "import json; print(json.load(open('.atomic/sessions/cc-harness.json')).get('transcript_path'))" 2>/dev/null || true)"
+if [[ "$before" == "None" || -z "$before" ]]; then
+    _pass "session has no transcript_path before Stop (the gap scenario)"
+else
+    _fail "session has no transcript_path before Stop (the gap scenario)" "got: $before"
+fi
+
+create_file "parser.rs" "fn main() {}"
+
+echo '{"session_id":"cc-harness","transcript_path":"'"$TRANSCRIPT"'","cwd":"'"$REPO_DIR"'"}' \
+    | atomic agent hooks claude-code stop >/dev/null 2>&1
+
+# #2 (timing fix) — transcript_path applied from the Stop event.
+after="$(python3 -c "import json; print(json.load(open('.atomic/sessions/cc-harness.json')).get('transcript_path') or '')")"
+if [[ "$after" == "$TRANSCRIPT" ]]; then
+    _pass "transcript_path applied from the Stop event"
+else
+    _fail "transcript_path applied from the Stop event" "got: $after"
+fi
+
+# #1 (transcript fallback) — response derived from the last assistant entry.
+cc_graph=".atomic/sessions/cc-harness/graph.json"
+if python3 - "$cc_graph" <<'EOF'
+import json, sys
+nodes = json.load(open(sys.argv[1]))["nodes"]
+resp = next(n for n in nodes if n["kind"] == "llm_response")
+assert resp["summary"] == "The parser is patched and verified.", resp["summary"]
+EOF
+then
+    _pass "llm_response derived from the transcript fallback"
+else
+    _fail "llm_response derived from the transcript fallback"
+fi
+
+# #2 — agent_turn persisted for the claude-code change too.
+CC_HASH="$(atomic log -f json 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin)[0]['hash'])")"
+cc_file="$(find .atomic/changes -name "$CC_HASH.change" | head -1)"
+if last_section_json "$cc_file" | python3 -c "
+import json, sys
+t = json.load(sys.stdin).get('agent_turn')
+assert t, 'no agent_turn key'
+texts = [e.get('content') for e in t['condensed_transcript'] if e.get('content')]
+assert any('patched and verified' in x for x in texts), texts
+"; then
+    _pass "claude-code agent_turn persisted on the change"
+else
+    _fail "claude-code agent_turn persisted on the change"
+fi
+
+print_summary

--- a/tests/harness/25_agent_provenance.sh
+++ b/tests/harness/25_agent_provenance.sh
@@ -87,7 +87,9 @@ INSERT INTO part VALUES
   '{"type":"step-finish","reason":"stop","cost":0.02,"tokens":{"input":40,"output":50,"reasoning":10,"cache":{"write":5,"read":20}}}'),
  ('p5','msg_a','ses_harness',$((ASST_MS+400)),$((ASST_MS+400)),
   '{"type":"tool","tool":"bash","state":{"title":"ran tests","status":"completed"}}'),
- ('p6','msg_a','ses_harness',$((ASST_MS+500)),$((ASST_MS+500)),
+ ('p6','msg_a','ses_harness',$((ASST_MS+450)),$((ASST_MS+450)),
+  '{"type":"tool","tool":"bash","callID":"call_h1","state":{"status":"completed","input":{"command":"cargo test"},"output":"test result: ok. 12 passed","title":"cargo test"}}'),
+ ('p7','msg_a','ses_harness',$((ASST_MS+500)),$((ASST_MS+500)),
   '{"type":"text","text":"The widget is fixed."}');
 EOF
 
@@ -99,6 +101,10 @@ echo '{"session_id":"ses_harness","prompt":"harness: fix the widget","cwd":"'"$R
     | OPENCODE_HOME="$OC_HOME" atomic agent hooks opencode user-prompt >/dev/null 2>&1
 
 create_file "widget.txt" "widget v1"
+# A tool hook carrying the same call id as the store's tool part — the join
+# key the enrichment uses to graft commands/outputs onto graph nodes.
+echo '{"session_id":"ses_harness","tool_name":"bash","tool_call_id":"call_h1","status":"completed","cwd":"'"$REPO_DIR"'"}' \
+    | OPENCODE_HOME="$OC_HOME" atomic agent hooks opencode after-tool >/dev/null 2>&1
 
 echo '{"session_id":"ses_harness","turn_number":1,"model":"test/model","provider":"testprovider","cwd":"'"$REPO_DIR"'"}' \
     | OPENCODE_HOME="$OC_HOME" atomic agent hooks opencode stop >/dev/null 2>&1
@@ -150,6 +156,7 @@ if echo "$prov_json" | python3 -c "
 import json, sys
 p = json.load(sys.stdin)['provenance']
 assert p.get('reasoning_text') == 'widget reasoning', p.get('reasoning_text')
+
 assert p.get('finish_reason') == 'stop'
 assert p.get('step_count') == 1
 assert (p.get('tokens') or {}).get('input') == 40
@@ -159,6 +166,22 @@ assert (p.get('cost') or {}).get('amount_micros') == 20000
 else
     _fail "change provenance carries reasoning_text/tokens/cost/steps" \
         "$(echo "$prov_json" | head -3)"
+fi
+
+# Tool nodes recorded from the thin payload get their command and output back
+# from the store, matched on the tool call id.
+if python3 - "$graph" <<'EOF'
+import json, sys
+nodes = json.load(open(sys.argv[1]))["nodes"]
+node = next(n for n in nodes if n.get("tool_call_id") == "call_h1")
+assert "cargo test" in node["summary"], node["summary"]
+assert node["detail"]["command"] == "cargo test", node["detail"]
+assert "12 passed" in node["detail"]["output_summary"], node["detail"]
+EOF
+then
+    _pass "tool node enriched from the store (command + output)"
+else
+    _fail "tool node enriched from the store (command + output)"
 fi
 
 # #2 — agent_turn persisted inside the change file (unhashed section).


### PR DESCRIPTION
Stacked on `fix/legacy-scalar-satisfies`. Closes gaps #1-#4 from
`noname/docs/agent-provenance-gaps.md`, each root-caused against real sessions
and verified end-to-end with hook-driven smoke sessions plus a new hermetic
harness suite.

## #1 `llm_response` nodes were never emitted
New `append_llm_response` (accumulator) + `inject_response_node`
(orchestrator), wired at turn end. Sources in priority order: stop payload
(`last_assistant_message` for codex/grok, `prompt_response` for gemini-cli,
`response` otherwise), then the last assistant entry of the session transcript
(claude-code via its Stop-carried `transcript_path`, opencode via the
synthesized transcript below). Live opencode session now shows
`goal → decision* → llm_response → patch_proposal`.

## #2 `change.unhashed["agent_turn"]` was never populated
Three root causes, not the one the handoff doc named:
- `handle_turn_end` never applied `event.transcript_path`, so claude-code
  sessions minted without one at SessionStart recorded with `None`. Now
  applied before record.
- opencode has no transcript file at all (see #3).
- **Undocumented bug**: `attach_unhashed` mutated the change after
  `repo.record()` had already written the file, and nothing re-saved it.
  `record_turn` now re-saves via `ChangeStore`; the unhashed section is
  outside the hash, so identity is unchanged.

## #3 opencode `transcript_path` never set
New `transcript::opencode` module reads OpenCode's SQLite store
(`OPENCODE_HOME` / XDG / `~/.local/share/opencode`, read-only, 100ms busy
timeout, validates the session directory against the repo root) and
synthesizes `.atomic/sessions/<id>/opencode-transcript.jsonl` plus the turn's
reasoning blocks, response text, tokens, cost, finish reason and step count,
folded into the stop payload where the plugin left them absent. New
`"opencode"` condense format feeds `build_unhashed_turn_data`.

## #4 `reasoning_text` parsed then dropped
The reasoning-in-graph demo already lives on the parent branch (Decision
nodes); this finishes the pipeline: `build_turn_provenance` derives
`reasoning_text` by joining structured `reasoning_blocks` when only those are
present, and `JsonProvenance` now surfaces every agent-context field
(`reasoning_text`, `reasoning_signature`, `agent_mode`, `finish_reason`,
`step_count`, `session_slug`, `task_plan`, `metadata`, `prompt_hash`) — the
JSON projection previously dropped all of them, which is exactly what the
handoff doc's repro measured.

## Also in this branch
- `feat(cli)`: `atomic change -f json` now carries `change.unhashed`
  (omitted when absent) so consumers like Sherpa can read `agent_turn`
  without parsing the V3 file.
- `feat(agent)`: opencode graph tool nodes recorded from thin payloads get
  their command/file/output back from the store at turn end, matched on
  `tool_call_id` ↔ `callID`; runs over all nodes so one enriched turn repairs
  earlier thin turns.
- `docs(agent)`: nine adapters still described the pre-#134 world
  ("standalone/npm package"); comments now point at the integrations engine,
  and `disable`'s stale `npx atomic-kilo` hint is gone.
- Drive-by fixes: `decision_count` double-increment in `append_reasoning`,
  mid-codepoint panic risk in the 10KB reasoning truncation.
- `test(harness)`: `25_agent_provenance.sh` — hermetic e2e (seeded fake
  opencode store + real hook invocations) asserting all four gaps plus
  enrichment, for both opencode and claude-code paths. 12/12.

## Verification
- `cargo test --workspace` green; clippy clean.
- Live: installed binary, real opencode session locally