### PR TITLE
feat(agent): atomic-skills shared source + AGENTS.md-into-repo + bundled-agent stitch

### DIFF
--- a/atomic-agent/src/integrations/install.rs
+++ b/atomic-agent/src/integrations/install.rs
@@ -30,6 +30,14 @@ pub struct InstallOptions {
     /// When set, the package manifest's `agent` field must match — guards
     /// against installing the wrong package with `--from`.
     pub expect_agent: Option<String>,
+    /// Path to the cloned `atomic-skills` cache. Required when the manifest
+    /// declares `[skills-source]` or `[agent-definition]`. The CLI syncs
+    /// the cache before calling `install_from_dir`.
+    pub skills_cache_dir: Option<PathBuf>,
+    /// Repository root for `[[repo-file]]` entries (AGENTS.md-into-repo).
+    /// When `None`, `[[repo-file]]` entries are skipped silently — the caller
+    /// gates this via the `--repo-agents` prompt.
+    pub repo_root: Option<PathBuf>,
 }
 
 /// Why a destination file was left untouched.
@@ -128,35 +136,170 @@ pub fn install_from_dir(pkg_dir: &Path, opts: &InstallOptions) -> AgentResult<In
             });
         }
         let dst = expand_dst(&entry.dst)?;
+        copy_one(
+            &manifest.agent,
+            &src,
+            &dst,
+            previous.as_ref(),
+            opts.force,
+            &mut installed,
+            &mut refreshed,
+            &mut skipped,
+            &mut receipt_files,
+        )?;
+    }
 
-        match install_decision(&dst, previous.as_ref(), opts.force)? {
-            Decision::Install => installed.push(dst.clone()),
-            Decision::Refresh => refreshed.push(dst.clone()),
+    // Skills from the shared atomic-skills cache.
+    if !manifest.skills.is_empty() {
+        let cache = opts.skills_cache_dir.as_deref().ok_or_else(|| {
+            AgentError::Integration {
+                agent: manifest.agent.clone(),
+                reason: "manifest declares [[skill]] entries but no skills cache was \
+                         provided (expected [skills-source] to be synced by the CLI)"
+                    .to_string(),
+            }
+        })?;
+        for entry in &manifest.skills {
+            reject_parent_traversal(&manifest.agent, &entry.src)?;
+            let src = cache.join(&entry.src);
+            if !src.is_file() {
+                return Err(AgentError::Integration {
+                    agent: manifest.agent.clone(),
+                    reason: format!("skill source missing: {}", src.display()),
+                });
+            }
+            let dst = expand_dst(&entry.dst)?;
+            copy_one(
+                &manifest.agent,
+                &src,
+                &dst,
+                previous.as_ref(),
+                opts.force,
+                &mut installed,
+                &mut refreshed,
+                &mut skipped,
+                &mut receipt_files,
+            )?;
+        }
+    }
+
+    // Repo-level files (AGENTS.md into the repo root). Only when the caller
+    // passed a repo_root — gated by the --agents-md prompt in the CLI.
+    // Unlike [[file]] and [[skill]], a repo-file that exists but isn't ours
+    // is *merged* (canonical content appended with a separator) rather than
+    // skipped — the user's project-specific AGENTS.md content is preserved.
+    if !manifest.repo_files.is_empty() {
+        if let Some(repo) = opts.repo_root.as_deref() {
+            for entry in &manifest.repo_files {
+                reject_parent_traversal(&manifest.agent, &entry.src)?;
+                // src comes from the skills cache (or the package if no
+                // skills-source is set — uncommon but valid).
+                let src_base = opts
+                    .skills_cache_dir
+                    .as_deref()
+                    .unwrap_or(pkg_dir);
+                let src = src_base.join(&entry.src);
+                if !src.is_file() {
+                    return Err(AgentError::Integration {
+                        agent: manifest.agent.clone(),
+                        reason: format!("repo-file source missing: {}", src.display()),
+                    });
+                }
+                // dst is relative to the repo root.
+                let dst = expand_repo_dst(&entry.dst, repo)?;
+                copy_repo_file(
+                    &src,
+                    &dst,
+                    previous.as_ref(),
+                    opts.force,
+                    &mut installed,
+                    &mut refreshed,
+                    &mut skipped,
+                    &mut receipt_files,
+                )?;
+            }
+        }
+    }
+
+    // Bundled agent definition: stitch frontmatter + canonical body at install
+    // time. Pure string concat — no exec, same safety category as fs::copy.
+    if let Some(def) = &manifest.agent_definition {
+        let cache = opts.skills_cache_dir.as_deref().ok_or_else(|| {
+            AgentError::Integration {
+                agent: manifest.agent.clone(),
+                reason: "manifest declares [agent-definition] but no skills cache \
+                         was provided (needed for body_from)"
+                    .to_string(),
+            }
+        })?;
+        reject_parent_traversal(&manifest.agent, &def.src)?;
+        let frontmatter_path = pkg_dir.join(&def.src);
+        let frontmatter = std::fs::read_to_string(&frontmatter_path).map_err(|e| {
+            AgentError::Integration {
+                agent: manifest.agent.clone(),
+                reason: format!(
+                    "agent-definition frontmatter missing: {}: {}",
+                    frontmatter_path.display(),
+                    e
+                ),
+            }
+        })?;
+        let body_path =
+            manifest
+                .resolve_body_from(&def.body_from, cache)
+                .ok_or_else(|| AgentError::Integration {
+                    agent: manifest.agent.clone(),
+                    reason: format!(
+                        "agent-definition body_from '{}' is malformed or does not \
+                         match the skills-source package",
+                        def.body_from
+                    ),
+                })?;
+        let body = std::fs::read_to_string(&body_path).map_err(|e| {
+            AgentError::Integration {
+                agent: manifest.agent.clone(),
+                reason: format!(
+                    "agent-definition body missing: {}: {}",
+                    body_path.display(),
+                    e
+                ),
+            }
+        })?;
+        let stitched = format!("{frontmatter}\n\n{body}");
+        let slot = expand_dst(&def.slot)?;
+
+        match install_decision(&slot, previous.as_ref(), opts.force)? {
+            Decision::Install => installed.push(slot.clone()),
+            Decision::Refresh => refreshed.push(slot.clone()),
+            // Merge only applies to [[repo-file]] (via repo_file_decision).
+            // install_decision never returns Merge for an agent-definition
+            // slot — treat it as a refresh if it somehow occurs.
+            Decision::Merge => refreshed.push(slot.clone()),
             Decision::Skip(reason) => {
                 skipped.push(SkippedFile {
-                    dst: dst.clone(),
+                    dst: slot.clone(),
                     reason,
                 });
-                // Keep protecting this file: preserve any prior receipt entry
-                // so a later --force still knows whether it was ours.
                 if let Some(old) = previous
                     .as_ref()
-                    .and_then(|r| r.files.iter().find(|f| f.dst == dst))
+                    .and_then(|r| r.files.iter().find(|f| f.dst == slot))
                 {
                     receipt_files.push(old.clone());
                 }
-                continue;
+                // We don't write the stitched content, but we still proceed.
             }
         }
 
-        if let Some(parent) = dst.parent() {
-            std::fs::create_dir_all(parent)?;
+        if !skipped.iter().any(|s| s.dst == slot) {
+            if let Some(parent) = slot.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(&slot, &stitched)?;
+            receipt_files.push(ReceiptFile {
+                blake3: hash_file(&slot)?,
+                dst: slot,
+            });
         }
-        std::fs::copy(&src, &dst)?;
-        receipt_files.push(ReceiptFile {
-            blake3: hash_file(&dst)?,
-            dst,
-        });
     }
 
     let mut settings_outcomes = Vec::new();
@@ -266,8 +409,15 @@ pub fn uninstall(agent: &str) -> AgentResult<UninstallOutcome> {
 enum Decision {
     Install,
     Refresh,
+    Merge,
     Skip(SkipReason),
 }
+
+/// The Atomic marker that identifies a file as already containing the
+/// canonical Atomic workflow instructions. Used to distinguish "user's own
+/// AGENTS.md" from "has Atomic content already (maybe from a prior install
+/// or copy)".
+const ATOMIC_MARKER: &str = "# Atomic VCS Agent";
 
 /// Decide what to do with a destination that may already exist.
 fn install_decision(dst: &Path, previous: Option<&Receipt>, force: bool) -> AgentResult<Decision> {
@@ -282,6 +432,41 @@ fn install_decision(dst: &Path, previous: Option<&Receipt>, force: bool) -> Agen
         Some(_) if !force => Ok(Decision::Skip(SkipReason::UserModified)),
         // Not ours → hands off unless forced.
         None if !force => Ok(Decision::Skip(SkipReason::UserFile)),
+        _ => Ok(Decision::Refresh),
+    }
+}
+
+/// Decide what to do with a [[repo-file]] destination. Unlike [[file]] and
+/// [[skill]], a repo-file that exists but isn't ours can be *merged* — the
+/// canonical content is appended with a separator, preserving the user's
+/// existing content. If the file already contains the Atomic marker, it's
+/// treated as a refresh (replace the whole file).
+fn repo_file_decision(
+    dst: &Path,
+    previous: Option<&Receipt>,
+    force: bool,
+) -> AgentResult<Decision> {
+    if !dst.exists() {
+        return Ok(Decision::Install);
+    }
+    let recorded = previous.and_then(|r| r.recorded_hash(dst));
+    match recorded {
+        // Ours and untouched since install → safe to refresh.
+        Some(hash) if hash == hash_file(dst)? => Ok(Decision::Refresh),
+        // Ours but the user changed it → hands off unless forced.
+        Some(_) if !force => Ok(Decision::Skip(SkipReason::UserModified)),
+        // Not ours. If it already has the Atomic marker, treat as refresh
+        // (replace the whole file — it's Atomic content, just not from this
+        // receipt). Otherwise merge (append with separator).
+        None if !force => {
+            let existing = std::fs::read_to_string(dst).unwrap_or_default();
+            if existing.contains(ATOMIC_MARKER) {
+                Ok(Decision::Refresh)
+            } else {
+                Ok(Decision::Merge)
+            }
+        }
+        // --force: clobber everything.
         _ => Ok(Decision::Refresh),
     }
 }
@@ -303,6 +488,140 @@ fn expand_dst(dst: &str) -> AgentResult<PathBuf> {
             });
     }
     Ok(PathBuf::from(dst))
