### PR TITLE
fix(git): push auth via git CLI, --branch flag, and round-trip dedup

### DIFF
--- a/atomic-cli/src/commands/git/import.rs
+++ b/atomic-cli/src/commands/git/import.rs
@@ -205,6 +205,7 @@ impl Import {
         branch_name: &str,
         repo: &mut Repository,
         imported_shas: &HashSet<String>,
+        known_states: &HashSet<atomic_core::types::Merkle>,
         mainline_only: bool,
     ) -> CliResult<usize> {
         // Get repository name from remote URL or working directory
@@ -221,6 +222,8 @@ impl Import {
             ),
             mainline_only,
             graph_only: !self.with_crdt,
+            target_view: branch_name.to_string(),
+            known_states: known_states.clone(),
         };
 
         let importer = ParallelImporter::new(git_repo, options);
@@ -258,8 +261,16 @@ impl Import {
             .unwrap_or_else(|| "unknown".to_string())
     }
 
-    /// Get the set of already imported Git SHAs from existing changes.
-    fn get_imported_shas(&self, repo: &Repository) -> HashSet<String> {
+    /// Get the set of already imported Git SHAs from existing changes,
+    /// plus the Merkle states already present in the current view.
+    ///
+    /// The states let the importer skip commits created by `atomic git
+    /// push`: such a commit trailers the view state it represents, and if
+    /// that state is already known the commit adds nothing.
+    fn get_incremental_markers(
+        &self,
+        repo: &Repository,
+    ) -> (HashSet<String>, HashSet<atomic_core::types::Merkle>) {
         use atomic_repository::HistoryOptions;
 
         // Ensure the GIT_SHA_INDEX is populated for repos imported before
@@ -268,11 +279,13 @@ impl Import {
         let _ = repo.backfill_git_sha_index();
 
         let mut shas = HashSet::new();
+        let mut states = HashSet::new();
 
         // Iterate through all changes on the current view via log
         let options = HistoryOptions::default();
         if let Ok(entries) = repo.log(options) {
             for entry in entries {
+                states.insert(entry.state);
                 if let Ok(change) = repo.load_change(&entry.hash) {
                     if let Some(ref unhashed) = change.unhashed {
                         if let Some(git) = unhashed.get("git") {
@@ -285,7 +298,7 @@ impl Import {
             }
         }
 
-        shas
+        (shas, states)
     }
 
     /// Get all local branch names.
@@ -432,11 +445,11 @@ impl Command for Import {
             Repository::init(workdir).map_err(|e| CliError::Internal(e.into()))?
         };
 
-        // Get already imported SHAs for incremental mode
-        let imported_shas = if self.incremental {
-            self.get_imported_shas(&repo)
+        // Get already imported SHAs and known view states for incremental mode
+        let (imported_shas, known_states) = if self.incremental {
+            self.get_incremental_markers(&repo)
         } else {
-            HashSet::new()
+            (HashSet::new(), HashSet::new())
         };
 
         if self.with_crdt {
@@ -473,8 +486,14 @@ impl Command for Import {
                     .map_err(|e| CliError::Internal(e.into()))?;
 
                 // Import the branch
-                let count =
-                    self.import_branch(&git_repo, &branch_name, &mut repo, &imported_shas, false)?;
+                let count = self.import_branch(
+                    &git_repo,
+                    &branch_name,
+                    &mut repo,
+                    &imported_shas,
+                    &known_states,
+                    false,
+                )?;
                 total_imported += count;
             }
 
@@ -536,8 +555,14 @@ impl Command for Import {
                 .map_err(|e| CliError::Internal(e.into()))?;
 
             // Import
-            let count =
-                self.import_branch(&git_repo, &branch_name, &mut repo, &imported_shas, true)?;
+            let count = self.import_branch(
+                &git_repo,
+                &branch_name,
+                &mut repo,
+                &imported_shas,
+                &known_states,
+                true,
+            )?;
 
             if current_git_branch(&git_repo).as_deref() == Some(branch_name.as_str()) {
                 print_info("Using Git working copy as imported materialization.");

--- a/atomic-cli/src/commands/git/mod.rs
+++ b/atomic-cli/src/commands/git/mod.rs
@@ -108,6 +108,7 @@ pub enum GitCommands {
     /// atomic git push
     /// atomic git push -m "feat: add auth"
     /// atomic git push --no-push
+    /// atomic git push --branch pr-42
     /// ```
     Push(Push),
 

--- a/atomic-cli/src/commands/git/parallel.rs
+++ b/atomic-cli/src/commands/git/parallel.rs
@@ -74,7 +74,9 @@ use atomic_core::record::workflow::extract_filename;
 use atomic_core::record::workflow::graph_op::BuiltHunk;
 use atomic_core::record::workflow::GitDiffLine;
 use atomic_core::record::workflow::RecordedFile;
-use atomic_core::types::{ChangePosition, EdgeFlags, GraphNode, Hash as ContentHash, Position};
+use atomic_core::types::{
+    Base32, ChangePosition, EdgeFlags, GraphNode, Hash as ContentHash, Merkle, Position,
+};
 use atomic_repository::Repository;
 
 use crate::error::{CliError, CliResult};
@@ -97,12 +99,29 @@ pub struct ImportStats {
     pub empty_commits: usize,
     /// Number of merge commits with duplicate content.
     pub merge_commits: usize,
+    /// Commits skipped because they were created by `atomic git push` and
+    /// the view already contains the state they reference.
+    pub self_push_skipped: usize,
     /// Time spent in Phase 1 (parsing).
     pub phase1_duration: std::time::Duration,
     /// Time spent in Phase 2 (writing).
     pub phase2_duration: std::time::Duration,
     /// Files processed across all commits.
     pub files_processed: usize,
+}
+
+/// `atomic git push` trailers parsed from a commit message.
+///
+/// Used to recognize commits that Atomic itself created: the `Atomic-State`
+/// they carry is the Merkle state of the view at push time, so if that state
+/// already exists in the view, importing the commit would duplicate changes
+/// the view already has.
+#[derive(Debug, Clone)]
+pub struct PushTrailer {
+    /// Value of the `Atomic-View` trailer.
+    pub view: String,
+    /// Value of the `Atomic-State` trailer.
+    pub state: Merkle,
 }
 
 /// A parsed git commit ready for Phase 2 processing.
@@ -122,6 +141,38 @@ pub struct ParsedCommit {
     pub is_merge: bool,
     /// Whether git reported 0 files changed.
     pub is_empty: bool,
+    /// `atomic git push` trailers, when the commit message ends with them.
+    pub push_trailer: Option<PushTrailer>,
+}
+
+impl ParsedCommit {
+    /// Full commit message (subject + body), for trailer-aware
+    /// classification of merges and squashes.
+    fn full_message(&self) -> String {
+        match &self.metadata.description {
+            Some(desc) => format!("{}\n\n{}", self.metadata.message, desc),
+            None => self.metadata.message.clone(),
+        }
+    }
+}
+
+/// Whether to skip importing this commit because `atomic git push` created
+/// it and the target view already contains the state it represents.
+///
+/// The trailer's `Atomic-State` is the Merkle of the view's change sequence
+/// at push time; if that state is in the view, every change the commit
+/// carries is already there by definition. Importing it would duplicate
+/// them (the push → pull → import round trip).
+fn should_skip_self_push(parsed: &ParsedCommit, options: &ParallelImportOptions) -> bool {
+    if !options.incremental {
+        return false;
+    }
+    match &parsed.push_trailer {
+        Some(trailer) => {
+            trailer.view == options.target_view && options.known_states.contains(&trailer.state)
+        }
+        None => false,
+    }
 }
 
 /// Metadata extracted from a git commit.
@@ -203,6 +254,14 @@ pub struct ParallelImportOptions {
     /// duplicate file content are omitted, which significantly reduces change
     /// size and import time for large repositories.
     pub graph_only: bool,
+    /// The view being imported into (the branch name). Compared against the
+    /// `Atomic-View` trailer when skipping self-pushed commits.
+    pub target_view: String,
+    /// Merkle states already present in the target view, used to skip
+    /// commits created by `atomic git push`: such a commit carries the
+    /// view state it represents, and if that state is already known the
+    /// commit adds nothing. Only populated for incremental imports.
+    pub known_states: HashSet<Merkle>,
 }
 
 impl Default for ParallelImportOptions {
@@ -214,6 +273,8 @@ impl Default for ParallelImportOptions {
             ignored_path_patterns: Vec::new(),
             mainline_only: true,
             graph_only: false,
+            target_view: String::new(),
+            known_states: HashSet::new(),
         }
     }
 }
@@ -2211,6 +2272,7 @@ impl ParallelImporter {
             stats.changes_written += write_stats.changes_written;
             stats.empty_commits += write_stats.empty_commits;
             stats.merge_commits += write_stats.merge_commits;
+            stats.self_push_skipped += write_stats.self_push_skipped;
             stats.files_processed += write_stats.files_processed;
 
             commits_written +=
@@ -2245,6 +2307,18 @@ impl ParallelImporter {
                 0.0
             },
         ));
+
+        if stats.self_push_skipped > 0 {
+            print_info(&format!(
+                "Skipped {} commit{} created by `atomic git push` (state already in view)",
+                stats.self_push_skipped,
+                if stats.self_push_skipped == 1 {
+                    ""
+                } else {
+                    "s"
+                },
+            ));
+        }
 
         // Post-import classification: detect merge/squash commits and
         // create ReviewGate tags.
@@ -2507,6 +2581,13 @@ impl ParallelImporter {
         let mut batch_start = Instant::now();
 
         for (idx, parsed) in commits.iter().enumerate() {
+            // Commits created by `atomic git push` whose referenced view
+            // state is already present add nothing — skip them entirely.
+            if should_skip_self_push(parsed, &self.options) {
+                stats.self_push_skipped += 1;
+                continue;
+            }
+
             // Progress reporting with per-batch timing
             if total > 100 && idx % 100 == 0 {
                 if idx == 0 {
@@ -2725,7 +2806,7 @@ impl ParallelImporter {
                 short_sha: parsed.short_sha.clone(),
                 atomic_hash: write_outcome.hash,
                 is_merge: parsed.is_merge,
-                message: parsed.metadata.message.clone(),
+                message: parsed.full_message(),
             });
         }
 
@@ -3200,7 +3281,7 @@ impl ParallelImporter {
             short_sha: parsed.short_sha.clone(),
             atomic_hash: write_outcome.hash,
             is_merge: parsed.is_merge,
-            message: parsed.metadata.message.clone(),
+            message: parsed.full_message(),
         })
     }
 
@@ -3236,7 +3317,7 @@ impl ParallelImporter {
             short_sha: parsed.short_sha.clone(),
             atomic_hash: write_outcome.hash,
             is_merge: parsed.is_merge,
-            message: parsed.metadata.message.clone(),
+            message: parsed.full_message(),
         })
     }
 
@@ -3383,7 +3464,10 @@ impl ParallelImporter {
     fn phase3_finalize(&self, stats: &ImportStats) -> CliResult<()> {
         // Verify counts
         let expected = stats.commits_parsed;
-        let actual = stats.changes_written + stats.empty_commits + stats.merge_commits;
+        let actual = stats.changes_written
+            + stats.empty_commits
+            + stats.merge_commits
+            + stats.self_push_skipped;
 
         if actual != expected {
             print_warning(&format!(
@@ -3406,6 +3490,7 @@ struct WriteStats {
     changes_written: usize,
     empty_commits: usize,
     merge_commits: usize,
+    self_push_skipped: usize,
     files_processed: usize,
 }
 
@@ -3729,6 +3814,39 @@ fn parse_commit(
         parent_index,
         is_merge,
         is_empty,
+        push_trailer: parse_push_trailer(commit.message().unwrap_or("")),
+    })
+}
+
+/// Parse `atomic git push` trailers from a commit message.
+///
+/// Only matches when the trailers form the message's final paragraph — the
+/// shape `atomic git push` itself produces. Trailer lines embedded mid-body
+/// (e.g. a GitHub squash-merge message quoting the original commit) do NOT
+/// match: those commits may carry conflict resolutions and must be imported.
+fn parse_push_trailer(message: &str) -> Option<PushTrailer> {
+    let last_paragraph = message.trim_end().rsplit("\n\n").next()?;
+
+    let mut view = None;
+    let mut state = None;
+    for line in last_paragraph.lines() {
+        let line = line.trim();
+        if let Some(value) = line.strip_prefix("Atomic-View:") {
+            view = Some(value.trim().to_string());
+        } else if let Some(value) = line.strip_prefix("Atomic-State:") {
+            state = Merkle::from_base32(value.trim().as_bytes());
+        } else if line.starts_with("Atomic-Changes:") {
+            // Optional trailer; not needed for self-push detection.
+        } else {
+            // Non-trailer content in the final paragraph — not a commit
+            // produced by `atomic git push`.
+            return None;
+        }
+    }
+
+    Some(PushTrailer {
+        view: view?,
+        state: state?,
     })
 }
 
@@ -4073,6 +4191,136 @@ mod tests {
         let (subject, desc) = parse_commit_message("");
         assert_eq!(subject, "(no message)");
         assert!(desc.is_none());
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Self-push trailer detection (round-trip dedup)
+    // ═══════════════════════════════════════════════════════════════════
+
+    fn test_state() -> (String, Merkle) {
+        let state = Merkle::of(b"test view state");
+        (state.to_base32(), state)
+    }
+
+    #[test]
+    fn test_parse_push_trailer_full_message() {
+        let (state_b32, state) = test_state();
+        let msg = format!(
+            "feat: add greet\n\nSome body text.\n\nAtomic-View: main\nAtomic-State: {}\nAtomic-Changes: ABC, DEF\n",
+            state_b32
+        );
+        let trailer = parse_push_trailer(&msg).expect("should parse");
+        assert_eq!(trailer.view, "main");
+        assert_eq!(trailer.state, state);
+    }
+
+    #[test]
+    fn test_parse_push_trailer_without_changes_trailer() {
+        let (state_b32, state) = test_state();
+        let msg = format!(
+            "Working copy changes\n\nAtomic-View: dev\nAtomic-State: {}",
+            state_b32
+        );
+        let trailer = parse_push_trailer(&msg).expect("should parse");
+        assert_eq!(trailer.view, "dev");
+        assert_eq!(trailer.state, state);
+    }
+
+    #[test]
+    fn test_parse_push_trailer_rejects_embedded_trailers() {
+        let (state_b32, _) = test_state();
+        // GitHub squash-merge shape: the original commit (trailers and all)
+        // is quoted mid-message, with more content after it.
+        let msg = format!(
+            "feat: add greet (#42)\n\n* feat: add greet\n\nAtomic-View: main\nAtomic-State: {}\nAtomic-Changes: ABC\n\nCo-authored-by: Dana <dana@acme.dev>",
+            state_b32
+        );
+        assert!(parse_push_trailer(&msg).is_none());
+    }
+
+    #[test]
+    fn test_parse_push_trailer_rejects_mixed_final_paragraph() {
+        let (state_b32, _) = test_state();
+        let msg = format!(
+            "feat: add greet\n\nAtomic-View: main\nAtomic-State: {}\nsome stray line",
+            state_b32
+        );
+        assert!(parse_push_trailer(&msg).is_none());
+    }
+
+    #[test]
+    fn test_parse_push_trailer_rejects_missing_state() {
+        assert!(parse_push_trailer("msg\n\nAtomic-View: main").is_none());
+    }
+
+    #[test]
+    fn test_parse_push_trailer_rejects_invalid_state() {
+        assert!(
+            parse_push_trailer("msg\n\nAtomic-View: main\nAtomic-State: not-valid-base32!!")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_parse_push_trailer_empty_message() {
+        assert!(parse_push_trailer("").is_none());
+        assert!(parse_push_trailer("plain subject, no trailers").is_none());
+    }
+
+    fn self_push_commit(view: &str, state_b32: &str) -> ParsedCommit {
+        ParsedCommit {
+            git_sha: "aabbccdd11223344".to_string(),
+            short_sha: "aabbccdd".to_string(),
+            metadata: CommitMetadata {
+                author_name: "Test".to_string(),
+                author_email: None,
+                timestamp: Utc::now(),
+                message: "feat: test".to_string(),
+                description: None,
+            },
+            files: Vec::new(),
+            parent_index: None,
+            is_merge: false,
+            is_empty: true,
+            push_trailer: parse_push_trailer(&format!(
+                "feat: test\n\nAtomic-View: {}\nAtomic-State: {}",
+                view, state_b32
+            )),
+        }
+    }
+
+    #[test]
+    fn test_should_skip_self_push() {
+        let (state_b32, state) = test_state();
+        let mut options = ParallelImportOptions {
+            incremental: true,
+            target_view: "main".to_string(),
+            ..ParallelImportOptions::default()
+        };
+        options.known_states.insert(state);
+
+        let parsed = self_push_commit("main", &state_b32);
+        assert!(should_skip_self_push(&parsed, &options));
+
+        // Wrong view (e.g. commit pushed from `dev`, now imported on `main`)
+        let mut options_dev = options.clone();
+        options_dev.target_view = "dev".to_string();
+        assert!(!should_skip_self_push(&parsed, &options_dev));
+
+        // Unknown state → must import (content may not be present locally)
+        let mut options_empty = options.clone();
+        options_empty.known_states = HashSet::new();
+        assert!(!should_skip_self_push(&parsed, &options_empty));
+
+        // No trailer → never skipped
+        let mut plain = self_push_commit("main", &state_b32);
+        plain.push_trailer = None;
+        assert!(!should_skip_self_push(&plain, &options));
+
+        // Full (non-incremental) imports never skip
+        let mut options_full = options.clone();
+        options_full.incremental = false;
+        assert!(!should_skip_self_push(&parsed, &options_full));
     }
 
     #[test]

--- a/atomic-cli/src/commands/git/push.rs
+++ b/atomic-cli/src/commands/git/push.rs
@@ -487,7 +487,9 @@ mod tests {
             .unwrap();
         assert_eq!(push.branch.as_deref(), Some("pr-42"));
 
-        let push = Push::try_parse_from(["push"]).map_err(|e| e.to_string()).unwrap();
+        let push = Push::try_parse_from(["push"])
+            .map_err(|e| e.to_string())
+            .unwrap();
         assert!(push.branch.is_none());
     }
 
@@ -566,7 +568,9 @@ mod tests {
         // Upstream tracking config for main → origin/main.
         let mut config = repo.config().unwrap();
         config.set_str("branch.main.remote", "origin").unwrap();
-        config.set_str("branch.main.merge", "refs/heads/main").unwrap();
+        config
+            .set_str("branch.main.merge", "refs/heads/main")
+            .unwrap();
 
         let push = Push::default();
         assert_eq!(push.unpushed_commit_count(&repo, "main"), 0);

--- a/atomic-cli/src/commands/git/push.rs
+++ b/atomic-cli/src/commands/git/push.rs
@@ -139,7 +139,33 @@ impl Command for Push {
                     message: format!("Failed to diff: {}", e),
                 })?;
             if diff.deltas().count() == 0 {
-                print_info("Working copy matches Git HEAD. Nothing to commit.");
+                // Nothing to commit — but a previous push may have failed
+                // after the commit was created, leaving unpushed commits.
+                let branch_name = git_repo
+                    .head()
+                    .ok()
+                    .and_then(|h| h.shorthand().map(str::to_owned))
+                    .unwrap_or_else(|| "HEAD".to_string());
+                let ahead = self.unpushed_commit_count(&git_repo, &branch_name);
+                if ahead == 0 {
+                    print_info("Working copy matches Git HEAD. Nothing to commit.");
+                    return Ok(());
+                }
+                if self.no_push {
+                    print_info(&format!(
+                        "Nothing to commit, but {} unpushed commit{} (--no-push set).",
+                        ahead,
+                        if ahead == 1 { "" } else { "s" }
+                    ));
+                    return Ok(());
+                }
+                print_info(&format!(
+                    "Nothing to commit, but {} unpushed commit{}. Pushing...",
+                    ahead,
+                    if ahead == 1 { "" } else { "s" }
+                ));
+                self.push_to_remote(&git_repo)?;
+                print_success(&format!("Pushed to {}/{}", self.remote, branch_name));
                 return Ok(());
             }
         }
@@ -296,39 +322,67 @@ impl Push {
         None
     }
 
+    /// Count commits on `branch_name` that haven't been pushed to its
+    /// upstream. Returns 0 when the branch has no configured upstream.
+    fn unpushed_commit_count(&self, git_repo: &GitRepository, branch_name: &str) -> usize {
+        let local_ref = format!("refs/heads/{}", branch_name);
+
+        // branch_upstream_name returns the full upstream refname
+        // (e.g. "refs/remotes/origin/main"), which resolves directly.
+        let upstream_oid = git_repo
+            .branch_upstream_name(&local_ref)
+            .ok()
+            .and_then(|buf| buf.as_str().map(str::to_owned))
+            .and_then(|name| git_repo.refname_to_id(&name).ok());
+
+        let local_oid = git_repo.refname_to_id(&local_ref).ok();
+
+        match (local_oid, upstream_oid) {
+            (Some(local), Some(upstream)) => git_repo
+                .graph_ahead_behind(local, upstream)
+                .map(|(ahead, _)| ahead)
+                .unwrap_or(0),
+            _ => 0,
+        }
+    }
+
     /// Push the current branch to the remote.
+    ///
+    /// Delegates the network operation to the `git` CLI so authentication
+    /// behaves exactly like a plain `git push`: OpenSSH client config
+    /// (`Host`/`IdentityFile`/`IdentitiesOnly`), ssh-agents, askpass
+    /// prompts, and HTTPS credential helpers all work as the user expects.
+    ///
+    /// Do not "simplify" this back to libgit2's transport: its credential
+    /// callback can only consult the ssh-agent, which fails for anyone
+    /// whose keys live in `~/.ssh/config` (a common setup, e.g.
+    /// `IdentityFile ~/.ssh_keys/github` with an empty agent).
     fn push_to_remote(&self, git_repo: &GitRepository) -> CliResult<()> {
         let head = git_repo.head().map_err(|e| CliError::GitError {
             message: format!("Failed to get HEAD: {}", e),
         })?;
         let branch_name = head.shorthand().unwrap_or("HEAD");
-        let refspec = format!("refs/heads/{}:refs/heads/{}", branch_name, branch_name);
+        let refspec = format!("refs/heads/{0}:refs/heads/{0}", branch_name);
 
-        let mut remote = git_repo
-            .find_remote(&self.remote)
+        let workdir = git_repo.workdir().ok_or_else(|| CliError::GitError {
+            message: "Git repository has no working directory (bare repository?)".to_string(),
+        })?;
+
+        // Inherit stdio so the user sees git's native output and any
+        // interactive auth prompts (ssh passphrase, askpass) work.
+        let status = std::process::Command::new("git")
+            .args(["push", &self.remote, &refspec])
+            .current_dir(workdir)
+            .status()
             .map_err(|e| CliError::GitError {
-                message: format!("Remote '{}' not found: {}", self.remote, e),
+                message: format!("Failed to run git push: {}", e),
             })?;
 
-        let mut push_options = git2::PushOptions::new();
-        let mut callbacks = git2::RemoteCallbacks::new();
-        callbacks.credentials(|_url, username_from_url, allowed_types| {
-            if allowed_types.contains(git2::CredentialType::SSH_KEY) {
-                let user = username_from_url.unwrap_or("git");
-                git2::Cred::ssh_key_from_agent(user)
-            } else if allowed_types.contains(git2::CredentialType::DEFAULT) {
-                git2::Cred::default()
-            } else {
-                Err(git2::Error::from_str("no suitable credential type"))
-            }
-        });
-        push_options.remote_callbacks(callbacks);
-
-        remote
-            .push(&[&refspec], Some(&mut push_options))
-            .map_err(|e| CliError::GitError {
-                message: format!("Push failed: {}", e),
-            })?;
+        if !status.success() {
+            return Err(CliError::GitError {
+                message: format!("git push exited with {}", status),
+            });
+        }
 
         Ok(())
     }
@@ -401,5 +455,62 @@ mod tests {
     fn test_parse_trailer_empty() {
         let msg = "msg\n\nAtomic-State:\n";
         assert_eq!(parse_trailer(msg, "Atomic-State"), None);
+    }
+
+    #[test]
+    fn test_unpushed_commit_count_no_upstream() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = GitRepository::init(dir.path()).unwrap();
+
+        // One commit so HEAD resolves.
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_oid = repo.index().unwrap().write_tree().unwrap();
+        let tree = repo.find_tree(tree_oid).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+            .unwrap();
+
+        let push = Push::default();
+        // No upstream configured → nothing counted as unpushed.
+        assert_eq!(push.unpushed_commit_count(&repo, "main"), 0);
+        // Unknown branch → 0, not an error.
+        assert_eq!(push.unpushed_commit_count(&repo, "nonexistent"), 0);
+    }
+
+    #[test]
+    fn test_unpushed_commit_count_ahead_of_upstream() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init_opts(
+            dir.path(),
+            git2::RepositoryInitOptions::new()
+                .initial_head("main")
+                .mkdir(false),
+        )
+        .unwrap();
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+
+        // First commit — this is what "origin/main" points at.
+        let tree_oid = repo.index().unwrap().write_tree().unwrap();
+        let tree = repo.find_tree(tree_oid).unwrap();
+        let first = repo
+            .commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+            .unwrap();
+        repo.remote("origin", "https://example.com/rocket.git")
+            .unwrap();
+        repo.reference("refs/remotes/origin/main", first, true, "remote")
+            .unwrap();
+
+        // Upstream tracking config for main → origin/main.
+        let mut config = repo.config().unwrap();
+        config.set_str("branch.main.remote", "origin").unwrap();
+        config.set_str("branch.main.merge", "refs/heads/main").unwrap();
+
+        let push = Push::default();
+        assert_eq!(push.unpushed_commit_count(&repo, "main"), 0);
+
+        // A second local commit puts us one ahead of the upstream.
+        let parent = repo.find_commit(first).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "work", &tree, &[&parent])
+            .unwrap();
+        assert_eq!(push.unpushed_commit_count(&repo, "main"), 1);
     }
 }

--- a/atomic-cli/src/commands/git/push.rs
+++ b/atomic-cli/src/commands/git/push.rs
@@ -32,7 +32,7 @@ use crate::output::{print_info, print_success, print_warning};
 /// # Commit without pushing to remote
 /// atomic git push --no-push
 /// ```
-#[derive(Debug, Args)]
+#[derive(Debug, clap::Parser)]
 pub struct Push {
     /// Custom commit message. If not provided, synthesizes from
     /// Atomic change messages.
@@ -46,6 +46,13 @@ pub struct Push {
     /// Remote name to push to.
     #[arg(long, default_value = "origin")]
     pub remote: String,
+
+    /// Target branch to push to on the remote. Defaults to the current
+    /// branch. The commit is still created on the current branch; this
+    /// only changes the remote destination (useful for pushing the
+    /// current view's state to a PR branch).
+    #[arg(long, short = 'b', value_name = "BRANCH")]
+    pub branch: Option<String>,
 }
 
 impl Default for Push {
@@ -54,6 +61,7 @@ impl Default for Push {
             message: None,
             no_push: false,
             remote: "origin".to_string(),
+            branch: None,
         }
     }
 }
@@ -146,26 +154,40 @@ impl Command for Push {
                     .ok()
                     .and_then(|h| h.shorthand().map(str::to_owned))
                     .unwrap_or_else(|| "HEAD".to_string());
+                let target = self.branch.as_deref().unwrap_or(&branch_name);
                 let ahead = self.unpushed_commit_count(&git_repo, &branch_name);
-                if ahead == 0 {
+                if ahead == 0 && self.branch.is_none() {
                     print_info("Working copy matches Git HEAD. Nothing to commit.");
                     return Ok(());
                 }
                 if self.no_push {
+                    if ahead > 0 {
+                        print_info(&format!(
+                            "Nothing to commit, but {} unpushed commit{} (--no-push set).",
+                            ahead,
+                            if ahead == 1 { "" } else { "s" }
+                        ));
+                    } else {
+                        print_info("Nothing to commit (--no-push set).");
+                    }
+                    return Ok(());
+                }
+                if ahead > 0 {
                     print_info(&format!(
-                        "Nothing to commit, but {} unpushed commit{} (--no-push set).",
+                        "Nothing to commit, but {} unpushed commit{}. Pushing...",
                         ahead,
                         if ahead == 1 { "" } else { "s" }
                     ));
-                    return Ok(());
+                } else {
+                    // Explicit --branch with nothing new: push the current
+                    // state to the target (may create the remote branch).
+                    print_info(&format!(
+                        "Nothing to commit. Pushing current state to {}/{}...",
+                        self.remote, target
+                    ));
                 }
-                print_info(&format!(
-                    "Nothing to commit, but {} unpushed commit{}. Pushing...",
-                    ahead,
-                    if ahead == 1 { "" } else { "s" }
-                ));
                 self.push_to_remote(&git_repo)?;
-                print_success(&format!("Pushed to {}/{}", self.remote, branch_name));
+                print_success(&format!("Pushed to {}/{}", self.remote, target));
                 return Ok(());
             }
         }
@@ -214,7 +236,8 @@ impl Command for Push {
         if !self.no_push {
             match self.push_to_remote(&git_repo) {
                 Ok(()) => {
-                    print_success(&format!("Pushed to {}/{}", self.remote, current_view));
+                    let target = self.target_branch(&git_repo);
+                    print_success(&format!("Pushed to {}/{}", self.remote, target));
                 }
                 Err(e) => {
                     // Keep the local commit, but report the failed push.
@@ -322,18 +345,39 @@ impl Push {
         None
     }
 
-    /// Count commits on `branch_name` that haven't been pushed to its
-    /// upstream. Returns 0 when the branch has no configured upstream.
+    /// The git branch the push will land on: `--branch` if given, else
+    /// the currently checked-out branch.
+    fn target_branch(&self, git_repo: &GitRepository) -> String {
+        if let Some(ref branch) = self.branch {
+            return branch.clone();
+        }
+        git_repo
+            .head()
+            .ok()
+            .and_then(|h| h.shorthand().map(str::to_owned))
+            .unwrap_or_else(|| "HEAD".to_string())
+    }
+
+    /// Count commits on `branch_name` that haven't been pushed to the push
+    /// target. The comparison point is the branch's configured upstream,
+    /// or `refs/remotes/<remote>/<branch>` when `--branch` overrides the
+    /// target. Returns 0 when there is no remote ref to compare against.
     fn unpushed_commit_count(&self, git_repo: &GitRepository, branch_name: &str) -> usize {
         let local_ref = format!("refs/heads/{}", branch_name);
 
-        // branch_upstream_name returns the full upstream refname
-        // (e.g. "refs/remotes/origin/main"), which resolves directly.
-        let upstream_oid = git_repo
-            .branch_upstream_name(&local_ref)
-            .ok()
-            .and_then(|buf| buf.as_str().map(str::to_owned))
-            .and_then(|name| git_repo.refname_to_id(&name).ok());
+        let upstream_oid = match &self.branch {
+            // Explicit target: compare against the remote-tracking ref.
+            Some(target) => git_repo
+                .refname_to_id(&format!("refs/remotes/{}/{}", self.remote, target))
+                .ok(),
+            // branch_upstream_name returns the full upstream refname
+            // (e.g. "refs/remotes/origin/main"), which resolves directly.
+            None => git_repo
+                .branch_upstream_name(&local_ref)
+                .ok()
+                .and_then(|buf| buf.as_str().map(str::to_owned))
+                .and_then(|name| git_repo.refname_to_id(&name).ok()),
+        };
 
         let local_oid = git_repo.refname_to_id(&local_ref).ok();
 
@@ -361,8 +405,9 @@ impl Push {
         let head = git_repo.head().map_err(|e| CliError::GitError {
             message: format!("Failed to get HEAD: {}", e),
         })?;
-        let branch_name = head.shorthand().unwrap_or("HEAD");
-        let refspec = format!("refs/heads/{0}:refs/heads/{0}", branch_name);
+        let current = head.shorthand().unwrap_or("HEAD");
+        let target = self.branch.as_deref().unwrap_or(current);
+        let refspec = format!("HEAD:refs/heads/{}", target);
 
         let workdir = git_repo.workdir().ok_or_else(|| CliError::GitError {
             message: "Git repository has no working directory (bare repository?)".to_string(),
@@ -406,6 +451,7 @@ fn parse_trailer(message: &str, key: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
 
     #[test]
     fn test_push_default() {
@@ -421,10 +467,28 @@ mod tests {
             message: Some("custom message".to_string()),
             no_push: true,
             remote: "upstream".to_string(),
+            branch: Some("pr-branch".to_string()),
         };
         assert_eq!(push.message.as_deref(), Some("custom message"));
         assert!(push.no_push);
         assert_eq!(push.remote, "upstream");
+        assert_eq!(push.branch.as_deref(), Some("pr-branch"));
+    }
+
+    #[test]
+    fn test_push_branch_flag() {
+        let push = Push::try_parse_from(["push", "--branch", "pr-42"])
+            .map_err(|e| e.to_string())
+            .unwrap();
+        assert_eq!(push.branch.as_deref(), Some("pr-42"));
+
+        let push = Push::try_parse_from(["push", "-b", "pr-42"])
+            .map_err(|e| e.to_string())
+            .unwrap();
+        assert_eq!(push.branch.as_deref(), Some("pr-42"));
+
+        let push = Push::try_parse_from(["push"]).map_err(|e| e.to_string()).unwrap();
+        assert!(push.branch.is_none());
     }
 
     #[test]
@@ -512,5 +576,44 @@ mod tests {
         repo.commit(Some("HEAD"), &sig, &sig, "work", &tree, &[&parent])
             .unwrap();
         assert_eq!(push.unpushed_commit_count(&repo, "main"), 1);
+
+        // With --branch pointing at a remote branch that has nothing, the
+        // same local state counts differently: refs/remotes/origin/feature
+        // doesn't exist → 0; after creating it at the first commit → 1.
+        let push_feature = Push {
+            branch: Some("feature".to_string()),
+            ..Push::default()
+        };
+        assert_eq!(push_feature.unpushed_commit_count(&repo, "main"), 0);
+        repo.reference("refs/remotes/origin/feature", first, true, "remote")
+            .unwrap();
+        assert_eq!(push_feature.unpushed_commit_count(&repo, "main"), 1);
+    }
+
+    #[test]
+    fn test_target_branch() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init_opts(
+            dir.path(),
+            git2::RepositoryInitOptions::new()
+                .initial_head("main")
+                .mkdir(false),
+        )
+        .unwrap();
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_oid = repo.index().unwrap().write_tree().unwrap();
+        let tree = repo.find_tree(tree_oid).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+            .unwrap();
+
+        // Default: the checked-out branch.
+        assert_eq!(Push::default().target_branch(&repo), "main");
+
+        // --branch wins.
+        let push = Push {
+            branch: Some("pr-42".to_string()),
+            ..Push::default()
+        };
+        assert_eq!(push.target_branch(&repo), "pr-42");
     }
 }

--- a/atomic-core/src/pristine/traits/tag.rs
+++ b/atomic-core/src/pristine/traits/tag.rs
@@ -42,7 +42,40 @@ pub struct TagRecord {
     pub kind: TagKind,
     /// Extensible metadata (not included in content hash).
     /// Carries Git provenance, CI status, review approvals, etc.
+    ///
+    /// Stored as JSON text because postcard (the TAG_RECORDS codec) is not
+    /// self-describing and cannot round-trip `serde_json::Value` directly.
+    #[serde(with = "json_metadata")]
     pub metadata: Option<serde_json::Value>,
+}
+
+/// Serde adapter that stores `Option<serde_json::Value>` as an
+/// `Option<String>` of JSON text. Postcard handles the string fine;
+/// `None` records (the pre-metadata format) decode unchanged.
+mod json_metadata {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(
+        value: &Option<serde_json::Value>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        match value {
+            Some(v) => serializer.serialize_some(&v.to_string()),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Option<serde_json::Value>, D::Error> {
+        let opt: Option<String> = Option::deserialize(deserializer)?;
+        match opt {
+            Some(s) => serde_json::from_str(&s)
+                .map(Some)
+                .map_err(serde::de::Error::custom),
+            None => Ok(None),
+        }
+    }
 }
 
 /// What the tag represents.
@@ -181,4 +214,48 @@ pub trait GitShaIndexMutTxnT: GitShaIndexTxnT {
 
     /// Remove a Git SHA mapping.
     fn del_git_sha(&mut self, sha: &str) -> Result<bool, PristineError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_tag(metadata: Option<serde_json::Value>) -> TagRecord {
+        TagRecord {
+            name: "pr-99".to_string(),
+            view: "main".to_string(),
+            sequence: 42,
+            state: Merkle::of(b"state"),
+            change_hash: Hash::of(b"change"),
+            timestamp: Utc::now(),
+            author: None,
+            message: Some("Squash merge abc123".to_string()),
+            kind: TagKind::ReviewGate,
+            metadata,
+        }
+    }
+
+    #[test]
+    fn test_tag_record_postcard_roundtrip_with_metadata() {
+        let metadata = serde_json::json!({
+            "git": { "sha": "abc123", "merge_strategy": "squash", "pr_number": 99 },
+            "changes": { "original_hashes": ["AAA", "BBB"] }
+        });
+        let tag = test_tag(Some(metadata.clone()));
+
+        let bytes = postcard::to_allocvec(&tag).unwrap();
+        let decoded: TagRecord = postcard::from_bytes(&bytes).unwrap();
+
+        assert_eq!(decoded, tag);
+        assert_eq!(decoded.metadata, Some(metadata));
+    }
+
+    #[test]
+    fn test_tag_record_postcard_roundtrip_without_metadata() {
+        let tag = test_tag(None);
+        let bytes = postcard::to_allocvec(&tag).unwrap();
+        let decoded: TagRecord = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(decoded, tag);
+        assert!(decoded.metadata.is_none());
+    }
 }


### PR DESCRIPTION
## Problem

Three issues in the Git shadow system, all verified live:

1. **`atomic git push` failed to authenticate** for anyone whose SSH setup isn't "keys in an agent". The libgit2 credential callback only called `ssh_key_from_agent()` — keys referenced via `Host`/`IdentityFile` in `~/.ssh/config` were never consulted, so pushes failed with `Failed getting response; class=Ssh (23)` after a hang-like retry loop, while plain `git push` worked fine. After a failed push, the local commit was stranded: the next run said "Nothing to commit" and exited.
2. **The push → pull → import round trip duplicated history.** A commit created by `atomic git push` came back into the view as a brand-new change on the next `atomic git import --incremental` (observed: 5 pushed commits reimported as 5 duplicates). Squash/merge classification also never fired — it parsed only the commit subject, but trailers live in the body — so no `ReviewGate` tags were created either.
3. **Tags with metadata were unreadable**: `TagRecord.metadata` is `Option<serde_json::Value>`, which postcard can't deserialize — every read of a classifier-created tag failed, breaking `atomic tag list`.

## Fixes

**Push auth (`git/push.rs`)** — `push_to_remote` delegates the network operation to the `git` CLI with inherited stdio, so auth behaves exactly like the user's own `git push` (ssh config, agents, askpass, HTTPS credential helpers). The nothing-to-commit path now checks upstream tracking and pushes stranded commits. New `--branch`/`-b` flag pushes the current view's state to a different remote branch (`HEAD:refs/heads/<target>`); commit is still created on the current branch.

**Round-trip dedup (`git/import.rs`, `git/parallel.rs`)** — on incremental import, parse `Atomic-View`/`Atomic-State` trailers (strictly: final paragraph only, so GitHub squash messages quoting them mid-body don't match) and skip the commit when its view is the import target and its state exists in the view's append-only `STATES` table — the Merkle proves every change it carries is already present. Retroactive: dedupes commits pushed before this fix. Cross-view (pushed from `dev`, imported on `main`) and full imports unaffected. Classification now receives the full commit message, so squash merges actually get their `pr-N` tags.

**Tag serialization (`pristine/traits/tag.rs`)** — `metadata` is stored as JSON text via a serde adapter; metadata-free records decode unchanged.

## Verified end-to-end (live GitHub repo)

- `record` → `git push` → `git import --incremental` → **0 changes written**, "Skipped 1 commit created by `atomic git push` (state already in view)" ✓
- Plain git commit (teammate) still imports normally ✓
- Squash-shaped commit imports + `pr-100` tag created with full metadata; `tag list`/`tag show` render it ✓
- `--branch pr-demo` creates a remote branch, `main` untouched ✓
- Stranded-commit recovery push ✓
- Tests: 1694 CLI (12 new) + 3361 core (2 new), all green