### PR TITLE
fix(agent): record the view a sandboxed session forked from

### DIFF
--- a/atomic-agent/src/turn/orchestrator/session_end.rs
+++ b/atomic-agent/src/turn/orchestrator/session_end.rs
@@ -60,7 +60,10 @@ impl TurnOrchestrator {
             // makes `record_turn` see a view mismatch and record nothing. Align
             // explicitly so the agent's uncommitted files are recorded on the
             // agent view. Best-effort — non-fatal if it can't switch.
-            match atomic_repository::Repository::open_existing(&self.repo_root) {
+            // Doubles as the "is there a worktree to protect?" answer for the
+            // failed-flush guard below, which is why it is captured rather
+            // than discarded. See there.
+            let has_worktree = match atomic_repository::Repository::open_existing(&self.repo_root) {
                 Ok(mut repo) => {
                     if repo.current_view() != session.view_name {
                         if let Err(e) = repo.align_to_view(&session.view_name) {
@@ -76,12 +79,16 @@ impl TurnOrchestrator {
                             );
                         }
                     }
+                    true
                 }
-                Err(e) => log::warn!(
-                    "SessionEnd: could not open repo to align view: {} (non-fatal)",
-                    e
-                ),
-            }
+                Err(e) => {
+                    log::warn!(
+                        "SessionEnd: could not open repo to align view: {} (non-fatal)",
+                        e
+                    );
+                    false
+                }
+            };
 
             let prompt = event
                 .prompt
@@ -132,7 +139,16 @@ impl TurnOrchestrator {
                     // working copy on the agent view so its unrecorded work
                     // remains visible and recoverable. Repo-less orchestrator
                     // tests and integrations have no worktree to protect.
-                    if session.parent_view.is_some() {
+                    //
+                    // This asks the question directly. It used to ask whether
+                    // the session had a `parent_view`, which was a stand-in
+                    // for the same thing — only the branch that opens a real
+                    // repository set one — and a stand-in that quietly
+                    // excluded sandboxes, whose unrecorded work is exactly
+                    // what most needs protecting. It would also have changed
+                    // meaning under anything that recorded a parent more
+                    // often, which is a trap for the next reader.
+                    if has_worktree {
                         return Err(e);
                     }
                 }

--- a/atomic-agent/src/turn/orchestrator/session_start.rs
+++ b/atomic-agent/src/turn/orchestrator/session_start.rs
@@ -193,10 +193,43 @@ impl TurnOrchestrator {
                             );
                         }
                     }
+                    // Record where the sandbox's view forked from. Not the
+                    // current view — inside a sandbox that IS the run's own
+                    // view, so it would name itself as its own parent. The
+                    // graph already knows: `sandbox create --from <base>`
+                    // stored the fork as the view's parent, so this is a read
+                    // of a recorded fact, and it stays within the constraints
+                    // above — no fork, no switch, nothing written.
+                    //
+                    // Without it a sandboxed session is the one kind that
+                    // reaches the ledger with `parent_view: null`, and every
+                    // reader downstream — `session show`, a UI grouping runs
+                    // by where they came from — has nothing to say about work
+                    // that plainly came from somewhere.
+                    match repo.get_view_info(&current) {
+                        Ok(info) => match info.parent_name {
+                            Some(parent) => session.set_parent_view(&parent),
+                            // A root view genuinely has no parent. Leaving the
+                            // field empty is the honest answer, not a failure.
+                            None => log::debug!(
+                                "Sandbox view '{}' is a root view — no parent to record",
+                                current,
+                            ),
+                        },
+                        Err(e) => log::debug!(
+                            "Could not read the parent of sandbox view '{}': {} — \
+                             continuing without it",
+                            current,
+                            e,
+                        ),
+                    }
+
                     log::info!(
-                        "Sandbox session {}: recording on provisioned view '{}' (no fork/switch)",
+                        "Sandbox session {}: recording on provisioned view '{}' \
+                         (forked from '{}'; no fork/switch)",
                         session_id,
                         current,
+                        session.parent_view.as_deref().unwrap_or("—"),
                     );
                     session.view_name = current;
                 }