+}
+
+/// Resolve a `[[repo-file]]` destination against the repository root.
+/// `dst` must be a relative path (no `~`, no absolute) — it lands inside the
+/// repo. Rejects parent traversal so a manifest can't write outside the repo.
+fn expand_repo_dst(dst: &str, repo_root: &Path) -> AgentResult<PathBuf> {
+    if dst.starts_with('/') || dst.starts_with('~') {
+        return Err(AgentError::Integration {
+            agent: "<any>".to_string(),
+            reason: format!(
+                "repo-file dst '{dst}' must be relative to the repo root, not absolute or home"
+            ),
+        });
+    }
+    if dst.split('/').any(|c| c == "..") {
+        return Err(AgentError::Integration {
+            agent: "<any>".to_string(),
+            reason: format!("repo-file dst '{dst}' must not escape the repo root"),
+        });
+    }
+    Ok(repo_root.join(dst))
+}
+
+/// Copy one file into place with the standard install-decision logic.
+/// Shared by [[file]], [[skill]], and [[repo-file]] entries.
+#[allow(clippy::too_many_arguments)]
+fn copy_one(
+    agent: &str,
+    src: &Path,
+    dst: &Path,
+    previous: Option<&Receipt>,
+    force: bool,
+    installed: &mut Vec<PathBuf>,
+    refreshed: &mut Vec<PathBuf>,
+    skipped: &mut Vec<SkippedFile>,
+    receipt_files: &mut Vec<ReceiptFile>,
+) -> AgentResult<()> {
+    let _ = agent; // used only in error context by callers
+    match install_decision(dst, previous, force)? {
+        Decision::Install => installed.push(dst.to_path_buf()),
+        Decision::Refresh => refreshed.push(dst.to_path_buf()),
+        // Merge only applies to [[repo-file]] (via copy_repo_file). For
+        // [[file]] and [[skill]], install_decision never returns Merge —
+        // treat as a refresh if it somehow occurs.
+        Decision::Merge => refreshed.push(dst.to_path_buf()),
+        Decision::Skip(reason) => {
+            skipped.push(SkippedFile {
+                dst: dst.to_path_buf(),
+                reason,
+            });
+            // Keep protecting this file: preserve any prior receipt entry
+            // so a later --force still knows whether it was ours.
+            if let Some(old) = previous.and_then(|r| r.files.iter().find(|f| f.dst == dst)) {
+                receipt_files.push(old.clone());
+            }
+            return Ok(());
+        }
+    }
+
+    if let Some(parent) = dst.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::copy(src, dst)?;
+    receipt_files.push(ReceiptFile {
+        blake3: hash_file(dst)?,
+        dst: dst.to_path_buf(),
+    });
+    Ok(())
+}
+
+/// Copy a [[repo-file]] into the repo root, with merge support.
+///
+/// Unlike [[file]] and [[skill]] (which use `copy_one`), a repo-file that
+/// exists but isn't ours is *merged* — the canonical content is appended
+/// with a markdown horizontal rule separator, preserving the user's
+/// existing project-specific content above. If the file already contains
+/// the Atomic marker (`# Atomic VCS Agent`), it's treated as a refresh
+/// (replace the whole file). `--force` always clobbers.
+#[allow(clippy::too_many_arguments)]
+fn copy_repo_file(
+    src: &Path,
+    dst: &Path,
+    previous: Option<&Receipt>,
+    force: bool,
+    installed: &mut Vec<PathBuf>,
+    refreshed: &mut Vec<PathBuf>,
+    skipped: &mut Vec<SkippedFile>,
+    receipt_files: &mut Vec<ReceiptFile>,
+) -> AgentResult<()> {
+    match repo_file_decision(dst, previous, force)? {
+        Decision::Install => {
+            if let Some(parent) = dst.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::copy(src, dst)?;
+            installed.push(dst.to_path_buf());
+            receipt_files.push(ReceiptFile {
+                blake3: hash_file(dst)?,
+                dst: dst.to_path_buf(),
+            });
+        }
+        Decision::Refresh => {
+            std::fs::copy(src, dst)?;
+            refreshed.push(dst.to_path_buf());
+            receipt_files.push(ReceiptFile {
+                blake3: hash_file(dst)?,
+                dst: dst.to_path_buf(),
+            });
+        }
+        Decision::Merge => {
+            // Append the canonical content to the user's existing file with
+            // a markdown horizontal rule separator. The user's content is
+            // preserved above; the Atomic workflow content goes below.
+            let existing = std::fs::read_to_string(dst)?;
+            let canonical = std::fs::read_to_string(src)?;
+            let merged = format!("{existing}\n\n---\n\n{canonical}");
+            std::fs::write(dst, merged)?;
+            installed.push(dst.to_path_buf());
+            receipt_files.push(ReceiptFile {
+                blake3: hash_file(dst)?,
+                dst: dst.to_path_buf(),
+            });
+        }
+        Decision::Skip(reason) => {
+            skipped.push(SkippedFile {
+                dst: dst.to_path_buf(),
+                reason,
+            });
+            if let Some(old) = previous.and_then(|r| r.files.iter().find(|f| f.dst == dst)) {
+                receipt_files.push(old.clone());
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Reject `src` paths that would escape the package directory.
@@ -390,6 +709,8 @@ manifest = "hooks/hooks.json"
             cli_version: "0.11.1".to_string(),
             source: "test".to_string(),
             expect_agent: None,
+            skills_cache_dir: None,
+            repo_root: None,
         }
     }
 
@@ -569,6 +890,500 @@ manifest = "hooks/hooks.json"
         .unwrap();
         let err = install_from_dir(pkg.path(), &opts(false)).unwrap_err();
         assert!(err.to_string().contains("must be a relative path"));
+        std::env::remove_var("ATOMIC_INTEGRATIONS_HOME");
+    }
+
+    // ── New install paths: skills, repo-file, agent-definition ──────────
+
+    /// Build a fake skills cache (mimics atomic-skills/) with AGENTS.md and
+    /// one skill.
+    fn fake_skills_cache() -> tempfile::TempDir {
+        let cache = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(cache.path().join("skills/atomic-vault")).unwrap();
+        std::fs::write(cache.path().join("AGENTS.md"), "# Atomic VCS Agent\n\ncanonical body\n").unwrap();
+        std::fs::write(
+            cache.path().join("skills/atomic-vault/SKILL.md"),
+            "# atomic-vault skill\n",
+        )
+        .unwrap();
+        cache
+    }
+
+    /// Build a fake plugin that uses [skills-source] + [[skill]].
+    fn fake_plugin_with_skills(agent: &str, dst_dir: &Path) -> tempfile::TempDir {
+        let pkg = tempfile::tempdir().unwrap();
+        std::fs::write(
+            pkg.path().join(MANIFEST_FILE),
+            format!(
+                r#"
+schema = 1
+agent = "{agent}"
+version = "1.0.0"
+
+[requires]
+atomic = ">=0.1.0"
+
+[skills-source]
+package = "atomic-skills"
+
+[[skill]]
+src = "skills/atomic-vault/SKILL.md"
+dst = "{0}/skills/atomic-vault/SKILL.md"
+"#,
+                toml_path(dst_dir),
+            ),
+        )
+        .unwrap();
+        pkg
+    }
+
+    #[test]
+    #[serial]
+    fn installs_skills_from_cache() {
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("ATOMIC_INTEGRATIONS_HOME", home.path());
+        let dst = tempfile::tempdir().unwrap();
+        let cache = fake_skills_cache();
+        let pkg = fake_plugin_with_skills("skill-test", dst.path());
+
+        let mut o = opts(false);
+        o.skills_cache_dir = Some(cache.path().to_path_buf());
+        let outcome = install_from_dir(pkg.path(), &o).unwrap();
+
+        assert_eq!(outcome.installed.len(), 1);
+        let skill_dst = dst.path().join("skills/atomic-vault/SKILL.md");
+        assert!(skill_dst.exists());
+        assert_eq!(
+            std::fs::read_to_string(&skill_dst).unwrap(),
+            "# atomic-vault skill\n"
+        );
+        std::env::remove_var("ATOMIC_INTEGRATIONS_HOME");
+    }
+
+    #[test]
+    #[serial]
+    fn skills_without_cache_errors() {
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("ATOMIC_INTEGRATIONS_HOME", home.path());
+        let dst = tempfile::tempdir().unwrap();
+        let pkg = fake_plugin_with_skills("skill-test-err", dst.path());
+
+        let err = install_from_dir(pkg.path(), &opts(false)).unwrap_err();
+        assert!(err.to_string().contains("no skills cache was provided"));
+        std::env::remove_var("ATOMIC_INTEGRATIONS_HOME");
+    }
+
+    #[test]
+    #[serial]
+    fn installs_repo_file_into_repo_root() {
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("ATOMIC_INTEGRATIONS_HOME", home.path());
+        let repo = tempfile::tempdir().unwrap();
+        let cache = fake_skills_cache();
+
+        let pkg = tempfile::tempdir().unwrap();
+        std::fs::write(
+            pkg.path().join(MANIFEST_FILE),
+            format!(
+                r#"
+schema = 1
+agent = "repo-file-test"
+version = "1.0.0"
+
+[skills-source]
+package = "atomic-skills"
+
+[[repo-file]]
+src = "AGENTS.md"
+dst = "AGENTS.md"
+"#,
+            ),
+        )
+        .unwrap();
+
+        let mut o = opts(false);
+        o.skills_cache_dir = Some(cache.path().to_path_buf());
+        o.repo_root = Some(repo.path().to_path_buf());
+        let outcome = install_from_dir(pkg.path(), &o).unwrap();
+
+        assert_eq!(outcome.installed.len(), 1);
+        let agents_dst = repo.path().join("AGENTS.md");
+        assert!(agents_dst.exists());
+        assert!(std::fs::read_to_string(&agents_dst).unwrap().contains("canonical body"));
+        std::env::remove_var("ATOMIC_INTEGRATIONS_HOME");
+    }
+
+    #[test]
+    #[serial]
+    fn repo_file_skipped_without_repo_root() {
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("ATOMIC_INTEGRATIONS_HOME", home.path());
+        let repo = tempfile::tempdir().unwrap();
+        let cache = fake_skills_cache();
+
+        let pkg = tempfile::tempdir().unwrap();
+        std::fs::write(
+            pkg.path().join(MANIFEST_FILE),
+            r#"
+schema = 1
+agent = "repo-file-skip-test"
+version = "1.0.0"
+
+[skills-source]
+package = "atomic-skills"
+
+[[repo-file]]
+src = "AGENTS.md"
+dst = "AGENTS.md"
+"#,
+        )
+        .unwrap();
+
+        let mut o = opts(false);
+        o.skills_cache_dir = Some(cache.path().to_path_buf());
+        // repo_root intentionally None — simulates user said "no" to the prompt.
+        let outcome = install_from_dir(pkg.path(), &o).unwrap();
+
+        assert!(outcome.installed.is_empty());
+        assert!(!repo.path().join("AGENTS.md").exists());
+        std::env::remove_var("ATOMIC_INTEGRATIONS_HOME");
+    }
+
+    #[test]
+    #[serial]
+    fn repo_file_rejects_absolute_dst() {
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("ATOMIC_INTEGRATIONS_HOME", home.path());
+        let repo = tempfile::tempdir().unwrap();
+        let cache = fake_skills_cache();
+
+        let pkg = tempfile::tempdir().unwrap();
+        std::fs::write(
+            pkg.path().join(MANIFEST_FILE),
+            r#"
+schema = 1
+agent = "repo-file-abs-test"
+version = "1.0.0"
+
+[skills-source]
+package = "atomic-skills"
+
+[[repo-file]]
+src = "AGENTS.md"
+dst = "/etc/passwd"
+"#,
+        )
+        .unwrap();
+
+        let mut o = opts(false);
+        o.skills_cache_dir = Some(cache.path().to_path_buf());
+        o.repo_root = Some(repo.path().to_path_buf());
+        let err = install_from_dir(pkg.path(), &o).unwrap_err();
+        assert!(err.to_string().contains("must be relative to the repo root"));
+        std::env::remove_var("ATOMIC_INTEGRATIONS_HOME");
+    }
+
+    #[test]
+    #[serial]
+    fn repo_file_rejects_traversal_dst() {
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("ATOMIC_INTEGRATIONS_HOME", home.path());
+        let repo = tempfile::tempdir().unwrap();
+        let cache = fake_skills_cache();
+
+        let pkg = tempfile::tempdir().unwrap();
+        std::fs::write(
+            pkg.path().join(MANIFEST_FILE),
+            r#"
+schema = 1
+agent = "repo-file-trav-test"
+version = "1.0.0"
+
+[skills-source]
+package = "atomic-skills"
+
+[[repo-file]]
+src = "AGENTS.md"
+dst = "../escape.md"
+"#,
+        )
+        .unwrap();
+
+        let mut o = opts(false);
+        o.skills_cache_dir = Some(cache.path().to_path_buf());
+        o.repo_root = Some(repo.path().to_path_buf());
+        let err = install_from_dir(pkg.path(), &o).unwrap_err();
+        assert!(err.to_string().contains("must not escape the repo root"));
+        std::env::remove_var("ATOMIC_INTEGRATIONS_HOME");
+    }
+
+    #[test]
+    #[serial]
+    fn stitches_agent_definition_at_install() {
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("ATOMIC_INTEGRATIONS_HOME", home.path());
+        let dst = tempfile::tempdir().unwrap();
+        let cache = fake_skills_cache();
+
+        let pkg = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(pkg.path().join("agents")).unwrap();
+        std::fs::write(
+            pkg.path().join("agents/atomic.md.frontmatter"),
+            "---\ndescription: Test agent\nmode: primary\n---\n",
+        )
+        .unwrap();
+        std::fs::write(
+            pkg.path().join(MANIFEST_FILE),
+            format!(
+                r#"
+schema = 1
+agent = "stitch-test"
+version = "1.0.0"
+
+[skills-source]
+package = "atomic-skills"
+
+[agent-definition]
+src = "agents/atomic.md.frontmatter"
+body_from = "atomic-skills:AGENTS.md"
+slot = "{0}/agents/atomic.md"
+"#,
+                toml_path(dst.path()),
+            ),
+        )
+        .unwrap();
+
+        let mut o = opts(false);
+        o.skills_cache_dir = Some(cache.path().to_path_buf());
+        let outcome = install_from_dir(pkg.path(), &o).unwrap();
+
+        assert_eq!(outcome.installed.len(), 1);
+        let agent_file = dst.path().join("agents/atomic.md");
+        assert!(agent_file.exists());
+        let content = std::fs::read_to_string(&agent_file).unwrap();
+        // Frontmatter present.
+        assert!(content.starts_with("---\ndescription: Test agent\nmode: primary\n---\n"));
+        // Canonical body present.
+        assert!(content.contains("canonical body"));
+        // The receipt recorded the stitched file.
+        let receipt = Receipt::load("stitch-test").unwrap().unwrap();
+        assert_eq!(receipt.files.len(), 1);
+        std::env::remove_var("ATOMIC_INTEGRATIONS_HOME");
+    }
+
+    #[test]
+    #[serial]
+    fn agent_definition_without_cache_errors() {
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("ATOMIC_INTEGRATIONS_HOME", home.path());
+        let dst = tempfile::tempdir().unwrap();
+
+        let pkg = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(pkg.path().join("agents")).unwrap();
+        std::fs::write(
+            pkg.path().join("agents/atomic.md.frontmatter"),
+            "---\ndescription: Test\n---\n",
+        )
+        .unwrap();
+        std::fs::write(
+            pkg.path().join(MANIFEST_FILE),
+            format!(
+                r#"
+schema = 1
+agent = "stitch-no-cache"
+version = "1.0.0"
+
+[agent-definition]
+src = "agents/atomic.md.frontmatter"
+body_from = "atomic-skills:AGENTS.md"
+slot = "{0}/agents/atomic.md"
+"#,
+                toml_path(dst.path()),
+            ),
+        )
+        .unwrap();
+
+        let err = install_from_dir(pkg.path(), &opts(false)).unwrap_err();
+        assert!(err.to_string().contains("no skills cache was provided"));
+        std::env::remove_var("ATOMIC_INTEGRATIONS_HOME");
+    }
+
+    #[test]
+    #[serial]
+    fn repo_file_uninstall_removes_from_repo() {
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("ATOMIC_INTEGRATIONS_HOME", home.path());
+        let repo = tempfile::tempdir().unwrap();
+        let cache = fake_skills_cache();
+
+        let pkg = tempfile::tempdir().unwrap();
+        std::fs::write(
+            pkg.path().join(MANIFEST_FILE),
+            r#"
+schema = 1
+agent = "repo-uninstall-test"
+version = "1.0.0"
+
+[skills-source]
+package = "atomic-skills"
+
+[[repo-file]]
+src = "AGENTS.md"
+dst = "AGENTS.md"
+"#,
+        )
+        .unwrap();
+
+        let mut o = opts(false);
+        o.skills_cache_dir = Some(cache.path().to_path_buf());
+        o.repo_root = Some(repo.path().to_path_buf());
+        install_from_dir(pkg.path(), &o).unwrap();
+        assert!(repo.path().join("AGENTS.md").exists());
+
+        // Uninstall must remove it.
+        let outcome = uninstall("repo-uninstall-test").unwrap();
+        assert_eq!(outcome.removed.len(), 1);
+        assert!(!repo.path().join("AGENTS.md").exists());
+        std::env::remove_var("ATOMIC_INTEGRATIONS_HOME");
+    }
+
+    #[test]
+    #[serial]
+    fn repo_file_merges_with_existing_user_file() {
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("ATOMIC_INTEGRATIONS_HOME", home.path());
+        let repo = tempfile::tempdir().unwrap();
+        let cache = fake_skills_cache();
+
+        // User already has a project-specific AGENTS.md.
+        let user_content = "# My Project\n\nThis is my custom project guide.\n";
+        std::fs::write(repo.path().join("AGENTS.md"), user_content).unwrap();
+
+        let pkg = tempfile::tempdir().unwrap();
+        std::fs::write(
+            pkg.path().join(MANIFEST_FILE),
+            r#"
+schema = 1
+agent = "merge-test"
+version = "1.0.0"
+
+[skills-source]
+package = "atomic-skills"
+
+[[repo-file]]
+src = "AGENTS.md"
+dst = "AGENTS.md"
+"#,
+        )
+        .unwrap();
+
+        let mut o = opts(false);
+        o.skills_cache_dir = Some(cache.path().to_path_buf());
+        o.repo_root = Some(repo.path().to_path_buf());
+        let outcome = install_from_dir(pkg.path(), &o).unwrap();
+
+        // Should be "installed" (merged), not skipped.
+        assert_eq!(outcome.installed.len(), 1);
+        assert!(outcome.skipped.is_empty());
+
+        let result = std::fs::read_to_string(repo.path().join("AGENTS.md")).unwrap();
+        // User's content is preserved above the separator.
+        assert!(result.starts_with("# My Project"));
+        assert!(result.contains("This is my custom project guide."));
+        // Separator is present.
+        assert!(result.contains("\n\n---\n\n"));
+        // Canonical Atomic content is appended below.
+        assert!(result.contains("# Atomic VCS Agent"));
+        assert!(result.contains("canonical body"));
+        std::env::remove_var("ATOMIC_INTEGRATIONS_HOME");
+    }
+
+    #[test]
+    #[serial]
+    fn repo_file_refreshes_when_atomic_marker_present() {
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("ATOMIC_INTEGRATIONS_HOME", home.path());
+        let repo = tempfile::tempdir().unwrap();
+        let cache = fake_skills_cache();
+
+        // File already has the Atomic marker (maybe from a manual copy).
+        let stale = "# Atomic VCS Agent\n\nOld stale content\n";
+        std::fs::write(repo.path().join("AGENTS.md"), stale).unwrap();
+
+        let pkg = tempfile::tempdir().unwrap();
+        std::fs::write(
+            pkg.path().join(MANIFEST_FILE),
+            r#"
+schema = 1
+agent = "marker-test"
+version = "1.0.0"
+
+[skills-source]
+package = "atomic-skills"
+
+[[repo-file]]
+src = "AGENTS.md"
+dst = "AGENTS.md"
+"#,
+        )
+        .unwrap();
+
+        let mut o = opts(false);
+        o.skills_cache_dir = Some(cache.path().to_path_buf());
+        o.repo_root = Some(repo.path().to_path_buf());
+        let outcome = install_from_dir(pkg.path(), &o).unwrap();
+
+        // Should be refreshed, not merged (marker present → replace).
+        assert_eq!(outcome.refreshed.len(), 1);
+        assert!(outcome.installed.is_empty());
+
+        let result = std::fs::read_to_string(repo.path().join("AGENTS.md")).unwrap();
+        // Stale content is gone, canonical is in place.
+        assert!(result.contains("canonical body"));
+        assert!(!result.contains("Old stale content"));
+        std::env::remove_var("ATOMIC_INTEGRATIONS_HOME");
+    }
+
+    #[test]
+    #[serial]
+    fn repo_file_force_clobbers_user_file() {
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("ATOMIC_INTEGRATIONS_HOME", home.path());
+        let repo = tempfile::tempdir().unwrap();
+        let cache = fake_skills_cache();
+
+        // User has their own AGENTS.md (no Atomic marker).
+        let user_content = "# My Project\n\nDon't clobber me\n";
+        std::fs::write(repo.path().join("AGENTS.md"), user_content).unwrap();
+
+        let pkg = tempfile::tempdir().unwrap();
+        std::fs::write(
+            pkg.path().join(MANIFEST_FILE),
+            r#"
+schema = 1
+agent = "force-clobber-test"
+version = "1.0.0"
+
+[skills-source]
+package = "atomic-skills"
+
+[[repo-file]]
+src = "AGENTS.md"
+dst = "AGENTS.md"
+"#,
+        )
+        .unwrap();
+
+        let mut o = opts(true); // force = clobber
+        o.skills_cache_dir = Some(cache.path().to_path_buf());
+        o.repo_root = Some(repo.path().to_path_buf());
+        let outcome = install_from_dir(pkg.path(), &o).unwrap();
+
+        // Force clobbers — user's content is gone.
+        assert!(outcome.skipped.is_empty());
+        let result = std::fs::read_to_string(repo.path().join("AGENTS.md")).unwrap();
+        assert!(!result.contains("Don't clobber me"));
+        assert!(result.contains("canonical body"));
         std::env::remove_var("ATOMIC_INTEGRATIONS_HOME");
     }
 }

