### PR TITLE
feat(cli): show who org members actually are, not just their UUIDs

### DIFF
--- a/atomic-cli/src/commands/org/member.rs
+++ b/atomic-cli/src/commands/org/member.rs
@@ -21,9 +21,12 @@
 //! ```text
 //! # List all members of the current org
 //! $ atomic org member list
-//! IDENTITY_ID                           ROLE     JOINED
-//! 550e8400-e29b-41d4-a716-446655440000  owner    2025-01-15T10:30:00Z
-//! 6ba7b810-9dad-11d1-80b4-00c04fd430c8  admin    2025-02-20T14:00:00Z
+//! NAME    EMAIL              ROLE    STATUS   KEY                   JOINED
+//! ada     ada@example.com    owner   active   MFRGGZDFMZTWQ2LK...   2025-01-15T10:30:00Z
+//! grace   grace@example.com  admin   active   NBSWY3DPEB3W64TM...   2025-02-20T14:00:00Z
+//!
+//! # The identity UUID and full public key are in the JSON form
+//! $ atomic org member list --format json
 //!
 //! # Add a member
 //! $ atomic org member add 6ba7b810-9dad-11d1-80b4-00c04fd430c8 --role admin
@@ -185,17 +188,31 @@ impl MemberList {
         } else if members.is_empty() {
             print_hint("No members found in this organization.");
         } else {
+            // The identity UUID is deliberately not a column: it is 36
+            // characters that identify nobody, and `member update`/`remove`
+            // accept a name or email just as well. It stays in `--format json`
+            // for callers that want it.
             let mut table = Table::new();
             table.set_columns(vec![
-                Column::new("IDENTITY_ID").min_width(36),
+                Column::new("NAME").min_width(14),
+                Column::new("EMAIL").min_width(22),
                 Column::new("ROLE").min_width(8),
+                Column::new("STATUS").min_width(9),
+                Column::new("KEY").min_width(19),
                 Column::new("JOINED").min_width(20),
             ]);
 
             for member in &members {
                 table.add_row(vec![
-                    member.identity_id.to_string(),
+                    member.name.clone().unwrap_or_else(unknown),
+                    member.email.clone().unwrap_or_else(unknown),
                     member.role.to_string(),
+                    member.status.clone().unwrap_or_else(unknown),
+                    member
+                        .public_key
+                        .as_deref()
+                        .map(short_key)
+                        .unwrap_or_else(unknown),
                     member.joined_at.to_rfc3339(),
                 ]);
             }
@@ -206,6 +223,28 @@ impl MemberList {
         }
 
         Ok(())
+    }
+}
+
+/// Placeholder for a field the server did not return.
+///
+/// A server older than the release that added identity details to
+/// `GET /orgs/{slug}/members` omits these, so the column is unknown rather
+/// than empty. Distinguishing the two matters: an empty `EMAIL` would suggest
+/// the member has no address on file.
+fn unknown() -> String {
+    "—".to_string()
+}
+
+/// Abbreviate a base32 public key for table display.
+///
+/// Matches `identity list --verbose`, which prints the first 16 base32
+/// characters followed by an ellipsis, so the same key is recognisable in
+/// both places. The full value stays in `--format json`.
+fn short_key(key: &str) -> String {
+    match key.char_indices().nth(16) {
+        Some((cut, _)) => format!("{}...", &key[..cut]),
+        None => key.to_string(),
     }
 }
 
@@ -654,5 +693,31 @@ mod tests {
             force: false,
         };
         assert_eq!(check_variant(&MemberCommands::Remove(remove)), "remove");
+    }
+
+    // -- Display helpers --
+
+    /// Keys are abbreviated the same way `identity list --verbose` does, so the
+    /// same key is recognisable in both listings.
+    #[test]
+    fn short_key_truncates_to_sixteen_chars_with_ellipsis() {
+        let key = "MFRGGZDFMZTWQ2LKNNWG23TPOBYXE43UOV3HO6DZPI";
+        assert_eq!(short_key(key), "MFRGGZDFMZTWQ2LK...");
+    }
+
+    /// A key at or under the cut is shown whole rather than gaining a
+    /// misleading ellipsis.
+    #[test]
+    fn short_key_leaves_short_input_untouched() {
+        assert_eq!(short_key("MFRGGZDFMZTWQ2LK"), "MFRGGZDFMZTWQ2LK");
+        assert_eq!(short_key("MFRG"), "MFRG");
+    }
+
+    /// A missing field reads as unknown, not as an empty value — an empty
+    /// EMAIL column would wrongly suggest the member has no address on file.
+    #[test]
+    fn unknown_is_a_visible_placeholder() {
+        assert_eq!(unknown(), "—");
+        assert!(!unknown().is_empty());
     }
 }

--- a/atomic-teams/src/types.rs
+++ b/atomic-teams/src/types.rs
@@ -278,6 +278,26 @@ pub struct OrgMemberInfo {
     /// Identity that sent the invitation, if applicable.
     #[serde(alias = "invited_by")]
     pub invited_by: Option<Uuid>,
+
+    // The fields below describe the member's *identity* rather than the
+    // membership. Every one is `#[serde(default)]` because a server older than
+    // the release that added them omits it entirely — without the defaults the
+    // whole response would fail to deserialize and `member list` would break
+    // against an un-upgraded deployment. `None` therefore means "this server
+    // did not say", not "this member has none".
+    /// Display name of the member's identity.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Ed25519 public key, base32 no-pad — the same encoding used elsewhere in
+    /// Atomic, and the value a caller's token is keyed by.
+    #[serde(default, alias = "public_key")]
+    pub public_key: Option<String>,
+    /// Identity lifecycle status: `active`, `suspended`, or `deleted`.
+    #[serde(default)]
+    pub status: Option<String>,
+    /// Preferred email — verified if available, otherwise the oldest on file.
+    #[serde(default)]
+    pub email: Option<String>,
 }
 
 /// Team metadata.
