### PR TITLE
fix(teams): accept everyone workspace grants

### DIFF
--- a/atomic-cli/src/commands/workspace/grant.rs
+++ b/atomic-cli/src/commands/workspace/grant.rs
@@ -351,6 +351,7 @@ fn subject_label(
         atomic_teams::GrantSubjectType::User => {
             format!("user {}", user_id.as_deref().unwrap_or("?"))
         }
+        atomic_teams::GrantSubjectType::Everyone => "everyone".to_string(),
     }
 }
 
@@ -487,5 +488,11 @@ mod tests {
             &Some("550e8400-e29b-41d4-a716-446655440000".to_string()),
         );
         assert_eq!(label, "user 550e8400-e29b-41d4-a716-446655440000");
+    }
+
+    #[test]
+    fn subject_label_everyone() {
+        let label = subject_label(atomic_teams::GrantSubjectType::Everyone, &None, &None);
+        assert_eq!(label, "everyone");
     }
 }

--- a/atomic-teams/README.md
+++ b/atomic-teams/README.md
@@ -450,10 +450,11 @@ async fn team_member_example(client: &StorageClient) -> TeamsResult<()> {
 
 ### Grants API
 
-Grants bind a subject (user or team) to a relation (read, write, admin,
-owner) on a resource (org or workspace). The server uses a Zanzibar-style
-ReBAC engine with structural inheritance — an org owner automatically has
-admin access to all workspaces within the org.
+Grants bind a subject to a relation (read, write, admin, owner) on a resource
+(org or workspace). Grant mutations target a concrete user or team; list
+responses can also contain `Everyone` for public/wildcard grants. The server
+uses a Zanzibar-style ReBAC engine with structural inheritance — an org owner
+automatically has admin access to all workspaces within the org.
 
 ```rust
 use atomic_teams::{grant, GrantInfo, GrantRelation, GrantSubjectType, TeamsResult};
@@ -809,7 +810,7 @@ async fn handle_errors(client: &atomic_remote::StorageClient) {
 | `TeamRole` | `Maintainer`, `Contributor`, `Collaborator`, `Consumer` | Team membership |
 | `TeamVisibility` | `Visible`, `Secret` | Team creation/update |
 | `GrantRelation` | `Read`, `Write`, `Admin`, `Owner` | Grant operations |
-| `GrantSubjectType` | `User`, `Team` | Grant operations |
+| `GrantSubjectType` | `User`, `Team`, `Everyone` | Grant operations and responses |
 
 All enums implement `Display`, `FromStr`, `Serialize`, and `Deserialize`.
 String representations are lowercase (`"owner"`, `"admin"`, `"maintainer"`, `"contributor"`, etc.).

--- a/atomic-teams/src/grant.rs
+++ b/atomic-teams/src/grant.rs
@@ -23,8 +23,21 @@ use uuid::Uuid;
 
 use atomic_remote::storage::StorageClient;
 
-use crate::error::{map_remote_error, TeamsResult};
+use crate::error::{map_remote_error, TeamsError, TeamsResult};
 use crate::types::{AddGrantRequest, GrantInfo, GrantRelation, GrantSubjectType};
+
+/// Ensure a grant mutation targets a concrete user or team.
+///
+/// `Everyone` is emitted by Storage when listing public grants, but the
+/// mutation endpoints require a non-null user or team UUID.
+fn validate_mutation_subject(subject_type: GrantSubjectType) -> TeamsResult<()> {
+    match subject_type {
+        GrantSubjectType::User | GrantSubjectType::Team => Ok(()),
+        GrantSubjectType::Everyone => Err(TeamsError::InvalidInput(
+            "grant mutations require a user or team subject".to_string(),
+        )),
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Organization grants
@@ -59,7 +72,9 @@ pub async fn list_org_grants(
 /// Returns [`TeamsError::AlreadyExists`](crate::error::TeamsError::AlreadyExists)
 /// if the grant already exists, or
 /// [`TeamsError::PermissionDenied`](crate::error::TeamsError::PermissionDenied)
-/// if the caller is not an org owner.
+/// if the caller is not an org owner. Returns
+/// [`TeamsError::InvalidInput`](crate::error::TeamsError::InvalidInput) when
+/// `subject_type` is [`GrantSubjectType::Everyone`].
 pub async fn add_org_grant(
     client: &StorageClient,
     org_slug: &str,
@@ -67,6 +82,7 @@ pub async fn add_org_grant(
     subject_id: Uuid,
     relation: GrantRelation,
 ) -> TeamsResult<GrantInfo> {
+    validate_mutation_subject(subject_type)?;
     let path = format!("/orgs/{org_slug}/grants");
     let body = AddGrantRequest {
         subject_type,
@@ -90,13 +106,16 @@ pub async fn add_org_grant(
 /// Returns [`TeamsError::OrgNotFound`](crate::error::TeamsError::OrgNotFound)
 /// if the org does not exist, or
 /// [`TeamsError::PermissionDenied`](crate::error::TeamsError::PermissionDenied)
-/// if the caller is not an org owner.
+/// if the caller is not an org owner. Returns
+/// [`TeamsError::InvalidInput`](crate::error::TeamsError::InvalidInput) when
+/// `subject_type` is [`GrantSubjectType::Everyone`].
 pub async fn revoke_org_grant(
     client: &StorageClient,
     org_slug: &str,
     subject_type: GrantSubjectType,
     subject_id: Uuid,
 ) -> TeamsResult<()> {
+    validate_mutation_subject(subject_type)?;
     let st = subject_type.to_string();
     let path = format!("/orgs/{org_slug}/grants/{st}/{subject_id}");
     client
@@ -137,7 +156,9 @@ pub async fn list_workspace_grants(
 /// Returns [`TeamsError::AlreadyExists`](crate::error::TeamsError::AlreadyExists)
 /// if the grant already exists, or
 /// [`TeamsError::PermissionDenied`](crate::error::TeamsError::PermissionDenied)
-/// if the caller is not a workspace admin.
+/// if the caller is not a workspace admin. Returns
+/// [`TeamsError::InvalidInput`](crate::error::TeamsError::InvalidInput) when
+/// `subject_type` is [`GrantSubjectType::Everyone`].
 pub async fn add_workspace_grant(
     client: &StorageClient,
     workspace_slug: &str,
@@ -145,6 +166,7 @@ pub async fn add_workspace_grant(
     subject_id: Uuid,
     relation: GrantRelation,
 ) -> TeamsResult<crate::types::WorkspaceGrantInfo> {
+    validate_mutation_subject(subject_type)?;
     let path = format!("/workspaces/{workspace_slug}/grants");
     let body = AddGrantRequest {
         subject_type,
@@ -167,13 +189,16 @@ pub async fn add_workspace_grant(
 ///
 /// Returns [`TeamsError::PermissionDenied`](crate::error::TeamsError::PermissionDenied)
 /// if the caller is not a workspace admin, or a not-found error if the
-/// workspace doesn't exist.
+/// workspace doesn't exist. Returns
+/// [`TeamsError::InvalidInput`](crate::error::TeamsError::InvalidInput) when
+/// `subject_type` is [`GrantSubjectType::Everyone`].
 pub async fn revoke_workspace_grant(
     client: &StorageClient,
     workspace_slug: &str,
     subject_type: GrantSubjectType,
     subject_id: Uuid,
 ) -> TeamsResult<()> {
+    validate_mutation_subject(subject_type)?;
     let st = subject_type.to_string();
     let path = format!("/workspaces/{workspace_slug}/grants/{st}/{subject_id}");
     client
@@ -214,6 +239,22 @@ mod tests {
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("\"subject_type\":\"user\""), "got: {json}");
         assert!(json.contains("\"relation\":\"read\""), "got: {json}");
+    }
+
+    #[test]
+    fn mutation_subject_rejects_everyone() {
+        let error = validate_mutation_subject(GrantSubjectType::Everyone).unwrap_err();
+        assert!(matches!(error, TeamsError::InvalidInput(_)));
+        assert_eq!(
+            error.to_string(),
+            "Invalid input: grant mutations require a user or team subject"
+        );
+    }
+
+    #[test]
+    fn mutation_subject_accepts_users_and_teams() {
+        assert!(validate_mutation_subject(GrantSubjectType::User).is_ok());
+        assert!(validate_mutation_subject(GrantSubjectType::Team).is_ok());
     }
 
     #[test]

--- a/atomic-teams/src/grant.rs
+++ b/atomic-teams/src/grant.rs
@@ -47,9 +47,9 @@ fn validate_mutation_subject(subject_type: GrantSubjectType) -> TeamsResult<()> 
 ///
 /// # Errors
 ///
-/// Returns [`TeamsError::OrgNotFound`](crate::error::TeamsError::OrgNotFound)
+/// Returns [`TeamsError::OrgNotFound`]
 /// if the org does not exist, or
-/// [`TeamsError::PermissionDenied`](crate::error::TeamsError::PermissionDenied)
+/// [`TeamsError::PermissionDenied`]
 /// if the caller lacks access.
 pub async fn list_org_grants(
     client: &StorageClient,
@@ -69,11 +69,11 @@ pub async fn list_org_grants(
 ///
 /// # Errors
 ///
-/// Returns [`TeamsError::AlreadyExists`](crate::error::TeamsError::AlreadyExists)
+/// Returns [`TeamsError::AlreadyExists`]
 /// if the grant already exists, or
-/// [`TeamsError::PermissionDenied`](crate::error::TeamsError::PermissionDenied)
+/// [`TeamsError::PermissionDenied`]
 /// if the caller is not an org owner. Returns
-/// [`TeamsError::InvalidInput`](crate::error::TeamsError::InvalidInput) when
+/// [`TeamsError::InvalidInput`] when
 /// `subject_type` is [`GrantSubjectType::Everyone`].
 pub async fn add_org_grant(
     client: &StorageClient,
@@ -103,11 +103,11 @@ pub async fn add_org_grant(
 ///
 /// # Errors
 ///
-/// Returns [`TeamsError::OrgNotFound`](crate::error::TeamsError::OrgNotFound)
+/// Returns [`TeamsError::OrgNotFound`]
 /// if the org does not exist, or
-/// [`TeamsError::PermissionDenied`](crate::error::TeamsError::PermissionDenied)
+/// [`TeamsError::PermissionDenied`]
 /// if the caller is not an org owner. Returns
-/// [`TeamsError::InvalidInput`](crate::error::TeamsError::InvalidInput) when
+/// [`TeamsError::InvalidInput`] when
 /// `subject_type` is [`GrantSubjectType::Everyone`].
 pub async fn revoke_org_grant(
     client: &StorageClient,
@@ -132,7 +132,7 @@ pub async fn revoke_org_grant(
 ///
 /// # Errors
 ///
-/// Returns [`TeamsError::PermissionDenied`](crate::error::TeamsError::PermissionDenied)
+/// Returns [`TeamsError::PermissionDenied`]
 /// if the caller lacks read access, or a not-found error if the workspace
 /// doesn't exist.
 pub async fn list_workspace_grants(
@@ -153,11 +153,11 @@ pub async fn list_workspace_grants(
 ///
 /// # Errors
 ///
-/// Returns [`TeamsError::AlreadyExists`](crate::error::TeamsError::AlreadyExists)
+/// Returns [`TeamsError::AlreadyExists`]
 /// if the grant already exists, or
-/// [`TeamsError::PermissionDenied`](crate::error::TeamsError::PermissionDenied)
+/// [`TeamsError::PermissionDenied`]
 /// if the caller is not a workspace admin. Returns
-/// [`TeamsError::InvalidInput`](crate::error::TeamsError::InvalidInput) when
+/// [`TeamsError::InvalidInput`] when
 /// `subject_type` is [`GrantSubjectType::Everyone`].
 pub async fn add_workspace_grant(
     client: &StorageClient,
@@ -187,10 +187,10 @@ pub async fn add_workspace_grant(
 ///
 /// # Errors
 ///
-/// Returns [`TeamsError::PermissionDenied`](crate::error::TeamsError::PermissionDenied)
+/// Returns [`TeamsError::PermissionDenied`]
 /// if the caller is not a workspace admin, or a not-found error if the
 /// workspace doesn't exist. Returns
-/// [`TeamsError::InvalidInput`](crate::error::TeamsError::InvalidInput) when
+/// [`TeamsError::InvalidInput`] when
 /// `subject_type` is [`GrantSubjectType::Everyone`].
 pub async fn revoke_workspace_grant(
     client: &StorageClient,

--- a/atomic-teams/src/types.rs
+++ b/atomic-teams/src/types.rs
@@ -172,6 +172,11 @@ pub enum GrantSubjectType {
     User,
     /// A team within the organization.
     Team,
+    /// Every caller, returned by the server for public/wildcard grants.
+    ///
+    /// Grant mutation helpers reject this response-only subject because the
+    /// Storage API only accepts concrete user or team UUIDs.
+    Everyone,
 }
 
 impl fmt::Display for GrantSubjectType {
@@ -179,6 +184,7 @@ impl fmt::Display for GrantSubjectType {
         match self {
             Self::User => write!(f, "user"),
             Self::Team => write!(f, "team"),
+            Self::Everyone => write!(f, "everyone"),
         }
     }
 }
@@ -190,6 +196,7 @@ impl FromStr for GrantSubjectType {
         match s.to_lowercase().as_str() {
             "user" => Ok(Self::User),
             "team" => Ok(Self::Team),
+            "everyone" => Ok(Self::Everyone),
             other => Err(format!("unknown grant subject type: {other}")),
         }
     }
@@ -352,7 +359,7 @@ pub struct TeamMemberInfo {
 pub struct GrantInfo {
     /// Unique identifier.
     pub id: Uuid,
-    /// Whether the subject is a user or team (`"user"` or `"team"`).
+    /// Whether the subject is a user, team, or everyone.
     pub subject_type: GrantSubjectType,
     /// The subject's identity or team ID (absent for wildcard/everyone grants).
     pub subject_id: Option<Uuid>,
@@ -374,7 +381,7 @@ pub struct GrantInfo {
 pub struct WorkspaceGrantInfo {
     /// Unique identifier of the ReBAC tuple.
     pub id: Uuid,
-    /// Whether the subject is a user or team (`"user"` or `"team"`).
+    /// Whether the subject is a user, team, or everyone.
     pub subject_type: GrantSubjectType,
     /// The subject's identity or team UUID (absent for wildcard/everyone grants).
     pub subject_id: Option<Uuid>,
@@ -569,7 +576,11 @@ mod tests {
 
     #[test]
     fn grant_subject_type_display_roundtrip() {
-        for st in [GrantSubjectType::User, GrantSubjectType::Team] {
+        for st in [
+            GrantSubjectType::User,
+            GrantSubjectType::Team,
+            GrantSubjectType::Everyone,
+        ] {
             let s = st.to_string();
             let parsed: GrantSubjectType = s.parse().unwrap();
             assert_eq!(parsed, st);
@@ -744,6 +755,29 @@ mod tests {
     }
 
     #[test]
+    fn workspace_grant_info_deserializes_public_everyone_grant() {
+        // Public workspaces use a wildcard grant. Its subject has no UUID,
+        // and Storage reports the subject type explicitly as `everyone`.
+        let json = r#"{
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "subject_type": "everyone",
+            "subject_id": null,
+            "subject_relation": null,
+            "relation": "read",
+            "object_type": "workspace",
+            "object_id": "550e8400-e29b-41d4-a716-446655440002",
+            "granted_at": "2024-01-01T00:00:00Z",
+            "granted_by": null
+        }"#;
+
+        let grant: WorkspaceGrantInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(grant.subject_type, GrantSubjectType::Everyone);
+        assert!(grant.subject_id.is_none());
+        assert_eq!(grant.relation, GrantRelation::Read);
+        assert_eq!(grant.subject_type.to_string(), "everyone");
+    }
+
+    #[test]
     fn domain_alias_info_serde_roundtrip() {
         let info = DomainAliasInfo {
             id: Uuid::new_v4(),
@@ -892,6 +926,9 @@ mod tests {
 
         let json = serde_json::to_string(&GrantSubjectType::Team).unwrap();
         assert_eq!(json, "\"team\"");
+
+        let json = serde_json::to_string(&GrantSubjectType::Everyone).unwrap();
+        assert_eq!(json, "\"everyone\"");
     }
 
     #[test]
@@ -904,5 +941,8 @@ mod tests {
 
         let rel: GrantRelation = serde_json::from_str("\"write\"").unwrap();
         assert_eq!(rel, GrantRelation::Write);
+
+        let subject: GrantSubjectType = serde_json::from_str("\"everyone\"").unwrap();
+        assert_eq!(subject, GrantSubjectType::Everyone);
     }
 }


### PR DESCRIPTION
## Summary

- add `GrantSubjectType::Everyone` so Atomic can deserialize public/wildcard grants returned by Storage
- preserve the exact `everyone` value in JSON and CLI output
- reject the response-only `Everyone` subject in add/revoke helpers, because Storage mutation endpoints accept only concrete user or team UUIDs
- document the public grant variant and add regression coverage for the production response shape

## Why

`atomic workspace grant list oss --org atomic --format json` failed in v0.13.0 with:

```text
invalid response JSON: unknown variant `everyone`, expected `user` or `team`
```

Storage represents a public workspace with an `everyone/read` ReBAC tuple whose `subject_id` is null. The CLI model did not include that valid server-side subject type.

## Test coverage

- `cargo fmt --all -- --check`
- `cargo test -p atomic-teams --quiet` (62 passed)
- `cargo test -p atomic-cli --quiet` (1,758 unit/integration tests passed)
- `cargo clippy -p atomic-teams -p atomic-cli --all-targets -- -D warnings`
- built the patched v0.13.0 CLI and verified the production command above returns the `everyone/read` grant successfully

## Scope

This fixes grant-list response compatibility. It does not change workspace ACLs; an OSS workspace with only `everyone: read` still requires an explicit user or team write grant for push/write operations.