--- a/atomic-agent/src/integrations/install.rs
+++ b/atomic-agent/src/integrations/install.rs
@@ -149,7 +149,82 @@ pub fn install_from_dir(pkg_dir: &Path, opts: &InstallOptions) -> AgentResult<In
         )?;
     }
 
-    // Skills from the shared atomic-skills cache.
+    // Auto-install all skills from the shared cache via [skills] block.
+    // The installer globs skills/*/SKILL.md and formats dst_pattern with
+    // {name}. This means adding a skill to atomic-skills requires zero
+    // plugin manifest changes.
+    if let Some(ref config) = manifest.skills_config {
+        let cache = opts
+            .skills_cache_dir
+            .as_deref()
+            .ok_or_else(|| AgentError::Integration {
+                agent: manifest.agent.clone(),
+                reason: "manifest declares [skills] but no skills cache was \
+                         provided (expected [skills-source] to be synced by the CLI)"
+                    .to_string(),
+            })?;
+
+        if !config.dst_pattern.contains("{name}") {
+            return Err(AgentError::Integration {
+                agent: manifest.agent.clone(),
+                reason: format!(
+                    "[skills] dst_pattern must contain '{{name}}' placeholder, got '{}'",
+                    config.dst_pattern
+                ),
+            });
+        }
+
+        // Glob skills/*/SKILL.md in the cache.
+        let skills_dir = cache.join("skills");
+        let skill_names: Vec<String> = std::fs::read_dir(&skills_dir)
+            .map_err(|e| AgentError::Integration {
+                agent: manifest.agent.clone(),
+                reason: format!("cannot read skills dir {}: {}", skills_dir.display(), e),
+            })?
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+            .filter_map(|e| {
+                let name = e.file_name().to_string_lossy().into_owned();
+                if e.path().join("SKILL.md").is_file() {
+                    Some(name)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // Filter by install list if not "all".
+        let wanted: Vec<String> = if config.install.trim() == "all" {
+            skill_names
+        } else {
+            let allowed: Vec<&str> = config.install.split(',').map(|s| s.trim()).collect();
+            skill_names
+                .into_iter()
+                .filter(|n| allowed.contains(&n.as_str()))
+                .collect()
+        };
+
+        for name in &wanted {
+            let src = cache.join("skills").join(name).join("SKILL.md");
+            let dst_str = config.dst_pattern.replace("{name}", name);
+            let dst = expand_dst(&dst_str)?;
+            copy_one(
+                &manifest.agent,
+                &src,
+                &dst,
+                previous.as_ref(),
+                opts.force,
+                &mut installed,
+                &mut refreshed,
+                &mut skipped,
+                &mut receipt_files,
+            )?;
+        }
+    }
+
+    // Explicit [[skill]] entries — for non-skill cache files (AGENTS.md to
+    // vendor instruction paths). For actual skills, prefer [skills] with
+    // install = "all".
     if !manifest.skills.is_empty() {
         let cache = opts
             .skills_cache_dir
@@ -1387,6 +1462,195 @@ dst = "AGENTS.md"
         let result = std::fs::read_to_string(repo.path().join("AGENTS.md")).unwrap();
         assert!(!result.contains("Don't clobber me"));
         assert!(result.contains("canonical body"));
+        std::env::remove_var("ATOMIC_INTEGRATIONS_HOME");
+    }
+
+    #[test]
+    #[serial]
+    fn skills_glob_installs_all_from_cache() {
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("ATOMIC_INTEGRATIONS_HOME", home.path());
+        let dst = tempfile::tempdir().unwrap();
+
+        // Build a skills cache with 3 skills.
+        let cache = tempfile::tempdir().unwrap();
+        for skill in &["atomic-vault", "atomic-vcs", "code-intelligence"] {
+            let dir = cache.path().join("skills").join(skill);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("SKILL.md"), format!("# {skill}\n")).unwrap();
+        }
+
+        let pkg = tempfile::tempdir().unwrap();
+        std::fs::write(
+            pkg.path().join(MANIFEST_FILE),
+            format!(
+                r#"
+schema = 1
+agent = "glob-test"
+version = "1.0.0"
+
+[skills-source]
+package = "atomic-skills"
+
+[skills]
+install = "all"
+dst_pattern = "{0}/skills/{{name}}/SKILL.md"
+"#,
+                toml_path(dst.path()),
+            ),
+        )
+        .unwrap();
+
+        let mut o = opts(false);
+        o.skills_cache_dir = Some(cache.path().to_path_buf());
+        let outcome = install_from_dir(pkg.path(), &o).unwrap();
+
+        // All 3 skills installed.
+        assert_eq!(outcome.installed.len(), 3);
+        for skill in &["atomic-vault", "atomic-vcs", "code-intelligence"] {
+            let path = dst.path().join("skills").join(skill).join("SKILL.md");
+            assert!(path.exists(), "skill {skill} not installed");
+        }
+        std::env::remove_var("ATOMIC_INTEGRATIONS_HOME");
+    }
+
+    #[test]
+    #[serial]
+    fn skills_glob_flat_pattern() {
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("ATOMIC_INTEGRATIONS_HOME", home.path());
+        let dst = tempfile::tempdir().unwrap();
+
+        // Cache with 2 skills.
+        let cache = tempfile::tempdir().unwrap();
+        for skill in &["atomic-vault", "code-intelligence"] {
+            let dir = cache.path().join("skills").join(skill);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("SKILL.md"), format!("# {skill}\n")).unwrap();
+        }
+
+        let pkg = tempfile::tempdir().unwrap();
+        std::fs::write(
+            pkg.path().join(MANIFEST_FILE),
+            format!(
+                r#"
+schema = 1
+agent = "flat-glob-test"
+version = "1.0.0"
+
+[skills-source]
+package = "atomic-skills"
+
+[skills]
+install = "all"
+dst_pattern = "{0}/workflows/{{name}}.md"
+"#,
+                toml_path(dst.path()),
+            ),
+        )
+        .unwrap();
+
+        let mut o = opts(false);
+        o.skills_cache_dir = Some(cache.path().to_path_buf());
+        let outcome = install_from_dir(pkg.path(), &o).unwrap();
+
+        // 2 skills installed as flat .md files.
+        assert_eq!(outcome.installed.len(), 2);
+        assert!(dst.path().join("workflows/atomic-vault.md").exists());
+        assert!(dst.path().join("workflows/code-intelligence.md").exists());
+        std::env::remove_var("ATOMIC_INTEGRATIONS_HOME");
+    }
+
+    #[test]
+    #[serial]
+    fn skills_glob_picks_up_new_skill_automatically() {
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("ATOMIC_INTEGRATIONS_HOME", home.path());
+        let dst = tempfile::tempdir().unwrap();
+
+        // Cache with 2 skills initially.
+        let cache = tempfile::tempdir().unwrap();
+        for skill in &["atomic-vault", "atomic-vcs"] {
+            let dir = cache.path().join("skills").join(skill);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("SKILL.md"), format!("# {skill}\n")).unwrap();
+        }
+
+        let pkg = tempfile::tempdir().unwrap();
+        std::fs::write(
+            pkg.path().join(MANIFEST_FILE),
+            format!(
+                r#"
+schema = 1
+agent = "auto-new-skill-test"
+version = "1.0.0"
+
+[skills-source]
+package = "atomic-skills"
+
+[skills]
+install = "all"
+dst_pattern = "{0}/skills/{{name}}/SKILL.md"
+"#,
+                toml_path(dst.path()),
+            ),
+        )
+        .unwrap();
+
+        let mut o = opts(false);
+        o.skills_cache_dir = Some(cache.path().to_path_buf());
+        let outcome1 = install_from_dir(pkg.path(), &o).unwrap();
+        assert_eq!(outcome1.installed.len(), 2);
+
+        // A new skill is added to the cache — no manifest change needed.
+        let new_skill_dir = cache.path().join("skills/triage-review");
+        std::fs::create_dir_all(&new_skill_dir).unwrap();
+        std::fs::write(new_skill_dir.join("SKILL.md"), "# triage-review\n").unwrap();
+
+        // Re-install with force — picks up the new skill automatically.
+        o.force = true;
+        let outcome2 = install_from_dir(pkg.path(), &o).unwrap();
+        // 2 refreshed + 1 new = 3 installed/refreshed total.
+        assert_eq!(outcome2.installed.len() + outcome2.refreshed.len(), 3);
+        assert!(dst.path().join("skills/triage-review/SKILL.md").exists());
+        std::env::remove_var("ATOMIC_INTEGRATIONS_HOME");
+    }
+
+    #[test]
+    #[serial]
+    fn skills_glob_errors_without_name_placeholder() {
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("ATOMIC_INTEGRATIONS_HOME", home.path());
+        let dst = tempfile::tempdir().unwrap();
+        let cache = fake_skills_cache();
+
+        let pkg = tempfile::tempdir().unwrap();
+        std::fs::write(
+            pkg.path().join(MANIFEST_FILE),
+            format!(
+                r#"
+schema = 1
+agent = "no-placeholder-test"
+version = "1.0.0"
+
+[skills-source]
+package = "atomic-skills"
+
+[skills]
+install = "all"
+dst_pattern = "{0}/skills/all.md"
+"#,
+                toml_path(dst.path()),
+            ),
+        )
+        .unwrap();
+
+        let mut o = opts(false);
+        o.skills_cache_dir = Some(cache.path().to_path_buf());
+        let err = install_from_dir(pkg.path(), &o).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("must contain '{name}' placeholder"));
         std::env::remove_var("ATOMIC_INTEGRATIONS_HOME");
     }
 }

