### PR TITLE
fix(agent): keep working copy on agent view at session end

### DIFF
--- a/atomic-agent/src/turn/orchestrator/session_end.rs
+++ b/atomic-agent/src/turn/orchestrator/session_end.rs
@@ -13,6 +13,10 @@ impl TurnOrchestrator {
     /// Transitions the session to Ended, saves it, and creates an
     /// attestation covering all changes recorded during the session.
     ///
+    /// The working copy stays on the session's agent view so the user
+    /// lands where the work happened and can review it before inserting
+    /// it into a shared view.
+    ///
     /// The attestation is a graph-level audit node — it captures agent
     /// identity, timing, and which changes were recorded. Cost and token
     /// data are left at zero (they're not available from the hook) and
@@ -46,9 +50,7 @@ impl TurnOrchestrator {
         // Flush any unrecorded turn BEFORE finalizing. Headless agents such as
         // Cursor's CLI fire sessionStart/postToolUse/sessionEnd but no per-turn
         // `stop` (TurnEnd), so the turn's file changes are still uncommitted at
-        // session end. Record them now — crucially *before* switching back to
-        // the parent view below, which restores the working copy and would
-        // otherwise discard the agent's work. Idempotent: agents that already
+        // session end. Record them now. Idempotent: agents that already
         // recorded each turn on `stop` leave a clean working copy here, so
         // `record_turn` returns `EmptyTurn` and this is a no-op for them.
         {
@@ -157,30 +159,12 @@ impl TurnOrchestrator {
             self.create_session_attestation(&session);
         }
 
-        // Switch back to the user's original view. session-start switched
-        // to the agent view so that all file writes happened there. Now
-        // that the session is over, restore the user's view.
-        if let Some(ref parent) = session.parent_view {
-            match atomic_repository::Repository::open_existing(&self.repo_root) {
-                Ok(mut repo) => {
-                    if let Err(e) = repo.switch_view(parent) {
-                        log::warn!(
-                            "Could not switch back to user view '{}': {} (non-fatal)",
-                            parent,
-                            e,
-                        );
-                    } else {
-                        log::info!("Restored user view '{}'", parent);
-                    }
-                }
-                Err(e) => {
-                    log::warn!(
-                        "Could not open repository to restore user view: {} (non-fatal)",
-                        e,
-                    );
-                }
-            }
-        }
+        // Deliberately do NOT switch back to `session.parent_view`: the
+        // working copy stays on the session's agent view so the user lands
+        // where the work happened and can review it (`atomic log`/`diff`)
+        // before deciding to insert it into a shared view. Switching back
+        // forced users to hunt through `atomic view list` for the view
+        // holding their agent's changes.
 
         Ok(DispatchResult::new(session_id, session.phase))
     }

--- a/atomic-agent/src/turn/orchestrator/session_start.rs
+++ b/atomic-agent/src/turn/orchestrator/session_start.rs
@@ -240,8 +240,9 @@ impl TurnOrchestrator {
                     // Switch to the agent view so that all file writes during
                     // the session (tool calls, npm install, builds, etc.) happen
                     // while current_view points to the agent view. This ensures
-                    // status/add/record see the right view. session-end will
-                    // switch back to the user's view.
+                    // status/add/record see the right view. The working copy
+                    // stays on the agent view after session-end so the user
+                    // lands where the agent's work happened.
                     if let Err(e) = repo.align_to_view(&session.view_name) {
                         log::warn!(
                             "Could not align to agent view '{}': {} (non-fatal)",

--- a/atomic-agent/src/turn/orchestrator/tests.rs
+++ b/atomic-agent/src/turn/orchestrator/tests.rs
@@ -961,7 +961,7 @@ async fn test_session_start_adopts_declared_managed_view() {
     assert_eq!(
         session.parent_view.as_deref(),
         Some("dev"),
-        "parent view is remembered so session-end can restore it"
+        "parent view is remembered as the fork/insert baseline"
     );
     let stamp = session
         .managed_run
@@ -987,15 +987,16 @@ async fn test_session_start_adopts_declared_managed_view() {
     );
     assert_eq!(result.view.as_deref(), Some("sherpa-run-view"));
 
-    // Session end restores the parent view.
+    // Session end leaves the working copy on the agent's view: the user
+    // lands where the work happened and can review/insert from there.
     orch.dispatch(session_end_event("sess-managed"))
         .await
         .unwrap();
     let repo = Repository::open_existing(dir.path()).unwrap();
     assert_eq!(
         repo.current_view(),
-        "dev",
-        "session-end restores the user's view"
+        "sherpa-run-view",
+        "session-end leaves the working copy on the agent's view"
     );
 }
 

--- a/atomic-repository/vault/skills/atomic-vault.md
+++ b/atomic-repository/vault/skills/atomic-vault.md
@@ -141,7 +141,8 @@ workflow orchestrator own all of that:
   view — depending on how you were launched).
 - **Turn end** records automatically with full AI provenance (model,
   session, decision graph).
-- **Session end** restores the original view.
+- **Session end** leaves the working copy on the session's view, where
+  the recorded work lives — review it there.
 - **Merging into a shared view** (`atomic insert`) is a human/orchestrator
   decision made at review time — never run it yourself.
 

--- a/docs/adding-agents.md
+++ b/docs/adding-agents.md
@@ -213,7 +213,7 @@ invocation is a fresh, stateless CLI process keyed by `session_id`.
 | `PreToolUse` | `before-tool`, `pre-tool` | before a tool runs | Bookkeeping only (no output yet) |
 | `PostToolUse` | `after-tool`, `post-tool` | after a tool runs | Appends a classified node (`Exploration` / `Commitment` / `Verification` / `Execution` / `Error`) plus inferred causal edges to the session's **decision graph** |
 | `TurnEnd` | `stop`, `after-agent`, `turn-end` | agent finishes a turn | **Records a change** on the draft view with full AI provenance embedded |
-| `SessionEnd` | `session-end` | agent session closes | Flushes any unrecorded work, writes the **AI attestation**, restores the parent view |
+| `SessionEnd` | `session-end` | agent session closes | Flushes any unrecorded work, writes the **AI attestation**; the working copy stays on the session's view so the user lands where the work happened |
 
 **The golden rule of responsibility:** the agent side (plugin or hook command)
 only does two things — fire the event at the right moment, and attach a JSON


### PR DESCRIPTION
## Problem

On `SessionEnd`, the turn orchestrator switched the working copy back to the session's parent view (`session_end.rs` called `repo.switch_view(parent)`). That makes the review flow clunky:

1. Open agent harness
2. Give it a direction — it creates an intent and code
3. Exit, having fulfilled the work you intended to do
4. `atomic view list`
5. Identify the view that has 1 change (hope it's the right one…)
6. `atomic insert from-view <the view you hope holds the work>`

Landing back on `dev` hides the work that was just done. Users who close their session (rather than keeping it open in another tab) have no idea which draft view holds their agent's changes.

## Fix

Remove the switch-back. The working copy **stays on the session's agent view** when the session ends, so the user lands exactly where the work happened and can review (`atomic log` / `atomic diff`) and `atomic insert` from there.

- `parent_view` is still captured at session start — it remains the fork baseline for the just-in-time self-heal in `record_turn` and the delta reference for `atomic agent attest --pending`.
- The pre-finalize flush (which records uncommitted turns for headless agents like Cursor's CLI) is unchanged — it still aligns to the agent view before recording.
- Sandbox sessions are unaffected (they never forked/switched in the first place).

## Changes

- `atomic-agent/src/turn/orchestrator/session_end.rs` — drop the `switch_view(parent)` block; document that staying on the agent view is deliberate
- `atomic-agent/src/turn/orchestrator/session_start.rs` — update stale comment claiming session-end switches back
- `atomic-agent/src/turn/orchestrator/tests.rs` — assert the new behavior: `current_view()` remains the agent view after session end
- `docs/adding-agents.md`, `atomic-repository/vault/skills/atomic-vault.md` — docs updated to match

## Testing

- `cargo test -p atomic-agent` — 1313 passed, 0 failed
- `cargo clippy -p atomic-agent` — clean