### PR TITLE
fix(vault): index inherited intents so clone + vault sync makes them queryable

### DIFF
--- a/atomic-repository/src/repository/vault.rs
+++ b/atomic-repository/src/repository/vault.rs
@@ -654,10 +654,6 @@ impl Repository {
     pub fn vault_record_working_copy(&self) -> Result<Vec<String>, RepositoryError> {
         let changes = self.vault_scan_working_copy()?;
 
-        if changes.is_empty() {
-            return Ok(Vec::new());
-        }
-
         let mut updated_paths = Vec::new();
 
         for change in &changes {
@@ -681,6 +677,13 @@ impl Repository {
                 }
             }
         }
+
+        // Index any intent entries the manifest is missing — even when no
+        // file changed. Entries can predate this call (clone bootstrap
+        // deflates inherited files) and `update_manifest_for_store` leaves
+        // intent summaries to higher-level methods; without this, inherited
+        // intents exist in redb but never show up in `intent list`.
+        self.vault_reconcile_intent_manifest()?;
 
         Ok(updated_paths)
     }

--- a/atomic-repository/src/repository/vault_intent.rs
+++ b/atomic-repository/src/repository/vault_intent.rs
@@ -350,8 +350,7 @@ impl Repository {
             else {
                 continue;
             };
-            let Ok(fm) = serde_json::from_str::<serde_json::Value>(&entry.frontmatter_json)
-            else {
+            let Ok(fm) = serde_json::from_str::<serde_json::Value>(&entry.frontmatter_json) else {
                 log::warn!(
                     "vault reconcile: skipping intent entry {} with unparsable frontmatter",
                     meta.path
@@ -360,8 +359,7 @@ impl Repository {
             };
             // `id` is the human key; an entry without one is not a canonical
             // intent scaffold and has nothing to index.
-            let Some(human_key) = fm.get("id").and_then(|v| v.as_str()).map(str::to_owned)
-            else {
+            let Some(human_key) = fm.get("id").and_then(|v| v.as_str()).map(str::to_owned) else {
                 continue;
             };
             if manifest.intents.contains_key(&human_key) {
@@ -1199,7 +1197,10 @@ mod tests {
         let receiver_dir = tempdir().unwrap();
         let receiver = init_repo_with_vault(receiver_dir.path());
         let src = author_dir.path().join(".vault").join(&created.intent_file);
-        let dst = receiver_dir.path().join(".vault").join(&created.intent_file);
+        let dst = receiver_dir
+            .path()
+            .join(".vault")
+            .join(&created.intent_file);
         fs::create_dir_all(dst.parent().unwrap()).unwrap();
         fs::copy(&src, &dst).unwrap();
 

--- a/atomic-repository/src/repository/vault_intent.rs
+++ b/atomic-repository/src/repository/vault_intent.rs
@@ -299,6 +299,135 @@ impl Repository {
         })
     }
 
+    /// Rebuild missing `manifest.intents` summaries from stored intent entries.
+    ///
+    /// Intent entries can reach the vault without `vault_intent_create` ever
+    /// running: clone bootstrap and `vault sync` deflate inherited
+    /// `.vault/intents/**` files straight into redb, and
+    /// `update_manifest_for_store` deliberately leaves intent summaries to
+    /// "higher-level methods". This is that higher-level method for the
+    /// ingestion path. Existing summaries are never overwritten — the
+    /// authoring path stays the source of truth for intents it created.
+    ///
+    /// Also adopts the authoring repo's intent prefix when the local one is
+    /// unset, and advances the per-author sequence allocator past inherited
+    /// keys so a later `vault_intent_create` cannot re-issue one.
+    ///
+    /// Returns the number of summaries added.
+    pub fn vault_reconcile_intent_manifest(&self) -> Result<usize, RepositoryError> {
+        if !self.has_vault()? {
+            return Ok(0);
+        }
+
+        let entries = self.vault_list("intents/", Some(VaultEntryType::Intent))?;
+        if entries.is_empty() {
+            return Ok(0);
+        }
+
+        let mut txn = self
+            .pristine
+            .write_txn()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        let mut manifest = txn
+            .get_vault_manifest()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        let mut added = 0usize;
+
+        for meta in &entries {
+            // Already indexed (the authoring path stores vault_path on every
+            // summary) — leave it alone.
+            if manifest
+                .intents
+                .values()
+                .any(|summary| summary.vault_path == meta.path)
+            {
+                continue;
+            }
+
+            let Some(entry) = txn
+                .get_vault_entry(&meta.path)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?
+            else {
+                continue;
+            };
+            let Ok(fm) = serde_json::from_str::<serde_json::Value>(&entry.frontmatter_json)
+            else {
+                log::warn!(
+                    "vault reconcile: skipping intent entry {} with unparsable frontmatter",
+                    meta.path
+                );
+                continue;
+            };
+            // `id` is the human key; an entry without one is not a canonical
+            // intent scaffold and has nothing to index.
+            let Some(human_key) = fm.get("id").and_then(|v| v.as_str()).map(str::to_owned)
+            else {
+                continue;
+            };
+            if manifest.intents.contains_key(&human_key) {
+                continue;
+            }
+
+            let text = |key: &str| fm.get(key).and_then(|v| v.as_str()).map(str::to_owned);
+            let seq = fm.get("seq").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+            let author = text("author").unwrap_or_default();
+
+            if manifest.intent_prefix.is_empty() {
+                if let Some(project) = text("project").filter(|p| !p.is_empty()) {
+                    manifest.intent_prefix = project;
+                }
+            }
+            if !author.is_empty() && seq > 0 {
+                let next = manifest.intent_seq.entry(author.clone()).or_insert(1);
+                if *next <= seq {
+                    *next = seq + 1;
+                }
+            }
+
+            manifest.intents.insert(
+                human_key.clone(),
+                IntentSummary {
+                    status: text("status").unwrap_or_else(|| "backlog".to_string()),
+                    priority: text("priority").unwrap_or_else(|| "medium".to_string()),
+                    assignee: text("assignee"),
+                    goals: fm
+                        .get("goals")
+                        .and_then(|v| v.as_array())
+                        .map(|a| a.len() as u32)
+                        .unwrap_or(0),
+                    blocked_by: fm
+                        .get("blocked_by")
+                        .and_then(|v| v.as_array())
+                        .map(|a| {
+                            a.iter()
+                                .filter_map(|b| b.as_str().map(str::to_owned))
+                                .collect()
+                        })
+                        .unwrap_or_default(),
+                    title: text("title").unwrap_or_default(),
+                    vault_path: meta.path.clone(),
+                    uid: text("uid").unwrap_or_default(),
+                    human_key: human_key.clone(),
+                    project: text("project").unwrap_or_default(),
+                    author,
+                    seq,
+                    session: text("session"),
+                    turn: fm.get("turn").and_then(|v| v.as_u64()).map(|t| t as u32),
+                },
+            );
+            added += 1;
+        }
+
+        if added > 0 {
+            manifest.updated_at = chrono::Utc::now().to_rfc3339();
+            txn.put_vault_manifest(&manifest)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+            txn.commit()
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        }
+        Ok(added)
+    }
+
     /// List vault intents.
     ///
     /// Optionally filtered by status. Pass `Some("all")` or `None` for all intents.
@@ -1050,6 +1179,67 @@ mod tests {
             session_id: None,
             turn_id: None,
         }
+    }
+
+    /// Reproduces the clone-inheritance gap: an intent file that arrives as
+    /// bytes (clone materializes it; `vault sync` deflates it) must become
+    /// listable and resolvable — `vault_intent_create` never runs on the
+    /// receiving side, so the sync path itself must index the entry.
+    #[test]
+    fn ingested_intent_is_indexed_by_vault_sync() {
+        // Author repo: create an intent the normal way.
+        let author_dir = tempdir().unwrap();
+        let author = init_repo_with_vault(author_dir.path());
+        let created = author
+            .vault_intent_create(create_opts_manual("Inherited intent"))
+            .unwrap();
+
+        // Receiver repo: inherit only the materialized intent file — exactly
+        // what clone delivers.
+        let receiver_dir = tempdir().unwrap();
+        let receiver = init_repo_with_vault(receiver_dir.path());
+        let src = author_dir.path().join(".vault").join(&created.intent_file);
+        let dst = receiver_dir.path().join(".vault").join(&created.intent_file);
+        fs::create_dir_all(dst.parent().unwrap()).unwrap();
+        fs::copy(&src, &dst).unwrap();
+
+        // Sync deflates the inherited file into redb…
+        let synced = receiver.vault_record_working_copy().unwrap();
+        assert!(
+            synced.iter().any(|p| p == &created.intent_file),
+            "sync should ingest the inherited file, got: {synced:?}"
+        );
+
+        // …and must also index it: the list shows it and the human key
+        // resolves.
+        let intents = receiver.vault_intent_list(None).unwrap();
+        assert_eq!(intents.len(), 1, "inherited intent must appear in the list");
+        assert_eq!(intents[0].id, created.id);
+        assert_eq!(intents[0].title, "Inherited intent");
+        assert_eq!(
+            receiver.resolve_intent_key(&created.id).unwrap(),
+            created.id
+        );
+
+        // The allocator must not re-issue the inherited seq for the same
+        // author — a later local create gets a fresh human key.
+        let second = receiver
+            .vault_intent_create(create_opts_manual("New local intent"))
+            .unwrap();
+        assert_ne!(
+            second.id, created.id,
+            "allocator must not collide with inherited human keys"
+        );
+        assert_eq!(
+            receiver.vault_intent_list(None).unwrap().len(),
+            2,
+            "both intents must be listed"
+        );
+
+        // Reconciliation is idempotent: a second sync with nothing to do
+        // leaves the index intact.
+        receiver.vault_record_working_copy().unwrap();
+        assert_eq!(receiver.vault_intent_list(None).unwrap().len(), 2);
     }
 
     #[test]

--- a/tests/harness/26_vault_intent_inherit.sh
+++ b/tests/harness/26_vault_intent_inherit.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# 26_vault_intent_inherit.sh — Inherited intents/memories become queryable.
+#
+# Spec for the clone → `atomic vault sync` → queryable contract (the flow
+# Lee described for option 1): when User B inherits User A's vault content
+# through changes, B's local index must make it addressable — not just
+# present as bytes.
+#
+# Regression guard for the manifest-index gap: intent entries used to reach
+# redb through the ingestion path (`update_manifest_for_store` leaves intent
+# summaries to "higher-level methods"), so `vault list` showed the entry but
+# `intent list` read an empty manifest and bare-number references resolved
+# through a freshly derived — wrong — prefix.
+#
+# Invariants tested on the receiving side, after `atomic vault sync`:
+#
+#   1. `intent list` shows the inherited intent under its ORIGINAL human key
+#   2. `intent show <human-key>` and `intent show <bare-seq>` both resolve
+#   3. `memory list` shows the inherited memory
+#   4. A locally created intent allocates the NEXT seq — it never re-issues
+#      an inherited human key (allocator advanced past inherited entries)
+#   5. A second `vault sync` is idempotent — nothing duplicated or lost
+
+HARNESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$HARNESS_DIR/helpers.sh"
+
+echo ""
+echo "${BOLD}══════════════════════════════════════════════════════════════${RESET}"
+echo "${BOLD}  Suite: 26_vault_intent_inherit${RESET}"
+echo "${BOLD}══════════════════════════════════════════════════════════════${RESET}"
+
+# ── Helper: copy all change files from one repo to another ──────────────
+
+copy_all_changes() {
+    local src_changes="$1/.atomic/changes"
+    local dst_changes="$2/.atomic/changes"
+
+    find "$src_changes" -name "*.change" -type f 2>/dev/null | while read -r f; do
+        local rel="${f#$src_changes/}"
+        local dst_dir="$dst_changes/$(dirname "$rel")"
+        mkdir -p "$dst_dir"
+        cp "$f" "$dst_dir/"
+    done
+}
+
+get_change_hashes() {
+    find "$1/.atomic/changes" -name "*.change" -type f 2>/dev/null \
+        | sort | xargs -I{} basename {} .change
+}
+
+# Extract the first PROJECT::author::seq human key from `intent list` output.
+first_human_key() {
+    atomic intent list 2>/dev/null | grep -oE '[^ ]+::[^ ]+::[0-9]+' | head -1
+}
+
+# ════════════════════════════════════════════════════════════════════════════
+begin_section "User A: create intent + memory, record"
+# ════════════════════════════════════════════════════════════════════════════
+
+make_temp_repo "vault-inherit-A"
+REPO_A="$REPO_DIR"
+init_repo --vault
+
+atomic intent new "Inherited from A" >/dev/null 2>&1
+A_KEY="$(first_human_key)"
+if [[ -n "$A_KEY" ]]; then
+    _pass "User A: intent created ($A_KEY)"
+else
+    _fail "User A: intent created" "no human key in intent list"
+fi
+A_SEQ="${A_KEY##*::}"
+
+atomic memory new --kind lesson --id inherited-note \
+    --text "Vault entries must survive inheritance." >/dev/null 2>&1
+assert_output_contains "User A: memory listed" "inherited-note" \
+    atomic memory list
+
+record_change "vault: intent + memory" -a >/dev/null 2>&1 || true
+
+A_HASHES="$(get_change_hashes "$REPO_A")"
+if [[ -n "$A_HASHES" ]]; then
+    _pass "User A: recorded vault content"
+else
+    _fail "User A: recorded vault content" "no change files produced"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+begin_section "User B: inherit changes, bootstrap, vault sync"
+# ════════════════════════════════════════════════════════════════════════════
+
+make_temp_repo "vault-inherit-B"
+REPO_B="$REPO_DIR"
+init_repo --no-vault
+
+copy_all_changes "$REPO_A" "$REPO_B"
+cd "$REPO_B"
+for hash in $A_HASHES; do
+    atomic insert "$hash" --view dev >/dev/null 2>&1 || true
+done
+atomic view switch dev >/dev/null 2>&1 || true
+assert_file_exists "User B: inherited memory materialized" \
+    ".vault/memory/inherited-note.md"
+
+# Bootstrap the vault tables from the materialized files (clone does this
+# automatically; we simulated the transfer with insert), then sync.
+atomic vault init >/dev/null 2>&1 || true
+atomic vault sync >/dev/null 2>&1 || true
+
+# ════════════════════════════════════════════════════════════════════════════
+begin_section "User B: inherited intent + memory are queryable"
+# ════════════════════════════════════════════════════════════════════════════
+
+assert_output_contains "User B: intent list shows inherited key" "$A_KEY" \
+    atomic intent list
+
+assert_output_contains "User B: intent show <human-key> resolves" \
+    "Inherited from A" atomic intent show "$A_KEY"
+
+assert_output_contains "User B: intent show <bare-seq> resolves" \
+    "Inherited from A" atomic intent show "$A_SEQ"
+
+assert_output_contains "User B: memory list shows inherited memory" \
+    "inherited-note" atomic memory list
+
+# ════════════════════════════════════════════════════════════════════════════
+begin_section "User B: local create allocates next seq; sync is idempotent"
+# ════════════════════════════════════════════════════════════════════════════
+
+atomic intent new "Created on B" >/dev/null 2>&1
+
+B_LIST="$(atomic intent list 2>/dev/null)"
+B_COUNT="$(echo "$B_LIST" | grep -cE '[^ ]+::[^ ]+::[0-9]+' || true)"
+if [[ "$B_COUNT" == "2" ]]; then
+    _pass "User B: both intents listed after local create"
+else
+    _fail "User B: both intents listed" "expected 2 keys, got $B_COUNT: $B_LIST"
+fi
+
+if [[ "$(echo "$B_LIST" | grep -oE '[^ ]+::[^ ]+::[0-9]+' | sort -u | wc -l | tr -d ' ')" == "2" ]]; then
+    _pass "User B: local intent got a fresh key (no collision with $A_KEY)"
+else
+    _fail "User B: allocator collision" "duplicate human keys: $B_LIST"
+fi
+
+atomic vault sync >/dev/null 2>&1 || true
+B_COUNT_AFTER="$(atomic intent list 2>/dev/null | grep -cE '[^ ]+::[^ ]+::[0-9]+' || true)"
+if [[ "$B_COUNT_AFTER" == "2" ]]; then
+    _pass "User B: second vault sync is idempotent"
+else
+    _fail "User B: second vault sync" "expected 2 keys, got $B_COUNT_AFTER"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+
+print_summary


### PR DESCRIPTION
## What

`atomic vault sync` now rebuild `manifest.intents` from stored intent entries: fills in summaries the manifest is missing, adopts the authoring repo's intent prefix when the local one is unset, and advances the per-author seq allocator past inherited keys. Authoring-path summaries are never overwritten; the pass is idempotent.

## Why

The clone → `vault sync` → queryable flow was broken for intents. The entry arrived fine (`vault list` / `vault show` / `memory list` all worked) but `intent list` returned nothing and `intent show 1` resolved a freshly derived — wrong — prefix.

Root cause: `intent list` reads the manifest index, and the only writer of `manifest.intents` was `vault_intent_create` — which never runs on the receiving side. The ingestion path (`update_manifest_for_store`) deliberately leaves intent summaries to "higher-level methods" (`_ => {}`), so inherited intents existed in redb but were never indexed. And `vault sync`'s dirty-check only compares disk files vs entries, so it reported "Vault is up to date" and could never repair the gap.

Reproduces on dev and on the branch off #150 (two repos + `cp` + `vault sync`, no server needed):

```
repo B:  vault sync      → Synced 1 vault files
         vault list      → intent entry present
         intent list     → No intents found        ← bug
         intent show 1   → 'VAULT::…::1' not found ← wrong prefix too
```

## Test plan

- [x] New unit test `ingested_intent_is_indexed_by_vault_sync` — written first (failed at "inherited intent must appear in the list"), passes with the fix; covers prefix adoption, allocator advance, idempotency
- [x] **New harness item `tests/harness/26_vault_intent_inherit.sh`** — scripts the full inherit → bootstrap → sync → query contract (11 assertions). Fails 5 on unfixed dev — including a real human-key collision where a local create on the receiver re-issues the inherited key — and passes 11/11 with the fix. Auto-discovered by `run_all.sh`.
- [x] Full `cargo test -p atomic-repository` green (831 tests)
- [x] CLI end-to-end: `intent list` / `intent show 1` work on the receiver; a new local intent allocates the next seq