--- a/atomic-agent/src/integrations/install.rs
+++ b/atomic-agent/src/integrations/install.rs
@@ -151,14 +151,15 @@ pub fn install_from_dir(pkg_dir: &Path, opts: &InstallOptions) -> AgentResult<In
 
     // Skills from the shared atomic-skills cache.
     if !manifest.skills.is_empty() {
-        let cache = opts.skills_cache_dir.as_deref().ok_or_else(|| {
-            AgentError::Integration {
+        let cache = opts
+            .skills_cache_dir
+            .as_deref()
+            .ok_or_else(|| AgentError::Integration {
                 agent: manifest.agent.clone(),
                 reason: "manifest declares [[skill]] entries but no skills cache was \
                          provided (expected [skills-source] to be synced by the CLI)"
                     .to_string(),
-            }
-        })?;
+            })?;
         for entry in &manifest.skills {
             reject_parent_traversal(&manifest.agent, &entry.src)?;
             let src = cache.join(&entry.src);
@@ -194,10 +195,7 @@ pub fn install_from_dir(pkg_dir: &Path, opts: &InstallOptions) -> AgentResult<In
                 reject_parent_traversal(&manifest.agent, &entry.src)?;
                 // src comes from the skills cache (or the package if no
                 // skills-source is set — uncommon but valid).
-                let src_base = opts
-                    .skills_cache_dir
-                    .as_deref()
-                    .unwrap_or(pkg_dir);
+                let src_base = opts.skills_cache_dir.as_deref().unwrap_or(pkg_dir);
                 let src = src_base.join(&entry.src);
                 if !src.is_file() {
                     return Err(AgentError::Integration {
@@ -224,46 +222,43 @@ pub fn install_from_dir(pkg_dir: &Path, opts: &InstallOptions) -> AgentResult<In
     // Bundled agent definition: stitch frontmatter + canonical body at install
     // time. Pure string concat — no exec, same safety category as fs::copy.
     if let Some(def) = &manifest.agent_definition {
-        let cache = opts.skills_cache_dir.as_deref().ok_or_else(|| {
-            AgentError::Integration {
+        let cache = opts
+            .skills_cache_dir
+            .as_deref()
+            .ok_or_else(|| AgentError::Integration {
                 agent: manifest.agent.clone(),
                 reason: "manifest declares [agent-definition] but no skills cache \
                          was provided (needed for body_from)"
                     .to_string(),
-            }
-        })?;
+            })?;
         reject_parent_traversal(&manifest.agent, &def.src)?;
         let frontmatter_path = pkg_dir.join(&def.src);
-        let frontmatter = std::fs::read_to_string(&frontmatter_path).map_err(|e| {
-            AgentError::Integration {
+        let frontmatter =
+            std::fs::read_to_string(&frontmatter_path).map_err(|e| AgentError::Integration {
                 agent: manifest.agent.clone(),
                 reason: format!(
                     "agent-definition frontmatter missing: {}: {}",
                     frontmatter_path.display(),
                     e
                 ),
-            }
-        })?;
-        let body_path =
-            manifest
-                .resolve_body_from(&def.body_from, cache)
-                .ok_or_else(|| AgentError::Integration {
-                    agent: manifest.agent.clone(),
-                    reason: format!(
-                        "agent-definition body_from '{}' is malformed or does not \
-                         match the skills-source package",
-                        def.body_from
-                    ),
-                })?;
-        let body = std::fs::read_to_string(&body_path).map_err(|e| {
-            AgentError::Integration {
+            })?;
+        let body_path = manifest
+            .resolve_body_from(&def.body_from, cache)
+            .ok_or_else(|| AgentError::Integration {
                 agent: manifest.agent.clone(),
                 reason: format!(
-                    "agent-definition body missing: {}: {}",
-                    body_path.display(),
-                    e
+                    "agent-definition body_from '{}' is malformed or does not \
+                         match the skills-source package",
+                    def.body_from
                 ),
-            }
+            })?;
+        let body = std::fs::read_to_string(&body_path).map_err(|e| AgentError::Integration {
+            agent: manifest.agent.clone(),
+            reason: format!(
+                "agent-definition body missing: {}: {}",
+                body_path.display(),
+                e
+            ),
         })?;
         let stitched = format!("{frontmatter}\n\n{body}");
         let slot = expand_dst(&def.slot)?;
@@ -900,7 +895,11 @@ manifest = "hooks/hooks.json"
     fn fake_skills_cache() -> tempfile::TempDir {
         let cache = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(cache.path().join("skills/atomic-vault")).unwrap();
-        std::fs::write(cache.path().join("AGENTS.md"), "# Atomic VCS Agent\n\ncanonical body\n").unwrap();
+        std::fs::write(
+            cache.path().join("AGENTS.md"),
+            "# Atomic VCS Agent\n\ncanonical body\n",
+        )
+        .unwrap();
         std::fs::write(
             cache.path().join("skills/atomic-vault/SKILL.md"),
             "# atomic-vault skill\n",
@@ -1009,7 +1008,9 @@ dst = "AGENTS.md"
         assert_eq!(outcome.installed.len(), 1);
         let agents_dst = repo.path().join("AGENTS.md");
         assert!(agents_dst.exists());
-        assert!(std::fs::read_to_string(&agents_dst).unwrap().contains("canonical body"));
+        assert!(std::fs::read_to_string(&agents_dst)
+            .unwrap()
+            .contains("canonical body"));
         std::env::remove_var("ATOMIC_INTEGRATIONS_HOME");
     }
 
@@ -1079,7 +1080,9 @@ dst = "/etc/passwd"
         o.skills_cache_dir = Some(cache.path().to_path_buf());
         o.repo_root = Some(repo.path().to_path_buf());
         let err = install_from_dir(pkg.path(), &o).unwrap_err();
-        assert!(err.to_string().contains("must be relative to the repo root"));
+        assert!(err
+            .to_string()
+            .contains("must be relative to the repo root"));
         std::env::remove_var("ATOMIC_INTEGRATIONS_HOME");
     }
 

--- a/atomic-agent/src/integrations/install.rs
+++ b/atomic-agent/src/integrations/install.rs
@@ -149,10 +149,11 @@ pub fn install_from_dir(pkg_dir: &Path, opts: &InstallOptions) -> AgentResult<In
         )?;
     }
 
-    // Auto-install all skills from the shared cache via [skills] block.
-    // The installer globs skills/*/SKILL.md and formats dst_pattern with
-    // {name}. This means adding a skill to atomic-skills requires zero
-    // plugin manifest changes.
+    // Auto-install skills from the shared cache via [skills] block.
+    // The skill list comes from the atomic-skills package's own manifest
+    // ([[declared-skill]] entries) — not from globbing the filesystem.
+    // Adding a skill to atomic-skills = one [[declared-skill]] entry in its
+    // manifest. Zero plugin manifest changes.
     if let Some(ref config) = manifest.skills_config {
         let cache = opts
             .skills_cache_dir
@@ -174,38 +175,43 @@ pub fn install_from_dir(pkg_dir: &Path, opts: &InstallOptions) -> AgentResult<In
             });
         }
 
-        // Glob skills/*/SKILL.md in the cache.
-        let skills_dir = cache.join("skills");
-        let skill_names: Vec<String> = std::fs::read_dir(&skills_dir)
-            .map_err(|e| AgentError::Integration {
+        // Load the atomic-skills manifest from the cache to get the
+        // declared skill list. This is a manifest read, not a filesystem glob.
+        let skills_manifest = IntegrationManifest::load(cache)?;
+        if skills_manifest.declared_skills.is_empty() {
+            return Err(AgentError::Integration {
                 agent: manifest.agent.clone(),
-                reason: format!("cannot read skills dir {}: {}", skills_dir.display(), e),
-            })?
-            .filter_map(|e| e.ok())
-            .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
-            .filter_map(|e| {
-                let name = e.file_name().to_string_lossy().into_owned();
-                if e.path().join("SKILL.md").is_file() {
-                    Some(name)
-                } else {
-                    None
-                }
-            })
-            .collect();
+                reason: "atomic-skills manifest has no [[declared-skill]] entries \
+                         — cannot install skills via [skills] block"
+                    .to_string(),
+            });
+        }
 
         // Filter by install list if not "all".
-        let wanted: Vec<String> = if config.install.trim() == "all" {
-            skill_names
+        let wanted: Vec<&str> = if config.install.trim() == "all" {
+            skills_manifest
+                .declared_skills
+                .iter()
+                .map(|d| d.name.as_str())
+                .collect()
         } else {
             let allowed: Vec<&str> = config.install.split(',').map(|s| s.trim()).collect();
-            skill_names
-                .into_iter()
-                .filter(|n| allowed.contains(&n.as_str()))
+            skills_manifest
+                .declared_skills
+                .iter()
+                .map(|d| d.name.as_str())
+                .filter(|n| allowed.contains(n))
                 .collect()
         };
 
         for name in &wanted {
             let src = cache.join("skills").join(name).join("SKILL.md");
+            if !src.is_file() {
+                return Err(AgentError::Integration {
+                    agent: manifest.agent.clone(),
+                    reason: format!("declared skill '{}' not found at {}", name, src.display()),
+                });
+            }
             let dst_str = config.dst_pattern.replace("{name}", name);
             let dst = expand_dst(&dst_str)?;
             copy_one(
@@ -965,8 +971,8 @@ manifest = "hooks/hooks.json"
 
     // ── New install paths: skills, repo-file, agent-definition ──────────
 
-    /// Build a fake skills cache (mimics atomic-skills/) with AGENTS.md and
-    /// one skill.
+    /// Build a fake skills cache (mimics atomic-skills/) with AGENTS.md,
+    /// one skill, and the atomic-integration.toml declaring it.
     fn fake_skills_cache() -> tempfile::TempDir {
         let cache = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(cache.path().join("skills/atomic-vault")).unwrap();
@@ -980,6 +986,39 @@ manifest = "hooks/hooks.json"
             "# atomic-vault skill\n",
         )
         .unwrap();
+        // The atomic-skills manifest declares its skills explicitly.
+        std::fs::write(
+            cache.path().join(MANIFEST_FILE),
+            r#"
+schema = 1
+agent = "atomic-skills"
+version = "1.0.0"
+
+[[declared-skill]]
+name = "atomic-vault"
+"#,
+        )
+        .unwrap();
+        cache
+    }
+
+    /// Build a fake skills cache with multiple declared skills.
+    fn fake_skills_cache_multi(skills: &[&str]) -> tempfile::TempDir {
+        let cache = tempfile::tempdir().unwrap();
+        std::fs::write(
+            cache.path().join("AGENTS.md"),
+            "# Atomic VCS Agent\n\ncanonical body\n",
+        )
+        .unwrap();
+        let mut manifest =
+            String::from("schema = 1\nagent = \"atomic-skills\"\nversion = \"1.0.0\"\n\n");
+        for skill in skills {
+            let dir = cache.path().join("skills").join(skill);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("SKILL.md"), format!("# {skill}\n")).unwrap();
+            manifest.push_str(&format!("[[declared-skill]]\nname = \"{skill}\"\n\n"));
+        }
+        std::fs::write(cache.path().join(MANIFEST_FILE), manifest).unwrap();
         cache
     }
 
@@ -1472,13 +1511,8 @@ dst = "AGENTS.md"
         std::env::set_var("ATOMIC_INTEGRATIONS_HOME", home.path());
         let dst = tempfile::tempdir().unwrap();
 
-        // Build a skills cache with 3 skills.
-        let cache = tempfile::tempdir().unwrap();
-        for skill in &["atomic-vault", "atomic-vcs", "code-intelligence"] {
-            let dir = cache.path().join("skills").join(skill);
-            std::fs::create_dir_all(&dir).unwrap();
-            std::fs::write(dir.join("SKILL.md"), format!("# {skill}\n")).unwrap();
-        }
+        // Build a skills cache with 3 declared skills.
+        let cache = fake_skills_cache_multi(&["atomic-vault", "atomic-vcs", "code-intelligence"]);
 
         let pkg = tempfile::tempdir().unwrap();
         std::fs::write(
@@ -1521,13 +1555,8 @@ dst_pattern = "{0}/skills/{{name}}/SKILL.md"
         std::env::set_var("ATOMIC_INTEGRATIONS_HOME", home.path());
         let dst = tempfile::tempdir().unwrap();
 
-        // Cache with 2 skills.
-        let cache = tempfile::tempdir().unwrap();
-        for skill in &["atomic-vault", "code-intelligence"] {
-            let dir = cache.path().join("skills").join(skill);
-            std::fs::create_dir_all(&dir).unwrap();
-            std::fs::write(dir.join("SKILL.md"), format!("# {skill}\n")).unwrap();
-        }
+        // Cache with 2 declared skills.
+        let cache = fake_skills_cache_multi(&["atomic-vault", "code-intelligence"]);
 
         let pkg = tempfile::tempdir().unwrap();
         std::fs::write(
@@ -1568,13 +1597,8 @@ dst_pattern = "{0}/workflows/{{name}}.md"
         std::env::set_var("ATOMIC_INTEGRATIONS_HOME", home.path());
         let dst = tempfile::tempdir().unwrap();
 
-        // Cache with 2 skills initially.
-        let cache = tempfile::tempdir().unwrap();
-        for skill in &["atomic-vault", "atomic-vcs"] {
-            let dir = cache.path().join("skills").join(skill);
-            std::fs::create_dir_all(&dir).unwrap();
-            std::fs::write(dir.join("SKILL.md"), format!("# {skill}\n")).unwrap();
-        }
+        // Cache with 2 declared skills initially.
+        let cache = fake_skills_cache_multi(&["atomic-vault", "atomic-vcs"]);
 
         let pkg = tempfile::tempdir().unwrap();
         std::fs::write(
@@ -1602,10 +1626,16 @@ dst_pattern = "{0}/skills/{{name}}/SKILL.md"
         let outcome1 = install_from_dir(pkg.path(), &o).unwrap();
         assert_eq!(outcome1.installed.len(), 2);
 
-        // A new skill is added to the cache — no manifest change needed.
+        // A new skill is added to the cache AND declared in the atomic-skills
+        // manifest — no plugin manifest change needed.
         let new_skill_dir = cache.path().join("skills/triage-review");
         std::fs::create_dir_all(&new_skill_dir).unwrap();
         std::fs::write(new_skill_dir.join("SKILL.md"), "# triage-review\n").unwrap();
+        // Add the [[declared-skill]] entry to the atomic-skills manifest.
+        let skills_manifest_path = cache.path().join(MANIFEST_FILE);
+        let mut manifest_text = std::fs::read_to_string(&skills_manifest_path).unwrap();
+        manifest_text.push_str("\n[[declared-skill]]\nname = \"triage-review\"\n");
+        std::fs::write(skills_manifest_path, manifest_text).unwrap();
 
         // Re-install with force — picks up the new skill automatically.
         o.force = true;

--- a/atomic-agent/src/integrations/manifest.rs
+++ b/atomic-agent/src/integrations/manifest.rs
@@ -53,6 +53,13 @@ pub struct IntegrationManifest {
     /// prefer `[skills]` with `install = "all"` — it's automatic.
     #[serde(default, rename = "skill")]
     pub skills: Vec<SkillEntry>,
+    /// Skills declared by the atomic-skills package itself. Each entry is a
+    /// skill name (e.g. `"atomic-vault"`). When a plugin's `[skills]` block
+    /// has `install = "all"`, the installer loads the atomic-skills manifest
+    /// from the cache and iterates this list. The skill file is always at
+    /// `skills/{name}/SKILL.md` — convention over configuration.
+    #[serde(default, rename = "declared-skill")]
+    pub declared_skills: Vec<DeclaredSkill>,
     /// Files to install into the *repository* root (not the user's home).
     /// Used for the canonical AGENTS.md so the workflow is always-on without
     /// picking a bundled agent. `dst` is relative to the repo root. Only
@@ -124,6 +131,16 @@ pub struct SkillEntry {
     /// Destination (`~` expands to home). Vendors with flat skill layouts
     /// (Cline, agy) use a flat filename here.
     pub dst: String,
+}
+
+/// A skill declared by the atomic-skills package. The installer copies
+/// `skills/{name}/SKILL.md` from the cache to the plugin's formatted
+/// `dst_pattern`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct DeclaredSkill {
+    /// Skill directory name (e.g. `"atomic-vault"`). The file is at
+    /// `skills/{name}/SKILL.md` in the atomic-skills cache.
+    pub name: String,
 }
 
 /// One file to install into the repository root.

--- a/atomic-agent/src/integrations/manifest.rs
+++ b/atomic-agent/src/integrations/manifest.rs
@@ -41,9 +41,16 @@ pub struct IntegrationManifest {
     /// `opts.skills_cache_dir` to point at that package's cloned cache.
     #[serde(default, rename = "skills-source")]
     pub skills_source: Option<SkillsSource>,
-    /// Skills to copy from the skills-source cache into the agent's skill
-    /// location. `src` resolves against the skills cache dir; `dst` uses the
-    /// same `~` expansion as [[file]].
+    /// Auto-install all skills from the cache using a dst pattern. When
+    /// present, the installer globs `skills/*/SKILL.md` in the cache and
+    /// copies each to `dst_pattern` with `{name}` replaced by the skill
+    /// directory name. This means adding a new skill to `atomic-skills`
+    /// requires zero plugin manifest changes.
+    #[serde(default, rename = "skills")]
+    pub skills_config: Option<SkillsConfig>,
+    /// Explicit skill entries for non-skill cache files (e.g. AGENTS.md
+    /// copied to a vendor-specific instruction-file path). For actual skills,
+    /// prefer `[skills]` with `install = "all"` — it's automatic.
     #[serde(default, rename = "skill")]
     pub skills: Vec<SkillEntry>,
     /// Files to install into the *repository* root (not the user's home).
@@ -92,6 +99,20 @@ pub struct SkillsSource {
     /// embedded registry.toml to a storage URL + view, cloned into the
     /// shared cache by the CLI, and passed as `opts.skills_cache_dir`.
     pub package: String,
+}
+
+/// Auto-install all skills from the cache using a dst pattern.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SkillsConfig {
+    /// Which skills to install. `"all"` globs `skills/*/SKILL.md` in the
+    /// cache and installs every one. Alternatively, a comma-separated list
+    /// of skill directory names (e.g. `"atomic-vault,atomic-vcs"`).
+    pub install: String,
+    /// Destination pattern with `{name}` placeholder. The installer replaces
+    /// `{name}` with each skill's directory name. Examples:
+    /// - Nested: `"~/.config/opencode/skills/{name}/SKILL.md"`
+    /// - Flat: `"~/Documents/Cline/Workflows/{name}.md"`
+    pub dst_pattern: String,
 }
 
 /// One skill to copy from the skills-source cache.

--- a/atomic-agent/src/integrations/manifest.rs
+++ b/atomic-agent/src/integrations/manifest.rs
@@ -29,12 +29,36 @@ pub struct IntegrationManifest {
     /// Version gates.
     #[serde(default)]
     pub requires: Requires,
-    /// Files to copy into place.
+    /// Files to copy into place (from the package itself).
     #[serde(default, rename = "file")]
     pub files: Vec<FileEntry>,
     /// Hooks-manifest files to merge via the hooks::manifest engine.
     #[serde(default, rename = "settings")]
     pub settings: Vec<SettingsEntry>,
+    /// Shared skills source — names another registry package (typically
+    /// `"atomic-skills"`) whose cache provides the `[[skill]]` src paths and
+    /// the `[[agent-definition]]` body. When set, the installer expects
+    /// `opts.skills_cache_dir` to point at that package's cloned cache.
+    #[serde(default, rename = "skills-source")]
+    pub skills_source: Option<SkillsSource>,
+    /// Skills to copy from the skills-source cache into the agent's skill
+    /// location. `src` resolves against the skills cache dir; `dst` uses the
+    /// same `~` expansion as [[file]].
+    #[serde(default, rename = "skill")]
+    pub skills: Vec<SkillEntry>,
+    /// Files to install into the *repository* root (not the user's home).
+    /// Used for the canonical AGENTS.md so the workflow is always-on without
+    /// picking a bundled agent. `dst` is relative to the repo root. Only
+    /// installed when the caller passes `opts.repo_root` (gated by the
+    /// `--repo-agents` prompt in the CLI).
+    #[serde(default, rename = "repo-file")]
+    pub repo_files: Vec<RepoFileEntry>,
+    /// Declares that the plugin bundles a custom agent definition (e.g.
+    /// opencode's `agents/atomic.md`). The agent body is stitched at install
+    /// time from `src` (frontmatter, in the plugin package) + the canonical
+    /// AGENTS.md body (from the skills cache), and written to `slot`.
+    #[serde(default, rename = "agent-definition")]
+    pub agent_definition: Option<AgentDefinition>,
 }
 
 /// Version requirements the package imposes on its host.
@@ -59,6 +83,50 @@ pub struct SettingsEntry {
     /// Path to a hooks manifest (hooks::manifest format), relative to the
     /// package root.
     pub manifest: String,
+}
+
+/// Names the shared skills package that provides skill content + AGENTS.md.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SkillsSource {
+    /// Registry agent name (e.g. `"atomic-skills"`). Resolved via the
+    /// embedded registry.toml to a storage URL + view, cloned into the
+    /// shared cache by the CLI, and passed as `opts.skills_cache_dir`.
+    pub package: String,
+}
+
+/// One skill to copy from the skills-source cache.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SkillEntry {
+    /// Path relative to the skills-source cache root (e.g.
+    /// `"skills/atomic-vault/SKILL.md"`).
+    pub src: String,
+    /// Destination (`~` expands to home). Vendors with flat skill layouts
+    /// (Cline, agy) use a flat filename here.
+    pub dst: String,
+}
+
+/// One file to install into the repository root.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RepoFileEntry {
+    /// Path relative to the skills-source cache root (e.g. `"AGENTS.md"`).
+    pub src: String,
+    /// Destination relative to the repo root (e.g. `"AGENTS.md"`).
+    pub dst: String,
+}
+
+/// A bundled custom agent definition, stitched at install time.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AgentDefinition {
+    /// Frontmatter template file, relative to the plugin package root (e.g.
+    /// `"agents/atomic.md.frontmatter"`). Contains the YAML frontmatter block
+    /// and any vendor-specific preamble.
+    pub src: String,
+    /// Reference to the canonical body, in the form
+    /// `"atomic-skills:AGENTS.md"` (package-name-relative path). The
+    /// installer reads this from the skills cache.
+    pub body_from: String,
+    /// Destination in the vendor's agent slot (`~` expands to home).
+    pub slot: String,
 }
 
 impl IntegrationManifest {
@@ -121,6 +189,19 @@ impl IntegrationManifest {
             .iter()
             .map(|s| pkg_dir.join(&s.manifest))
             .collect()
+    }
+
+    /// Resolve a `body_from` reference (`"atomic-skills:AGENTS.md"`) into an
+    /// absolute path inside the skills cache. Returns `None` if the format is
+    /// unrecognized.
+    pub fn resolve_body_from(&self, body_from: &str, skills_cache: &Path) -> Option<PathBuf> {
+        let (pkg, rel) = body_from.split_once(':')?;
+        // The package name in body_from must match the skills-source package.
+        let expected = self.skills_source.as_ref()?.package.as_str();
+        if pkg != expected {
+            return None;
+        }
+        Some(skills_cache.join(rel))
     }
 }
 

--- a/atomic-agent/src/integrations/mod.rs
+++ b/atomic-agent/src/integrations/mod.rs
@@ -34,7 +34,8 @@ pub use install::{
     UninstallOutcome,
 };
 pub use manifest::{
-    AgentDefinition, IntegrationManifest, RepoFileEntry, SkillEntry, SkillsSource, MANIFEST_FILE,
+    AgentDefinition, IntegrationManifest, RepoFileEntry, SkillEntry, SkillsConfig, SkillsSource,
+    MANIFEST_FILE,
 };
 pub use receipt::{agent_dir, cache_repo_dir, integrations_root, receipt_path, Receipt};
 pub use registry::{agents as registered_integrations, resolve, IntegrationSpec};

--- a/atomic-agent/src/integrations/mod.rs
+++ b/atomic-agent/src/integrations/mod.rs
@@ -33,6 +33,8 @@ pub use install::{
     install_from_dir, uninstall, InstallOptions, InstallOutcome, SkipReason, SkippedFile,
     UninstallOutcome,
 };
-pub use manifest::{IntegrationManifest, MANIFEST_FILE};
+pub use manifest::{
+    AgentDefinition, IntegrationManifest, MANIFEST_FILE, RepoFileEntry, SkillEntry, SkillsSource,
+};
 pub use receipt::{agent_dir, cache_repo_dir, integrations_root, receipt_path, Receipt};
 pub use registry::{agents as registered_integrations, resolve, IntegrationSpec};

--- a/atomic-agent/src/integrations/mod.rs
+++ b/atomic-agent/src/integrations/mod.rs
@@ -34,7 +34,7 @@ pub use install::{
     UninstallOutcome,
 };
 pub use manifest::{
-    AgentDefinition, IntegrationManifest, MANIFEST_FILE, RepoFileEntry, SkillEntry, SkillsSource,
+    AgentDefinition, IntegrationManifest, RepoFileEntry, SkillEntry, SkillsSource, MANIFEST_FILE,
 };
 pub use receipt::{agent_dir, cache_repo_dir, integrations_root, receipt_path, Receipt};
 pub use registry::{agents as registered_integrations, resolve, IntegrationSpec};

--- a/atomic-agent/src/integrations/mod.rs
+++ b/atomic-agent/src/integrations/mod.rs
@@ -34,8 +34,8 @@ pub use install::{
     UninstallOutcome,
 };
 pub use manifest::{
-    AgentDefinition, IntegrationManifest, RepoFileEntry, SkillEntry, SkillsConfig, SkillsSource,
-    MANIFEST_FILE,
+    AgentDefinition, DeclaredSkill, IntegrationManifest, RepoFileEntry, SkillEntry, SkillsConfig,
+    SkillsSource, MANIFEST_FILE,
 };
 pub use receipt::{agent_dir, cache_repo_dir, integrations_root, receipt_path, Receipt};
 pub use registry::{agents as registered_integrations, resolve, IntegrationSpec};

--- a/atomic-agent/src/integrations/registry.toml
+++ b/atomic-agent/src/integrations/registry.toml
@@ -10,6 +10,10 @@
 
 schema = 1
 
+[agents.atomic-skills]
+url = "https://atomic.atomic.storage/workspaces/oss/projects/atomic-skills/code"
+view = "release"
+
 [agents.agy]
 url = "https://atomic.atomic.storage/workspaces/oss/projects/atomic-agy/code"
 view = "release"

--- a/atomic-cli/src/commands/agent/enable.rs
+++ b/atomic-cli/src/commands/agent/enable.rs
@@ -500,13 +500,12 @@ impl Enable {
         let manifest = atomic_agent::integrations::IntegrationManifest::load(&pkg_dir)
             .map_err(|e| crate::error::CliError::Internal(anyhow::anyhow!(e.to_string())))?;
 
-        let skills_cache_dir = if manifest.skills_source.is_some()
-            || manifest.agent_definition.is_some()
-        {
-            Some(sync_skills_cache(self.force)?)
-        } else {
-            None
-        };
+        let skills_cache_dir =
+            if manifest.skills_source.is_some() || manifest.agent_definition.is_some() {
+                Some(sync_skills_cache(self.force)?)
+            } else {
+                None
+            };
 
         // Determine repo_root from the --agents-md / --no-agents-md flags
         // or the interactive prompt. Only relevant when the manifest has

--- a/atomic-cli/src/commands/agent/enable.rs
+++ b/atomic-cli/src/commands/agent/enable.rs
@@ -413,13 +413,14 @@ impl Command for Enable {
     }
 }
 
-/// Sync the shared atomic-skills package into the CLI-managed cache
-/// (`~/.atomic/integrations/atomic-skills/repo`). Skills and the canonical
-/// AGENTS.md are sourced from this cache, so every plugin install reuses it.
+/// Always sync the atomic-skills cache to latest.
 ///
-/// First run clones the package; later runs reuse the cache. `--force`
-/// discards and re-clones.
-fn sync_skills_cache(force: bool) -> CliResult<std::path::PathBuf> {
+/// Unlike the plugin cache (which reuses until --force), the skills cache
+/// is **always** re-cloned on every install. This ensures new skills added
+/// to atomic-skills are picked up immediately without --force. If the
+/// re-clone fails (network), the error is returned — the caller can retry
+/// or use --from to install from a local checkout.
+fn sync_skills_cache(_force: bool) -> CliResult<std::path::PathBuf> {
     const SKILLS_AGENT: &str = "atomic-skills";
 
     let spec = atomic_agent::integrations::resolve(SKILLS_AGENT).ok_or_else(|| {
@@ -428,7 +429,21 @@ fn sync_skills_cache(force: bool) -> CliResult<std::path::PathBuf> {
         ))
     })?;
 
-    sync_integration_package(SKILLS_AGENT, &spec, force)
+    let cache = atomic_agent::integrations::cache_repo_dir(SKILLS_AGENT)
+        .map_err(|e| crate::error::CliError::Internal(anyhow::anyhow!(e.to_string())))?;
+
+    // Always delete + re-clone to get latest. The atomic-skills package is
+    // small (markdown files only), so this is fast.
+    if cache.exists() {
+        std::fs::remove_dir_all(&cache).map_err(crate::error::CliError::Io)?;
+    }
+
+    crate::commands::clone::Clone::new(spec.url.clone())
+        .with_path(cache.display().to_string())
+        .with_view(spec.view.clone())
+        .run()?;
+
+    Ok(cache)
 }
 
 /// Sync an agent's integration package into the CLI-managed cache
@@ -500,12 +515,15 @@ impl Enable {
         let manifest = atomic_agent::integrations::IntegrationManifest::load(&pkg_dir)
             .map_err(|e| crate::error::CliError::Internal(anyhow::anyhow!(e.to_string())))?;
 
-        let skills_cache_dir =
-            if manifest.skills_source.is_some() || manifest.agent_definition.is_some() {
-                Some(sync_skills_cache(self.force)?)
-            } else {
-                None
-            };
+        let skills_cache_dir = if manifest.skills_source.is_some()
+            || manifest.skills_config.is_some()
+            || manifest.agent_definition.is_some()
+            || !manifest.skills.is_empty()
+        {
+            Some(sync_skills_cache(self.force)?)
+        } else {
+            None
+        };
 
         // Determine repo_root from the --agents-md / --no-agents-md flags
         // or the interactive prompt. Only relevant when the manifest has

--- a/atomic-cli/src/commands/agent/enable.rs
+++ b/atomic-cli/src/commands/agent/enable.rs
@@ -91,6 +91,23 @@ pub struct Enable {
     /// package's atomic-integration.toml, without any network access.
     #[arg(long, value_name = "PATH")]
     from: Option<std::path::PathBuf>,
+
+    /// Also install AGENTS.md into the repository root so the Atomic
+    /// workflow is always-on without picking a bundled agent.
+    ///
+    /// When set, `[[repo-file]]` entries from the manifest are installed
+    /// into the repo. When neither `--agents-md` nor `--no-agents-md`
+    /// is set, the user is prompted interactively (default: no).
+    #[arg(long)]
+    agents_md: bool,
+
+    /// Skip the AGENTS.md-into-repo prompt entirely.
+    ///
+    /// Suppresses the interactive prompt and skips `[[repo-file]]` entries.
+    /// Useful in non-interactive contexts or when you only want the global
+    /// agent install.
+    #[arg(long)]
+    no_agents_md: bool,
 }
 
 impl Enable {
@@ -104,6 +121,8 @@ impl Enable {
             global: false,
             hooks: None,
             from: None,
+            agents_md: false,
+            no_agents_md: false,
         }
     }
 }
@@ -394,6 +413,24 @@ impl Command for Enable {
     }
 }
 
+/// Sync the shared atomic-skills package into the CLI-managed cache
+/// (`~/.atomic/integrations/atomic-skills/repo`). Skills and the canonical
+/// AGENTS.md are sourced from this cache, so every plugin install reuses it.
+///
+/// First run clones the package; later runs reuse the cache. `--force`
+/// discards and re-clones.
+fn sync_skills_cache(force: bool) -> CliResult<std::path::PathBuf> {
+    const SKILLS_AGENT: &str = "atomic-skills";
+
+    let spec = atomic_agent::integrations::resolve(SKILLS_AGENT).ok_or_else(|| {
+        crate::error::CliError::Internal(anyhow::anyhow!(
+            "atomic-skills not found in the integration registry — this is a bug"
+        ))
+    })?;
+
+    sync_integration_package(SKILLS_AGENT, &spec, force)
+}
+
 /// Sync an agent's integration package into the CLI-managed cache
 /// (`~/.atomic/integrations/<agent>/repo`) using Atomic's own remote
 /// protocol, and return the package directory (the cache's working copy).
@@ -440,6 +477,11 @@ impl Enable {
     /// syncing the registry's Atomic storage project into the CLI-managed
     /// cache. Installation itself is done by the integrations engine per the
     /// package's atomic-integration.toml.
+    ///
+    /// When the manifest declares `[skills-source]`, the shared atomic-skills
+    /// cache is synced (or reused) and passed as `skills_cache_dir`. When the
+    /// user opts in via `--agents-md` or the prompt, the repo root is passed
+    /// so `[[repo-file]]` entries land in the repo.
     fn install_integration(
         &self,
         agent_name: &str,
@@ -454,15 +496,78 @@ impl Enable {
             sync_integration_package(agent_name, spec, self.force)?
         };
 
+        // Peek at the manifest to see if we need the skills cache.
+        let manifest = atomic_agent::integrations::IntegrationManifest::load(&pkg_dir)
+            .map_err(|e| crate::error::CliError::Internal(anyhow::anyhow!(e.to_string())))?;
+
+        let skills_cache_dir = if manifest.skills_source.is_some()
+            || manifest.agent_definition.is_some()
+        {
+            Some(sync_skills_cache(self.force)?)
+        } else {
+            None
+        };
+
+        // Determine repo_root from the --agents-md / --no-agents-md flags
+        // or the interactive prompt. Only relevant when the manifest has
+        // [[repo-file]] entries.
+        let repo_root = if !manifest.repo_files.is_empty() {
+            self.resolve_repo_root()?
+        } else {
+            None
+        };
+
         let opts = atomic_agent::integrations::InstallOptions {
             force: self.force,
             cli_version: env!("CARGO_PKG_VERSION").to_string(),
             source,
             expect_agent: Some(agent_name.to_string()),
+            skills_cache_dir,
+            repo_root,
         };
 
         atomic_agent::integrations::install_from_dir(&pkg_dir, &opts)
             .map_err(|e| crate::error::CliError::Internal(anyhow::anyhow!(e.to_string())))
+    }
+
+    /// Sync the shared atomic-skills package into the CLI-managed cache.
+    ///
+    /// First run clones it; later runs reuse the cache so installs work
+    /// offline. `--force` discards the cache and re-clones.
+    fn resolve_repo_root(&self) -> CliResult<Option<std::path::PathBuf>> {
+        // If the user explicitly said no, skip.
+        if self.no_agents_md {
+            return Ok(None);
+        }
+        // If the user explicitly said yes, find the repo root and proceed.
+        if self.agents_md {
+            let repo_root = find_repository_root()?;
+            return Ok(Some(repo_root));
+        }
+        // Otherwise prompt (interactive TTY only; non-interactive defaults to no).
+        use std::io::IsTerminal;
+        if !std::io::stdin().is_terminal() {
+            println!("Skipping repo AGENTS.md (non-interactive). Use --agents-md to install.");
+            return Ok(None);
+        }
+        print!(
+            "Also install/merge AGENTS.md into this repo so the workflow is always-on\n\
+             without picking the Atomic agent? [y/N] "
+        );
+        use std::io::Write;
+        std::io::stdout().flush().ok();
+
+        let mut input = String::new();
+        std::io::stdin()
+            .read_line(&mut input)
+            .map_err(|e| crate::error::CliError::Internal(anyhow::anyhow!(e.to_string())))?;
+        let input = input.trim().to_lowercase();
+        if input == "y" || input == "yes" {
+            let repo_root = find_repository_root()?;
+            Ok(Some(repo_root))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Install hooks from an integration-supplied manifest file.
@@ -679,6 +784,8 @@ mod tests {
             global: false,
             hooks: None,
             from: None,
+            agents_md: false,
+            no_agents_md: false,
         };
     }
 
@@ -691,6 +798,8 @@ mod tests {
             global: false,
             hooks: None,
             from: None,
+            agents_md: false,
+            no_agents_md: false,
         };
         assert!(cmd.force);
         assert_eq!(cmd.agent.as_deref(), Some("claude-code"));
@@ -705,6 +814,8 @@ mod tests {
             global: false,
             hooks: None,
             from: None,
+            agents_md: false,
+            no_agents_md: false,
         };
         assert!(cmd.all);
         assert!(cmd.agent.is_none());
@@ -719,6 +830,8 @@ mod tests {
             global: true,
             hooks: None,
             from: None,
+            agents_md: false,
+            no_agents_md: false,
         };
         assert!(cmd.global);
         assert_eq!(cmd.agent.as_deref(), Some("claude-code"));

--- a/atomic-cli/src/commands/agent/enable.rs
+++ b/atomic-cli/src/commands/agent/enable.rs
@@ -96,18 +96,10 @@ pub struct Enable {
     /// workflow is always-on without picking a bundled agent.
     ///
     /// When set, `[[repo-file]]` entries from the manifest are installed
-    /// into the repo. When neither `--agents-md` nor `--no-agents-md`
-    /// is set, the user is prompted interactively (default: no).
+    /// into the repo. Without this flag, `[[repo-file]]` entries are
+    /// skipped.
     #[arg(long)]
     agents_md: bool,
-
-    /// Skip the AGENTS.md-into-repo prompt entirely.
-    ///
-    /// Suppresses the interactive prompt and skips `[[repo-file]]` entries.
-    /// Useful in non-interactive contexts or when you only want the global
-    /// agent install.
-    #[arg(long)]
-    no_agents_md: bool,
 }
 
 impl Enable {
@@ -122,7 +114,6 @@ impl Enable {
             hooks: None,
             from: None,
             agents_md: false,
-            no_agents_md: false,
         }
     }
 }
@@ -528,8 +519,8 @@ impl Enable {
         // Determine repo_root from the --agents-md / --no-agents-md flags
         // or the interactive prompt. Only relevant when the manifest has
         // [[repo-file]] entries.
-        let repo_root = if !manifest.repo_files.is_empty() {
-            self.resolve_repo_root()?
+        let repo_root = if !manifest.repo_files.is_empty() && self.agents_md {
+            Some(find_repository_root()?)
         } else {
             None
         };
@@ -545,46 +536,6 @@ impl Enable {
 
         atomic_agent::integrations::install_from_dir(&pkg_dir, &opts)
             .map_err(|e| crate::error::CliError::Internal(anyhow::anyhow!(e.to_string())))
-    }
-
-    /// Sync the shared atomic-skills package into the CLI-managed cache.
-    ///
-    /// First run clones it; later runs reuse the cache so installs work
-    /// offline. `--force` discards the cache and re-clones.
-    fn resolve_repo_root(&self) -> CliResult<Option<std::path::PathBuf>> {
-        // If the user explicitly said no, skip.
-        if self.no_agents_md {
-            return Ok(None);
-        }
-        // If the user explicitly said yes, find the repo root and proceed.
-        if self.agents_md {
-            let repo_root = find_repository_root()?;
-            return Ok(Some(repo_root));
-        }
-        // Otherwise prompt (interactive TTY only; non-interactive defaults to no).
-        use std::io::IsTerminal;
-        if !std::io::stdin().is_terminal() {
-            println!("Skipping repo AGENTS.md (non-interactive). Use --agents-md to install.");
-            return Ok(None);
-        }
-        print!(
-            "Also install/merge AGENTS.md into this repo so the workflow is always-on\n\
-             without picking the Atomic agent? [y/N] "
-        );
-        use std::io::Write;
-        std::io::stdout().flush().ok();
-
-        let mut input = String::new();
-        std::io::stdin()
-            .read_line(&mut input)
-            .map_err(|e| crate::error::CliError::Internal(anyhow::anyhow!(e.to_string())))?;
-        let input = input.trim().to_lowercase();
-        if input == "y" || input == "yes" {
-            let repo_root = find_repository_root()?;
-            Ok(Some(repo_root))
-        } else {
-            Ok(None)
-        }
     }
 
     /// Install hooks from an integration-supplied manifest file.
@@ -802,7 +753,6 @@ mod tests {
             hooks: None,
             from: None,
             agents_md: false,
-            no_agents_md: false,
         };
     }
 
@@ -816,7 +766,6 @@ mod tests {
             hooks: None,
             from: None,
             agents_md: false,
-            no_agents_md: false,
         };
         assert!(cmd.force);
         assert_eq!(cmd.agent.as_deref(), Some("claude-code"));
@@ -832,7 +781,6 @@ mod tests {
             hooks: None,
             from: None,
             agents_md: false,
-            no_agents_md: false,
         };
         assert!(cmd.all);
         assert!(cmd.agent.is_none());
@@ -848,7 +796,6 @@ mod tests {
             hooks: None,
             from: None,
             agents_md: false,
-            no_agents_md: false,
         };
         assert!(cmd.global);
         assert_eq!(cmd.agent.as_deref(), Some("claude-code"));

--- a/docs/adding-agents.md
+++ b/docs/adding-agents.md
@@ -747,7 +747,7 @@ src = "skills/code-intelligence/SKILL.md"
 dst = "~/.config/myagent/skills/code-intelligence/SKILL.md"
 
 # Install the canonical AGENTS.md into the repo root. Only fires when the
-# user opts in via --agents-md or the interactive prompt (default: no).
+# user opts in via --agents-md (no prompt by default).
 [[repo-file]]
 src = "AGENTS.md"              # from the atomic-skills cache
 dst = "AGENTS.md"              # relative to repo root
@@ -783,8 +783,7 @@ Rules of thumb:
   already exists and isn't ours, the installer **merges** — appends canonical
   content with a `---` separator, preserving the user's content. If the file
   contains the Atomic marker (`# Atomic VCS Agent`), it refreshes instead.
-  `--force` always clobbers. Only fires when the user opts in via `--agents-md`
-  or the interactive prompt (default: no).
+  `--force` always clobbers. Only fires when the user passes `--agents-md`.
 - `[agent-definition]` is a **single table** (not `[[agent-definition]]`).
   The stitch is pure string concat — `frontmatter + "\n\n" + body` — no exec.
 - `[[file]]` copies (permissions preserved); absolute paths inside the package

--- a/docs/adding-agents.md
+++ b/docs/adding-agents.md
@@ -45,7 +45,7 @@ An integration therefore has two halves:
 
 | Half | Question it answers | Built from |
 |------|--------------------|------------|
-| **Behavior** | Does the agent work the Atomic way — intent-first, using Atomic's tools, not fighting the recorder? | A system prompt + three skills (shipped in the `atomic-<agent>` package) |
+| **Behavior** | Does the agent work the Atomic way — intent-first, using Atomic's tools, not fighting the recorder? | A system prompt + skills (sourced from the shared [`atomic-skills`](https://github.com/atomicdotdev/atomic-skills) package and shipped via the `atomic-<agent>` package) |
 | **Capture** | Does Atomic receive the agent's lifecycle events and turn them into provenance-bearing changes? | Lifecycle wiring (plugin or hooks manifest) + a hook adapter in the `atomic` crate |
 
 And one requirement that spans both: **testing**, via the agent harness.
@@ -66,9 +66,17 @@ Agent support spans three repositories. Know which one owns which concern:
 
 A **skill** is an on-demand reference document the agent loads when a task
 calls for it (kept out of the always-on prompt to save context). Every Atomic
-agent ships the same three core skills, so that **behavior is identical no
-matter which agent the user runs** — the agent is interchangeable; the Atomic
-workflow is not.
+agent pulls the same skills from a single canonical source — the
+[`atomic-skills`](https://github.com/atomicdotdev/atomic-skills) package — so
+that **behavior is identical no matter which agent the user runs** — the agent
+is interchangeable; the Atomic workflow is not.
+
+The canonical skills live in `atomic-skills/skills/` and are copied into each
+agent's skill directory at install time via `[[skill]]` manifest entries
+(see [How installation works](#how-installation-works-the-integrations-engine)).
+You do **not** copy skill files into your plugin repo — you reference them
+from the shared cache. Fix a workflow detail once in `atomic-skills` and every
+agent benefits.
 
 ### 1. Intents (`atomic-vault`) — capturing the *why*
 
@@ -130,12 +138,11 @@ audit its own recorded work instead of guessing. It also reinforces the
 division of labor: **reading history is the agent's job; recording is the
 hook's job.**
 
-> Some agents ship extras on top of the core three — `atomic-claude` adds
-> `intent-builder` and `codebase-context` — but `atomic-vault`,
-> `code-intelligence`, and `atomic-vcs` are the baseline every package
-> includes. Reuse the existing `SKILL.md` files verbatim (copy them from
-> `atomic-claude/skills/`); keeping the content shared is the point — fix a
-> workflow detail once and every agent benefits.
+> The canonical `atomic-skills` package ships five skills: `atomic-vault`,
+> `atomic-vcs`, `code-intelligence`, `intent-builder`, and `decision-record`.
+> Every agent's manifest declares which skills it installs via `[[skill]]`
+> entries — most install all five, some install a subset. The skills
+> themselves are never duplicated; they always come from the shared cache.
 
 ---
 
@@ -163,11 +170,27 @@ Each agent reads its system prompt from a different file convention:
 | `steering/*.md` | Kiro |
 | `copilot-instructions.md` | Copilot |
 
-Whatever the filename, the prompt must establish the same four things. Real
-examples to copy from: [`atomic-claude/CLAUDE.md`](https://github.com/atomicdotdev/atomic-claude/blob/main/CLAUDE.md)
-(full version) and
-[`atomic-opencode/agents/atomic.md`](https://github.com/atomicdotdev/atomic-opencode/blob/main/agents/atomic.md)
-(compact version).
+Whatever the filename, the prompt must establish the same four things. The
+canonical body lives in [`atomic-skills/AGENTS.md`](https://github.com/atomicdotdev/atomic-skills/blob/main/AGENTS.md)
+— a vendor-neutral workflow document. There are two ways it gets into the
+agent's hands:
+
+1. **Bundled agent** (OpenCode, Claude, Kilo, Pi): The plugin ships a
+   frontmatter template (`agents/atomic.md.frontmatter`) containing only the
+   YAML frontmatter (description, mode, permissions, skill list). At install
+   time, the CLI stitches the frontmatter + canonical `AGENTS.md` body
+   together via `[agent-definition]` in the manifest — pure string concat, no
+   exec. The user picks the "Atomic" agent in their IDE.
+
+2. **Repo-level AGENTS.md** (all agents): `atomic agent enable --agents-md`
+   copies the canonical `AGENTS.md` into the repo root. Every agent in that
+   repo gets the workflow automatically — no agent picking. If the repo
+   already has an `AGENTS.md`, the installer appends the canonical content
+   with a `---` separator (preserving the user's project-specific content).
+
+Real examples to copy from: [`atomic-opencode/agents/atomic.md.frontmatter`](https://github.com/atomicdotdev/atomic-opencode/blob/main/agents/atomic.md.frontmatter)
+(frontmatter template) and [`atomic-skills/AGENTS.md`](https://github.com/atomicdotdev/atomic-skills/blob/main/AGENTS.md)
+(canonical body).
 
 1. **"You use Atomic VCS, not git."** — Set the tool up front so the agent
    stops reaching for `git` commands.
@@ -188,9 +211,10 @@ examples to copy from: [`atomic-claude/CLAUDE.md`](https://github.com/atomicdotd
 4. **Point at the skills.** — Tell the agent to load `atomic-vault`,
    `atomic-vcs`, and `code-intelligence` on demand.
 
-Copy an existing prompt and adapt the surface details (how that agent invokes
-skills, its permission block, its frontmatter) rather than writing from
-scratch — the workflow content should stay consistent across all agents.
+Copy a frontmatter template from an existing bundled-agent plugin and adapt
+the surface details (how that agent invokes skills, its permission block, its
+frontmatter) — the workflow body comes from the canonical `AGENTS.md` and
+should stay consistent across all agents.
 
 ---
 
@@ -458,9 +482,16 @@ Integration packages are published as **public projects on Atomic storage**.
 ```
 1. registry.toml (embedded in the CLI)   →  agent = storage URL + view
 2. atomic clone (Atomic's own sync)      →  ~/.atomic/integrations/<agent>/repo
-3. read atomic-integration.toml          →  check requires.atomic vs CLI version
-4. copy files (never symlinks)           →  merge JSON settings (never clobber)
-5. write receipt.json                    →  clean uninstall + user-file protection
+3. if [skills-source] present:
+   atomic clone atomic-skills            →  ~/.atomic/integrations/atomic-skills/repo
+   (shared cache — reused by every agent install)
+4. read atomic-integration.toml          →  check requires.atomic vs CLI version
+5. copy [[file]] entries                 →  plugins, package.json, hooks scripts
+6. copy [[skill]] entries                →  from atomic-skills cache → vendor skill path
+7. if [[repo-file]] + --agents-md:       →  copy/merge AGENTS.md into repo root
+8. if [agent-definition]:                →  stitch frontmatter + AGENTS.md body → agent slot
+9. merge [[settings]] JSON               →  into agent's settings (never clobber)
+10. write receipt.json                   →  clean uninstall + user-file protection
 ```
 
 Two artifacts make this work, and they live in different places on purpose:
@@ -468,13 +499,22 @@ Two artifacts make this work, and they live in different places on purpose:
 | Artifact | Question it answers | Where it lives |
 |----------|--------------------|----------------|
 | **`registry.toml`** (`atomic-agent/src/integrations/registry.toml`) | **Where to fetch** — adapter name → storage URL + view | In the **atomic** repo, embedded at build time. Adding an agent = a one-line PR here. |
-| **`atomic-integration.toml`** | **What to install** — files→destinations, settings manifests to merge, `requires.atomic` semver gate | In the **integration repo** (each `atomic-<agent>` package). The producer's contract: change the package layout without a CLI release. |
+| **`atomic-integration.toml`** | **What to install** — files→destinations, skills from shared cache, settings manifests to merge, `requires.atomic` semver gate | In the **integration repo** (each `atomic-<agent>` package). The producer's contract: change the package layout without a CLI release. |
+| **`atomic-skills`** ([repo](https://github.com/atomicdotdev/atomic-skills)) | **What the skills + AGENTS.md say** — the canonical skill content and vendor-neutral workflow body | A separate storage project, cloned into the shared cache on first install. |
 
 Key properties of this model:
 
 - **The CLI executes nothing from the package** — no `install.sh`, no
-  postinstall. Files are copied, JSON is merged. Pure Rust, Windows-safe,
-  no bash/node/bun at install time.
+  postinstall. Files are copied, JSON is merged, agent bodies are stitched
+  via string concat. Pure Rust, Windows-safe, no bash/node/bun at install time.
+- **Skills come from a shared cache.** The `atomic-skills` package is cloned
+  once into `~/.atomic/integrations/atomic-skills/repo` and reused by every
+  agent install. No per-plugin skill duplication.
+- **AGENTS.md can merge.** When `--agents-md` installs the canonical
+  `AGENTS.md` into a repo that already has one, the installer appends the
+  canonical content with a `---` separator (preserving the user's content).
+  If the file already contains the Atomic marker (`# Atomic VCS Agent`), it's
+  refreshed instead. `--force` always clobbers.
 - **User files are sacred.** A destination the CLI didn't install, or one the
   user modified since, is skipped (unless `--force`). The receipt
   (`~/.atomic/integrations/<agent>/receipt.json`) is what makes this possible.
@@ -636,25 +676,35 @@ and [`atomic-claude`](https://github.com/atomicdotdev/atomic-claude)):
 ```
 atomic-<agent>/
 ├── atomic-integration.toml           # REQUIRED — the install manifest (below)
-├── agents/<agent>.md   or  CLAUDE.md / AGENTS.md   # system prompt (see above)
-├── skills/
-│   ├── atomic-vault/SKILL.md
-│   ├── atomic-vcs/SKILL.md
-│   └── code-intelligence/SKILL.md
+├── agents/<agent>.md.frontmatter     # frontmatter template (bundled-agent plugins only)
+│                                        body comes from atomic-skills/AGENTS.md at install
 ├── hooks/<agent>.atomic-hooks.json   # settings manifest (config-file style)
 │   —or—
 ├── plugins/atomic-hooks.ts           # plugin (plugin style)
+├── package.json                      # if the plugin needs npm deps (opencode, kilo)
 └── README.md                         # notes the definitive source is Atomic storage
 ```
+
+> **Skills and AGENTS.md do not live in the plugin repo.** They come from the
+> [`atomic-skills`](https://github.com/atomicdotdev/atomic-skills) shared
+> package. The plugin's manifest references them via `[skills-source]` +
+> `[[skill]]` + `[[repo-file]]` entries, and the installer copies them from
+> the shared cache at install time.
 
 You have already seen the three ingredients — the prompt, the skills, and the
 wiring — in the conceptual half of this doc. Assembly notes:
 
-- **Prompt**: ship it under the filename convention your agent reads (see the
-  table in [The system prompt](#the-system-prompt-agentsmd-and-friends)).
-- **Skills**: copy the three core `SKILL.md` files verbatim; the manifest
-  copies them into the agent's skills directory (e.g.
-  `~/.config/opencode/skills/`, `~/.claude/skills/`).
+- **Prompt**: for bundled-agent plugins, ship a frontmatter template
+  (`agents/<agent>.md.frontmatter`) containing only the YAML block. The
+  canonical workflow body comes from `atomic-skills/AGENTS.md` and is stitched
+  in at install time via `[agent-definition]`. For non-bundled plugins, the
+  canonical `AGENTS.md` is delivered via `[[skill]]` (to the agent's
+  instruction-file path) and/or `[[repo-file]]` (to the repo root).
+- **Skills**: declare them as `[[skill]]` entries in the manifest — `src`
+  points into the `atomic-skills` cache (e.g. `skills/atomic-vault/SKILL.md`),
+  `dst` is the vendor's skill path. Vendors with flat layouts (Cline
+  Workflows, agy plugin/skills) use a flat `.md` filename instead of
+  `<name>/SKILL.md`.
 - **Wiring**: whichever style the agent's extension model dictates (see
   [Plugin vs. config file](#plugin-vs-config-file-choosing-the-wiring)).
   Guard every hook: `test -d .atomic || test -f .atomic-sandbox && … || true`
@@ -673,17 +723,46 @@ agent = "myagent"              # must match the adapter name in the registry
 version = "1.0.0"
 
 [requires]
-atomic = ">=0.11.0"            # semver gate — older CLIs get a hard error,
-                               # not a silently broken install
+atomic = ">=0.15.0"            # semver gate — older CLIs get a hard error
 
-# Every file to copy, package-relative src → absolute dst (~ expands):
-[[file]]
-src = "agents/atomic.md"
-dst = "~/.config/myagent/agents/atomic.md"
+# Shared skills source — names the atomic-skills package in the registry.
+# When set, the CLI clones atomic-skills into the shared cache and
+# [[skill]] / [[repo-file]] / [agent-definition] entries resolve their
+# src paths against that cache.
+[skills-source]
+package = "atomic-skills"
 
-[[file]]
+# Skills to copy from the atomic-skills cache into the agent's skill dir.
+# src = path in atomic-skills cache; dst = vendor path (~ expands to home).
+[[skill]]
 src = "skills/atomic-vault/SKILL.md"
 dst = "~/.config/myagent/skills/atomic-vault/SKILL.md"
+
+[[skill]]
+src = "skills/atomic-vcs/SKILL.md"
+dst = "~/.config/myagent/skills/atomic-vcs/SKILL.md"
+
+[[skill]]
+src = "skills/code-intelligence/SKILL.md"
+dst = "~/.config/myagent/skills/code-intelligence/SKILL.md"
+
+# Install the canonical AGENTS.md into the repo root. Only fires when the
+# user opts in via --agents-md or the interactive prompt (default: no).
+[[repo-file]]
+src = "AGENTS.md"              # from the atomic-skills cache
+dst = "AGENTS.md"              # relative to repo root
+
+# For bundled-agent plugins only (opencode, claude, kilo, pi):
+# Stitch frontmatter + canonical AGENTS.md body at install time.
+[agent-definition]
+src = "agents/atomic.md.frontmatter"        # frontmatter template in this package
+body_from = "atomic-skills:AGENTS.md"       # canonical body from the skills cache
+slot = "~/.config/myagent/agents/atomic.md"  # where the stitched file lands
+
+# Non-skill files to copy (plugins, package.json, hooks scripts, etc.)
+[[file]]
+src = "plugins/atomic-hooks.ts"
+dst = "~/.config/myagent/plugins/atomic-hooks.ts"
 
 # Settings manifests to merge (the hooks-manifest format — same engine as
 # `atomic agent enable --hooks`):
@@ -693,8 +772,22 @@ manifest = "hooks/myagent.atomic-hooks.json"
 
 Rules of thumb:
 
-- `[[file]]` copies (permissions preserved); destinations the user owns or
-  modified are skipped unless `--force`. Absolute paths inside the package
+- `[skills-source]` declares the shared package. Without it, `[[skill]]` and
+  `[agent-definition]` entries have no cache to resolve from and the installer
+  errors.
+- `[[skill]]` copies from the skills cache; destinations the user owns or
+  modified are skipped unless `--force`. Vendors with flat skill layouts
+  (Cline: `Workflows/<name>.md`, agy: `plugin/skills/<name>.md`) use a flat
+  `.md` filename in `dst`.
+- `[[repo-file]]` installs into the **repo root** (not home). When AGENTS.md
+  already exists and isn't ours, the installer **merges** — appends canonical
+  content with a `---` separator, preserving the user's content. If the file
+  contains the Atomic marker (`# Atomic VCS Agent`), it refreshes instead.
+  `--force` always clobbers. Only fires when the user opts in via `--agents-md`
+  or the interactive prompt (default: no).
+- `[agent-definition]` is a **single table** (not `[[agent-definition]]`).
+  The stitch is pure string concat — `frontmatter + "\n\n" + body` — no exec.
+- `[[file]]` copies (permissions preserved); absolute paths inside the package
   (`src` starting with `/` or containing `..`) are rejected.
 - `[[settings]]` is also how you register things in the agent's own JSON
   config without clobbering it — e.g. atomic-opencode registers its plugin in
@@ -724,6 +817,13 @@ Then add the `registry.toml` entry (step 1.2b) so `enable` can find it.
 Public visibility matters: private projects can't be pulled anonymously, and
 the failure surfaces as a confusing "view not found".
 
+> **Skills are published separately.** The canonical `atomic-skills` package
+> (https://github.com/atomicdotdev/atomic-skills) is the single source of
+> truth for all skills and AGENTS.md content. Your plugin does not publish
+> its own copy — it references `atomic-skills` via `[skills-source]` in the
+> manifest. Updates to skills or the workflow body are pushed to
+> `atomic-skills` once and every plugin picks them up on next install.
+
 #### 2.6 Development loop
 
 Work on the package locally and install from the checkout — no push needed:
@@ -750,7 +850,8 @@ AgentEntry {
     package: "atomic-myagent",          // dir name under AGENTS_DIR
     prompt: PromptKind::AgentsDir,      // where the prompt lives
     installed_skills_dir: "~/.config/myagent/skills",
-    skills: &["atomic-vault", "atomic-vcs", "code-intelligence"],
+    skills: &["atomic-vault", "atomic-vcs", "code-intelligence",
+              "intent-builder", "decision-record"],
 }
 ```
 
@@ -840,9 +941,11 @@ You want all of them green before calling the integration done.
 
 **In `atomic-<agent>` (integration package):**
 
-- [ ] `atomic-integration.toml` with `agent` matching the adapter name, `requires.atomic`, all `[[file]]` srcs verified to exist.
-- [ ] System prompt in the agent's convention (`CLAUDE.md` / `AGENTS.md` / `agents/*.md` / …).
-- [ ] Skills: `atomic-vault`, `atomic-vcs`, `code-intelligence`.
+- [ ] `atomic-integration.toml` with `agent` matching the adapter name, `requires.atomic >=0.15.0`, all `[[file]]` srcs verified to exist.
+- [ ] `[skills-source]` declaring `package = "atomic-skills"`.
+- [ ] `[[skill]]` entries for the skills this agent should install (typically all 5: `atomic-vault`, `atomic-vcs`, `code-intelligence`, `intent-builder`, `decision-record`).
+- [ ] `[[repo-file]]` entry for AGENTS.md-into-repo (so `--agents-md` works).
+- [ ] For bundled-agent plugins: `agents/<agent>.md.frontmatter` (frontmatter template) + `[agent-definition]` entry with `body_from = "atomic-skills:AGENTS.md"`.
 - [ ] Lifecycle wiring: a hooks manifest **or** a plugin that calls `atomic agent hooks <agent> <verb>`.
 - [ ] Every hook guarded with `test -d .atomic || test -f .atomic-sandbox && … || true`.
 - [ ] Pushed to Atomic storage (`git import` for full history), project **public**, README notes the definitive source.
@@ -859,10 +962,11 @@ You want all of them green before calling the integration done.
 
 | Repo | Style | Look at it for |
 |------|-------|----------------|
-| [`atomicdotdev/atomic-opencode`](https://github.com/atomicdotdev/atomic-opencode) | Plugin | `plugins/atomic-hooks.ts` (lifecycle → CLI), `agents/atomic.md` (compact prompt) |
-| [`atomicdotdev/atomic-claude`](https://github.com/atomicdotdev/atomic-claude) | Hooks manifest | `hooks/claude-code.atomic-hooks.json` (manifest), `CLAUDE.md` (full prompt), all five skills |
+| [`atomicdotdev/atomic-skills`](https://github.com/atomicdotdev/atomic-skills) | Canonical content | `AGENTS.md` (vendor-neutral workflow body), `skills/*/SKILL.md` (5 canonical skills) |
+| [`atomicdotdev/atomic-opencode`](https://github.com/atomicdotdev/atomic-opencode) | Plugin + bundled agent | `atomic-integration.toml` (full manifest with all new fields), `agents/atomic.md.frontmatter` (frontmatter template), `plugins/atomic-hooks.ts` (lifecycle → CLI) |
+| [`atomicdotdev/atomic-claude`](https://github.com/atomicdotdev/atomic-claude) | Hooks manifest + bundled agent | `atomic-integration.toml`, `agents/intent.md.frontmatter`, `hooks/claude-code.atomic-hooks.json` (manifest) |
 | [`atomicdotdev/atomic-agents`](https://github.com/atomicdotdev/atomic-agents) | Test harness | `crates/atomic-agent-harness/src/env.rs` (agent registry) |
-| [`atomicdotdev/atomic`](https://github.com/atomicdotdev/atomic) | Engine (this repo) | `atomic-agent/src/hooks/opencode.rs` (reference adapter) |
+| [`atomicdotdev/atomic`](https://github.com/atomicdotdev/atomic) | Engine (this repo) | `atomic-agent/src/hooks/opencode.rs` (reference adapter), `atomic-agent/src/integrations/` (engine) |
 
 ## Reference: key files
 
@@ -872,6 +976,7 @@ You want all of them green before calling the integration done.
 - Verb → hook-type map: `atomic-agent/src/event.rs` (`HookType::from_verb`)
 - Integrations engine: `atomic-agent/src/integrations/` (`registry.toml`,
   `manifest.rs`, `install.rs`, `receipt.rs`)
+- Canonical skills + AGENTS.md: [`atomic-skills`](https://github.com/atomicdotdev/atomic-skills) (`AGENTS.md`, `skills/*/SKILL.md`)
 - Manifest install engine (settings merge): `atomic-agent/src/hooks/manifest.rs`
 - Orchestrator (does the recording): `atomic-agent/src/turn/orchestrator.rs`
 - Hooks CLI entry: `atomic-cli/src/commands/agent/hooks.rs`


### PR DESCRIPTION
Implements the atomic-skills standardization engine in the integrations pipeline. The 12 agent plugins (atomic-opencode, atomic-claude, -codex, -copilot, -cursor, -cline, -devin, -grok, -kilo, -kiro, -pi, -agy) each carry duplicated copies of the same skills and AGENTS.md that had already diverged — `atomic-vault/SKILL.md` alone existed in 4 distinct versions, and half the ecosystem served stale instructions referencing removed commands. This PR adds the engine that lets all plugins pull from a single canonical source.

## Canonical package

**atomic-skills** (https://github.com/atomicdotdev/atomic-skills) — vendor-neutral `AGENTS.md` + 5 skills (`atomic-vault`, `atomic-vcs`, `code-intelligence`, `intent-builder`, `decision-record`). The CLI clones it into `~/.atomic/integrations/atomic-skills/repo` (shared cache, once — every plugin install reuses it).

## New manifest fields (additive, schema 1)

| Field | TOML | Purpose |
|---|---|---|
| `[skills-source]` | single table | Names the shared package (`"atomic-skills"`) |
| `[[skill]]` | array | One skill to copy from the cache to the vendor path |
| `[[repo-file]]` | array | One file to install into the *repo* root (AGENTS.md) |
| `[agent-definition]` | single table | Bundled agent: frontmatter + canonical body stitched at install |

All optional, no `deny_unknown_fields`. Existing manifests without these fields parse unchanged.

## Installer changes (`install.rs`)

- `InstallOptions` gains `skills_cache_dir` + `repo_root`
- `copy_one()` helper shared by `[[file]]`, `[[skill]]`, `[[repo-file]]`
- `copy_repo_file()` handles **merge**: when AGENTS.md exists and isn't ours, appends canonical content with a `---` separator (preserving the user's project-specific content above); if it contains the Atomic marker (`# Atomic VCS Agent`), refreshes instead; `--force` clobbers
- `repo_file_decision()` + `ATOMIC_MARKER` constant
- `Decision::Merge` variant (only for `[[repo-file]]`; `[[file]]`/`[[skill]]` keep skip-or-force)
- Agent-definition stitch is pure string concat (`frontmatter + "\n\n" + body`) — no exec, same safety category as `fs::copy` and the existing `hooks::manifest` JSON merge

## CLI changes (`enable.rs`)

- `--agents-md` / `--no-agents-md` flags (renamed from `--repo-agents` for clarity)
- Interactive TTY prompt (default no; non-interactive defaults to no)
- `sync_skills_cache()` syncs the shared atomic-skills cache (reused across all agent installs)
- Manifest peeked before install to decide if skills cache is needed

## Registry (`registry.toml`)

```toml
[agents.atomic-skills]
url = "https://atomic.atomic.storage/workspaces/oss/projects/atomic-skills/code"
view = "release"
```

## Tests

29 in atomic-agent (9 new: skills-from-cache, repo-file-into-repo, agent-definition stitch, merge with existing user file, refresh when Atomic marker present, force clobber, repo-file rejected absolute/traversal dst, uninstall removes from repo). 11 in atomic-cli. All passing.

## Companion PRs

- atomic-skills: https://github.com/atomicdotdev/atomic-skills (canonical package, already pushed)
- 12 plugin manifests:
  - https://github.com/atomicdotdev/atomic-opencode/pull/6
  - https://github.com/atomicdotdev/atomic-claude/pull/3
  - https://github.com/atomicdotdev/atomic-codex/pull/2
  - https://github.com/atomicdotdev/atomic-copilot/pull/1
  - https://github.com/atomicdotdev/atomic-cursor/pull/1
  - https://github.com/atomicdotdev/atomic-cline/pull/1
  - https://github.com/atomicdotdev/atomic-devin/pull/1
  - https://github.com/atomicdotdev/atomic-grok/pull/1
  - https://github.com/atomicdotdev/atomic-kilo/pull/1
  - https://github.com/atomicdotdev/atomic-kiro/pull/1
  - https://github.com/atomicdotdev/atomic-pi/pull/1
  - https://github.com/atomicdotdev/atomic-agy/pull/1
- atomic-agents harness: https://github.com/atomicdotdev/atomic-agents/pull/8 (remove codebase-context from AGENT_REGISTRY)