--- a/atomic-agent/src/turn/orchestrator/tests.rs
+++ b/atomic-agent/src/turn/orchestrator/tests.rs
@@ -165,9 +165,15 @@ async fn test_session_start_in_sandbox_adopts_view_without_forking() {
     // The session records on the sandbox's own view — not a freshly forked one.
     let session = orch.session_store.load("sess-sbx").unwrap().unwrap();
     assert_eq!(session.view_name, "agent-sbx");
-    assert!(
-        session.parent_view.is_none(),
-        "sandbox session must not fork a child view"
+    // And it says where that view came from. This used to assert `is_none()`
+    // under the heading "must not fork a child view", which conflated two
+    // different things: not forking, and having nothing to say about the fork
+    // that already happened. Only the first is an invariant, and the canonical
+    // -graph assertions below are what actually enforce it.
+    assert_eq!(
+        session.parent_view.as_deref(),
+        Some(user_view.as_str()),
+        "a sandboxed session should record the view its sandbox forked from"
     );
 
     // The canonical graph is untouched: no spurious agent view was forked and
@@ -181,6 +187,66 @@ async fn test_session_start_in_sandbox_adopts_view_without_forking() {
         "sandbox session must not fork a new view into the canonical graph"
     );
     assert_eq!(canonical_after.current_view(), user_view);
+}
+
+#[tokio::test]
+async fn test_sandbox_session_records_the_draft_it_forked_from() {
+    // A sandbox forked from another DRAFT, not from the trunk. The parent is
+    // the view it actually came from — the immediate one, matching what the
+    // non-sandbox path records — rather than the nearest shared ancestor.
+    let canonical = TempDir::new().unwrap();
+    let mut repo = Repository::init(canonical.path()).unwrap();
+    let trunk = repo.current_view().to_string(); // "dev"
+    repo.create_view_from("feature-x", &trunk).unwrap();
+    repo.create_view_from("agent-sbx", "feature-x").unwrap();
+
+    let sandbox_dir = TempDir::new().unwrap();
+    repo.provision_sandbox(sandbox_dir.path(), "agent-sbx")
+        .unwrap();
+    drop(repo);
+
+    let session_store = SessionStore::for_repo(sandbox_dir.path()).unwrap();
+    let watcher = FallbackWatcher::new(WatcherConfig::new(sandbox_dir.path()));
+    let mut orch =
+        TurnOrchestrator::with_watcher(sandbox_dir.path(), session_store, Box::new(watcher));
+
+    orch.dispatch(session_start_event("sess-draft-parent"))
+        .await
+        .unwrap();
+
+    let session = orch
+        .session_store
+        .load("sess-draft-parent")
+        .unwrap()
+        .unwrap();
+    assert_eq!(session.view_name, "agent-sbx");
+    assert_eq!(session.parent_view.as_deref(), Some("feature-x"));
+}
+
+#[tokio::test]
+async fn test_sandbox_session_on_a_root_view_records_no_parent() {
+    // Nothing to report, and saying so is the honest answer: a root view has
+    // no fork behind it. The point is that this does not error or invent one.
+    let canonical = TempDir::new().unwrap();
+    let mut repo = Repository::init(canonical.path()).unwrap();
+    let root = repo.current_view().to_string(); // "dev", created with no parent
+
+    let sandbox_dir = TempDir::new().unwrap();
+    repo.provision_sandbox(sandbox_dir.path(), &root).unwrap();
+    drop(repo);
+
+    let session_store = SessionStore::for_repo(sandbox_dir.path()).unwrap();
+    let watcher = FallbackWatcher::new(WatcherConfig::new(sandbox_dir.path()));
+    let mut orch =
+        TurnOrchestrator::with_watcher(sandbox_dir.path(), session_store, Box::new(watcher));
+
+    orch.dispatch(session_start_event("sess-root"))
+        .await
+        .unwrap();
+
+    let session = orch.session_store.load("sess-root").unwrap().unwrap();
+    assert_eq!(session.view_name, root);
+    assert!(session.parent_view.is_none());
 }
 
 #[tokio::test]

--- a/atomic-agent/src/turn/orchestrator/tests.rs
+++ b/atomic-agent/src/turn/orchestrator/tests.rs
@@ -228,7 +228,9 @@ async fn test_sandbox_session_on_a_root_view_records_no_parent() {
     // Nothing to report, and saying so is the honest answer: a root view has
     // no fork behind it. The point is that this does not error or invent one.
     let canonical = TempDir::new().unwrap();
-    let mut repo = Repository::init(canonical.path()).unwrap();
+    // Not `mut`, unlike its siblings: this one forks no view, so nothing here
+    // needs a mutable handle.
+    let repo = Repository::init(canonical.path()).unwrap();
     let root = repo.current_view().to_string(); // "dev", created with no parent
 
     let sandbox_dir = TempDir::new().unwrap();


### PR DESCRIPTION
A session started inside a sandbox reached the ledger with `parent_view: null` — the only kind of session with that hole.

Not a decision: SessionStart skips the fork in a sandbox (correctly — forking would inject a view into the canonical graph, switching would clobber the user's current view), and the parent was only ever set by the branch that forks.

Recording it needs no fork. `sandbox create --from <base>` already stored the parent on the view, so this reads back what atomic wrote. Reports the immediate parent, matching the non-sandbox branch; a root view stays empty.

Same repo, same `--from dev`, same session-start payload:

| | `parent_view` |
|---|---|
| 0.14.0 | `null` |
| this | `"dev"` |

**Look here:** the first commit changes error-path behaviour. SessionEnd decided whether it had a worktree to protect by asking `parent_view.is_some()` — a stand-in that excluded sandboxes. It now asks directly, reusing the repo handle opened just above. Separated so it is reviewable on its own.

The existing sandbox test asserted `parent_view.is_none()` under "must not fork a child view"; the no-fork invariant is still asserted by the canonical-graph checks below it. Two tests added.

`cargo test --workspace`, `clippy -D warnings`, `fmt --check` all pass.