### PR TITLE
docs: remove stale private-repo references from Related Projects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,13 +28,10 @@ atomic/
 
 ### Related Projects
 
-- **atomic-remote** (`atomic-remote/`, this repo) - HTTP client for the Atomic storage server (wire protocol + management API)
+- **atomic-remote** (`atomic-remote/`) - HTTP client for the storage server
 
-The storage server itself is a separate, closed-source product and is
-**primarily transport** — clients keep everything they need locally, so
-nothing in this repo should assume server-side read surface. Internal
-contributors: the server lives as a sibling checkout in the team workspace;
-its own README/AGENTS.md are authoritative for server work.
+The server is a separate closed-source product, primarily transport —
+clients have everything locally. Server work happens in its own repo.
 
 ## Core Concepts
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,10 +28,7 @@ atomic/
 
 ### Related Projects
 
-- **atomic-remote** (`atomic-remote/`) - HTTP client for the storage server
-
-The server is a separate closed-source product, primarily transport —
-clients have everything locally. Server work happens in its own repo.
+- **atomic-remote** (`atomic-remote/`) - HTTP client for push/pull/clone
 
 ## Core Concepts
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,9 @@ atomic/
 
 ### Related Projects
 
-- **atomic-remote-client** (`atomic-enterprise/atomic-remote`) - Clean-room HTTP client for remote operations
-- **atomic-api** (`atomic-enterprise/atomic-api`) - Server-side HTTP API for remote operations
+- **atomic-storage** (`atomicdotdev/atomic-storage`) - The live multi-tenant storage server. Primarily transport (push/pull/clone protocol, provenance/attestation storage); clients keep everything they need locally, so server-side read surface is added only deliberately.
+- **atomic-remote** (`atomic-remote/`, this repo) - HTTP client for the storage server (wire protocol + management API)
+- **atomic-enterprise** - LEGACY server, no longer in use. Do not build against it.
 
 ## Core Concepts
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,9 +28,13 @@ atomic/
 
 ### Related Projects
 
-- **atomic-storage** (`atomicdotdev/atomic-storage`) - The live multi-tenant storage server. Primarily transport (push/pull/clone protocol, provenance/attestation storage); clients keep everything they need locally, so server-side read surface is added only deliberately.
-- **atomic-remote** (`atomic-remote/`, this repo) - HTTP client for the storage server (wire protocol + management API)
-- **atomic-enterprise** - LEGACY server, no longer in use. Do not build against it.
+- **atomic-remote** (`atomic-remote/`, this repo) - HTTP client for the Atomic storage server (wire protocol + management API)
+
+The storage server itself is a separate, closed-source product and is
+**primarily transport** — clients keep everything they need locally, so
+nothing in this repo should assume server-side read surface. Internal
+contributors: the server lives as a sibling checkout in the team workspace;
+its own README/AGENTS.md are authoritative for server work.
 
 ## Core Concepts
 

--- a/README.md
+++ b/README.md
@@ -405,9 +405,6 @@ atomic/
 | **atomic-remote** | `atomic-remote/` | HTTP client for push/pull/clone |
 | **atomic-docs** | `atomic-docs/` | Documentation site ([docs.atomic.dev](https://docs.atomic.dev/)) |
 
-Everything runs locally. The hosted server is a separate product and is
-primarily transport — see [atomic.dev](https://atomic.dev).
-
 ## Atomic + smolvm: Concurrent Agent Sandboxes
 
 When several agents work a repository at once, each needs an isolated build

--- a/README.md
+++ b/README.md
@@ -402,11 +402,14 @@ atomic/
 
 | Project | Location | Description |
 |---------|----------|-------------|
-| **atomic-storage** | `atomicdotdev/atomic-storage` | The live multi-tenant storage server (Axum + PostgreSQL). Primarily transport — push/pull/clone protocol plus provenance and attestation storage. Everything a client needs lives locally; be deliberate before adding server-side read surface. |
 | **atomic-remote** | `atomic-remote/` (this repo) | HTTP client library for push/pull/clone and the storage management API |
 | **atomic-docs** | `atomic-docs/` | Documentation site ([docs.atomic.dev](https://docs.atomic.dev/)) |
 
-> `atomic-enterprise` is the **legacy** server and is no longer in use — do not build against it.
+This repository contains everything needed to run Atomic locally — repositories,
+views, the vault, provenance, and the knowledge graph all live on your machine.
+The hosted storage server is a separate product and is primarily **transport**:
+it moves changes, attestations, and provenance between machines. See
+[atomic.dev](https://atomic.dev) for hosted offerings.
 
 ## Atomic + smolvm: Concurrent Agent Sandboxes
 

--- a/README.md
+++ b/README.md
@@ -402,9 +402,11 @@ atomic/
 
 | Project | Location | Description |
 |---------|----------|-------------|
-| **atomic-api** | `atomic-enterprise/atomic-api` | HTTP API for remote operations and multi-tenant hosting |
-| **atomic-remote-client** | `atomic-enterprise/atomic-remote` | HTTP client library for push/pull/clone |
+| **atomic-storage** | `atomicdotdev/atomic-storage` | The live multi-tenant storage server (Axum + PostgreSQL). Primarily transport — push/pull/clone protocol plus provenance and attestation storage. Everything a client needs lives locally; be deliberate before adding server-side read surface. |
+| **atomic-remote** | `atomic-remote/` (this repo) | HTTP client library for push/pull/clone and the storage management API |
 | **atomic-docs** | `atomic-docs/` | Documentation site ([docs.atomic.dev](https://docs.atomic.dev/)) |
+
+> `atomic-enterprise` is the **legacy** server and is no longer in use — do not build against it.
 
 ## Atomic + smolvm: Concurrent Agent Sandboxes
 

--- a/README.md
+++ b/README.md
@@ -402,14 +402,11 @@ atomic/
 
 | Project | Location | Description |
 |---------|----------|-------------|
-| **atomic-remote** | `atomic-remote/` (this repo) | HTTP client library for push/pull/clone and the storage management API |
+| **atomic-remote** | `atomic-remote/` | HTTP client for push/pull/clone |
 | **atomic-docs** | `atomic-docs/` | Documentation site ([docs.atomic.dev](https://docs.atomic.dev/)) |
 
-This repository contains everything needed to run Atomic locally — repositories,
-views, the vault, provenance, and the knowledge graph all live on your machine.
-The hosted storage server is a separate product and is primarily **transport**:
-it moves changes, attestations, and provenance between machines. See
-[atomic.dev](https://atomic.dev) for hosted offerings.
+Everything runs locally. The hosted server is a separate product and is
+primarily transport — see [atomic.dev](https://atomic.dev).
 
 ## Atomic + smolvm: Concurrent Agent Sandboxes
 


### PR DESCRIPTION


README and AGENTS.md "Related Projects" referenced two crates in a private repo as the HTTP client and server. Replaced with the one thing that's actually in this repo: `atomic-remote`, the HTTP client. No server mention at all.