@@ -748,11 +768,62 @@ mod tests {
             role: OrgRole::Admin,
             joined_at: now,
             invited_by: Some(Uuid::new_v4()),
+            name: Some("ada".to_string()),
+            public_key: Some("MFRGGZDFMZTWQ2LK".to_string()),
+            status: Some("active".to_string()),
+            email: Some("ada@example.com".to_string()),
         };
         let json = serde_json::to_string(&info).unwrap();
         let de: OrgMemberInfo = serde_json::from_str(&json).unwrap();
         assert_eq!(de.role, OrgRole::Admin);
         assert!(de.invited_by.is_some());
+        assert_eq!(de.name.as_deref(), Some("ada"));
+        assert_eq!(de.public_key.as_deref(), Some("MFRGGZDFMZTWQ2LK"));
+        assert_eq!(de.status.as_deref(), Some("active"));
+        assert_eq!(de.email.as_deref(), Some("ada@example.com"));
+    }
+
+    /// A server predating the identity-detail fields omits them entirely.
+    ///
+    /// Without `#[serde(default)]` on each, the whole response would fail to
+    /// parse and `org member list` would break against an un-upgraded
+    /// deployment rather than degrading to the columns it does know.
+    #[test]
+    fn org_member_info_tolerates_server_without_identity_details() {
+        let json = r#"{
+            "org_id": "00000000-0000-0000-0000-000000000001",
+            "identity_id": "00000000-0000-0000-0000-000000000002",
+            "role": "member",
+            "joined_at": "2026-01-01T00:00:00Z",
+            "invited_by": null
+        }"#;
+
+        let de: OrgMemberInfo = serde_json::from_str(json).expect("legacy payload must parse");
+        assert_eq!(de.role, OrgRole::Member);
+        assert_eq!(de.name, None);
+        assert_eq!(de.public_key, None);
+        assert_eq!(de.status, None);
+        assert_eq!(de.email, None);
+    }
+
+    /// The server serializes these as snake_case; the struct is camelCase.
+    #[test]
+    fn org_member_info_accepts_snake_case_public_key() {
+        let json = r#"{
+            "org_id": "00000000-0000-0000-0000-000000000001",
+            "identity_id": "00000000-0000-0000-0000-000000000002",
+            "role": "owner",
+            "joined_at": "2026-01-01T00:00:00Z",
+            "invited_by": null,
+            "name": "ada",
+            "public_key": "MFRGGZDFMZTWQ2LK",
+            "status": "active",
+            "email": "ada@example.com"
+        }"#;
+
+        let de: OrgMemberInfo = serde_json::from_str(json).expect("snake_case payload must parse");
+        assert_eq!(de.public_key.as_deref(), Some("MFRGGZDFMZTWQ2LK"));
+        assert_eq!(de.name.as_deref(), Some("ada"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`atomic org member list` rendered `IDENTITY_ID`, `ROLE`, `JOINED`. The identity id is an opaque server-assigned UUID, so the only column that identified anyone identified nobody:

```
IDENTITY_ID                           ROLE   JOINED
550e8400-e29b-41d4-a716-446655440000  owner  2025-01-15T10:30:00Z
```

The server had nothing better to give: `GET /orgs/{slug}/members` returned the raw membership row with no join to `identities`.

## Change

Paired with atomicdotdev/atomic-storage — "org member list returns identity details", which adds `name`, `public_key`, `status`, and `email` to the member payload. This renders them:

```
NAME   EMAIL            ROLE   STATUS  KEY                  JOINED
ada    ada@example.com  owner  active  MFRGGZDFMZTWQ2LK...  2025-01-15T10:30:00Z
```

- **The UUID column is dropped, not kept alongside.** It is 36 characters wide, and `member update`/`remove` already accept a name or email, so nothing needed it. It stays in `--format json`.
- **`KEY` is a 16-character base32 prefix** of the Ed25519 public key, matching `identity list --verbose` so the same key is recognisable in both listings. The full value is in the JSON form.

## Why the public key earns a column

It is the value a caller's token is keyed by — the JWT `kid`. That makes it the field that answers *"is my identity the one registered here?"*, which is the question behind a `401 Token references an identity that is not registered`. Nothing else in the previous output could distinguish a stale registration from a wrong server.

## Compatibility

Every new field is `#[serde(default)] Option<String>`. A server predating them omits them entirely, and **without the defaults the whole response would fail to deserialize** — `member list` would break against an un-upgraded deployment rather than degrading to the columns it does know. Missing values render as an em dash, so "the server did not say" stays distinguishable from "this member has no email on file".

This means the CLI can ship before or after the server; neither ordering breaks the other.

## Testing

- `cargo test --workspace` — 34 binaries, 0 failures
- `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` — both clean
- New coverage: serde round-trip with the new fields, a legacy payload with them absent, snake_case `public_key`, and the two display helpers

A test on the server side pins the JSON field names this client reads, since that contract now spans two repos.