### PR TITLE
Fix Remote Draft Views

### DIFF
--- a/atomic-cli/src/commands/clone/command.rs
+++ b/atomic-cli/src/commands/clone/command.rs
@@ -14,11 +14,19 @@
 //! 3. **Create with Guard**: Create directory with cleanup on error
 //! 4. **Initialize Repository**: Set up empty local repository
 //! 5. **Connect to Remote**: Establish HTTP connection
-//! 6. **Query Remote State**: Get channel state and changelist
-//! 7. **Download Changes**: Fetch all changes in order
-//! 8. **Apply Changes**: Apply to local view (unless download-only)
+//! 6. **Fetch View Manifests**: Get the requested view's manifest and walk
+//!    its parent chain to the root
+//! 7. **Download Changes**: Fetch the missing union of the chain's changes
+//! 8. **Apply Manifests**: Apply root→leaf, preserving each view's
+//!    scope and parent (unless download-only)
 //! 9. **Configure Remote**: Save "origin" remote configuration
 //! 10. **Report Results**: Display summary to user
+//!
+//! View reconstruction is manifest-based: each view arrives as a
+//! [`ViewManifest`] carrying its full identity (name, scope, parent, ordered
+//! change log, merkle state), so a draft cloned back is still a draft with
+//! its parent intact. Servers that predate `?view-manifest` support cannot
+//! be cloned from — that is a hard error, not a lossy fallback.
 //!
 //! # Error Handling
 //!
@@ -26,15 +34,17 @@
 //! resolution. If the clone fails partway through, the `CleanupGuard`
 //! ensures the partially created directory is removed.
 
+use std::collections::HashSet;
 use std::path::Path;
 use std::time::Duration;
 
 use clap::Parser;
 use git2::Repository as GitRepository;
 
-use atomic_core::types::Base32;
-use atomic_remote::{HttpRemote, HttpRemoteConfig};
-use atomic_repository::Repository;
+use atomic_core::pristine::ViewScope;
+use atomic_core::types::{Base32, Hash};
+use atomic_remote::{HttpRemote, HttpRemoteConfig, RemoteError};
+use atomic_repository::{ManifestApplyOutcome, Repository, ViewManifest};
 
 use crate::commands::Command;
 use crate::error::{CliError, CliResult};
@@ -45,8 +55,9 @@ use crate::output::{
 };
 
 use super::helpers::{
-    convert_remote_error, format_bytes, format_count, infer_repo_name, resolve_target_path,
-    save_downloaded_change, validate_target_path, CleanupGuard,
+    change_union, classify_inventory, convert_remote_error, format_bytes, format_count,
+    infer_repo_name, manifest_apply_order, parse_remote_manifest, resolve_target_path,
+    save_downloaded_change, validate_target_path, CleanupGuard, InventoryOutcome,
 };
 use super::types::{ClonePhase, CloneProgress, CloneStats};
 
@@ -62,6 +73,15 @@ pub const DEFAULT_VIEW: &str = "dev";
 /// 30 seconds provides a reasonable balance between allowing slow networks
 /// and failing quickly on unresponsive servers.
 pub const DEFAULT_TIMEOUT_SECS: u64 = 30;
+
+/// Temporary parking view used while deleting an init scaffold view.
+///
+/// `Repository::init` pre-creates a shared root view and leaves it current.
+/// When the remote's manifest for that view declares a different identity
+/// (draft, or a parent), the empty scaffold must be deleted and recreated —
+/// but the current view cannot be deleted, so clone briefly parks on this
+/// view and removes it again before finishing.
+const SCAFFOLD_PARK_VIEW: &str = "atomic-clone-scaffold-park";
 
 // Clone Command
 
@@ -301,34 +321,318 @@ impl Clone {
             .unwrap_or_else(|| "repo".to_string())
     }
 
-    /// Clone every remote view other than the primary `--view`.
+    /// Convert a manifest-fetch failure into a CLI error.
     ///
-    /// Each view is created locally (as a shared view, matching how the
-    /// server stores pushed views) and populated from its remote changelist.
-    /// Changes are content-addressed, so any already downloaded for the
-    /// primary view are reused — only genuinely new changes are fetched.
-    /// Returns the number of additional views cloned.
+    /// A protocol error means the server predates `?view-manifest` support.
+    /// That is fatal: without manifests a clone cannot preserve view
+    /// identity (scope and parent), so there is no fallback to the old flat
+    /// changelist path.
+    fn manifest_fetch_error(&self, err: RemoteError) -> CliError {
+        if matches!(err, RemoteError::ProtocolError { .. }) {
+            CliError::RemoteError {
+                message: "This server is too old for identity-preserving clone: it does not \
+                          support view manifests (?view-manifest). Upgrade the server."
+                    .to_string(),
+                url: Some(self.url.clone()),
+            }
+        } else {
+            convert_remote_error(err, &self.url)
+        }
+    }
+
+    /// Fetch and validate one view's manifest from the remote.
+    ///
+    /// Returns `Ok(None)` if the remote does not have the view.
+    async fn fetch_view_manifest(
+        &self,
+        remote: &HttpRemote,
+        view: &str,
+    ) -> CliResult<Option<ViewManifest>> {
+        match remote.get_view_manifest(view).await {
+            Ok(Some(text)) => parse_remote_manifest(view, &text, &self.url).map(Some),
+            Ok(None) => Ok(None),
+            Err(e) => Err(self.manifest_fetch_error(e)),
+        }
+    }
+
+    /// Fetch the requested view's manifest and walk its parent chain up to
+    /// the root, returning the manifests in root→leaf apply order.
+    ///
+    /// Returns `Ok(None)` when the requested view does not exist on the
+    /// remote. A declared parent that is missing remotely, or a parent chain
+    /// that loops, means the remote's view metadata is corrupted and is a
+    /// hard error.
+    async fn fetch_manifest_chain(
+        &self,
+        remote: &HttpRemote,
+    ) -> CliResult<Option<Vec<ViewManifest>>> {
+        let Some(leaf) = self.fetch_view_manifest(remote, &self.view).await? else {
+            return Ok(None);
+        };
+
+        let mut visited: HashSet<String> = HashSet::new();
+        visited.insert(leaf.name.clone());
+        let mut next_parent = leaf.parent.clone();
+        let mut chain = vec![leaf];
+
+        while let Some(parent) = next_parent {
+            if !visited.insert(parent.clone()) {
+                return Err(CliError::RemoteError {
+                    message: format!(
+                        "View parent chain loops at '{}' — the remote's view metadata is corrupted",
+                        parent
+                    ),
+                    url: Some(self.url.clone()),
+                });
+            }
+            let child_name = chain
+                .last()
+                .map(|m| m.name.clone())
+                .unwrap_or_else(|| self.view.clone());
+            let manifest = self
+                .fetch_view_manifest(remote, &parent)
+                .await?
+                .ok_or_else(|| CliError::RemoteError {
+                    message: format!(
+                        "View '{}' declares parent '{}', but the remote has no such view",
+                        child_name, parent
+                    ),
+                    url: Some(self.url.clone()),
+                })?;
+            next_parent = manifest.parent.clone();
+            chain.push(manifest);
+        }
+
+        // Collected leaf→root; parents must be applied first.
+        chain.reverse();
+        Ok(Some(chain))
+    }
+
+    /// Download every change in `missing` and save it to the change store.
+    ///
+    /// Stops on the first download failure to maintain consistency (the
+    /// manifest apply would fail on the missing change anyway).
+    async fn download_missing_changes(
+        &self,
+        repo: &Repository,
+        remote: &HttpRemote,
+        missing: &[Hash],
+        stats: &mut CloneStats,
+        progress: &mut CloneProgress,
+    ) -> CliResult<()> {
+        if missing.is_empty() {
+            return Ok(());
+        }
+
+        print_blank();
+        println!("Downloading {}:", format_count(missing.len(), "change"));
+        print_blank();
+
+        let progress_bar = create_progress_bar(missing.len() as u64, "Downloading changes");
+
+        for (i, hash) in missing.iter().enumerate() {
+            let hash_str = hash.to_base32();
+            let hash_display = &hash_str[..12.min(hash_str.len())];
+
+            match remote.download_change(&hash_str).await {
+                Ok(data) => {
+                    let data_len = data.len() as u64;
+
+                    // Save to local change store
+                    match save_downloaded_change(repo, hash, data) {
+                        Ok(()) => {
+                            stats.record_change_downloaded(data_len);
+                            progress.record_downloaded();
+                            println!(
+                                "  {} {}... ({}/{})",
+                                success("✓"),
+                                style_hash(hash_display),
+                                i + 1,
+                                missing.len()
+                            );
+                        }
+                        Err(e) => {
+                            stats.record_failed();
+                            println!(
+                                "  {} {}... ({}/{}) save failed: {}",
+                                error("✗"),
+                                hash_display,
+                                i + 1,
+                                missing.len(),
+                                e
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    stats.record_failed();
+                    println!(
+                        "  {} {}... ({}/{}) download failed: {}",
+                        error("✗"),
+                        hash_display,
+                        i + 1,
+                        missing.len(),
+                        e
+                    );
+
+                    // Stop on first failure to maintain consistency
+                    return Err(convert_remote_error(e, &self.url));
+                }
+            }
+
+            progress_bar.inc(1);
+        }
+
+        finish_success(
+            &progress_bar,
+            &format!(
+                "Downloaded {} ({})",
+                format_count(stats.changes_downloaded, "change"),
+                format_bytes(stats.bytes_transferred)
+            ),
+        );
+
+        Ok(())
+    }
+
+    /// Remove an empty locally-created view whose identity conflicts with
+    /// the manifest about to be applied.
+    ///
+    /// `Repository::init` pre-creates a shared root view (e.g. "dev"). If
+    /// the remote's view of the same name is a draft or has a parent,
+    /// `apply_view_manifest` would report an identity mismatch even though
+    /// the local view is just an empty scaffold. Deleting the scaffold lets
+    /// the manifest recreate the view with its declared identity.
+    ///
+    /// Views with changes are left alone: a genuine divergence must surface
+    /// as an apply error, never a silent delete.
+    fn reconcile_scaffold_view(
+        &self,
+        repo: &mut Repository,
+        manifest: &ViewManifest,
+    ) -> CliResult<()> {
+        if !repo
+            .view_exists(&manifest.name)
+            .map_err(CliError::Repository)?
+        {
+            return Ok(());
+        }
+        let info = repo
+            .get_view_info(&manifest.name)
+            .map_err(CliError::Repository)?;
+        if info.scope == manifest.scope && info.parent_name == manifest.parent {
+            // Identity matches; apply_view_manifest handles the log.
+            return Ok(());
+        }
+        if info.change_count > 0 {
+            // Not a scaffold; let apply_view_manifest report the mismatch.
+            return Ok(());
+        }
+
+        // The scaffold may be the current view (init leaves it current),
+        // and the current view cannot be deleted — park on a temporary
+        // root view first. It is removed again before clone finishes.
+        if repo.current_view() == manifest.name {
+            if !repo
+                .view_exists(SCAFFOLD_PARK_VIEW)
+                .map_err(CliError::Repository)?
+            {
+                repo.create_shared_view(SCAFFOLD_PARK_VIEW)
+                    .map_err(CliError::Repository)?;
+            }
+            repo.align_to_view(SCAFFOLD_PARK_VIEW)
+                .map_err(CliError::Repository)?;
+        }
+
+        // Shared views cannot be deleted directly; demote first.
+        if info.scope.is_shared() {
+            repo.set_view_scope(&manifest.name, ViewScope::Draft)
+                .map_err(CliError::Repository)?;
+        }
+        repo.delete_view(&manifest.name)
+            .map_err(CliError::Repository)?;
+        Ok(())
+    }
+
+    /// Remove the temporary parking view, if scaffold reconciliation
+    /// created it. Best-effort: a leftover parking view is cosmetic.
+    fn remove_park_view(&self, repo: &mut Repository) {
+        if let Ok(true) = repo.view_exists(SCAFFOLD_PARK_VIEW) {
+            let _ = repo.set_view_scope(SCAFFOLD_PARK_VIEW, ViewScope::Draft);
+            if let Err(e) = repo.delete_view(SCAFFOLD_PARK_VIEW) {
+                log::warn!(
+                    "could not remove temporary view '{}': {}",
+                    SCAFFOLD_PARK_VIEW,
+                    e
+                );
+            }
+        }
+    }
+
+    /// Apply manifests in root→leaf order, reconciling scaffold views first.
+    ///
+    /// Returns one outcome per manifest, in apply order.
+    fn apply_manifests(
+        &self,
+        repo: &mut Repository,
+        manifests: &[ViewManifest],
+    ) -> CliResult<Vec<ManifestApplyOutcome>> {
+        let mut outcomes = Vec::with_capacity(manifests.len());
+        for manifest in manifests {
+            self.reconcile_scaffold_view(repo, manifest)?;
+            let outcome = repo.apply_view_manifest(manifest).map_err(|e| {
+                CliError::Internal(anyhow::anyhow!(
+                    "apply manifest for view '{}': {}",
+                    manifest.name,
+                    e
+                ))
+            })?;
+            outcomes.push(outcome);
+        }
+        Ok(outcomes)
+    }
+
+    /// Clone every remote view not already applied by the primary chain.
+    ///
+    /// Each view arrives as a manifest and is applied with the same
+    /// primitive as the primary view, so scope and parent are preserved.
+    /// Manifests are ordered parents-before-children; changes are
+    /// content-addressed and deduplicated against everything already
+    /// downloaded. Returns the number of additional views cloned.
     async fn clone_additional_views(
         &self,
         repo: &mut Repository,
         remote: &HttpRemote,
         stats: &mut CloneStats,
+        applied: &mut HashSet<String>,
     ) -> CliResult<usize> {
-        let remote_views = match remote.list_views().await {
-            Ok(v) => v,
-            // Older servers don't expose the inventory — treat as single-view.
-            Err(_) => return Ok(0),
+        // The user explicitly asked for every view, so a missing inventory
+        // is a hard error, not a silent single-view clone.
+        let remote_views = remote
+            .list_views()
+            .await
+            .map_err(|e| CliError::RemoteError {
+                message: format!(
+                    "--all-views requires the view inventory (?views), but the request failed: {}",
+                    e
+                ),
+                url: Some(self.url.clone()),
+            })?;
+
+        let names: Vec<String> = remote_views.into_iter().map(|v| v.name).collect();
+        let others = match classify_inventory(&names, applied) {
+            InventoryOutcome::Views(others) => others,
+            InventoryOutcome::NothingNew => return Ok(0),
+            InventoryOutcome::Unsupported => {
+                return Err(CliError::RemoteError {
+                    message: "--all-views requires the view inventory (?views), but this \
+                              server does not support it (empty inventory). Upgrade the \
+                              server, or clone a single view without --all-views."
+                        .to_string(),
+                    url: Some(self.url.clone()),
+                })
+            }
         };
-
-        let others: Vec<String> = remote_views
-            .into_iter()
-            .map(|v| v.name)
-            .filter(|name| name != &self.view)
-            .collect();
-
-        if others.is_empty() {
-            return Ok(0);
-        }
 
         print_blank();
         println!(
@@ -337,20 +641,66 @@ impl Clone {
             if others.len() == 1 { "view" } else { "views" }
         );
 
-        let mut cloned = 0usize;
+        // Fetch manifests for every remaining view.
+        let mut manifests: Vec<ViewManifest> = Vec::with_capacity(others.len());
         for name in &others {
-            match self.clone_one_view(repo, remote, name, stats).await {
-                Ok(applied) => {
+            match self.fetch_view_manifest(remote, name).await {
+                Ok(Some(m)) => manifests.push(m),
+                Ok(None) => {
+                    print_warning(&format!(
+                        "View '{}' vanished from the remote — skipped",
+                        name
+                    ));
+                }
+                Err(e) => {
+                    print_warning(&format!(
+                        "Failed to fetch manifest for view '{}': {}",
+                        name, e
+                    ));
+                }
+            }
+        }
+
+        // Parents must apply before children; anything unorderable (parent
+        // cycle or a parent that exists nowhere) is reported and skipped.
+        let (order, stuck) = manifest_apply_order(&manifests, applied);
+        for &i in &stuck {
+            print_warning(&format!(
+                "Cannot clone view '{}': parent '{}' is not available (cycle or missing view)",
+                manifests[i].name,
+                manifests[i].parent.as_deref().unwrap_or("-"),
+            ));
+        }
+
+        let ordered: Vec<ViewManifest> = order.iter().map(|&i| manifests[i].clone()).collect();
+
+        // Download the union of changes these views need, minus everything
+        // the primary chain already fetched (content-addressed dedupe).
+        let missing: Vec<Hash> = change_union(&ordered)
+            .into_iter()
+            .filter(|h| !repo.has_change(h))
+            .collect();
+        let mut progress = CloneProgress::new(missing.len());
+        progress.phase = ClonePhase::Downloading;
+        self.download_missing_changes(repo, remote, &missing, stats, &mut progress)
+            .await?;
+
+        let mut cloned = 0usize;
+        for manifest in &ordered {
+            self.reconcile_scaffold_view(repo, manifest)?;
+            match repo.apply_view_manifest(manifest) {
+                Ok(outcome) => {
                     cloned += 1;
+                    applied.insert(manifest.name.clone());
                     println!(
                         "  {} {} ({})",
                         success("\u{2713}"),
-                        style_view(name),
-                        format_count(applied, "change")
+                        style_view(&manifest.name),
+                        format_count(outcome.already_present + outcome.replayed, "change")
                     );
                 }
                 Err(e) => {
-                    print_warning(&format!("Failed to clone view '{}': {}", name, e));
+                    print_warning(&format!("Failed to clone view '{}': {}", manifest.name, e));
                 }
             }
         }
@@ -358,83 +708,19 @@ impl Clone {
         Ok(cloned)
     }
 
-    /// Create one view locally and populate it from its remote changelist.
-    ///
-    /// Returns the number of changes inserted into the view.
-    async fn clone_one_view(
-        &self,
-        repo: &mut Repository,
-        remote: &HttpRemote,
-        view_name: &str,
-        stats: &mut CloneStats,
-    ) -> CliResult<usize> {
-        if !repo.view_exists(view_name).map_err(CliError::Repository)? {
-            repo.create_shared_view(view_name)
-                .map_err(CliError::Repository)?;
-        }
-
-        let entries = remote
-            .get_changelist(view_name, 0)
-            .await
-            .map_err(|e| convert_remote_error(e, &self.url))?;
-
-        let mut applied = 0usize;
-        for entry in &entries {
-            let Some(hash) = atomic_core::types::Hash::from_base32(entry.hash.as_bytes()) else {
-                continue;
-            };
-
-            // Reuse content already present locally; fetch only what's missing.
-            if !repo.has_change(&hash) {
-                let data = remote
-                    .download_change(&entry.hash)
-                    .await
-                    .map_err(|e| convert_remote_error(e, &self.url))?;
-                let len = data.len() as u64;
-                save_downloaded_change(&*repo, &hash, data).map_err(|e| {
-                    CliError::Internal(anyhow::anyhow!("save change {}: {}", entry.hash, e))
-                })?;
-                stats.record_change_downloaded(len);
-            }
-
-            // Insert the change (and its dependency closure) into this view.
-            // Changes arrive in dependency order, so deps are already present.
-            let opts = atomic_repository::InsertOptions::default()
-                .apply_deps(true)
-                .view(view_name);
-            match repo.insert_change_rec(&hash, opts) {
-                Ok(_) => applied += 1,
-                Err(e) => {
-                    let msg = e.to_string();
-                    if msg.contains("already applied") || msg.contains("AlreadyApplied") {
-                        applied += 1;
-                    } else {
-                        return Err(CliError::Internal(anyhow::anyhow!(
-                            "insert {} into '{}': {}",
-                            entry.hash,
-                            view_name,
-                            e
-                        )));
-                    }
-                }
-            }
-        }
-
-        Ok(applied)
-    }
-
     /// Print a hint listing the other views available on the remote.
     ///
-    /// Best-effort: silent if the server has no inventory endpoint or only
-    /// the primary view.
-    async fn hint_other_views(&self, remote: &HttpRemote) {
+    /// Views already cloned (the requested view and its ancestor chain) are
+    /// not hinted. Best-effort: silent if the server has no inventory
+    /// endpoint or nothing else to clone.
+    async fn hint_other_views(&self, remote: &HttpRemote, applied: &HashSet<String>) {
         let Ok(remote_views) = remote.list_views().await else {
             return;
         };
         let others: Vec<String> = remote_views
             .into_iter()
             .map(|v| v.name)
-            .filter(|name| name != &self.view)
+            .filter(|name| name != &self.view && !applied.contains(name))
             .collect();
         if others.is_empty() {
             return;
@@ -489,14 +775,10 @@ impl Clone {
         })?;
         finish_success(&spinner, "Repository initialized");
 
-        // Clone must insert remote changes into the requested local view,
-        // rather than whichever default view repository initialization chose.
-        if !repo.view_exists(&self.view).map_err(CliError::Repository)? {
-            repo.create_shared_view(&self.view)
-                .map_err(CliError::Repository)?;
-        }
-        repo.align_to_view(&self.view)
-            .map_err(CliError::Repository)?;
+        // The requested view is NOT pre-created here: its manifest declares
+        // its identity (scope + parent), and `apply_view_manifest` creates it
+        // accordingly. Pre-creating it as a shared root would clash with a
+        // remote draft or child view.
 
         // Connect to remote
         let spinner = create_spinner("Connecting to remote...");
@@ -507,15 +789,33 @@ impl Clone {
         })?;
         finish_success(&spinner, "Connected");
 
-        // Query remote state
-        let spinner = create_spinner("Querying remote state...");
-        let remote_state = remote.get_state(&self.view).await.map_err(|e| {
-            finish_error(&spinner, "Failed to query state");
-            convert_remote_error(e, &self.url)
-        })?;
+        // Fetch the requested view's manifest chain (view → ... → root).
+        // The manifests carry each view's identity, so clone reconstructs
+        // scope and parent exactly. An old server without manifest support
+        // is a hard error — there is no identity-losing fallback.
+        let spinner = create_spinner("Fetching view manifests...");
+        let manifests = match self.fetch_manifest_chain(&remote).await {
+            Ok(m) => m,
+            Err(e) => {
+                finish_error(&spinner, "Failed to fetch view manifests");
+                return Err(e);
+            }
+        };
 
-        if remote_state.is_empty() {
-            finish_success(&spinner, &format!("View '{}' is empty", self.view));
+        let Some(manifests) = manifests else {
+            // The remote doesn't have this view: create it empty locally,
+            // matching the empty-view clone behavior.
+            finish_success(
+                &spinner,
+                &format!("View '{}' not found on remote — starting empty", self.view),
+            );
+
+            if !repo.view_exists(&self.view).map_err(CliError::Repository)? {
+                repo.create_shared_view(&self.view)
+                    .map_err(CliError::Repository)?;
+            }
+            repo.align_to_view(&self.view)
+                .map_err(CliError::Repository)?;
 
             // Configure remote as "origin" even for empty repositories
             let spinner = create_spinner("Configuring remote...");
@@ -540,134 +840,55 @@ impl Clone {
                 guard.disable();
             }
             return Ok(());
-        }
+        };
 
-        let remote_merkle = remote_state.merkle().map(|m| m.to_string());
+        let leaf = manifests
+            .last()
+            .expect("manifest chain contains at least the requested view");
+        let leaf_state = if leaf.changes.is_empty() {
+            "(empty)".to_string()
+        } else {
+            let full = leaf.state.to_base32();
+            format!("{}...", &full[..12.min(full.len())])
+        };
         finish_success(
             &spinner,
             &format!(
-                "View '{}' at {}",
+                "View '{}' at {} ({} in chain)",
                 self.view,
-                remote_merkle
-                    .as_ref()
-                    .map(|m| format!("{}...", &m[..12.min(m.len())]))
-                    .unwrap_or_else(|| "(empty)".to_string())
+                leaf_state,
+                format_count(manifests.len(), "view"),
             ),
         );
 
-        // Get remote changelist
-        let spinner = create_spinner("Fetching changelist...");
-        let remote_entries = remote.get_changelist(&self.view, 0).await.map_err(|e| {
-            finish_error(&spinner, "Failed to fetch changelist");
-            convert_remote_error(e, &self.url)
-        })?;
-        finish_success(
-            &spinner,
-            &format!("Found {}", format_count(remote_entries.len(), "change")),
-        );
+        // The union of changes across the chain, deduplicated: changes
+        // shared between views (a draft's inherited prefix) download once.
+        let missing: Vec<Hash> = change_union(&manifests)
+            .into_iter()
+            .filter(|h| !repo.has_change(h))
+            .collect();
 
         // Initialize progress tracking
         let mut stats = CloneStats::new();
-        let mut progress = CloneProgress::new(remote_entries.len());
+        let mut progress = CloneProgress::new(missing.len());
         progress.phase = ClonePhase::Downloading;
 
-        // Download changes
-        if !remote_entries.is_empty() {
-            print_blank();
-            println!(
-                "Downloading {}:",
-                format_count(remote_entries.len(), "change")
-            );
-            print_blank();
-
-            let progress_bar =
-                create_progress_bar(remote_entries.len() as u64, "Downloading changes");
-
-            for (i, entry) in remote_entries.iter().enumerate() {
-                let hash_str = &entry.hash;
-                let hash_display = &hash_str[..12.min(hash_str.len())];
-
-                // Download the change
-                let result = remote.download_change(hash_str).await;
-
-                match result {
-                    Ok(data) => {
-                        let data_len = data.len() as u64;
-
-                        // Parse and verify the hash
-                        let expected_hash =
-                            match atomic_core::types::Hash::from_base32(hash_str.as_bytes()) {
-                                Some(h) => h,
-                                None => {
-                                    stats.record_failed();
-                                    println!(
-                                        "  {} {}... ({}/{}) invalid hash format",
-                                        error("✗"),
-                                        hash_display,
-                                        i + 1,
-                                        remote_entries.len()
-                                    );
-                                    continue;
-                                }
-                            };
-
-                        // Save to local change store
-                        match save_downloaded_change(&repo, &expected_hash, data) {
-                            Ok(()) => {
-                                stats.record_change_downloaded(data_len);
-                                progress.record_downloaded();
-                                println!(
-                                    "  {} {}... ({}/{})",
-                                    success("✓"),
-                                    style_hash(hash_display),
-                                    i + 1,
-                                    remote_entries.len()
-                                );
-                            }
-                            Err(e) => {
-                                stats.record_failed();
-                                println!(
-                                    "  {} {}... ({}/{}) save failed: {}",
-                                    error("✗"),
-                                    hash_display,
-                                    i + 1,
-                                    remote_entries.len(),
-                                    e
-                                );
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        stats.record_failed();
-                        println!(
-                            "  {} {}... ({}/{}) download failed: {}",
-                            error("✗"),
-                            hash_display,
-                            i + 1,
-                            remote_entries.len(),
-                            e
-                        );
-
-                        // Stop on first failure to maintain consistency
-                        return Err(convert_remote_error(e, &self.url));
-                    }
-                }
-
-                progress_bar.inc(1);
-            }
-
-            finish_success(
-                &progress_bar,
-                &format!(
-                    "Downloaded {} ({})",
-                    format_count(stats.changes_downloaded, "change"),
-                    format_bytes(stats.bytes_transferred)
-                ),
-            );
-        }
+        // Download the missing changes
+        self.download_missing_changes(&repo, &remote, &missing, &mut stats, &mut progress)
+            .await?;
 
         // Apply changes (unless download-only)
         if self.download_only {
+            // Keep the pre-manifest behavior: the requested view exists and
+            // is current, but nothing is applied to it. (The manifest is not
+            // applied, so the downloaded changes stay in the change store.)
+            if !repo.view_exists(&self.view).map_err(CliError::Repository)? {
+                repo.create_shared_view(&self.view)
+                    .map_err(CliError::Repository)?;
+            }
+            repo.align_to_view(&self.view)
+                .map_err(CliError::Repository)?;
+
             // Configure remote as "origin" even for download-only mode
             let spinner = create_spinner("Configuring remote...");
             if let Err(e) = repo.add_remote_default("origin", &self.url) {
@@ -696,63 +917,60 @@ impl Clone {
             return Ok(());
         }
 
-        // Apply downloaded changes to the local view
+        // Apply the manifest chain root→leaf: each apply creates the view
+        // with its declared scope/parent (parents exist first) and replays
+        // its log — metadata-only for changes already in the graph.
         let mut apply_errors = Vec::new();
-        if stats.changes_downloaded > 0 {
+        let mut applied_views: HashSet<String> = HashSet::new();
+        {
             print_blank();
             progress.phase = ClonePhase::Applying;
-            let spinner = create_spinner("Inserting changes into view...");
+            let spinner = create_spinner("Applying view manifests...");
 
-            // Insert each downloaded change in order to build the graph
-            let insert_options = atomic_repository::InsertOptions::default();
-
-            for entry in &remote_entries {
-                let hash = match atomic_core::types::Hash::from_base32(entry.hash.as_bytes()) {
-                    Some(h) => h,
-                    None => continue,
-                };
-
-                match repo.insert_change(&hash, insert_options.clone()) {
-                    Ok(_outcome) => {
-                        stats.record_applied();
-                        progress.record_applied();
+            match self.apply_manifests(&mut repo, &manifests) {
+                Ok(outcomes) => {
+                    for outcome in &outcomes {
+                        applied_views.insert(outcome.view.clone());
                     }
-                    Err(e) => {
-                        let msg = e.to_string();
-                        // "already applied" is fine — skip it
-                        if msg.contains("already applied") || msg.contains("AlreadyApplied") {
+                    // The requested view's log length (inherited + own).
+                    if let Some(leaf_outcome) = outcomes.last() {
+                        for _ in 0..(leaf_outcome.already_present + leaf_outcome.replayed) {
                             stats.record_applied();
                             progress.record_applied();
-                        } else {
-                            apply_errors.push(format!(
-                                "{}...: {}",
-                                &entry.hash[..12.min(entry.hash.len())],
-                                msg
-                            ));
+                        }
+                    }
+                }
+                Err(e) => apply_errors.push(e.to_string()),
+            }
+
+            // Make the requested view current.
+            if apply_errors.is_empty() {
+                if let Err(e) = repo.align_to_view(&self.view) {
+                    apply_errors.push(format!("align to view '{}': {}", self.view, e));
+                }
+            }
+
+            if apply_errors.is_empty() {
+                if self.into_existing {
+                    print_info("Preserving the existing Git working copy.");
+                } else {
+                    // Output the working copy — reconstruct files from the graph
+                    match repo.materialize() {
+                        Ok(output) => {
+                            log::info!(
+                                "Output working copy: {} files, {} dirs",
+                                output.files_written,
+                                output.directories_created
+                            );
+                        }
+                        Err(e) => {
+                            apply_errors.push(format!("output working copy: {}", e));
                         }
                     }
                 }
             }
 
-            if self.into_existing {
-                print_info("Preserving the existing Git working copy.");
-            } else {
-                // Output the working copy — reconstruct files from the graph
-                match repo.materialize() {
-                    Ok(output) => {
-                        log::info!(
-                            "Output working copy: {} files, {} dirs",
-                            output.files_written,
-                            output.directories_created
-                        );
-                    }
-                    Err(e) => {
-                        apply_errors.push(format!("output working copy: {}", e));
-                    }
-                }
-            }
-
-            if stats.has_applied() {
+            if apply_errors.is_empty() {
                 finish_success(
                     &spinner,
                     &format!(
@@ -762,10 +980,7 @@ impl Clone {
                     ),
                 );
             } else {
-                finish_error(&spinner, "No changes were applied");
-            }
-
-            if !apply_errors.is_empty() {
+                finish_error(&spinner, "Failed to apply view manifests");
                 for err in &apply_errors {
                     print_warning(err);
                 }
@@ -788,13 +1003,13 @@ impl Clone {
         }
 
         // Clone additional views (--all-views), or at least tell the user
-        // that other views exist on the remote. The remote stores every view
-        // as shared, so a draft's parent relationship isn't recoverable — but
-        // the sibling views themselves can be reconstructed by name.
-        if !self.download_only {
+        // that other views exist on the remote. View manifests carry each
+        // view's scope and parent, so a draft's parent relationship is
+        // recoverable and preserved — cloned views keep their identity.
+        if !self.download_only && apply_errors.is_empty() {
             if self.all_views {
                 match self
-                    .clone_additional_views(&mut repo, &remote, &mut stats)
+                    .clone_additional_views(&mut repo, &remote, &mut stats, &mut applied_views)
                     .await
                 {
                     Ok(0) => {}
@@ -803,12 +1018,18 @@ impl Clone {
                         n,
                         if n == 1 { "view" } else { "views" }
                     )),
-                    Err(e) => print_warning(&format!("Failed to clone additional views: {}", e)),
+                    // --all-views was an explicit request: failing to honor
+                    // it fails the clone rather than degrading silently.
+                    Err(e) => return Err(e),
                 }
             } else {
-                self.hint_other_views(&remote).await;
+                self.hint_other_views(&remote, &applied_views).await;
             }
         }
+
+        // Drop the temporary parking view, if scaffold reconciliation
+        // needed one while recreating an init-created view.
+        self.remove_park_view(&mut repo);
 
         // Build content search index and enrich KG
         if stats.has_applied() {
@@ -1171,6 +1392,45 @@ mod tests {
                 assert!(message.contains("URL"));
             }
             _ => panic!("Expected InvalidArgument error"),
+        }
+    }
+
+    // Manifest Error Mapping Tests
+
+    /// A protocol error (server predates ?view-manifest) is a hard error
+    /// telling the user to upgrade the server — clone never falls back to
+    /// the identity-losing flat path.
+    #[test]
+    fn test_manifest_fetch_error_old_server() {
+        let clone = Clone::new("https://example.com/repo".to_string());
+        let err = clone.manifest_fetch_error(RemoteError::protocol(
+            "server does not support view manifests (?view-manifest)",
+        ));
+
+        match err {
+            CliError::RemoteError { message, url } => {
+                assert!(message.contains("too old"));
+                assert!(message.contains("Upgrade the server"));
+                assert_eq!(url.as_deref(), Some("https://example.com/repo"));
+            }
+            other => panic!("Expected RemoteError, got {:?}", other),
+        }
+    }
+
+    /// Non-protocol failures pass through the standard remote-error mapping.
+    #[test]
+    fn test_manifest_fetch_error_other_errors_pass_through() {
+        let clone = Clone::new("https://example.com/repo".to_string());
+        let err = clone.manifest_fetch_error(RemoteError::ViewNotFound {
+            view: "dev".to_string(),
+        });
+
+        match err {
+            CliError::RemoteError { message, .. } => {
+                assert!(message.contains("View 'dev' not found"));
+                assert!(!message.contains("too old"));
+            }
+            other => panic!("Expected RemoteError, got {:?}", other),
         }
     }
 }

--- a/atomic-cli/src/commands/clone/helpers.rs
+++ b/atomic-cli/src/commands/clone/helpers.rs
@@ -20,6 +20,7 @@
 //!
 //! This module provides the helper functions that support these operations.
 
+use std::collections::HashSet;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
 
@@ -28,7 +29,7 @@ use bytes::Bytes;
 use atomic_core::change::Change;
 use atomic_core::types::{Base32, Hash};
 use atomic_remote::RemoteError;
-use atomic_repository::Repository;
+use atomic_repository::{Repository, ViewManifest};
 
 use crate::error::{CliError, CliResult};
 
@@ -351,6 +352,146 @@ pub fn save_downloaded_change(repo: &Repository, hash: &Hash, data: Bytes) -> Cl
         .map_err(|e| CliError::Internal(anyhow::anyhow!("Failed to save change: {}", e)))?;
 
     Ok(())
+}
+
+// View Manifests
+
+/// Parse and verify a view manifest downloaded from the remote.
+///
+/// Validates three things before the manifest is trusted:
+///
+/// 1. The text parses structurally (header + base32 change log).
+/// 2. The header names the view that was requested.
+/// 3. The declared merkle state equals the fold of the change log.
+///
+/// # Arguments
+///
+/// * `view` - The view name that was requested from the remote
+/// * `text` - The raw manifest text returned by the server
+/// * `url` - The remote URL (for error context)
+pub fn parse_remote_manifest(view: &str, text: &str, url: &str) -> CliResult<ViewManifest> {
+    let manifest = ViewManifest::parse(text).map_err(|e| CliError::RemoteError {
+        message: format!("Corrupt manifest for view '{}': {}", view, e),
+        url: Some(url.to_string()),
+    })?;
+
+    if manifest.name != view {
+        return Err(CliError::RemoteError {
+            message: format!(
+                "Manifest name mismatch: requested view '{}', server sent '{}'",
+                view, manifest.name
+            ),
+            url: Some(url.to_string()),
+        });
+    }
+
+    manifest.verify().map_err(|e| CliError::RemoteError {
+        message: format!("Corrupt manifest for view '{}': {}", view, e),
+        url: Some(url.to_string()),
+    })?;
+
+    Ok(manifest)
+}
+
+/// Order manifests so every parent is applied before its children.
+///
+/// A manifest is ready when its declared parent is `None` (a root view),
+/// already applied locally (`already_applied`), or emitted earlier in the
+/// order. Repeatedly emits ready manifests until no progress can be made.
+///
+/// # Returns
+///
+/// `(ordered, stuck)` — indices into `manifests`. `ordered` is a valid
+/// root→leaf apply order; `stuck` holds manifests that can never apply
+/// (their parent chain has a cycle or references a view that is neither
+/// in the set nor already applied).
+pub fn manifest_apply_order(
+    manifests: &[ViewManifest],
+    already_applied: &HashSet<String>,
+) -> (Vec<usize>, Vec<usize>) {
+    let mut ordered: Vec<usize> = Vec::with_capacity(manifests.len());
+    let mut emitted: HashSet<&str> = HashSet::with_capacity(manifests.len());
+    let mut remaining: Vec<usize> = (0..manifests.len()).collect();
+
+    loop {
+        let before = ordered.len();
+        remaining.retain(|&i| {
+            let ready = match manifests[i].parent.as_deref() {
+                None => true,
+                Some(p) => already_applied.contains(p) || emitted.contains(p),
+            };
+            if ready {
+                emitted.insert(manifests[i].name.as_str());
+                ordered.push(i);
+                false
+            } else {
+                true
+            }
+        });
+        if ordered.len() == before {
+            break;
+        }
+    }
+
+    (ordered, remaining)
+}
+
+/// The union of change hashes across a set of manifests.
+///
+/// Changes are content-addressed and shared across views (a draft's log
+/// includes its inherited prefix), so the union is deduplicated: each hash
+/// appears once, at its first occurrence. Iterating manifests root→leaf
+/// therefore yields parents' changes before children's own suffixes.
+pub fn change_union(manifests: &[ViewManifest]) -> Vec<Hash> {
+    let mut seen: HashSet<Hash> = HashSet::new();
+    let mut union = Vec::new();
+    for manifest in manifests {
+        for hash in &manifest.changes {
+            if seen.insert(*hash) {
+                union.push(*hash);
+            }
+        }
+    }
+    union
+}
+
+// Inventory Support Detection
+
+/// Interpretation of an `?views` inventory response under `--all-views`.
+#[derive(Debug, PartialEq, Eq)]
+pub enum InventoryOutcome {
+    /// The inventory lists views beyond those already applied — clone them.
+    Views(Vec<String>),
+    /// The inventory lists only views the primary chain already applied —
+    /// a genuinely single-chain remote; nothing more to do.
+    NothingNew,
+    /// The inventory is empty. A server that supports `?views` always lists
+    /// at least the view that was just cloned, so an empty inventory is the
+    /// signature of a server without inventory support (its generic info
+    /// blob parses to zero views). Under `--all-views` this must be a hard
+    /// error, never a silent single-view clone.
+    Unsupported,
+}
+
+/// Classify an `?views` inventory for `--all-views`.
+///
+/// `applied` is the set of view names the primary manifest chain already
+/// reconstructed (always non-empty by the time additional views are
+/// considered).
+pub fn classify_inventory(inventory: &[String], applied: &HashSet<String>) -> InventoryOutcome {
+    if inventory.is_empty() {
+        return InventoryOutcome::Unsupported;
+    }
+    let others: Vec<String> = inventory
+        .iter()
+        .filter(|name| !applied.contains(*name))
+        .cloned()
+        .collect();
+    if others.is_empty() {
+        InventoryOutcome::NothingNew
+    } else {
+        InventoryOutcome::Views(others)
+    }
 }
 
 // Error Conversion
@@ -913,5 +1054,189 @@ mod tests {
     #[test]
     fn test_format_bytes_gb() {
         assert_eq!(format_bytes(1024 * 1024 * 1024), "1.0 GB");
+    }
+
+    // View Manifest Helper Tests
+
+    use atomic_core::pristine::ViewScope;
+    use std::collections::HashSet;
+
+    /// Deterministic test hash.
+    fn h(n: u8) -> Hash {
+        Hash::of(&[n])
+    }
+
+    /// Build a manifest with a computed (consistent) state.
+    fn manifest(
+        name: &str,
+        scope: ViewScope,
+        parent: Option<&str>,
+        changes: Vec<Hash>,
+    ) -> ViewManifest {
+        ViewManifest::new(name, scope, parent.map(String::from), changes)
+    }
+
+    /// A leaf→root chain orders root→leaf for apply.
+    #[test]
+    fn test_manifest_apply_order_chain_root_to_leaf() {
+        // Collected in walk order (leaf first): feature → dev → main.
+        let manifests = vec![
+            manifest("feature", ViewScope::Draft, Some("dev"), vec![h(1), h(2)]),
+            manifest("dev", ViewScope::Shared, Some("main"), vec![h(1)]),
+            manifest("main", ViewScope::Shared, None, vec![]),
+        ];
+
+        let (ordered, stuck) = manifest_apply_order(&manifests, &HashSet::new());
+        assert!(stuck.is_empty());
+        let names: Vec<&str> = ordered
+            .iter()
+            .map(|&i| manifests[i].name.as_str())
+            .collect();
+        assert_eq!(names, vec!["main", "dev", "feature"]);
+    }
+
+    /// A parent already applied locally counts as satisfied.
+    #[test]
+    fn test_manifest_apply_order_uses_already_applied() {
+        let manifests = vec![manifest(
+            "feature",
+            ViewScope::Draft,
+            Some("dev"),
+            vec![h(1)],
+        )];
+        let applied: HashSet<String> = ["dev".to_string()].into_iter().collect();
+
+        let (ordered, stuck) = manifest_apply_order(&manifests, &applied);
+        assert_eq!(ordered, vec![0]);
+        assert!(stuck.is_empty());
+    }
+
+    /// A parent cycle can never be ordered: both manifests end up stuck.
+    #[test]
+    fn test_manifest_apply_order_detects_cycle() {
+        let manifests = vec![
+            manifest("a", ViewScope::Shared, Some("b"), vec![h(1)]),
+            manifest("b", ViewScope::Shared, Some("a"), vec![h(2)]),
+        ];
+
+        let (ordered, stuck) = manifest_apply_order(&manifests, &HashSet::new());
+        assert!(ordered.is_empty());
+        assert_eq!(stuck.len(), 2);
+    }
+
+    /// A parent that is neither in the set nor applied leaves the child
+    /// stuck without blocking unrelated manifests.
+    #[test]
+    fn test_manifest_apply_order_missing_parent_is_stuck() {
+        let manifests = vec![
+            manifest("orphan", ViewScope::Draft, Some("ghost"), vec![h(1)]),
+            manifest("main", ViewScope::Shared, None, vec![h(2)]),
+        ];
+
+        let (ordered, stuck) = manifest_apply_order(&manifests, &HashSet::new());
+        assert_eq!(ordered, vec![1]);
+        assert_eq!(stuck, vec![0]);
+    }
+
+    /// The union dedupes hashes shared between manifests (a draft's
+    /// inherited prefix repeats its ancestors' changes) and preserves
+    /// first-occurrence order.
+    #[test]
+    fn test_change_union_dedupes_across_manifests() {
+        let manifests = vec![
+            manifest("main", ViewScope::Shared, None, vec![h(1), h(2)]),
+            manifest(
+                "dev",
+                ViewScope::Shared,
+                Some("main"),
+                vec![h(1), h(2), h(3)],
+            ),
+            manifest(
+                "feature",
+                ViewScope::Draft,
+                Some("dev"),
+                vec![h(1), h(2), h(3), h(4)],
+            ),
+        ];
+
+        let union = change_union(&manifests);
+        assert_eq!(union, vec![h(1), h(2), h(3), h(4)]);
+    }
+
+    /// The union of no manifests (or all-empty manifests) is empty.
+    #[test]
+    fn test_change_union_empty() {
+        assert!(change_union(&[]).is_empty());
+        let manifests = vec![manifest("main", ViewScope::Shared, None, vec![])];
+        assert!(change_union(&manifests).is_empty());
+    }
+
+    /// A valid manifest for the requested view parses and verifies.
+    #[test]
+    fn test_parse_remote_manifest_round_trip() {
+        let m = manifest("dev", ViewScope::Shared, Some("main"), vec![h(1), h(2)]);
+        let parsed = parse_remote_manifest("dev", &m.to_text(), "http://example.com").unwrap();
+        assert_eq!(parsed, m);
+    }
+
+    /// A manifest naming a different view than requested is rejected.
+    #[test]
+    fn test_parse_remote_manifest_rejects_name_mismatch() {
+        let m = manifest("other", ViewScope::Shared, None, vec![h(1)]);
+        let err = parse_remote_manifest("dev", &m.to_text(), "http://example.com").unwrap_err();
+        match err {
+            CliError::RemoteError { message, .. } => {
+                assert!(message.contains("Manifest name mismatch"));
+            }
+            other => panic!("Expected RemoteError, got {:?}", other),
+        }
+    }
+
+    /// A declared state that doesn't fold from the log is rejected.
+    #[test]
+    fn test_parse_remote_manifest_rejects_state_mismatch() {
+        let mut m = manifest("dev", ViewScope::Shared, None, vec![h(1)]);
+        m.state = atomic_core::types::Merkle::of(b"tampered");
+        let err = parse_remote_manifest("dev", &m.to_text(), "http://example.com").unwrap_err();
+        match err {
+            CliError::RemoteError { message, .. } => {
+                assert!(message.contains("Corrupt manifest"));
+            }
+            other => panic!("Expected RemoteError, got {:?}", other),
+        }
+    }
+
+    /// An empty inventory is the no-support signature: a supporting server
+    /// always lists at least the view that was just cloned.
+    #[test]
+    fn test_classify_inventory_empty_is_unsupported() {
+        let applied: HashSet<String> = ["dev".to_string()].into();
+        assert_eq!(
+            classify_inventory(&[], &applied),
+            InventoryOutcome::Unsupported
+        );
+    }
+
+    /// An inventory listing only already-applied views is a genuinely
+    /// single-chain remote — quiet success.
+    #[test]
+    fn test_classify_inventory_only_applied_is_nothing_new() {
+        let applied: HashSet<String> = ["dev".to_string()].into();
+        assert_eq!(
+            classify_inventory(&["dev".to_string()], &applied),
+            InventoryOutcome::NothingNew
+        );
+    }
+
+    /// Views beyond the applied set are returned for cloning; applied ones
+    /// are filtered out.
+    #[test]
+    fn test_classify_inventory_returns_unapplied_views() {
+        let applied: HashSet<String> = ["dev".to_string()].into();
+        let inventory = vec!["dev".to_string(), "snowy-mountain-75eb".to_string()];
+        assert_eq!(
+            classify_inventory(&inventory, &applied),
+            InventoryOutcome::Views(vec!["snowy-mountain-75eb".to_string()])
+        );
     }
 }

--- a/atomic-cli/src/commands/clone/mod.rs
+++ b/atomic-cli/src/commands/clone/mod.rs
@@ -22,12 +22,11 @@
 //! 3. **Create target directory** with cleanup guard for error recovery
 //! 4. **Initialize empty repository** using `Repository::init()`
 //! 5. **Connect to remote** using HTTP client
-//! 6. **Query remote state** to get the view's changelist
-//! 7. **Download all changes** in dependency order
-//! 8. **Apply changes** to the local view
-//! 9. **Download tags** for any tagged states
-//! 10. **Configure remote** as "origin" in repository config
-//! 11. **Report results** to the user
+//! 6. **Fetch view manifests** for the requested view and its parent chain
+//! 7. **Download the missing changes** (deduplicated union across the chain)
+//! 8. **Apply manifests** root→leaf, preserving each view's scope and parent
+//! 9. **Configure remote** as "origin" in repository config
+//! 10. **Report results** to the user
 //!
 //! # Usage
 //!

--- a/atomic-cli/src/commands/push/command.rs
+++ b/atomic-cli/src/commands/push/command.rs
@@ -2,6 +2,11 @@
 //!
 //! This module contains the `Push` struct and its `Command` implementation,
 //! which orchestrates the push operation from the CLI.
+//!
+//! Push is **identity-preserving**: it syncs the target view's full parent
+//! chain (root → leaf) via view manifests instead of flattening a draft into
+//! a shared remote view. Each view's scope, parent, and exact change log
+//! survive the transfer.
 
 use std::collections::HashSet;
 use std::time::Duration;
@@ -11,20 +16,20 @@ use clap::Parser;
 
 use atomic_core::types::{Base32, Hash};
 use atomic_remote::{HttpRemote, HttpRemoteConfig};
-use atomic_repository::Repository;
+use atomic_repository::{Repository, ViewManifest};
 
 use crate::commands::{find_repository_root, format_hash, Command};
 use crate::error::{CliError, CliResult};
 use crate::output::{
-    create_progress_bar, create_spinner, error, finish_error, finish_success, hash as style_hash,
-    hint, print_blank, print_hint, print_success, print_warning, success, view as style_view,
+    create_progress_bar, create_spinner, finish_error, finish_success, hash as style_hash, hint,
+    print_blank, print_hint, print_success, print_warning, success, view as style_view,
 };
 
 use super::helpers::{
-    calculate_push_delta, convert_remote_error, display_state_comparison, format_count,
-    has_diverged, upload_change_smart,
+    build_view_chain, convert_remote_error, display_manifest_divergence, format_count,
+    load_change_data, load_change_message, parse_remote_manifest, plan_view_sync,
+    require_manifest_support, ChainError, ViewSyncConflict, ViewSyncPlan,
 };
-use super::types::PushChange;
 
 // Constants
 
@@ -38,9 +43,11 @@ pub const DEFAULT_TIMEOUT_SECS: u64 = 30;
 
 /// Push changes to a remote repository.
 ///
-/// Uploads local changes to the specified remote, making them available
-/// to other users. Changes are pushed in dependency order to ensure the
-/// remote can apply them correctly.
+/// Syncs the local view — and every ancestor in its parent chain — to the
+/// remote via view manifests. Each view is transferred with its identity
+/// intact: a draft stays a draft, parented on the same view, with the same
+/// ordered change log. Change files are stored content-first (idempotent),
+/// then the view's manifest is declared, so a view is never half-created.
 ///
 /// # Remote Configuration
 ///
@@ -51,7 +58,8 @@ pub const DEFAULT_TIMEOUT_SECS: u64 = 30;
 /// # View Mapping
 ///
 /// By default, the local view is pushed to a view with the same name
-/// on the remote. Use `--to-view` to push to a different remote view.
+/// on the remote. Use `--to-view` to declare the leaf view under a
+/// different name on the remote; ancestors keep their own names.
 ///
 /// # Examples
 ///
@@ -62,13 +70,13 @@ pub const DEFAULT_TIMEOUT_SECS: u64 = 30;
 /// # Push to a specific remote
 /// atomic push upstream
 ///
-/// # Push to a different view
+/// # Push the leaf view under a different remote name
 /// atomic push --to-view main
 ///
 /// # Preview what would be pushed
 /// atomic push --dry-run
 ///
-/// # Force push (overwrite remote)
+/// # Attempt the push even if histories have diverged (server decides)
 /// atomic push --force
 /// ```
 #[derive(Parser, Debug, Clone)]
@@ -82,9 +90,10 @@ pub struct Push {
     #[arg()]
     pub remote: Option<String>,
 
-    /// Remote view to push to.
+    /// Remote view name to declare the leaf view under.
     ///
-    /// If not specified, uses the same name as the local view.
+    /// If not specified, uses the same name as the local view. Ancestor
+    /// views in the parent chain always keep their own names.
     #[arg(long = "to-view")]
     pub to_view: Option<String>,
 
@@ -100,15 +109,19 @@ pub struct Push {
     #[arg(short = 'n', long)]
     pub dry_run: bool,
 
-    /// Force push even if histories have diverged.
+    /// Attempt the push even if histories have diverged.
     ///
-    /// Use with caution: this can overwrite remote changes.
+    /// Stores every local change the remote view lacks and declares the
+    /// manifest anyway. The server remains authoritative: manifests only
+    /// fast-forward, so a genuinely diverged remote will still reject the
+    /// declare. Identity mismatches (scope/parent) are never forced.
     #[arg(short, long)]
     pub force: bool,
 
-    /// Push all changes, not just those missing on the remote.
+    /// Store all changes in the view's log, not just those missing on the remote.
     ///
-    /// Useful for ensuring all dependencies are present.
+    /// Useful for repairing a remote that is missing change files. Storing
+    /// is content-addressed and idempotent.
     #[arg(short, long)]
     pub all: bool,
 
@@ -131,6 +144,25 @@ pub struct Push {
     /// Example: `atomic push --identity alice-staging`
     #[arg(long)]
     pub identity: Option<String>,
+}
+
+/// Per-view sync work computed before any writes happen.
+///
+/// Built once per view in the chain; drives the dry-run preview and the
+/// actual store/declare phase.
+struct ViewSync {
+    /// Name of the view on the remote (leaf may be renamed via `--to-view`).
+    remote_name: String,
+
+    /// The local manifest to declare (name already rewritten for the leaf).
+    manifest: ViewManifest,
+
+    /// The plan: what to store, whether to declare.
+    plan: ViewSyncPlan,
+
+    /// Changes that actually need storing (plan suffix minus hashes already
+    /// known to be on the remote from earlier views in this push).
+    to_store: Vec<Hash>,
 }
 
 impl Push {
@@ -252,7 +284,7 @@ impl Push {
             .unwrap_or_else(|| repo.current_view().to_string())
     }
 
-    /// Get the remote view name to push to.
+    /// Get the remote view name to declare the leaf view under.
     ///
     /// Returns the explicitly specified view or the local view name.
     fn get_remote_view(&self, local_view: &str) -> String {
@@ -277,37 +309,98 @@ impl Push {
         crate::commands::auth::attach_identity(config, remote_url, identity_hint).await
     }
 
-    /// Display the dry run preview.
+    /// Display the dry run preview: per-view manifest sync plans.
     fn display_dry_run(
         &self,
+        repo: &Repository,
         remote_name: &str,
         remote_url: &str,
-        remote_view: &str,
-        to_upload: &[PushChange],
+        syncs: &[ViewSync],
     ) -> CliResult<()> {
-        if to_upload.is_empty() {
+        let active: Vec<&ViewSync> = syncs.iter().filter(|s| !s.plan.is_noop()).collect();
+
+        if active.is_empty() {
             print_success("Already up to date - nothing to push");
             return Ok(());
         }
 
         println!(
-            "Would push {} to {} (view: {}):",
-            format_count(to_upload.len(), "change"),
-            remote_name,
-            remote_view
+            "Would sync {} to {}:",
+            format_count(active.len(), "view"),
+            remote_name
         );
         print_blank();
 
-        for change in to_upload {
-            let hash_str = format_hash(&change.hash, false);
-            let msg = change.message_or_default();
-            println!("  {} {}", style_hash(&hash_str), msg);
+        for sync in &active {
+            let scope = sync.manifest.scope.to_string();
+            let parent = sync
+                .manifest
+                .parent
+                .as_deref()
+                .map(|p| format!(", parent {}", p))
+                .unwrap_or_default();
+            println!(
+                "  {} [{}{}]: {} to store, declare manifest ({} in log)",
+                style_view(&sync.remote_name),
+                scope,
+                parent,
+                format_count(sync.to_store.len(), "change"),
+                format_count(sync.manifest.changes.len(), "change"),
+            );
+            for hash in &sync.to_store {
+                let msg =
+                    load_change_message(repo, hash).unwrap_or_else(|| "(no message)".to_string());
+                println!("    {} {}", style_hash(&format_hash(hash, false)), msg);
+            }
         }
 
         print_blank();
         print_hint(&format!("Remote URL: {}", remote_url));
 
         Ok(())
+    }
+
+    /// Report a divergence conflict and build the error to return.
+    fn divergence_error(
+        &self,
+        local_view: &str,
+        local: &ViewManifest,
+        remote: Option<&ViewManifest>,
+        conflict: &ViewSyncConflict,
+    ) -> CliError {
+        match conflict {
+            ViewSyncConflict::Diverged { .. } => {
+                crate::output::print_error(&format!(
+                    "View '{}' has diverged from the remote",
+                    local_view
+                ));
+                print_blank();
+                if let Some(remote) = remote {
+                    display_manifest_divergence(local_view, local, remote);
+                    print_blank();
+                }
+                print_hint("The remote view's log is not a prefix of your local log.");
+                print_hint("Use 'atomic pull' to fetch remote changes, or");
+                print_hint("Use 'atomic push --force' to attempt the push anyway (server decides)");
+                CliError::Conflict {
+                    description: format!("View '{}': {}", local_view, conflict),
+                }
+            }
+            ViewSyncConflict::IdentityMismatch { .. } => {
+                crate::output::print_error(&format!(
+                    "View '{}' exists on the remote with a different identity",
+                    local_view
+                ));
+                print_blank();
+                print_hint(&format!("{}", conflict));
+                print_hint("A view's scope and parent are fixed at creation and cannot be");
+                print_hint("changed by a push. Rename the local view or push to a different");
+                print_hint("remote view with '--to-view'.");
+                CliError::Conflict {
+                    description: format!("View '{}': {}", local_view, conflict),
+                }
+            }
+        }
     }
 
     /// Async implementation of the push command.
@@ -319,10 +412,9 @@ impl Push {
         // Resolve remote name, URL, and identity hint
         let (remote_name, remote_url, identity_hint) = self.resolve_remote_url(&repo)?;
 
-        // Determine views
+        // Determine views: the leaf we push, and its name on the remote.
         let local_view = self.get_local_view(&repo);
         let remote_view = self.get_remote_view(&local_view);
-        let default_remote_view = "dev".to_string();
 
         // Print header
         println!(
@@ -339,6 +431,19 @@ impl Push {
         // actionable error instead.
         crate::commands::auth::check_push_credentials(&remote_url, identity_hint.as_deref())?;
 
+        // Build the local ancestor chain, root → leaf. A draft's parent must
+        // exist on the remote before the draft's manifest can reference it,
+        // so the whole chain is synced in order.
+        let chain = build_view_chain(&local_view, |name| {
+            repo.get_view_info(name).map(|info| info.parent_name)
+        })
+        .map_err(|e| match e {
+            ChainError::Cycle { view } => CliError::InvalidRepository {
+                reason: format!("view parent chain contains a cycle at '{}'", view),
+            },
+            ChainError::Lookup(err) => CliError::Repository(err),
+        })?;
+
         // Connect to remote
         let spinner = create_spinner("Connecting to remote...");
         let config = self
@@ -350,233 +455,231 @@ impl Push {
         })?;
         finish_success(&spinner, "Connected");
 
-        // Query remote state
-        let spinner = create_spinner("Querying remote state...");
-        let remote_state = remote.get_state(&remote_view).await.map_err(|e| {
-            finish_error(&spinner, "Failed to query state");
-            convert_remote_error(e, &remote_url)
-        })?;
-        finish_success(&spinner, "Got remote state");
+        // Plan phase: for each view in the chain, export the local manifest,
+        // fetch the remote's, and compute the fast-forward suffix. Hashes
+        // known to be on the remote (remote prefixes, or stored for an
+        // earlier view in this push) are skipped when storing — a draft's
+        // inherited prefix was already synced with its parent.
+        let mut known_on_remote: HashSet<Hash> = HashSet::new();
+        let mut syncs: Vec<ViewSync> = Vec::with_capacity(chain.len());
 
-        // Get the target view's full effective change set in dependency
-        // order. For a draft view this includes the changes inherited from
-        // its shared base, not just the draft's own delta — the remote view
-        // is flattened (shared) and needs the complete graph. Changes the
-        // remote already has are skipped by the delta/adopt logic below, so
-        // re-including the base is idempotent. Using `local_view` (not the
-        // current view) also ensures `--to-view` pushes the right view.
-        let spinner = create_spinner("Loading local history...");
-        let local_entries = repo
-            .effective_history(Some(&local_view))
-            .map_err(CliError::Repository)?;
-        finish_success(
-            &spinner,
-            &format!("Loaded {} local changes", local_entries.len()),
-        );
+        for name in &chain {
+            let is_leaf = name == &local_view;
+            let remote_view_name = if is_leaf {
+                remote_view.clone()
+            } else {
+                name.clone()
+            };
 
-        // Get remote changelist for the target view
-        let spinner = create_spinner("Fetching remote changelist...");
-        let remote_entries = if !remote_state.is_empty() {
-            // Remote has changes - fetch the full changelist from position 0
-            remote.get_changelist(&remote_view, 0).await.map_err(|e| {
-                finish_error(&spinner, "Failed to fetch changelist");
-                convert_remote_error(e, &remote_url)
-            })?
-        } else {
-            // Remote is empty (returned "-") - no changes to fetch
-            Vec::new()
-        };
-        finish_success(
-            &spinner,
-            &format!("Got {} remote changes", remote_entries.len()),
-        );
-
-        // If the target view is empty/new and differs from the default,
-        // check the default view to find a fork source. Views are perspectives
-        // of the same graph — we can fork instead of re-uploading.
-        let mut fork_source: Option<String> = None;
-        let mut graph_hashes: HashSet<String> = HashSet::new();
-
-        if remote_entries.is_empty() && remote_view != default_remote_view {
-            let default_state = remote.get_state(&default_remote_view).await;
-            if let Ok(ref state) = default_state {
-                if !state.is_empty() {
-                    if let Ok(default_entries) =
-                        remote.get_changelist(&default_remote_view, 0).await
-                    {
-                        for entry in &default_entries {
-                            graph_hashes.insert(entry.hash.clone());
-                        }
-                        if !default_entries.is_empty() {
-                            fork_source = Some(default_remote_view.clone());
-                        }
-                    }
-                }
+            // Export the local view identity. For a renamed leaf
+            // (`--to-view`) the manifest is declared under the remote name.
+            let mut manifest = repo.view_manifest(name).map_err(CliError::Repository)?;
+            if manifest.name != remote_view_name {
+                manifest.name = remote_view_name.clone();
             }
-        }
-        // Also include the target view's own entries
-        for entry in &remote_entries {
-            graph_hashes.insert(entry.hash.clone());
-        }
 
-        // Display state comparison
-        print_blank();
-        display_state_comparison(
-            &local_view,
-            &local_entries,
-            &remote_view,
-            &remote_state,
-            &remote_entries,
-        );
-        print_blank();
+            // Fetch the remote's manifest. A server without manifest support
+            // is a hard error: there is no flatten fallback.
+            let spinner = create_spinner(&format!(
+                "Fetching remote manifest for {}...",
+                style_view(&remote_view_name)
+            ));
+            let remote_text = require_manifest_support(
+                remote.get_view_manifest(&remote_view_name).await,
+                &remote_url,
+            )
+            .inspect_err(|_| finish_error(&spinner, "Failed to fetch manifest"))?;
+            let remote_manifest = match remote_text {
+                Some(text) => Some(parse_remote_manifest(
+                    &remote_view_name,
+                    &text,
+                    &remote_url,
+                )?),
+                None => None,
+            };
+            finish_success(
+                &spinner,
+                &format!(
+                    "Remote {} {}",
+                    style_view(&remote_view_name),
+                    match &remote_manifest {
+                        Some(m) => format!("has {}", format_count(m.changes.len(), "change")),
+                        None => "does not exist yet".to_string(),
+                    }
+                ),
+            );
 
-        // Calculate what to push
-        let to_upload = calculate_push_delta(
-            &repo,
-            &local_entries,
-            &remote_entries,
-            &graph_hashes,
-            self.all,
-        )?;
+            // Everything the remote view already logs is known-present.
+            if let Some(rm) = &remote_manifest {
+                known_on_remote.extend(rm.changes.iter().copied());
+            }
+
+            let plan = plan_view_sync(&manifest, remote_manifest.as_ref(), self.force).map_err(
+                |conflict| {
+                    self.divergence_error(name, &manifest, remote_manifest.as_ref(), &conflict)
+                },
+            )?;
+
+            if plan.forced {
+                print_warning(&format!(
+                    "View '{}' has diverged; pushing anyway (--force). The server may still reject it.",
+                    remote_view_name
+                ));
+            }
+
+            // With --all, re-store the full log (content-addressed and
+            // idempotent) to repair a remote missing change files. Otherwise
+            // store only the suffix, minus what's already known present.
+            let candidates: &[Hash] = if self.all {
+                &manifest.changes
+            } else {
+                &plan.suffix
+            };
+            let to_store: Vec<Hash> = candidates
+                .iter()
+                .filter(|h| self.all || !known_on_remote.contains(h))
+                .copied()
+                .collect();
+
+            syncs.push(ViewSync {
+                remote_name: remote_view_name,
+                manifest,
+                plan,
+                to_store,
+            });
+        }
 
         // Handle dry run
         if self.dry_run {
-            return self.display_dry_run(&remote_name, &remote_url, &remote_view, &to_upload);
+            return self.display_dry_run(&repo, &remote_name, &remote_url, &syncs);
         }
 
         // Check for nothing to push
-        if to_upload.is_empty() {
+        if syncs.iter().all(|s| s.plan.is_noop()) {
             print_success("Already up to date");
             return Ok(());
         }
 
-        // Check for diverged history (unless forcing)
-        if !self.force && has_diverged(&local_entries, &remote_entries) {
-            crate::output::print_error("Histories have diverged");
-            print_blank();
-            print_hint("The remote has changes that are not in your local history.");
-            print_hint("Use 'atomic pull' to fetch remote changes, or");
-            print_hint("Use 'atomic push --force' to overwrite remote (use with caution)");
-            return Err(CliError::Conflict {
-                description: "Remote has changes not present locally".to_string(),
-            });
-        }
+        // Sync phase: store change files, then declare each manifest,
+        // root → leaf so a draft's parent always exists before the draft.
+        let mut total_stored = 0usize;
+        let mut views_declared = 0usize;
+        let mut stored_hashes: Vec<Hash> = Vec::new();
 
-        // Partition into changes that need uploading vs already in graph
-        let new_changes: Vec<&PushChange> = to_upload.iter().filter(|c| c.needs_upload()).collect();
-        let adopt_count = to_upload.iter().filter(|c| c.in_graph).count();
-
-        // If there's a fork source and changes to adopt, fork the view first.
-        // This is a single server-side operation that copies the changelog —
-        // no data transfer, no per-change round trips. Views are perspectives.
-        if let Some(ref source) = fork_source {
-            if adopt_count > 0 {
-                let spinner = create_spinner(&format!(
-                    "Forking {} view from {}...",
-                    style_view(&remote_view),
-                    style_view(source)
-                ));
-
-                match remote.fork_view(&remote_view, source).await {
-                    Ok(count) => {
-                        finish_success(
-                            &spinner,
-                            &format!("Forked {} → {} ({} changes)", source, remote_view, count),
-                        );
-                    }
-                    Err(e) => {
-                        finish_error(&spinner, "Fork failed");
-                        return Err(convert_remote_error(e, &remote_url));
-                    }
-                }
+        for sync in &syncs {
+            if sync.plan.is_noop() {
+                println!(
+                    "  {} {} already up to date",
+                    success("✓"),
+                    style_view(&sync.remote_name)
+                );
+                continue;
             }
-        }
 
-        // Now upload only the truly new changes (not in any remote view)
-        if new_changes.is_empty() {
-            // Everything was handled by the fork
-            print_blank();
-            print_success(&format!(
-                "Push complete: {} view created on {}",
-                remote_view, remote_name
+            // Store the change files the remote lacks.
+            if !sync.to_store.is_empty() {
+                println!(
+                    "Syncing view {} ({} new):",
+                    style_view(&sync.remote_name),
+                    format_count(sync.to_store.len(), "change")
+                );
+
+                let progress = create_progress_bar(sync.to_store.len() as u64, "Storing changes");
+
+                for (i, hash) in sync.to_store.iter().enumerate() {
+                    // Loaded fully into memory for now; a streamed `?store`
+                    // for large changes is a known follow-up.
+                    let data = load_change_data(&repo, hash)?;
+                    let msg = load_change_message(&repo, hash)
+                        .unwrap_or_else(|| "(no message)".to_string());
+
+                    match remote.store_change(&hash.to_base32(), data).await {
+                        Ok(()) => {
+                            println!(
+                                "  {} {} ({}/{}) {}",
+                                success("✓"),
+                                style_hash(&format_hash(hash, false)),
+                                i + 1,
+                                sync.to_store.len(),
+                                msg,
+                            );
+                        }
+                        Err(e) => {
+                            finish_error(&progress, "Store failed");
+                            println!(
+                                "  {} {} ({}/{}) {}",
+                                crate::output::error("✗"),
+                                style_hash(&format_hash(hash, false)),
+                                i + 1,
+                                sync.to_store.len(),
+                                msg,
+                            );
+                            return Err(convert_remote_error(e, &remote_url));
+                        }
+                    }
+                    progress.inc(1);
+                }
+
+                finish_success(
+                    &progress,
+                    &format!("Stored {}", format_count(sync.to_store.len(), "change")),
+                );
+
+                total_stored += sync.to_store.len();
+                stored_hashes.extend(sync.to_store.iter().copied());
+            }
+
+            // Declare the view's identity and log. The server creates the
+            // view (with the declared scope/parent) if absent, fast-forwards
+            // its log, and verifies the merkle state.
+            let spinner = create_spinner(&format!(
+                "Declaring view {}...",
+                style_view(&sync.remote_name)
             ));
-            return Ok(());
-        }
-
-        // Upload new changes
-        println!(
-            "Uploading {}:",
-            format_count(new_changes.len(), "new change")
-        );
-        print_blank();
-
-        let progress = create_progress_bar(new_changes.len() as u64, "Pushing changes");
-
-        let mut _total_bytes_sent: u64 = 0;
-        let mut _total_bytes_saved: u64 = 0;
-        let mut _delta_count: usize = 0;
-
-        for (i, change) in new_changes.iter().enumerate() {
-            let transfer = upload_change_smart(&remote, &repo, &change.hash, &remote_view).await;
-
-            match transfer {
-                Ok(result) => {
-                    let msg = change.message_or_default();
-                    let transfer_info = if result.used_delta {
-                        _delta_count += 1;
-                        format!(" [{}]", result)
-                    } else {
-                        String::new()
-                    };
-                    _total_bytes_sent += result.bytes_sent;
-                    _total_bytes_saved += result.bytes_saved;
-
-                    println!(
-                        "  {} {} ({}/{}) {}{}",
-                        success("✓"),
-                        style_hash(&format_hash(&change.hash, false)),
-                        i + 1,
-                        new_changes.len(),
-                        msg,
-                        transfer_info,
+            match remote
+                .put_view_manifest(&sync.remote_name, sync.manifest.to_text())
+                .await
+            {
+                Ok(()) => {
+                    views_declared += 1;
+                    finish_success(
+                        &spinner,
+                        &format!(
+                            "Declared {} [{}] ({} in log)",
+                            style_view(&sync.remote_name),
+                            sync.manifest.scope,
+                            format_count(sync.manifest.changes.len(), "change"),
+                        ),
                     );
                 }
                 Err(e) => {
-                    let msg = change.message_or_default();
-                    println!(
-                        "  {} {} ({}/{}) {} - {}",
-                        error("✗"),
-                        style_hash(&format_hash(&change.hash, false)),
-                        i + 1,
-                        new_changes.len(),
-                        msg,
-                        e
-                    );
-                    return Err(e);
+                    finish_error(&spinner, "Declare failed");
+                    return Err(convert_remote_error(e, &remote_url));
                 }
             }
-
-            progress.inc(1);
         }
 
-        finish_success(&progress, &format!("Pushed {} changes", new_changes.len()));
+        // All changes in the leaf view's log are on the remote after a
+        // successful sync (chain views are subsets by the prefix rule).
+        let all_synced: HashSet<Hash> = syncs
+            .last()
+            .map(|s| s.manifest.changes.iter().copied().collect())
+            .unwrap_or_default();
 
         // Upload attestations that cover the pushed changes.
         // Attestations are graph-level audit nodes — they travel with
         // their dependencies but aren't part of any view's changelog.
         let mut attest_count = 0;
         {
-            let all_pushed_hashes: Vec<Hash> = to_upload.iter().map(|c| c.hash).collect();
-
             // Collect unique attestations — the same attestation can cover
             // multiple changes, so searching per-change produces duplicates.
-            let mut seen_attest: std::collections::HashSet<Hash> = std::collections::HashSet::new();
+            let mut seen_attest: HashSet<Hash> = HashSet::new();
             let mut unique_attestations: Vec<(
                 Hash,
                 atomic_core::change::attestation::Attestation,
             )> = Vec::new();
 
-            for pushed_hash in &all_pushed_hashes {
+            for pushed_hash in &stored_hashes {
                 let attestations = repo
                     .find_attestations_for_change(pushed_hash)
                     .unwrap_or_default();
@@ -586,11 +689,11 @@ impl Push {
                         continue; // Already collected this attestation
                     }
 
-                    // Only upload if all covered changes have been pushed
+                    // Only upload if all covered changes are on the remote
                     let all_covered = attestation
                         .changes_covered
                         .iter()
-                        .all(|h| all_pushed_hashes.contains(h));
+                        .all(|h| all_synced.contains(h));
 
                     if all_covered {
                         unique_attestations.push((attest_hash, attestation));
@@ -638,20 +741,18 @@ impl Push {
         // upload only what it does not already hold.
         let mut provenance_count = 0;
         {
-            let remote_provenance: std::collections::HashSet<String> = remote
+            let remote_provenance: HashSet<String> = remote
                 .get_provenance_list()
                 .await
                 .unwrap_or_default()
                 .into_iter()
                 .collect();
 
-            let all_pushed_hashes: Vec<Hash> = to_upload.iter().map(|c| c.hash).collect();
-
             // Collect unique provenance graphs — same dedup logic as attestations.
-            let mut seen_prov: std::collections::HashSet<Hash> = std::collections::HashSet::new();
+            let mut seen_prov: HashSet<Hash> = HashSet::new();
             let mut unique_graphs: Vec<(Hash, atomic_core::change::ProvenanceGraph)> = Vec::new();
 
-            for pushed_hash in &all_pushed_hashes {
+            for pushed_hash in &stored_hashes {
                 let graphs = repo
                     .find_provenance_for_change(pushed_hash)
                     .unwrap_or_default();
@@ -664,11 +765,11 @@ impl Push {
             }
 
             for (prov_hash, graph) in &unique_graphs {
-                // Only upload if all explained changes have been pushed
+                // Only upload if all explained changes are on the remote
                 let all_explained = graph
                     .changes_explained
                     .iter()
-                    .all(|h| all_pushed_hashes.contains(h));
+                    .all(|h| all_synced.contains(h));
 
                 if !all_explained {
                     continue;
@@ -710,10 +811,12 @@ impl Push {
             }
         }
 
-        // Upload tags for the pushed view.
+        // Upload tags for the pushed leaf view. Tags live locally under the
+        // local view name but are declared remotely under the (possibly
+        // renamed) remote view name.
         let mut tag_count = 0;
         {
-            let tags = repo.list_tags_for_view(&remote_view).unwrap_or_default();
+            let tags = repo.list_tags_for_view(&local_view).unwrap_or_default();
 
             for tag in &tags {
                 let tag_hash = tag.content_hash();
@@ -751,17 +854,11 @@ impl Push {
         // Summary
         print_blank();
         let mut summary = format!(
-            "Push complete: {} uploaded to {}",
-            format_count(new_changes.len(), "change"),
-            remote_view
+            "Push complete: {} synced ({} stored) to {}",
+            format_count(views_declared, "view"),
+            format_count(total_stored, "change"),
+            remote_name
         );
-        if adopt_count > 0 {
-            summary.push_str(&format!(
-                " (forked {} from {})",
-                format_count(adopt_count, "change"),
-                fork_source.as_deref().unwrap_or("graph")
-            ));
-        }
         if attest_count > 0 {
             summary.push_str(&format!(
                 ", {} synced",
@@ -792,34 +889,25 @@ impl Default for Push {
 impl Command for Push {
     /// Execute the push command.
     ///
-    /// # Workflow
-    ///
-    /// 1. Find and open the local repository
-    /// 2. Resolve the remote URL from configuration or argument
-    /// 3. Determine local and remote view names
-    /// 4. Connect to the remote server
-    /// 5. Query remote state and changelist
-    /// 6. Calculate which changes need to be pushed
-    /// 7. If dry run, display preview and exit
-    /// 8. Upload changes in dependency order
-    /// 9. Upload any tagged states
-    /// 10. Display summary
+    /// Syncs the current (or specified) view's parent chain to the remote
+    /// via view manifests, then uploads attestations, provenance graphs,
+    /// and tags that travel with the pushed changes.
     ///
     /// # Errors
     ///
-    /// Returns errors for:
-    /// - Repository not found
-    /// - Remote not configured
-    /// - Network/connection failures
-    /// - Authentication failures
-    /// - Diverged histories (without --force)
+    /// - `CliError::RepositoryNotFound` - Not in a repository
+    /// - `CliError::RemoteNotFound` - Remote doesn't exist
+    /// - `CliError::AuthenticationFailed` - Auth failure
+    /// - `CliError::Conflict` - Histories diverged or view identity mismatch
+    /// - `CliError::RemoteError` - Network/server error (including servers
+    ///   that predate view-manifest support)
     fn run(&self) -> CliResult<()> {
-        // Create a tokio runtime for async operations
-        let rt = tokio::runtime::Runtime::new().map_err(|e| {
+        // Create async runtime for HTTP operations
+        let runtime = tokio::runtime::Runtime::new().map_err(|e| {
             CliError::Internal(anyhow::anyhow!("Failed to create async runtime: {}", e))
         })?;
 
-        rt.block_on(self.run_async())
+        runtime.block_on(self.run_async())
     }
 }
 
@@ -829,7 +917,7 @@ impl Command for Push {
 mod tests {
     use super::*;
 
-    // Push Command Construction Tests
+    // Constructor Tests
 
     #[test]
     fn test_push_new() {
@@ -850,28 +938,33 @@ mod tests {
         assert!(push.remote.is_none());
     }
 
+    // Builder Tests
+
     #[test]
     fn test_push_with_remote() {
         let push = Push::new().with_remote("upstream");
-        assert_eq!(push.remote.as_deref(), Some("upstream"));
+        assert_eq!(push.remote, Some("upstream".to_string()));
     }
 
     #[test]
     fn test_push_with_remote_url() {
-        let push = Push::new().with_remote("https://example.com/repo");
-        assert_eq!(push.remote.as_deref(), Some("https://example.com/repo"));
+        let push = Push::new().with_remote("https://api.example.com/repo");
+        assert_eq!(
+            push.remote,
+            Some("https://api.example.com/repo".to_string())
+        );
     }
 
     #[test]
     fn test_push_with_to_view() {
-        let push = Push::new().with_to_view("main");
-        assert_eq!(push.to_view, Some("main".to_string()));
+        let push = Push::new().with_to_view("production");
+        assert_eq!(push.to_view, Some("production".to_string()));
     }
 
     #[test]
     fn test_push_with_from_view() {
-        let push = Push::new().with_from_view("dev");
-        assert_eq!(push.from_view, Some("dev".to_string()));
+        let push = Push::new().with_from_view("feature");
+        assert_eq!(push.from_view, Some("feature".to_string()));
     }
 
     #[test]
@@ -879,8 +972,8 @@ mod tests {
         let push = Push::new().with_dry_run(true);
         assert!(push.dry_run);
 
-        let push2 = push.with_dry_run(false);
-        assert!(!push2.dry_run);
+        let push = Push::new().with_dry_run(false);
+        assert!(!push.dry_run);
     }
 
     #[test]
@@ -914,16 +1007,16 @@ mod tests {
             .with_to_view("main")
             .with_from_view("feature")
             .with_dry_run(true)
-            .with_force(false)
+            .with_force(true)
             .with_all(true)
             .with_insecure(true)
             .with_timeout(120);
 
-        assert_eq!(push.remote.as_deref(), Some("upstream"));
+        assert_eq!(push.remote, Some("upstream".to_string()));
         assert_eq!(push.to_view, Some("main".to_string()));
         assert_eq!(push.from_view, Some("feature".to_string()));
         assert!(push.dry_run);
-        assert!(!push.force);
+        assert!(push.force);
         assert!(push.all);
         assert!(push.insecure);
         assert_eq!(push.timeout, 120);
@@ -931,11 +1024,11 @@ mod tests {
 
     #[test]
     fn test_push_clone() {
-        let push = Push::new().with_remote("test").with_dry_run(true);
+        let push = Push::new().with_remote("origin").with_dry_run(true);
         let cloned = push.clone();
 
-        assert_eq!(push.remote, cloned.remote);
-        assert_eq!(push.dry_run, cloned.dry_run);
+        assert_eq!(cloned.remote, push.remote);
+        assert_eq!(cloned.dry_run, push.dry_run);
     }
 
     #[test]
@@ -947,18 +1040,18 @@ mod tests {
         assert!(debug_str.contains("origin"));
     }
 
-    // Remote Channel Tests
+    // View Resolution Tests
 
     #[test]
     fn test_get_remote_view_explicit() {
-        let push = Push::new().with_to_view("main");
-        assert_eq!(push.get_remote_view("dev"), "main");
+        let push = Push::new().with_to_view("production");
+        assert_eq!(push.get_remote_view("local"), "production");
     }
 
     #[test]
     fn test_get_remote_view_default() {
         let push = Push::new();
-        assert_eq!(push.get_remote_view("dev"), "dev");
+        assert_eq!(push.get_remote_view("local"), "local");
     }
 
     // Remote Config Tests
@@ -967,7 +1060,7 @@ mod tests {
     async fn test_build_remote_config_default() {
         let push = Push::new();
         let config = push
-            .build_remote_config("http://test.localhost:8080/code", None)
+            .build_remote_config("https://api.example.com/none", None)
             .await;
 
         assert_eq!(config.timeout, Duration::from_secs(DEFAULT_TIMEOUT_SECS));
@@ -976,25 +1069,25 @@ mod tests {
 
     #[tokio::test]
     async fn test_build_remote_config_custom_timeout() {
-        let push = Push::new().with_timeout(120);
+        let push = Push::new().with_timeout(60);
         let config = push
-            .build_remote_config("http://test.localhost:8080/code", None)
+            .build_remote_config("https://api.example.com/none", None)
             .await;
 
-        assert_eq!(config.timeout, Duration::from_secs(120));
+        assert_eq!(config.timeout, Duration::from_secs(60));
     }
 
     #[tokio::test]
     async fn test_build_remote_config_insecure() {
         let push = Push::new().with_insecure(true);
         let config = push
-            .build_remote_config("http://test.localhost:8080/code", None)
+            .build_remote_config("https://api.example.com/none", None)
             .await;
 
         assert!(config.danger_accept_invalid_certs);
     }
 
-    // Constants Tests
+    // Constant Tests
 
     #[test]
     fn test_default_remote() {

--- a/atomic-cli/src/commands/push/helpers.rs
+++ b/atomic-cli/src/commands/push/helpers.rs
@@ -1,152 +1,307 @@
 //! Helper functions for the push command.
 //!
-//! # Delta Transfer Protocol
+//! # Manifest Sync Model
 //!
-//! The push command uses a threshold-gated delta transfer protocol:
+//! Push syncs views by **identity**, not by flattening. Each view in the
+//! local parent chain (root → leaf) is exported as a [`ViewManifest`] —
+//! name, scope, parent, ordered change log, merkle state — and declared on
+//! the remote:
 //!
-//! - **Small changes (< 1 MB)**: Sent directly as a single HTTP POST.
-//!   No manifest exchange, no chunk negotiation. This covers 99% of
-//!   source code changes where each change is already a small delta.
+//! 1. Fetch the remote's manifest for the view (`?view-manifest=<name>`).
+//! 2. Require the remote log to be a **prefix** of the local log
+//!    (fast-forward rule); otherwise the histories have diverged.
+//! 3. Store the suffix's change files (`?store=<hash>`, content-only,
+//!    idempotent, no view application).
+//! 4. Declare the local manifest (`POST ?view-manifest=<name>`); the server
+//!    creates/fast-forwards the view and verifies the merkle state.
 //!
-//! - **Large changes (≥ 1 MB)**: Negotiate chunks first. The client sends
-//!   a chunk manifest (list of content chunk hashes + sizes), the server
-//!   responds with which chunks it already has, and the client sends only
-//!   the missing chunks + metadata. This saves significant bandwidth for
-//!   large binary files or initial records where the server has a prior version.
-//!
-//! The threshold is configurable via [`DELTA_TRANSFER_THRESHOLD`].
-//!
-//! This module provides utility functions used by the push command, including:
-//!
-//! - Delta calculation between local and remote changelists
-//! - Error conversion from remote errors to CLI errors
-//! - State comparison display
-//! - Change data loading and formatting
+//! The pure planning pieces live here so they can be unit tested without a
+//! repository or network: chain construction ([`build_view_chain`]), suffix
+//! computation and divergence detection ([`plan_view_sync`]), and the
+//! old-server hard error ([`require_manifest_support`]).
 
 use std::collections::HashSet;
 
 use bytes::Bytes;
 
-use atomic_core::types::{Base32, Hash, Merkle, NodeId};
-use atomic_remote::{ChangelistEntry, RemoteError, StateResponse};
-use atomic_repository::history::HistoryEntry;
-use atomic_repository::Repository;
+use atomic_core::types::{Base32, Hash};
+use atomic_remote::RemoteError;
+use atomic_repository::{Repository, ViewManifest};
 
 use crate::error::{CliError, CliResult};
 use crate::output::{info, view as style_view};
 
-use super::types::PushChange;
+// View Chain Construction
 
-// Delta Calculation
+/// Errors from walking a view's parent chain.
+#[derive(Debug)]
+pub enum ChainError<E> {
+    /// The parent chain loops back on itself at this view.
+    Cycle { view: String },
 
-/// Calculate which changes need to be pushed to the remote.
+    /// Looking up a view's parent failed.
+    Lookup(E),
+}
+
+/// Build the ancestor chain for a view, ordered root → leaf.
 ///
-/// Compares local and remote changelists to determine which local
-/// changes are missing from the remote. Changes are returned in
-/// dependency order (earliest first) so they can be uploaded correctly.
+/// Walks `parent_of` from the leaf upward, guarding against cycles with a
+/// visited set. A root view (no parent) yields a chain of length 1.
 ///
-/// # Arguments
-///
-/// * `repo` - The local repository (for loading change metadata)
-/// * `local_entries` - Local history entries in forward order
-/// * `remote_entries` - Remote changelist entries
-/// * `push_all` - Whether to push all changes regardless of remote state
-///
-/// # Returns
-///
-/// A vector of changes that should be uploaded to the remote.
+/// `parent_of` is injected so the traversal is pure and unit-testable; the
+/// command wires it to `Repository::get_view_info(...).parent_name`.
 ///
 /// # Example
 ///
 /// ```rust,ignore
-/// let graph_hashes = std::collections::HashSet::new();
-/// let to_push = calculate_push_delta(&repo, &local_history, &remote_list, &graph_hashes, false)?;
-/// println!("Need to push {} changes", to_push.len());
+/// // draft `orange` parented on `dev` → ["dev", "orange"]
+/// let chain = build_view_chain("orange", |name| {
+///     repo.get_view_info(name).map(|info| info.parent_name)
+/// })?;
 /// ```
-pub fn calculate_push_delta(
-    repo: &Repository,
-    local_entries: &[HistoryEntry],
-    remote_entries: &[ChangelistEntry],
-    graph_hashes: &HashSet<String>,
-    push_all: bool,
-) -> CliResult<Vec<PushChange>> {
-    // Build set of remote hashes for quick lookup (changes already in this view)
-    let remote_hashes: HashSet<String> = remote_entries.iter().map(|e| e.hash.clone()).collect();
+pub fn build_view_chain<E>(
+    leaf: &str,
+    mut parent_of: impl FnMut(&str) -> Result<Option<String>, E>,
+) -> Result<Vec<String>, ChainError<E>> {
+    let mut chain = vec![leaf.to_string()];
+    let mut visited: HashSet<String> = HashSet::new();
+    visited.insert(leaf.to_string());
 
-    let mut to_upload = Vec::new();
-
-    for entry in local_entries {
-        let hash_str = entry.hash.to_base32();
-
-        // Skip if already on this view on the remote (unless pushing all)
-        if !push_all && remote_hashes.contains(&hash_str) {
-            continue;
+    let mut current = leaf.to_string();
+    while let Some(parent) = parent_of(&current).map_err(ChainError::Lookup)? {
+        if !visited.insert(parent.clone()) {
+            return Err(ChainError::Cycle { view: parent });
         }
-
-        // Try to load the change header to get the message
-        let message = load_change_message(repo, &entry.hash);
-
-        // Check if the change is already in the remote graph (via another view).
-        // If so, only view adoption is needed — no data transfer.
-        let already_in_graph = graph_hashes.contains(&hash_str);
-
-        let push_change = PushChange::new(entry.hash, entry.sequence, entry.state)
-            .with_tagged(entry.is_tagged)
-            .with_in_graph(already_in_graph);
-
-        let push_change = if let Some(msg) = message {
-            push_change.with_message(msg)
-        } else {
-            push_change
-        };
-
-        to_upload.push(push_change);
+        chain.push(parent.clone());
+        current = parent;
     }
 
-    Ok(to_upload)
+    chain.reverse();
+    Ok(chain)
 }
 
-/// Load the message from a change, returning None if it fails.
-fn load_change_message(repo: &Repository, hash: &Hash) -> Option<String> {
-    repo.load_change(hash)
-        .ok()
-        .map(|c| c.hashed.header.message.clone())
+// Sync Planning
+
+/// Why a view cannot be fast-forwarded on the remote.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ViewSyncConflict {
+    /// The remote log is not a prefix of the local log.
+    Diverged {
+        /// Index of the first differing entry, or `None` if the remote log
+        /// is simply longer than the local log.
+        first_mismatch: Option<usize>,
+        local_len: usize,
+        remote_len: usize,
+    },
+
+    /// The view exists on both sides with different identity (scope or
+    /// parent). The server would reject the declare with a 409; catching it
+    /// client-side gives a clearer message.
+    IdentityMismatch {
+        field: &'static str,
+        local: String,
+        remote: String,
+    },
 }
 
-/// Check if local and remote histories have diverged.
+impl std::fmt::Display for ViewSyncConflict {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Diverged {
+                first_mismatch,
+                local_len,
+                remote_len,
+            } => match first_mismatch {
+                Some(i) => write!(
+                    f,
+                    "remote log ({} changes) is not a prefix of local log ({} changes): \
+                     first mismatch at position {}",
+                    remote_len, local_len, i
+                ),
+                None => write!(
+                    f,
+                    "remote log ({} changes) is longer than local log ({} changes)",
+                    remote_len, local_len
+                ),
+            },
+            Self::IdentityMismatch {
+                field,
+                local,
+                remote,
+            } => write!(
+                f,
+                "view {} differs: local '{}' vs remote '{}'",
+                field, local, remote
+            ),
+        }
+    }
+}
+
+/// Plan for syncing one view to the remote.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ViewSyncPlan {
+    /// Changes to store on the remote, in log order. For a fast-forward
+    /// this is the local log beyond the remote prefix; for a forced push
+    /// against a diverged remote it is every local-log hash the remote
+    /// view lacks.
+    pub suffix: Vec<Hash>,
+
+    /// Whether the manifest needs to be declared (PUT). False only when
+    /// local and remote logs are already identical.
+    pub declare: bool,
+
+    /// True when divergence was overridden with `--force`. The server is
+    /// still authoritative and may reject the declare.
+    pub forced: bool,
+}
+
+impl ViewSyncPlan {
+    /// True when neither storing nor declaring is needed.
+    pub fn is_noop(&self) -> bool {
+        self.suffix.is_empty() && !self.declare
+    }
+}
+
+/// Compute the sync plan for one view: what to store and whether to declare.
 ///
-/// Returns true if the remote has changes that are not in the local history.
-/// This indicates a conflict that needs to be resolved before pushing.
+/// `remote` is the remote's parsed manifest, or `None` if the view does not
+/// exist on the remote (the remote log is empty).
 ///
-/// # Arguments
+/// The fast-forward rule: the remote log must be a prefix of the local log.
+/// The suffix (everything beyond the prefix) is what needs storing — its
+/// dependencies are either earlier in the log or already on the remote by
+/// induction over the root→leaf chain.
 ///
-/// * `local_entries` - Local history entries
-/// * `remote_entries` - Remote changelist entries
-///
-/// # Returns
-///
-/// `true` if the remote has changes not present locally.
-///
-/// # Example
-///
-/// ```rust,ignore
-/// if has_diverged(&local_history, &remote_list) {
-///     println!("Histories have diverged - need to pull first");
-/// }
-/// ```
-pub fn has_diverged(local_entries: &[HistoryEntry], remote_entries: &[ChangelistEntry]) -> bool {
-    // Empty remote can't have diverged
-    if remote_entries.is_empty() {
-        return false;
+/// With `force`, a diverged remote does not fail the plan: the suffix
+/// becomes the set difference (local-log hashes the remote view lacks) and
+/// the declare is attempted anyway, leaving the server as the authority.
+/// Identity mismatches (scope/parent) are never forced — they are
+/// structural, and the server would reject them regardless.
+pub fn plan_view_sync(
+    local: &ViewManifest,
+    remote: Option<&ViewManifest>,
+    force: bool,
+) -> Result<ViewSyncPlan, ViewSyncConflict> {
+    let remote = match remote {
+        None => {
+            // View absent on remote: the whole log is the suffix.
+            return Ok(ViewSyncPlan {
+                suffix: local.changes.clone(),
+                declare: true,
+                forced: false,
+            });
+        }
+        Some(r) => r,
+    };
+
+    // Identity must match: the manifest declares scope and parent, and the
+    // server refuses to mutate an existing view's identity.
+    if remote.scope != local.scope {
+        return Err(ViewSyncConflict::IdentityMismatch {
+            field: "scope",
+            local: local.scope.to_string(),
+            remote: remote.scope.to_string(),
+        });
+    }
+    if remote.parent != local.parent {
+        let show = |p: &Option<String>| p.clone().unwrap_or_else(|| "(none)".to_string());
+        return Err(ViewSyncConflict::IdentityMismatch {
+            field: "parent",
+            local: show(&local.parent),
+            remote: show(&remote.parent),
+        });
     }
 
-    // Build set of local hashes
-    let local_hashes: HashSet<String> = local_entries.iter().map(|e| e.hash.to_base32()).collect();
+    // Prefix rule.
+    let diverged = if remote.changes.len() > local.changes.len() {
+        Some(ViewSyncConflict::Diverged {
+            first_mismatch: None,
+            local_len: local.changes.len(),
+            remote_len: remote.changes.len(),
+        })
+    } else {
+        remote
+            .changes
+            .iter()
+            .zip(local.changes.iter())
+            .position(|(r, l)| r != l)
+            .map(|i| ViewSyncConflict::Diverged {
+                first_mismatch: Some(i),
+                local_len: local.changes.len(),
+                remote_len: remote.changes.len(),
+            })
+    };
 
-    // Check if any remote change is not in local
-    remote_entries
-        .iter()
-        .any(|e| !local_hashes.contains(&e.hash))
+    if let Some(conflict) = diverged {
+        if !force {
+            return Err(conflict);
+        }
+        // Forced: store whatever the remote view lacks and attempt the
+        // declare anyway. The server remains authoritative.
+        let remote_set: HashSet<&Hash> = remote.changes.iter().collect();
+        let suffix: Vec<Hash> = local
+            .changes
+            .iter()
+            .filter(|h| !remote_set.contains(h))
+            .copied()
+            .collect();
+        return Ok(ViewSyncPlan {
+            suffix,
+            declare: true,
+            forced: true,
+        });
+    }
+
+    // Remote is a (possibly complete) prefix of local.
+    let suffix: Vec<Hash> = local.changes[remote.changes.len()..].to_vec();
+    let declare = !suffix.is_empty();
+    Ok(ViewSyncPlan {
+        suffix,
+        declare,
+        forced: false,
+    })
+}
+
+// Manifest Support Detection
+
+/// Interpret the result of `get_view_manifest`, turning "server predates
+/// manifest support" into a hard, actionable error.
+///
+/// Identity-preserving push has no fallback: this client no longer flattens
+/// views, so a server without `?view-manifest` support cannot be pushed to.
+pub fn require_manifest_support(
+    result: Result<Option<String>, RemoteError>,
+    url: &str,
+) -> CliResult<Option<String>> {
+    match result {
+        Ok(text) => Ok(text),
+        Err(RemoteError::ProtocolError { message }) => Err(CliError::RemoteError {
+            message: format!(
+                "The server does not support view manifests ({}). \
+                 Identity-preserving push requires a server upgrade; \
+                 this client no longer flattens views on push.",
+                message
+            ),
+            url: Some(url.to_string()),
+        }),
+        Err(e) => Err(convert_remote_error(e, url)),
+    }
+}
+
+/// Parse and verify a remote manifest, mapping failures to remote errors.
+///
+/// The declared state must equal the fold of the log — a remote that sends
+/// an inconsistent manifest is broken, and we refuse to plan against it.
+pub fn parse_remote_manifest(view: &str, text: &str, url: &str) -> CliResult<ViewManifest> {
+    let manifest = ViewManifest::parse(text).map_err(|e| CliError::RemoteError {
+        message: format!("Invalid manifest for view '{}' from remote: {}", view, e),
+        url: Some(url.to_string()),
+    })?;
+    manifest.verify().map_err(|e| CliError::RemoteError {
+        message: format!("Corrupt manifest for view '{}' from remote: {}", view, e),
+        url: Some(url.to_string()),
+    })?;
+    Ok(manifest)
 }
 
 // Change Data Loading
@@ -155,15 +310,6 @@ pub fn has_diverged(local_entries: &[HistoryEntry], remote_entries: &[Changelist
 ///
 /// Loads the change from the repository and serializes it to bytes
 /// suitable for uploading to a remote.
-///
-/// # Arguments
-///
-/// * `repo` - The repository to load from
-/// * `hash` - The hash of the change to load
-///
-/// # Returns
-///
-/// The serialized change data as bytes.
 ///
 /// # Errors
 ///
@@ -203,160 +349,11 @@ pub fn load_change_data(repo: &Repository, hash: &Hash) -> CliResult<Bytes> {
     Ok(Bytes::from(buffer))
 }
 
-// Delta Transfer Protocol
-
-/// Size threshold (in bytes) for delta transfer negotiation.
-///
-/// Changes smaller than this are sent directly — the overhead of a manifest
-/// exchange round trip (two HTTP requests) exceeds any bandwidth savings for
-/// small changes. For source code changes, this covers 99% of cases.
-///
-/// Changes larger than this trigger the delta protocol:
-/// 1. Client sends chunk manifest to server
-/// 2. Server responds with which chunks it already has
-/// 3. Client sends only missing chunks + metadata
-///
-/// The 1 MB threshold was chosen because:
-/// - A typical source code change is 200 bytes – 50 KB (well below)
-/// - A manifest exchange adds ~100ms latency (two round trips)
-/// - Below 1 MB, sending the full file on a 100 Mbps link takes <80ms
-/// - Above 1 MB, delta savings can be 90%+ (worth the negotiation cost)
-pub const DELTA_TRANSFER_THRESHOLD: usize = 1024 * 1024; // 1 MB
-
-/// Result of a push operation for a single change.
-///
-/// Describes whether the change was sent directly (fast path) or via
-/// delta transfer (large path), and the bytes transferred.
-#[derive(Debug)]
-pub struct PushTransferResult {
-    /// Whether delta transfer was used.
-    pub used_delta: bool,
-
-    /// Total bytes sent over the wire.
-    pub bytes_sent: u64,
-
-    /// Bytes saved by delta transfer (0 if direct send).
-    pub bytes_saved: u64,
-
-    /// Number of content chunks the server already had (0 if direct send).
-    pub chunks_reused: u32,
-
-    /// Total content chunks in the change (0 if direct send).
-    pub chunks_total: u32,
-}
-
-impl PushTransferResult {
-    /// Create a result for a direct (non-delta) send.
-    pub fn direct(bytes_sent: u64) -> Self {
-        Self {
-            used_delta: false,
-            bytes_sent,
-            bytes_saved: 0,
-            chunks_reused: 0,
-            chunks_total: 0,
-        }
-    }
-
-    /// Percentage of bytes saved (0.0–100.0).
-    pub fn savings_pct(&self) -> f64 {
-        let total = self.bytes_sent + self.bytes_saved;
-        if total == 0 {
-            return 0.0;
-        }
-        self.bytes_saved as f64 / total as f64 * 100.0
-    }
-}
-
-impl std::fmt::Display for PushTransferResult {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.used_delta {
-            write!(
-                f,
-                "delta: sent {} ({} saved, {}/{} chunks reused, {:.0}% savings)",
-                format_bytes(self.bytes_sent),
-                format_bytes(self.bytes_saved),
-                self.chunks_reused,
-                self.chunks_total,
-                self.savings_pct(),
-            )
-        } else {
-            write!(f, "direct: sent {}", format_bytes(self.bytes_sent))
-        }
-    }
-}
-
-/// Upload a single change using the threshold-gated delta transfer protocol.
-///
-/// - Changes smaller than [`DELTA_TRANSFER_THRESHOLD`]: sent directly (fast path)
-/// - Changes larger: manifest exchange → send only missing chunks (delta path)
-///
-/// # Arguments
-///
-/// * `remote` - The HTTP remote to push to.
-/// * `repo` - The local repository.
-/// * `hash` - The change hash.
-/// * `view` - The target view name on the remote.
-///
-/// # Returns
-///
-/// A [`PushTransferResult`] describing the transfer, or an error.
-pub async fn upload_change_smart(
-    remote: &atomic_remote::HttpRemote,
-    repo: &Repository,
-    hash: &Hash,
-    view: &str,
-) -> CliResult<PushTransferResult> {
-    let hash_str = hash.to_base32();
-
-    // Prefer streaming from the on-disk change file for large changes.
-    // This avoids loading 50MB+ into memory and uses chunked transfer
-    // encoding so the server can stream-to-disk instead of buffering.
-    let change_path = repo.change_store().change_path(hash);
-    let file_size = change_path.metadata().map(|m| m.len()).unwrap_or(0);
-
-    log::debug!(
-        "push: uploading {} ({} bytes / {}){}",
-        &hash_str[..12.min(hash_str.len())],
-        file_size,
-        format_bytes(file_size),
-        if file_size as usize >= DELTA_TRANSFER_THRESHOLD {
-            " [streamed]"
-        } else {
-            ""
-        },
-    );
-
-    // For large changes, stream directly from disk.
-    if file_size as usize >= DELTA_TRANSFER_THRESHOLD && change_path.exists() {
-        remote
-            .upload_change_streamed(&hash_str, view, &change_path)
-            .await
-            .map_err(|e| convert_remote_error(e, remote.url().as_ref()))?;
-
-        return Ok(PushTransferResult::direct(file_size));
-    }
-
-    // Small changes: load into memory and send directly.
-    let change_data = load_change_data(repo, hash)?;
-    let data_len = change_data.len();
-
-    remote
-        .upload_change(&hash_str, view, change_data)
-        .await
-        .map_err(|e| convert_remote_error(e, remote.url().as_ref()))?;
-
-    Ok(PushTransferResult::direct(data_len as u64))
-}
-
-/// Format a byte count for display.
-fn format_bytes(bytes: u64) -> String {
-    if bytes >= 1024 * 1024 {
-        format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
-    } else if bytes >= 1024 {
-        format!("{:.1} KB", bytes as f64 / 1024.0)
-    } else {
-        format!("{} B", bytes)
-    }
+/// Load the message from a change, returning None if it fails.
+pub fn load_change_message(repo: &Repository, hash: &Hash) -> Option<String> {
+    repo.load_change(hash)
+        .ok()
+        .map(|c| c.hashed.header.message.clone())
 }
 
 // Error Conversion
@@ -460,70 +457,37 @@ pub fn convert_remote_error(err: RemoteError, url: &str) -> CliError {
 
 // Display Helpers
 
-/// Display the state comparison between local and remote.
+/// Display a local vs remote manifest state comparison for one view.
 ///
-/// Shows the user a summary of where local and remote are at,
-/// helping them understand what will be pushed.
-///
-/// # Arguments
-///
-/// * `local_view` - Name of the local view
-/// * `local_entries` - Local history entries
-/// * `remote_view` - Name of the remote view
-/// * `remote_state` - Current state of the remote
-/// * `remote_entries` - Remote changelist entries
-pub fn display_state_comparison(
-    local_view: &str,
-    local_entries: &[HistoryEntry],
-    remote_view: &str,
-    remote_state: &StateResponse,
-    remote_entries: &[ChangelistEntry],
-) {
-    let local_state_str = format_local_state(local_entries);
-    let remote_state_str = format_remote_state(remote_state, remote_entries);
-
+/// Used when a view has diverged, so the user can see where each side is.
+pub fn display_manifest_divergence(local_view: &str, local: &ViewManifest, remote: &ViewManifest) {
     println!(
         "  Local:  {} at {}",
         style_view(local_view),
-        info(&local_state_str)
+        info(&format_manifest_state(local))
     );
     println!(
         "  Remote: {} at {}",
-        style_view(remote_view),
-        info(&remote_state_str)
+        style_view(&remote.name),
+        info(&format_manifest_state(remote))
     );
 }
 
-/// Format the local state for display.
-fn format_local_state(entries: &[HistoryEntry]) -> String {
-    if let Some(entry) = entries.last() {
-        let short_state = &entry.state.to_base32()[..12];
-        format!("{} ({} changes)", short_state, entries.len())
-    } else {
+/// Format a manifest's state for display.
+fn format_manifest_state(manifest: &ViewManifest) -> String {
+    if manifest.changes.is_empty() {
         "(empty)".to_string()
-    }
-}
-
-/// Format the remote state for display.
-fn format_remote_state(state: &StateResponse, entries: &[ChangelistEntry]) -> String {
-    if let Some(merkle_str) = state.merkle() {
-        let short_state = &merkle_str[..12.min(merkle_str.len())];
-        format!("{} ({} changes)", short_state, entries.len())
     } else {
-        "(empty)".to_string()
+        let state = manifest.state.to_base32();
+        format!(
+            "{} ({} changes)",
+            &state[..12.min(state.len())],
+            manifest.changes.len()
+        )
     }
 }
 
 /// Format a count with singular/plural suffix.
-///
-/// # Arguments
-///
-/// * `count` - The count to format
-/// * `singular` - The singular form of the word
-///
-/// # Returns
-///
-/// A formatted string like "1 change" or "5 changes".
 ///
 /// # Example
 ///
@@ -544,63 +508,310 @@ pub fn format_count(count: usize, singular: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use atomic_core::pristine::ViewScope;
+    use std::collections::HashMap;
 
-    // Delta Calculation Tests
+    /// Deterministic test hash.
+    fn h(n: u8) -> Hash {
+        Hash::of(&[n])
+    }
+
+    /// Build a manifest with a computed (consistent) state.
+    fn manifest(
+        name: &str,
+        scope: ViewScope,
+        parent: Option<&str>,
+        changes: Vec<Hash>,
+    ) -> ViewManifest {
+        ViewManifest::new(name, scope, parent.map(str::to_string), changes)
+    }
+
+    /// Parent lookup backed by a map, for pure chain tests.
+    fn parents(
+        pairs: &[(&str, Option<&str>)],
+    ) -> impl FnMut(&str) -> Result<Option<String>, String> {
+        let map: HashMap<String, Option<String>> = pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.map(str::to_string)))
+            .collect();
+        move |name: &str| {
+            map.get(name)
+                .cloned()
+                .ok_or_else(|| format!("view '{}' not found", name))
+        }
+    }
+
+    // Chain Construction Tests
 
     #[test]
-    fn test_has_diverged_empty_remote() {
-        let local_entries = vec![
-            create_test_entry(0, "ABC123"),
-            create_test_entry(1, "DEF456"),
-        ];
-        let remote_entries: Vec<ChangelistEntry> = vec![];
-
-        assert!(!has_diverged(&local_entries, &remote_entries));
+    fn test_chain_root_view_is_length_one() {
+        let chain = build_view_chain("main", parents(&[("main", None)])).unwrap();
+        assert_eq!(chain, vec!["main"]);
     }
 
     #[test]
-    fn test_has_diverged_subset() {
-        // Remote is a subset of local - no divergence
-        let local_entries = vec![
-            create_test_entry(0, "ABC123"),
-            create_test_entry(1, "DEF456"),
-            create_test_entry(2, "GHI789"),
-        ];
-        let remote_entries = vec![
-            create_test_changelist_entry(0, "ABC123"),
-            create_test_changelist_entry(1, "DEF456"),
-        ];
-
-        assert!(!has_diverged(&local_entries, &remote_entries));
+    fn test_chain_orders_root_to_leaf() {
+        // orange → dev → main should come out as [main, dev, orange]
+        let chain = build_view_chain(
+            "orange",
+            parents(&[
+                ("orange", Some("dev")),
+                ("dev", Some("main")),
+                ("main", None),
+            ]),
+        )
+        .unwrap();
+        assert_eq!(chain, vec!["main", "dev", "orange"]);
     }
 
     #[test]
-    fn test_has_diverged_different_changes() {
-        // Remote has a change not in local - diverged
-        let local_entries = vec![
-            create_test_entry(0, "ABC123"),
-            create_test_entry(1, "DEF456"),
-        ];
-        let remote_entries = vec![
-            create_test_changelist_entry(0, "ABC123"),
-            create_test_changelist_entry(1, "XYZ999"), // Different!
-        ];
-
-        assert!(has_diverged(&local_entries, &remote_entries));
+    fn test_chain_detects_cycle() {
+        // a → b → a is a corrupt parent chain, not an infinite loop.
+        let err =
+            build_view_chain("a", parents(&[("a", Some("b")), ("b", Some("a"))])).unwrap_err();
+        match err {
+            ChainError::Cycle { view } => assert_eq!(view, "a"),
+            other => panic!("Expected Cycle, got {:?}", other),
+        }
     }
 
     #[test]
-    fn test_has_diverged_identical() {
-        let local_entries = vec![
-            create_test_entry(0, "ABC123"),
-            create_test_entry(1, "DEF456"),
-        ];
-        let remote_entries = vec![
-            create_test_changelist_entry(0, "ABC123"),
-            create_test_changelist_entry(1, "DEF456"),
-        ];
+    fn test_chain_detects_self_cycle() {
+        let err = build_view_chain("a", parents(&[("a", Some("a"))])).unwrap_err();
+        assert!(matches!(err, ChainError::Cycle { view } if view == "a"));
+    }
 
-        assert!(!has_diverged(&local_entries, &remote_entries));
+    #[test]
+    fn test_chain_propagates_lookup_error() {
+        // Parent references a view that cannot be resolved.
+        let err = build_view_chain("a", parents(&[("a", Some("ghost"))])).unwrap_err();
+        assert!(matches!(err, ChainError::Lookup(msg) if msg.contains("ghost")));
+    }
+
+    // Sync Planning Tests
+
+    #[test]
+    fn test_plan_absent_remote_uploads_full_log() {
+        let local = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2), h(3)]);
+        let plan = plan_view_sync(&local, None, false).unwrap();
+
+        assert_eq!(plan.suffix, vec![h(1), h(2), h(3)]);
+        assert!(plan.declare);
+        assert!(!plan.forced);
+    }
+
+    #[test]
+    fn test_plan_remote_prefix_uploads_suffix_only() {
+        let local = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2), h(3), h(4)]);
+        let remote = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2)]);
+        let plan = plan_view_sync(&local, Some(&remote), false).unwrap();
+
+        assert_eq!(plan.suffix, vec![h(3), h(4)]);
+        assert!(plan.declare);
+        assert!(!plan.forced);
+    }
+
+    #[test]
+    fn test_plan_identical_logs_is_noop() {
+        let local = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2)]);
+        let remote = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2)]);
+        let plan = plan_view_sync(&local, Some(&remote), false).unwrap();
+
+        assert!(plan.suffix.is_empty());
+        assert!(!plan.declare);
+        assert!(plan.is_noop());
+    }
+
+    #[test]
+    fn test_plan_empty_remote_view_uploads_full_log() {
+        // View exists on the remote but its log is empty (freshly declared).
+        let local = manifest("dev", ViewScope::Shared, None, vec![h(1)]);
+        let remote = manifest("dev", ViewScope::Shared, None, vec![]);
+        let plan = plan_view_sync(&local, Some(&remote), false).unwrap();
+
+        assert_eq!(plan.suffix, vec![h(1)]);
+        assert!(plan.declare);
+    }
+
+    #[test]
+    fn test_plan_diverged_hash_mismatch() {
+        let local = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2), h(3)]);
+        let remote = manifest("dev", ViewScope::Shared, None, vec![h(1), h(9)]);
+        let err = plan_view_sync(&local, Some(&remote), false).unwrap_err();
+
+        assert_eq!(
+            err,
+            ViewSyncConflict::Diverged {
+                first_mismatch: Some(1),
+                local_len: 3,
+                remote_len: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn test_plan_diverged_remote_longer() {
+        // Remote is ahead of local: not a prefix, so pull first.
+        let local = manifest("dev", ViewScope::Shared, None, vec![h(1)]);
+        let remote = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2)]);
+        let err = plan_view_sync(&local, Some(&remote), false).unwrap_err();
+
+        assert_eq!(
+            err,
+            ViewSyncConflict::Diverged {
+                first_mismatch: None,
+                local_len: 1,
+                remote_len: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn test_plan_forced_diverged_stores_set_difference() {
+        let local = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2), h(3)]);
+        let remote = manifest("dev", ViewScope::Shared, None, vec![h(1), h(9)]);
+        let plan = plan_view_sync(&local, Some(&remote), true).unwrap();
+
+        // h(1) is already on the remote view; h(2), h(3) are not.
+        assert_eq!(plan.suffix, vec![h(2), h(3)]);
+        assert!(plan.declare);
+        assert!(plan.forced);
+    }
+
+    #[test]
+    fn test_plan_scope_mismatch_is_conflict_even_forced() {
+        let local = manifest("x", ViewScope::Draft, Some("dev"), vec![h(1)]);
+        let remote = manifest("x", ViewScope::Shared, Some("dev"), vec![h(1)]);
+
+        let err = plan_view_sync(&local, Some(&remote), false).unwrap_err();
+        assert!(matches!(
+            err,
+            ViewSyncConflict::IdentityMismatch { field: "scope", .. }
+        ));
+
+        // Identity mismatches are structural — force does not bypass them.
+        let err = plan_view_sync(&local, Some(&remote), true).unwrap_err();
+        assert!(matches!(
+            err,
+            ViewSyncConflict::IdentityMismatch { field: "scope", .. }
+        ));
+    }
+
+    #[test]
+    fn test_plan_parent_mismatch_is_conflict() {
+        let local = manifest("x", ViewScope::Draft, Some("dev"), vec![h(1)]);
+        let remote = manifest("x", ViewScope::Draft, Some("release"), vec![h(1)]);
+        let err = plan_view_sync(&local, Some(&remote), false).unwrap_err();
+
+        match err {
+            ViewSyncConflict::IdentityMismatch {
+                field,
+                local,
+                remote,
+            } => {
+                assert_eq!(field, "parent");
+                assert_eq!(local, "dev");
+                assert_eq!(remote, "release");
+            }
+            other => panic!("Expected IdentityMismatch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_conflict_display_is_actionable() {
+        let diverged = ViewSyncConflict::Diverged {
+            first_mismatch: Some(2),
+            local_len: 5,
+            remote_len: 4,
+        };
+        let msg = diverged.to_string();
+        assert!(msg.contains("not a prefix"));
+        assert!(msg.contains("position 2"));
+
+        let longer = ViewSyncConflict::Diverged {
+            first_mismatch: None,
+            local_len: 1,
+            remote_len: 3,
+        };
+        assert!(longer.to_string().contains("longer than local"));
+    }
+
+    // Old-Server Hard Error Tests
+
+    #[test]
+    fn test_require_manifest_support_passes_through_manifest() {
+        let text = "dev\tshared\t-\t-\n".to_string();
+        let result = require_manifest_support(Ok(Some(text.clone())), "http://example.com");
+        assert_eq!(result.unwrap(), Some(text));
+    }
+
+    #[test]
+    fn test_require_manifest_support_passes_through_absent_view() {
+        let result = require_manifest_support(Ok(None), "http://example.com");
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[test]
+    fn test_require_manifest_support_hard_errors_on_old_server() {
+        // A protocol error from get_view_manifest means the server predates
+        // manifest support — there is no flatten fallback anymore.
+        let err = require_manifest_support(
+            Err(RemoteError::protocol(
+                "server does not support view manifests (?view-manifest)",
+            )),
+            "http://example.com",
+        )
+        .unwrap_err();
+
+        match err {
+            CliError::RemoteError { message, url } => {
+                assert!(message.contains("does not support view manifests"));
+                assert!(message.contains("server upgrade"));
+                assert!(message.contains("no longer flattens"));
+                assert_eq!(url.as_deref(), Some("http://example.com"));
+            }
+            other => panic!("Expected RemoteError, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_require_manifest_support_converts_other_errors() {
+        let err = require_manifest_support(
+            Err(RemoteError::auth_failed("http://example.com", "nope")),
+            "http://example.com",
+        )
+        .unwrap_err();
+        assert!(matches!(err, CliError::AuthenticationFailed { .. }));
+    }
+
+    // Remote Manifest Parsing Tests
+
+    #[test]
+    fn test_parse_remote_manifest_round_trip() {
+        let m = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2)]);
+        let parsed = parse_remote_manifest("dev", &m.to_text(), "http://example.com").unwrap();
+        assert_eq!(parsed, m);
+    }
+
+    #[test]
+    fn test_parse_remote_manifest_rejects_garbage() {
+        let err = parse_remote_manifest("dev", "", "http://example.com").unwrap_err();
+        assert!(matches!(err, CliError::RemoteError { .. }));
+    }
+
+    #[test]
+    fn test_parse_remote_manifest_rejects_state_mismatch() {
+        // Header declares a state that does not fold from the log.
+        let mut m = manifest("dev", ViewScope::Shared, None, vec![h(1)]);
+        m.state = atomic_core::types::Merkle::of(b"tampered");
+        let err = parse_remote_manifest("dev", &m.to_text(), "http://example.com").unwrap_err();
+
+        match err {
+            CliError::RemoteError { message, .. } => {
+                assert!(message.contains("Corrupt manifest"));
+            }
+            other => panic!("Expected RemoteError, got {:?}", other),
+        }
     }
 
     // Error Conversion Tests
@@ -718,60 +929,16 @@ mod tests {
     // Display Helper Tests
 
     #[test]
-    fn test_format_local_state_empty() {
-        let entries: Vec<HistoryEntry> = vec![];
-        assert_eq!(format_local_state(&entries), "(empty)");
+    fn test_format_manifest_state_empty() {
+        let m = manifest("dev", ViewScope::Shared, None, vec![]);
+        assert_eq!(format_manifest_state(&m), "(empty)");
     }
 
     #[test]
-    fn test_format_local_state_with_entries() {
-        let entries = vec![
-            create_test_entry(0, "ABC123"),
-            create_test_entry(1, "DEF456"),
-        ];
-        let result = format_local_state(&entries);
-
-        assert!(result.contains("2 changes"));
-    }
-
-    #[test]
-    fn test_format_remote_state_empty() {
-        let state = StateResponse::empty();
-        let entries: Vec<ChangelistEntry> = vec![];
-
-        assert_eq!(format_remote_state(&state, &entries), "(empty)");
-    }
-
-    // Test Helpers
-
-    /// Create a test history entry with a deterministic hash.
-    /// The hash is created from the hash_str so that when compared with
-    /// a ChangelistEntry using the same string, they will match.
-    fn create_test_entry(sequence: u64, hash_str: &str) -> HistoryEntry {
-        // Create a hash that will produce the expected base32 string
-        // For testing, we use a hash derived from the string itself
-        let hash = Hash::of(hash_str.as_bytes());
-        HistoryEntry {
-            sequence,
-            hash,
-            state: Merkle::ZERO,
-            node_id: NodeId::from(sequence),
-            header: None,
-            is_tagged: false,
-        }
-    }
-
-    /// Create a test changelist entry.
-    /// The hash should be the base32 encoding of the same hash used in create_test_entry.
-    fn create_test_changelist_entry(sequence: u64, hash_str: &str) -> ChangelistEntry {
-        // Use the same hash derivation as create_test_entry
-        let hash = Hash::of(hash_str.as_bytes());
-        let hash_base32 = hash.to_base32();
-        ChangelistEntry::new(
-            sequence,
-            &hash_base32,
-            "ABCD1234ABCD1234ABCD1234ABCD1234",
-            false,
-        )
+    fn test_format_manifest_state_with_changes() {
+        let m = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2)]);
+        let text = format_manifest_state(&m);
+        assert!(text.contains("2 changes"));
+        assert!(text.starts_with(&m.state.to_base32()[..12]));
     }
 }

--- a/atomic-cli/src/commands/push/mod.rs
+++ b/atomic-cli/src/commands/push/mod.rs
@@ -1,8 +1,9 @@
-//! The `push` command for uploading changes to a remote repository.
+//! The `push` command for syncing views to a remote repository.
 //!
-//! This module implements the `atomic push` command, which uploads local changes
-//! to a remote repository. It communicates with `atomic-api` servers using the
-//! HTTP protocol defined in the `atomic-remote-client` crate.
+//! This module implements the `atomic push` command, which syncs local views
+//! to a remote repository **identity-preservingly** via view manifests. It
+//! communicates with `atomic-api` servers using the HTTP protocol defined in
+//! the `atomic-remote` crate.
 //!
 //! # Module Structure
 //!
@@ -10,20 +11,38 @@
 //!
 //! - [`command`]: The main `Push` struct and `Command` implementation
 //! - [`types`]: Data structures (`PushChange`, `PushStats`, `PushOutcome`)
-//! - [`helpers`]: Utility functions for delta calculation, error conversion, etc.
+//! - [`helpers`]: Chain construction, sync planning, error conversion, etc.
 //!
 //! # Overview
 //!
-//! The push command performs the following workflow:
+//! Push no longer flattens a draft view into a shared remote view. Instead,
+//! each view in the target's parent chain is transferred as a
+//! [`ViewManifest`](atomic_repository::ViewManifest) — name, scope, parent,
+//! ordered change log, merkle state — so the remote ends up with the same
+//! view hierarchy as the local repository:
 //!
-//! 1. **Open local repository** and determine current view
-//! 2. **Load remote configuration** from repository settings
+//! 1. **Open local repository** and determine the leaf view (current or
+//!    `--from-view`)
+//! 2. **Build the ancestor chain** root → leaf by walking view parents
+//!    (cycle-guarded)
 //! 3. **Connect to remote** using HTTP client
-//! 4. **Query remote state** to determine what changes exist remotely
-//! 5. **Calculate delta** between local and remote changelists
-//! 6. **Upload changes** in dependency order (dependencies first)
-//! 7. **Upload tags** for any tagged states
-//! 8. **Report results** to the user
+//! 4. For each view in the chain, root → leaf:
+//!    - **Export the local manifest** (`Repository::view_manifest`)
+//!    - **Fetch the remote manifest** (`?view-manifest=<name>`); a server
+//!      without manifest support is a hard error — no flatten fallback
+//!    - **Require the fast-forward rule**: the remote log must be a prefix
+//!      of the local log, otherwise the push reports divergence
+//!    - **Store the suffix** — change files the remote lacks — via
+//!      `?store=<hash>` (content-only, idempotent, no view application)
+//!    - **Declare the manifest** (`POST ?view-manifest=<name>`); the server
+//!      creates/fast-forwards the view and verifies the merkle state
+//! 5. **Upload attestations, provenance graphs, and tags** that travel with
+//!    the pushed changes
+//! 6. **Report results** to the user
+//!
+//! Because the chain is synced root → leaf, a draft's parent always exists
+//! on the remote before the draft's manifest references it, and a draft's
+//! inherited prefix is never re-stored (it was synced with the parent).
 //!
 //! # Usage
 //!
@@ -34,43 +53,49 @@
 //!   [REMOTE]  Remote name or URL (default: the configured default remote, or "origin")
 //!
 //! Options:
-//!       --to-channel <CHANNEL>    Remote channel to push to (default: same as local)
-//!       --from-channel <CHANNEL>  Local channel to push from (default: current)
-//!   -n, --dry-run                 Show what would be pushed without pushing
-//!   -f, --force                   Force push even with diverged history
-//!   -a, --all                     Push all changes (not just new ones)
-//!   -k, --insecure                Skip TLS certificate verification
-//!       --timeout <SECONDS>       Request timeout in seconds (default: 30)
-//!   -h, --help                    Print help information
+//!       --to-view <VIEW>      Remote name for the leaf view (default: same as local)
+//!       --from-view <VIEW>    Local view to push from (default: current)
+//!   -n, --dry-run             Show what would be synced without pushing
+//!   -f, --force               Attempt the push even with diverged history
+//!                             (server remains authoritative)
+//!   -a, --all                 Store all changes in the log, not just the suffix
+//!   -k, --insecure            Skip TLS certificate verification
+//!       --timeout <SECONDS>   Request timeout in seconds (default: 30)
+//!   -h, --help                Print help information
 //! ```
 //!
 //! # Output
 //!
-//! On success, the command displays information about pushed changes:
+//! On success, the command displays the per-view sync progress:
 //!
 //! ```text
 //! Pushing to origin (https://api.example.com/tenant/t/portfolio/p/project/pr/code)
-//!   Remote: main at ABC123...
-//!   Local:  main at DEF456...
+//! ✓ Remote dev has 2 changes
+//! ✓ Remote orange does not exist yet
+//! Syncing view dev (1 new):
+//!   ✓ GHI789... (1/1) Fix login bug
+//! ✓ Declared dev [shared] (3 changes in log)
+//! Syncing view orange (2 new):
+//!   ✓ JKL012... (1/2) Add authentication module
+//!   ✓ DEF456... (2/2) Update tests
+//! ✓ Declared orange [draft] (5 changes in log)
 //!
-//! Uploading 3 changes:
-//!   ✓ GHI789... (1/3) Add authentication module
-//!   ✓ JKL012... (2/3) Fix login bug
-//!   ✓ DEF456... (3/3) Update tests
-//!
-//! Push complete: 3 changes uploaded
+//! Push complete: 2 views synced (3 changes stored) to origin
 //! ```
 //!
 //! # Dry Run
 //!
-//! Use `--dry-run` to preview what would be pushed:
+//! Use `--dry-run` to preview what would be synced:
 //!
 //! ```text
 //! $ atomic push --dry-run
-//! Would push 3 changes to origin:
-//!   GHI789... Add authentication module
-//!   JKL012... Fix login bug
-//!   DEF456... Update tests
+//! Would sync 2 views to origin:
+//!
+//!   dev [shared]: 1 change to store, declare manifest (3 changes in log)
+//!     GHI789... Fix login bug
+//!   orange [draft, parent dev]: 2 changes to store, declare manifest (5 changes in log)
+//!     JKL012... Add authentication module
+//!     DEF456... Update tests
 //! ```
 //!
 //! # Error Handling
@@ -80,8 +105,12 @@
 //! - **No remote configured**: Suggests adding a remote
 //! - **Authentication failed**: Suggests checking credentials
 //! - **Network errors**: Provides retry suggestions
-//! - **Diverged history**: Explains the situation and suggests `--force`
-//! - **Missing dependencies**: Suggests pushing with `--all`
+//! - **Diverged history**: The remote log is not a prefix of the local log;
+//!   suggests `atomic pull`, or `--force` to let the server decide
+//! - **Identity mismatch**: The view exists remotely with a different
+//!   scope/parent; never forceable
+//! - **Old server**: A server without `?view-manifest` support is a hard
+//!   error — identity-preserving push has no flatten fallback
 //!
 //! # Architecture
 //!
@@ -92,22 +121,26 @@
 //! │                                                                         │
 //! │  ┌─────────────┐    ┌─────────────┐    ┌─────────────────────────────┐ │
 //! │  │  Repository │    │ ChangeStore │    │      HttpRemote             │ │
-//! │  │  (local)    │    │ (local)     │    │ (atomic-remote-client)      │ │
+//! │  │  (local)    │    │ (local)     │    │ (atomic-remote)             │ │
 //! │  └──────┬──────┘    └──────┬──────┘    └────────────┬────────────────┘ │
 //! │         │                  │                        │                  │
-//! │         │  1. Get history  │                        │                  │
+//! │         │ 1. Build chain + │                        │                  │
+//! │         │    export manifests                       │                  │
 //! │         ├─────────────────►│                        │                  │
 //! │         │                  │                        │                  │
-//! │         │           2. Query remote state           │                  │
+//! │         │           2. GET ?view-manifest per view  │                  │
 //! │         │───────────────────────────────────────────►                  │
 //! │         │                  │                        │                  │
-//! │         │           3. Calculate delta              │                  │
+//! │         │           3. Plan fast-forward suffix     │                  │
 //! │         │◄──────────────────────────────────────────┤                  │
 //! │         │                  │                        │                  │
 //! │         │  4. Load changes │                        │                  │
 //! │         ├─────────────────►│                        │                  │
 //! │         │                  │                        │                  │
-//! │         │           5. Upload changes               │                  │
+//! │         │           5. POST ?store per new change   │                  │
+//! │         │───────────────────────────────────────────►                  │
+//! │         │                  │                        │                  │
+//! │         │           6. POST ?view-manifest per view │                  │
 //! │         │───────────────────────────────────────────►                  │
 //! │         │                  │                        │                  │
 //! └─────────────────────────────────────────────────────────────────────────┘

--- a/atomic-cli/src/commands/view/delete.rs
+++ b/atomic-cli/src/commands/view/delete.rs
@@ -38,6 +38,9 @@
 //! ```
 
 use clap::Parser;
+use clap_complete::engine::ArgValueCompleter;
+
+use crate::commands::complete::complete_view_names;
 
 use atomic_repository::Repository;
 
@@ -64,7 +67,7 @@ pub struct Delete {
     /// Name of the view to delete.
     ///
     /// The view must exist and cannot be the current view.
-    #[arg(value_name = "NAME")]
+    #[arg(value_name = "NAME", add = ArgValueCompleter::new(complete_view_names))]
     pub name: Option<String>,
 
     /// Force deletion without confirmation.

--- a/atomic-cli/src/commands/view/new.rs
+++ b/atomic-cli/src/commands/view/new.rs
@@ -52,6 +52,9 @@
 //! ```
 
 use clap::Parser;
+use clap_complete::engine::ArgValueCompleter;
+
+use crate::commands::complete::complete_view_names;
 
 use atomic_repository::Repository;
 
@@ -155,7 +158,7 @@ pub struct New {
     /// The new view inherits all changes from the source and gets
     /// its own view filter on the canonical `GRAPH` so that future
     /// changes recorded on it are invisible to the source.
-    #[arg(long, value_name = "VIEW")]
+    #[arg(long, value_name = "VIEW", add = ArgValueCompleter::new(complete_view_names))]
     pub from: Option<String>,
 
     /// Create an empty view with no inherited history.
@@ -211,7 +214,7 @@ pub struct New {
     /// # Parent on dev (the default if dev is current)
     /// atomic view create bugfix-123 --draft --parent dev
     /// ```
-    #[arg(long, value_name = "VIEW")]
+    #[arg(long, value_name = "VIEW", add = ArgValueCompleter::new(complete_view_names))]
     pub parent: Option<String>,
 }
 

--- a/atomic-cli/src/commands/view/promote.rs
+++ b/atomic-cli/src/commands/view/promote.rs
@@ -8,6 +8,9 @@
 //! change-loading slow path.
 
 use clap::Parser;
+use clap_complete::engine::ArgValueCompleter;
+
+use crate::commands::complete::complete_view_names;
 
 use atomic_core::pristine::ViewScope;
 use atomic_repository::Repository;
@@ -34,7 +37,7 @@ use crate::output::{print_info, print_success};
 #[derive(Parser, Debug)]
 pub struct Promote {
     /// Name of the view to promote. Defaults to the current view.
-    #[arg(value_name = "NAME")]
+    #[arg(value_name = "NAME", add = ArgValueCompleter::new(complete_view_names))]
     pub name: Option<String>,
 }
 

--- a/atomic-cli/src/commands/view/switch.rs
+++ b/atomic-cli/src/commands/view/switch.rs
@@ -37,6 +37,9 @@
 //! ```
 
 use clap::Parser;
+use clap_complete::engine::ArgValueCompleter;
+
+use crate::commands::complete::complete_view_names;
 
 use atomic_repository::Repository;
 
@@ -64,7 +67,7 @@ pub struct Switch {
     ///
     /// The view must already exist. Use `atomic view list` to see
     /// available views, or `atomic view create` to create a new one.
-    #[arg(value_name = "NAME")]
+    #[arg(value_name = "NAME", add = ArgValueCompleter::new(complete_view_names))]
     pub name: Option<String>,
 
     /// Force switch even with unrecorded changes.

--- a/atomic-remote/src/http/queries.rs
+++ b/atomic-remote/src/http/queries.rs
@@ -427,6 +427,68 @@ impl HttpRemote {
         }
     }
 
+    /// Fetch a view's manifest from the remote.
+    ///
+    /// The manifest is the view's complete identity — header line
+    /// `name\tscope\tparent\tstate` followed by the view's change log, one
+    /// base32 hash per line, exactly as stored on the remote. Returns
+    /// `Ok(None)` if the remote does not have the view, and
+    /// [`RemoteError::protocol`] if the server predates manifest support
+    /// (callers decide whether that is fatal — e.g. draft push — or not).
+    ///
+    /// This method is string-level: parsing into a typed manifest happens in
+    /// `atomic-repository`, which owns the format.
+    pub async fn get_view_manifest(&self, view: &str) -> RemoteResult<Option<String>> {
+        let url = format!("{}?view-manifest={}", self.base_url, view);
+        debug!("GET view-manifest: {}", url);
+
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| RemoteError::connection_failed(&url, e))?;
+
+        crate::check_min_version_header(response.headers());
+        let status = response.status();
+
+        match status {
+            StatusCode::OK => {
+                let text = response
+                    .text()
+                    .await
+                    .map_err(|e| RemoteError::connection_failed(&url, e))?;
+                // A manifest response is line-based with a tab-separated
+                // header. An older server answers `?view-manifest` with its
+                // generic JSON info blob — detect that and report missing
+                // support rather than handing garbage to the parser.
+                let looks_like_manifest = text
+                    .lines()
+                    .find(|l| !l.trim().is_empty())
+                    .map(|l| l.contains('\t'))
+                    .unwrap_or(false);
+                if text.trim().is_empty() {
+                    Ok(None)
+                } else if looks_like_manifest {
+                    Ok(Some(text))
+                } else {
+                    Err(RemoteError::protocol(
+                        "server does not support view manifests (?view-manifest)",
+                    ))
+                }
+            }
+            StatusCode::NOT_FOUND => Ok(None),
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
+                let msg = response.text().await.unwrap_or_default();
+                Err(RemoteError::auth_failed(&url, msg))
+            }
+            _ => {
+                let msg = response.text().await.unwrap_or_default();
+                Err(RemoteError::http(status.as_u16(), msg))
+            }
+        }
+    }
+
     /// List all provenance graph hashes the remote holds.
     ///
     /// This mirrors the `.change` sync model: the server advertises a flat

--- a/atomic-remote/src/http/upload.rs
+++ b/atomic-remote/src/http/upload.rs
@@ -65,6 +65,109 @@ impl HttpRemote {
         }
     }
 
+    /// Store a change file on the remote without applying it to any view.
+    ///
+    /// Content-only companion to [`Self::upload_change`]: the server writes
+    /// the change file (content-addressed, idempotent — 200 if it already
+    /// exists) but does not touch any view's change log. View membership is
+    /// declared separately via [`Self::put_view_manifest`], which is what
+    /// makes the store/declare split safe: a view is never half-created
+    /// with guessed identity.
+    pub async fn store_change(&self, hash: &str, data: Bytes) -> RemoteResult<()> {
+        let url = format!("{}?store={}", self.base_url, hash);
+        debug!("POST store: {} ({} bytes)", url, data.len());
+
+        let response = self
+            .client
+            .post(&url)
+            .header(CONTENT_TYPE, "application/octet-stream")
+            .body(data)
+            .send()
+            .await
+            .map_err(|e| RemoteError::connection_failed(&url, e))?;
+
+        crate::check_min_version_header(response.headers());
+        let status = response.status();
+
+        match status {
+            StatusCode::OK => {
+                debug!("Successfully stored change {}", hash);
+                Ok(())
+            }
+            StatusCode::NOT_FOUND => Err(RemoteError::repo_not_found(&url)),
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
+                let msg = response.text().await.unwrap_or_default();
+                Err(RemoteError::auth_failed(&url, msg))
+            }
+            _ => {
+                let msg = response.text().await.unwrap_or_default();
+                Err(RemoteError::http(status.as_u16(), msg))
+            }
+        }
+    }
+
+    /// Declare a view's identity and change log on the remote.
+    ///
+    /// POSTs the manifest text (header `name\tscope\tparent\tstate` plus the
+    /// change log, one base32 hash per line). The server applies it
+    /// declaratively: creates the view with the declared scope/parent if
+    /// absent, fast-forwards its log, and verifies the resulting merkle
+    /// equals the declared state. Every referenced change must already be
+    /// on the server (see [`Self::store_change`]); push manifests
+    /// root → leaf so a draft's parent exists before the draft.
+    ///
+    /// String-level like the rest of this client: serialization lives in
+    /// `atomic-repository`.
+    pub async fn put_view_manifest(&self, view: &str, manifest_text: String) -> RemoteResult<()> {
+        let url = format!("{}?view-manifest={}", self.base_url, view);
+        debug!(
+            "POST view-manifest: {} ({} bytes)",
+            url,
+            manifest_text.len()
+        );
+
+        let response = self
+            .client
+            .post(&url)
+            .header(CONTENT_TYPE, "text/plain")
+            .body(manifest_text)
+            .send()
+            .await
+            .map_err(|e| RemoteError::connection_failed(&url, e))?;
+
+        crate::check_min_version_header(response.headers());
+        let status = response.status();
+
+        match status {
+            StatusCode::OK => {
+                debug!("Successfully declared view manifest for {}", view);
+                Ok(())
+            }
+            StatusCode::NOT_FOUND => Err(RemoteError::repo_not_found(&url)),
+            StatusCode::CONFLICT => {
+                // Divergence / identity mismatch / state mismatch.
+                let msg = response.text().await.unwrap_or_default();
+                Err(RemoteError::protocol(msg))
+            }
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
+                let msg = response.text().await.unwrap_or_default();
+                Err(RemoteError::auth_failed(&url, msg))
+            }
+            StatusCode::BAD_REQUEST => {
+                let msg = response.text().await.unwrap_or_default();
+                if msg.contains("missing") && msg.contains("change") {
+                    Err(RemoteError::missing_deps(vec![]))
+                } else {
+                    Err(RemoteError::http(status.as_u16(), msg))
+                }
+            }
+            _ => {
+                let msg = response.text().await.unwrap_or_default();
+                Err(RemoteError::http(status.as_u16(), msg))
+            }
+        }
+    }
+
     /// Upload a tag (short format).
     ///
     /// # Arguments

--- a/atomic-repository/src/error.rs
+++ b/atomic-repository/src/error.rs
@@ -164,6 +164,50 @@ pub enum RepositoryError {
     /// Walkdir error (during file traversal)
     #[error("Directory traversal error: {0}")]
     WalkDir(#[from] walkdir::Error),
+
+    /// View manifest structural error (parse or fold verification)
+    #[error("Manifest error: {0}")]
+    Manifest(#[from] crate::manifest::ManifestError),
+
+    /// Manifest references change files not present in the local store
+    #[error("Manifest for view '{view}' references {count} change(s) not present locally (first: {first})")]
+    ManifestMissingChanges {
+        view: String,
+        count: usize,
+        first: String,
+    },
+
+    /// A change in the manifest log has a dependency that is neither earlier
+    /// in the log nor already applied locally
+    #[error("Manifest for view '{view}': change {change} depends on {dependency}, which is neither earlier in the log nor present locally")]
+    ManifestDependencyMissing {
+        view: String,
+        change: String,
+        dependency: String,
+    },
+
+    /// The local view log is not a prefix of the manifest log
+    #[error("View '{view}' has diverged from the manifest (first mismatch at sequence {at})")]
+    ManifestDiverged { view: String, at: u64 },
+
+    /// The local view exists with a different identity (scope or parent)
+    #[error("View '{view}' identity mismatch: {reason}")]
+    ManifestIdentityMismatch { view: String, reason: String },
+
+    /// The manifest declares a parent view that does not exist locally
+    #[error("Manifest for view '{view}' requires parent view '{parent}', which does not exist")]
+    ManifestParentMissing { view: String, parent: String },
+
+    /// After replaying the manifest, the view state does not match the
+    /// declared merkle
+    #[error(
+        "View '{view}' state mismatch after manifest apply: declared {declared}, got {actual}"
+    )]
+    ManifestStateMismatch {
+        view: String,
+        declared: String,
+        actual: String,
+    },
 }
 
 impl RepositoryError {

--- a/atomic-repository/src/lib.rs
+++ b/atomic-repository/src/lib.rs
@@ -91,6 +91,7 @@ pub mod apply;
 pub mod changestore;
 pub mod error;
 pub mod ignore;
+pub mod manifest;
 pub mod record;
 pub mod repository;
 pub mod status;
@@ -139,6 +140,8 @@ pub use changestore::{ChangeStore, ChangeStoreError, ChangeStoreResult, DEFAULT_
 
 // Error exports
 pub use error::*;
+
+pub use manifest::{ManifestError, ViewManifest};
 
 // Repository exports
 pub use repository::*;

--- a/atomic-repository/src/manifest.rs
+++ b/atomic-repository/src/manifest.rs
@@ -1,0 +1,365 @@
+//! View manifests: a view's identity as a self-contained, verifiable artifact.
+//!
+//! A view in the ambient-graph model is nothing more than an ordered
+//! change-ref log plus `(scope, parent)`, whose merkle state is a fold over
+//! that log (`state_n = H(state_{n-1} || change_hash_n)`, seeded at
+//! [`Merkle::ZERO`]). A [`ViewManifest`] captures exactly that — no more, no
+//! less — so a view can be transferred between repositories with byte-exact
+//! round-trip fidelity and verified structurally on both ends.
+//!
+//! The manifest carries the view's log **exactly as stored** in
+//! `VIEW_CHANGES`. For a draft view this includes the inherited prefix copied
+//! from its parent at fork time, not a computed delta: the declared `state`
+//! is the fold over the full sequence, which is what makes verification
+//! possible without trusting the sender.
+//!
+//! # Wire format
+//!
+//! Text, line-based, tab-separated header — consistent with the rest of the
+//! protocol (`?views`, changelists), and extensible via trailing fields:
+//!
+//! ```text
+//! name\tscope\tparent\tstate
+//! <change hash, base32>
+//! <change hash, base32>
+//! ...
+//! ```
+//!
+//! * `scope` is `shared` or `draft`.
+//! * `parent` is the parent view name, or `-` for a root view.
+//! * `state` is the base32 merkle fold of the change sequence, or `-` for an
+//!   empty view (fold seed [`Merkle::ZERO`]).
+//!
+//! Dependency truth is **not** part of the manifest: change files are
+//! self-describing (they embed their dependency hashes), so a receiver
+//! validates dependencies against the change files it holds, never against
+//! sender claims.
+
+use atomic_core::pristine::ViewScope;
+use atomic_core::types::{Base32, Hash, Merkle};
+use thiserror::Error;
+
+/// Marker for "no parent" / "empty state" in the text format.
+const NONE_FIELD: &str = "-";
+
+/// Errors from parsing or verifying a view manifest.
+#[derive(Debug, Error)]
+pub enum ManifestError {
+    /// The manifest text has no header line.
+    #[error("Empty manifest: missing header line")]
+    Empty,
+
+    /// The header line is missing required fields.
+    #[error("Malformed manifest header: {0:?}")]
+    MalformedHeader(String),
+
+    /// The scope field is neither `shared` nor `draft`.
+    #[error("Unknown view scope {scope:?} in manifest for {name:?}")]
+    UnknownScope { name: String, scope: String },
+
+    /// A change line is not a valid base32 hash.
+    #[error("Invalid change hash on line {line}: {text:?}")]
+    InvalidHash { line: usize, text: String },
+
+    /// The declared state is not a valid base32 merkle.
+    #[error("Invalid state {state:?} in manifest for {name:?}")]
+    InvalidState { name: String, state: String },
+
+    /// The fold of the change log does not equal the declared state.
+    #[error(
+        "Manifest state mismatch for view {name:?}: declared {declared}, log folds to {computed}"
+    )]
+    StateMismatch {
+        name: String,
+        declared: String,
+        computed: String,
+    },
+}
+
+/// A view's complete identity: name, scope, parent, ordered change log, and
+/// the declared merkle state of that log.
+///
+/// See the [module docs](self) for the semantics and wire format.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ViewManifest {
+    /// The view name.
+    pub name: String,
+
+    /// The view scope (shared or draft).
+    pub scope: ViewScope,
+
+    /// Parent view name, or `None` for a root view.
+    pub parent: Option<String>,
+
+    /// The view's change log, exactly as stored in `VIEW_CHANGES`, in
+    /// sequence order. For a draft this includes the inherited prefix.
+    pub changes: Vec<Hash>,
+
+    /// Declared merkle state: the fold of `changes` seeded at
+    /// [`Merkle::ZERO`]. Receivers must verify this with [`Self::verify`].
+    pub state: Merkle,
+}
+
+impl ViewManifest {
+    /// Fold a change sequence into its merkle state.
+    ///
+    /// This mirrors `put_change`: `state_n = state_{n-1}.next(hash_n)`,
+    /// seeded at [`Merkle::ZERO`].
+    pub fn fold(changes: &[Hash]) -> Merkle {
+        changes
+            .iter()
+            .fold(Merkle::ZERO, |state, hash| state.next(hash))
+    }
+
+    /// Build a manifest from parts, computing the state from the log.
+    pub fn new(
+        name: impl Into<String>,
+        scope: ViewScope,
+        parent: Option<String>,
+        changes: Vec<Hash>,
+    ) -> Self {
+        let state = Self::fold(&changes);
+        Self {
+            name: name.into(),
+            scope,
+            parent,
+            changes,
+            state,
+        }
+    }
+
+    /// Verify that the declared state equals the fold of the change log.
+    pub fn verify(&self) -> Result<(), ManifestError> {
+        let computed = Self::fold(&self.changes);
+        if computed != self.state {
+            return Err(ManifestError::StateMismatch {
+                name: self.name.clone(),
+                declared: self.state.to_base32(),
+                computed: computed.to_base32(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Serialize to the text wire format.
+    pub fn to_text(&self) -> String {
+        let scope = if self.scope.is_draft() {
+            "draft"
+        } else {
+            "shared"
+        };
+        let parent = self.parent.as_deref().unwrap_or(NONE_FIELD);
+        let state = if self.changes.is_empty() {
+            NONE_FIELD.to_string()
+        } else {
+            self.state.to_base32()
+        };
+
+        let mut out = format!("{}\t{}\t{}\t{}\n", self.name, scope, parent, state);
+        for hash in &self.changes {
+            out.push_str(&hash.to_base32());
+            out.push('\n');
+        }
+        out
+    }
+
+    /// Parse the text wire format.
+    ///
+    /// Parsing validates structure only; call [`Self::verify`] to check that
+    /// the declared state matches the log. Unknown trailing header fields are
+    /// ignored so the format can grow without breaking older readers.
+    pub fn parse(text: &str) -> Result<Self, ManifestError> {
+        let mut lines = text.lines();
+
+        let header = loop {
+            match lines.next() {
+                Some(line) if line.trim().is_empty() => continue,
+                Some(line) => break line,
+                None => return Err(ManifestError::Empty),
+            }
+        };
+
+        let mut fields = header.split('\t');
+        let name = fields
+            .next()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| ManifestError::MalformedHeader(header.to_string()))?
+            .to_string();
+        let scope_text = fields
+            .next()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| ManifestError::MalformedHeader(header.to_string()))?;
+        let parent_text = fields
+            .next()
+            .map(str::trim)
+            .ok_or_else(|| ManifestError::MalformedHeader(header.to_string()))?;
+        let state_text = fields
+            .next()
+            .map(str::trim)
+            .ok_or_else(|| ManifestError::MalformedHeader(header.to_string()))?;
+
+        let scope = match scope_text.to_ascii_lowercase().as_str() {
+            "shared" => ViewScope::Shared,
+            "draft" => ViewScope::Draft,
+            other => {
+                return Err(ManifestError::UnknownScope {
+                    name,
+                    scope: other.to_string(),
+                })
+            }
+        };
+
+        let parent = match parent_text {
+            NONE_FIELD | "" => None,
+            p => Some(p.to_string()),
+        };
+
+        let mut changes = Vec::new();
+        for (i, line) in lines.enumerate() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let hash = Hash::from_base32(line.as_bytes()).ok_or(ManifestError::InvalidHash {
+                // +2: 1-based, plus the header line.
+                line: i + 2,
+                text: line.to_string(),
+            })?;
+            changes.push(hash);
+        }
+
+        let state = match state_text {
+            NONE_FIELD | "" => Merkle::ZERO,
+            s => Merkle::from_base32(s.as_bytes()).ok_or_else(|| ManifestError::InvalidState {
+                name: name.clone(),
+                state: s.to_string(),
+            })?,
+        };
+
+        Ok(Self {
+            name,
+            scope,
+            parent,
+            changes,
+            state,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn h(n: u8) -> Hash {
+        Hash::of(&[n])
+    }
+
+    /// A shared root view round-trips through text with an identical fold.
+    #[test]
+    fn round_trip_shared_root() {
+        let m = ViewManifest::new("dev", ViewScope::Shared, None, vec![h(1), h(2)]);
+        m.verify().unwrap();
+
+        let parsed = ViewManifest::parse(&m.to_text()).unwrap();
+        assert_eq!(parsed, m);
+        parsed.verify().unwrap();
+        assert_eq!(parsed.parent, None);
+        assert!(parsed.scope.is_shared());
+    }
+
+    /// A draft with a parent keeps scope, parent, and full log (inherited
+    /// prefix included) through the round-trip.
+    #[test]
+    fn round_trip_draft_with_parent() {
+        // Log = inherited prefix (1, 2) + own suffix (3, 4, 5): the manifest
+        // carries the stored log, never a delta.
+        let m = ViewManifest::new(
+            "orange-night-44fb",
+            ViewScope::Draft,
+            Some("dev".to_string()),
+            vec![h(1), h(2), h(3), h(4), h(5)],
+        );
+        m.verify().unwrap();
+
+        let parsed = ViewManifest::parse(&m.to_text()).unwrap();
+        assert_eq!(parsed, m);
+        assert!(parsed.scope.is_draft());
+        assert_eq!(parsed.parent.as_deref(), Some("dev"));
+        assert_eq!(parsed.changes.len(), 5);
+    }
+
+    /// An empty view serializes its state as `-` and folds to ZERO.
+    #[test]
+    fn round_trip_empty_view() {
+        let m = ViewManifest::new("fresh", ViewScope::Shared, None, vec![]);
+        assert_eq!(m.state, Merkle::ZERO);
+
+        let text = m.to_text();
+        assert!(text.starts_with("fresh\tshared\t-\t-"));
+
+        let parsed = ViewManifest::parse(&text).unwrap();
+        assert_eq!(parsed, m);
+        parsed.verify().unwrap();
+    }
+
+    /// A declared state that doesn't match the log fails verification.
+    #[test]
+    fn verify_rejects_state_mismatch() {
+        let mut m = ViewManifest::new("dev", ViewScope::Shared, None, vec![h(1), h(2)]);
+        m.state = Merkle::of(b"tampered");
+        let err = m.verify().unwrap_err();
+        assert!(matches!(err, ManifestError::StateMismatch { .. }));
+    }
+
+    /// The fold matches put_change's incremental construction.
+    #[test]
+    fn fold_matches_incremental_next() {
+        let changes = vec![h(9), h(8), h(7)];
+        let mut state = Merkle::ZERO;
+        for c in &changes {
+            state = state.next(c);
+        }
+        assert_eq!(ViewManifest::fold(&changes), state);
+        // Order matters: the fold is a chain, not a set hash.
+        let reordered = vec![h(7), h(8), h(9)];
+        assert_ne!(ViewManifest::fold(&reordered), state);
+    }
+
+    /// Structural parse errors are reported distinctly.
+    #[test]
+    fn parse_rejects_malformed_input() {
+        assert!(matches!(ViewManifest::parse(""), Err(ManifestError::Empty)));
+        assert!(matches!(
+            ViewManifest::parse("dev\tshared"),
+            Err(ManifestError::MalformedHeader(_))
+        ));
+        assert!(matches!(
+            ViewManifest::parse("dev\tcosmic\t-\t-"),
+            Err(ManifestError::UnknownScope { .. })
+        ));
+        let bad_hash = "dev\tshared\t-\t-\nnot-a-hash\n";
+        assert!(matches!(
+            ViewManifest::parse(bad_hash),
+            Err(ManifestError::InvalidHash { line: 2, .. })
+        ));
+        let bad_state = "dev\tshared\t-\tzzz!\n";
+        assert!(matches!(
+            ViewManifest::parse(bad_state),
+            Err(ManifestError::InvalidState { .. })
+        ));
+    }
+
+    /// Trailing header fields (future extensions) don't break parsing.
+    #[test]
+    fn parse_ignores_trailing_header_fields() {
+        let m = ViewManifest::new("dev", ViewScope::Shared, None, vec![h(1)]);
+        let mut text = m.to_text();
+        // Simulate a newer sender appending a field to the header line.
+        let nl = text.find('\n').unwrap();
+        text.insert_str(nl, "\tfuture-field");
+        let parsed = ViewManifest::parse(&text).unwrap();
+        assert_eq!(parsed, m);
+    }
+}

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -90,7 +90,7 @@ pub use filter::{
     expand_indexed_dependency_closure,
 };
 pub use sandbox::{SealOptions, SealResult, StageOptions, StageResult, SANDBOX_POINTER};
-pub use views::ViewInfo;
+pub use views::{ManifestApplyOutcome, ViewInfo};
 
 // Re-import workspace helpers from `switch` so they are available to
 // `mod.rs` (used in `init`) and to sibling sub-modules via `use super::*;`.

--- a/atomic-repository/src/repository/views.rs
+++ b/atomic-repository/src/repository/views.rs
@@ -1,5 +1,10 @@
 use super::*;
 
+use std::collections::HashSet;
+
+use crate::apply::InsertOptions;
+use crate::manifest::ViewManifest;
+
 /// Information about a view.
 ///
 /// This struct provides metadata about a view including its current
@@ -541,4 +546,332 @@ impl Repository {
             parent_name,
         })
     }
+
+    /// Create a new Draft view parented on an explicit named parent.
+    ///
+    /// Unlike [`Repository::create_view`], which parents on the nearest
+    /// shared ancestor of the *current* view, this method parents on the
+    /// given view regardless of what is currently checked out. The new
+    /// view's change log starts empty.
+    ///
+    /// Returns `ViewNotFound` if the parent does not exist and
+    /// `ViewAlreadyExists` if the name is taken.
+    pub fn create_draft_view(
+        &mut self,
+        name: &str,
+        parent_name: &str,
+    ) -> Result<(), RepositoryError> {
+        self.create_view_with_identity(name, ViewScope::Draft, Some(parent_name))
+    }
+
+    /// Create a view with an explicit scope and optional named parent.
+    ///
+    /// The view's change log starts empty; this only establishes identity.
+    fn create_view_with_identity(
+        &mut self,
+        name: &str,
+        scope: ViewScope,
+        parent_name: Option<&str>,
+    ) -> Result<(), RepositoryError> {
+        ensure_workspace_dir(&self.dot_dir, name)?;
+
+        let mut txn = self
+            .pristine
+            .write_txn()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        if txn
+            .get_view(name)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+            .is_some()
+        {
+            return Err(RepositoryError::ViewAlreadyExists {
+                name: name.to_string(),
+            });
+        }
+
+        let parent_id = match parent_name {
+            Some(p) => Some(
+                txn.get_view(p)
+                    .map_err(|e| RepositoryError::Database(e.to_string()))?
+                    .ok_or_else(|| RepositoryError::ViewNotFound {
+                        name: p.to_string(),
+                    })?
+                    .id,
+            ),
+            None => None,
+        };
+
+        txn.create_view(name, scope, parent_id)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        txn.commit()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        Ok(())
+    }
+
+    /// Export a view's complete identity as a [`ViewManifest`].
+    ///
+    /// The manifest carries the view's change log **exactly as stored** in
+    /// `VIEW_CHANGES` (for a draft this includes the inherited prefix copied
+    /// at fork time), plus scope, parent name, and the view's merkle state.
+    /// The exported manifest is verified before it is returned, so a
+    /// corrupted log surfaces here rather than on the receiving end.
+    pub fn view_manifest(&self, name: &str) -> Result<ViewManifest, RepositoryError> {
+        let txn = self
+            .pristine
+            .read_txn()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        let view = txn
+            .get_view(name)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+            .ok_or_else(|| RepositoryError::ViewNotFound {
+                name: name.to_string(),
+            })?;
+
+        let parent = match view.parent {
+            Some(parent_id) => txn
+                .get_view_by_id(parent_id)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?
+                .map(|p| p.name),
+            None => None,
+        };
+
+        let mut changes = Vec::with_capacity(view.change_count as usize);
+        for item in txn
+            .iter_changes(&view, 0)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+        {
+            let (_seq, node_id, _merkle) =
+                item.map_err(|e| RepositoryError::Database(e.to_string()))?;
+            let hash = txn
+                .get_external(node_id)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?
+                .ok_or_else(|| {
+                    RepositoryError::Database(format!(
+                        "change {} in view '{}' has no external hash",
+                        node_id.0, name
+                    ))
+                })?;
+            changes.push(hash);
+        }
+
+        let manifest = ViewManifest {
+            name: view.name.clone(),
+            scope: view.kind,
+            parent,
+            changes,
+            state: view.state,
+        };
+        manifest.verify()?;
+        Ok(manifest)
+    }
+
+    /// Declaratively apply a [`ViewManifest`]: create the view with its
+    /// declared identity if absent, then fast-forward its change log to
+    /// match the manifest.
+    ///
+    /// # Semantics
+    ///
+    /// Everything is validated **before** any write:
+    ///
+    /// 1. The manifest's declared state must equal the fold of its log.
+    /// 2. Every referenced change file must be present in the local store.
+    /// 3. Every dependency of every change must appear earlier in the log
+    ///    or already be applied locally (dependency truth is read from the
+    ///    change files themselves, never from sender claims).
+    /// 4. If the view exists, its scope and parent must match the manifest
+    ///    and its log must be a prefix of the manifest log; anything else
+    ///    is a divergence error, never a silent merge.
+    /// 5. If the view is absent, the declared parent must already exist
+    ///    (apply manifests root → leaf).
+    ///
+    /// Replay is prefix-resumable, not single-transaction: each change
+    /// application is individually atomic, so an interrupted apply leaves
+    /// the view at a valid earlier prefix and re-applying the same manifest
+    /// resumes where it stopped. After replay the view's merkle state is
+    /// verified against the declared state.
+    pub fn apply_view_manifest(
+        &mut self,
+        manifest: &ViewManifest,
+    ) -> Result<ManifestApplyOutcome, RepositoryError> {
+        // 1. Structural integrity: declared state == fold of the log.
+        manifest.verify()?;
+
+        // 2. Presence: every change file must exist locally.
+        let missing: Vec<&Hash> = manifest
+            .changes
+            .iter()
+            .filter(|h| !self.has_change(h))
+            .collect();
+        if let Some(first) = missing.first() {
+            return Err(RepositoryError::ManifestMissingChanges {
+                view: manifest.name.clone(),
+                count: missing.len(),
+                first: first.to_base32(),
+            });
+        }
+
+        // 3. Dependency closure: deps must be earlier in the log or already
+        //    applied locally. Read from the change files (self-contained DAG).
+        {
+            let txn = self
+                .pristine
+                .read_txn()
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+            let mut seen: HashSet<Hash> = HashSet::with_capacity(manifest.changes.len());
+            for hash in &manifest.changes {
+                let change = self.load_change(hash)?;
+                for dep in change.dependencies() {
+                    if seen.contains(dep) {
+                        continue;
+                    }
+                    let applied = txn
+                        .get_internal(dep)
+                        .map_err(|e| RepositoryError::Database(e.to_string()))?
+                        .is_some();
+                    if !applied {
+                        return Err(RepositoryError::ManifestDependencyMissing {
+                            view: manifest.name.clone(),
+                            change: hash.to_base32(),
+                            dependency: dep.to_base32(),
+                        });
+                    }
+                }
+                seen.insert(*hash);
+            }
+        }
+
+        // 4. Identity + prefix rule against the existing view (if any).
+        let prefix_len = {
+            let txn = self
+                .pristine
+                .read_txn()
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+            match txn
+                .get_view(&manifest.name)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?
+            {
+                Some(view) => {
+                    if view.kind != manifest.scope {
+                        return Err(RepositoryError::ManifestIdentityMismatch {
+                            view: manifest.name.clone(),
+                            reason: format!(
+                                "local scope is {:?}, manifest declares {:?}",
+                                view.kind, manifest.scope
+                            ),
+                        });
+                    }
+                    let local_parent = match view.parent {
+                        Some(pid) => txn
+                            .get_view_by_id(pid)
+                            .map_err(|e| RepositoryError::Database(e.to_string()))?
+                            .map(|p| p.name),
+                        None => None,
+                    };
+                    if local_parent != manifest.parent {
+                        return Err(RepositoryError::ManifestIdentityMismatch {
+                            view: manifest.name.clone(),
+                            reason: format!(
+                                "local parent is {:?}, manifest declares {:?}",
+                                local_parent, manifest.parent
+                            ),
+                        });
+                    }
+
+                    // Local log must be a prefix of the manifest log.
+                    let mut local_len = 0usize;
+                    for item in txn
+                        .iter_changes(&view, 0)
+                        .map_err(|e| RepositoryError::Database(e.to_string()))?
+                    {
+                        let (_seq, node_id, _merkle) =
+                            item.map_err(|e| RepositoryError::Database(e.to_string()))?;
+                        let local_hash = txn
+                            .get_external(node_id)
+                            .map_err(|e| RepositoryError::Database(e.to_string()))?
+                            .ok_or_else(|| {
+                                RepositoryError::Database(format!(
+                                    "change {} in view '{}' has no external hash",
+                                    node_id.0, manifest.name
+                                ))
+                            })?;
+                        match manifest.changes.get(local_len) {
+                            Some(expected) if *expected == local_hash => local_len += 1,
+                            _ => {
+                                return Err(RepositoryError::ManifestDiverged {
+                                    view: manifest.name.clone(),
+                                    at: local_len as u64,
+                                })
+                            }
+                        }
+                    }
+                    local_len
+                }
+                None => 0,
+            }
+        };
+
+        // 5. Create the view with its declared identity if absent.
+        if prefix_len == 0 && !self.view_exists(&manifest.name)? {
+            match self.create_view_with_identity(
+                &manifest.name,
+                manifest.scope,
+                manifest.parent.as_deref(),
+            ) {
+                Ok(()) => {}
+                Err(RepositoryError::ViewNotFound { name }) => {
+                    return Err(RepositoryError::ManifestParentMissing {
+                        view: manifest.name.clone(),
+                        parent: name,
+                    })
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        // 6. Replay the suffix in exact log order. insert_change appends to
+        //    this view's log (put_change) and skips hunk application for
+        //    changes already in the global graph, so replaying a draft's
+        //    inherited prefix is a metadata-only operation.
+        let mut replayed = 0usize;
+        for hash in &manifest.changes[prefix_len..] {
+            let options = InsertOptions::default().view(&manifest.name);
+            self.insert_change(hash, options)?;
+            replayed += 1;
+        }
+
+        // 7. End-to-end verification: the view's state must now equal the
+        //    declared merkle.
+        let info = self.get_view_info(&manifest.name)?;
+        if info.state != manifest.state {
+            return Err(RepositoryError::ManifestStateMismatch {
+                view: manifest.name.clone(),
+                declared: manifest.state.to_base32(),
+                actual: info.state.to_base32(),
+            });
+        }
+
+        Ok(ManifestApplyOutcome {
+            view: manifest.name.clone(),
+            already_present: prefix_len,
+            replayed,
+            state: info.state,
+        })
+    }
+}
+
+/// Outcome of [`Repository::apply_view_manifest`].
+#[derive(Debug, Clone)]
+pub struct ManifestApplyOutcome {
+    /// The view the manifest was applied to.
+    pub view: String,
+    /// Log entries that were already present locally (the matched prefix).
+    pub already_present: usize,
+    /// Log entries replayed by this apply.
+    pub replayed: usize,
+    /// The view's merkle state after apply (equals the declared state).
+    pub state: Merkle,
 }

--- a/atomic-repository/tests/view_manifest_test.rs
+++ b/atomic-repository/tests/view_manifest_test.rs
@@ -1,0 +1,264 @@
+//! Integration tests for view manifest export/apply (`view_manifest` /
+//! `apply_view_manifest`).
+//!
+//! These exercise the round-trip that the wire protocol is built on: a
+//! shared view plus a draft off it, exported from one repository and
+//! reconstructed in another with byte-exact identity — same scope, same
+//! parent, same change log (inherited prefix included), same merkle state.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use atomic_core::change::{Author, ChangeHeader};
+use atomic_core::pristine::ViewScope;
+use atomic_core::types::{Hash, Merkle};
+use atomic_repository::{manifest::ViewManifest, RecordOptions, Repository, RepositoryError};
+use tempfile::TempDir;
+
+fn init_repo() -> (Repository, TempDir, PathBuf) {
+    let temp = TempDir::new().expect("temp dir");
+    let path = temp.path().to_path_buf();
+    let repo = Repository::init(&path).expect("init repository");
+    (repo, temp, path)
+}
+
+fn write_and_add(repo: &Repository, root: &Path, name: &str, content: &str) {
+    fs::write(root.join(name), content).expect("write file");
+    repo.add(name, Default::default()).expect("add file");
+}
+
+fn record(repo: &Repository, message: &str) -> Hash {
+    let header = ChangeHeader::builder()
+        .message(message)
+        .author(Author::new("Test", Some("test@example.com")))
+        .build();
+    *repo
+        .record(header, RecordOptions::default())
+        .expect("record")
+        .hash()
+}
+
+/// Build the canonical fixture: `dev` (shared) with two changes, and a
+/// draft `orange` forked from it with three more changes on top.
+fn build_origin() -> (Repository, TempDir, PathBuf, Vec<Hash>) {
+    let (mut repo, temp, root) = init_repo();
+
+    write_and_add(&repo, &root, "base.txt", "base\n");
+    let c1 = record(&repo, "initial");
+    write_and_add(&repo, &root, "map.txt", "map\n");
+    let c2 = record(&repo, "concepts");
+
+    // Fork a draft the way session views are created: copy of the log,
+    // Draft scope, parented on dev.
+    repo.create_view_from("orange", "dev").expect("fork draft");
+    repo.switch_view("orange").expect("switch to draft");
+
+    write_and_add(&repo, &root, "tracks.txt", "A -> B\n");
+    let c3 = record(&repo, "inbound track");
+    write_and_add(&repo, &root, "rules.txt", "numbers\n");
+    let c4 = record(&repo, "key concepts");
+    fs::write(root.join("tracks.txt"), "A -> B -> C\n").expect("modify");
+    let c5 = record(&repo, "math");
+
+    (repo, temp, root, vec![c1, c2, c3, c4, c5])
+}
+
+/// Copy every change file referenced by a manifest into another repository's
+/// store (stands in for the `?store` / `?change` transfer).
+fn transfer_changes(from: &Repository, to: &Repository, manifest: &ViewManifest) {
+    for hash in &manifest.changes {
+        let change = from.load_change(hash).expect("load change");
+        let saved = to.save_change(&change).expect("save change");
+        assert_eq!(saved, *hash, "content address must survive the transfer");
+    }
+}
+
+#[test]
+fn export_captures_exact_identity() {
+    let (repo, _temp, _root, hashes) = build_origin();
+
+    let dev = repo.view_manifest("dev").expect("dev manifest");
+    assert_eq!(dev.name, "dev");
+    assert_eq!(dev.scope, ViewScope::Shared);
+    assert_eq!(dev.parent, None);
+    assert_eq!(dev.changes, &hashes[..2]);
+    dev.verify().expect("dev fold matches stored state");
+
+    let orange = repo.view_manifest("orange").expect("orange manifest");
+    assert_eq!(orange.scope, ViewScope::Draft);
+    assert_eq!(orange.parent.as_deref(), Some("dev"));
+    // The stored log, not a delta: inherited prefix + own suffix.
+    assert_eq!(orange.changes, hashes);
+    orange.verify().expect("orange fold matches stored state");
+
+    // Exported state equals the live view state.
+    let info = repo.get_view_info("orange").expect("view info");
+    assert_eq!(orange.state, info.state);
+}
+
+#[test]
+fn round_trip_reconstructs_shared_and_draft() {
+    let (origin, _t1, _r1, hashes) = build_origin();
+    let dev_m = origin.view_manifest("dev").unwrap();
+    let orange_m = origin.view_manifest("orange").unwrap();
+
+    let (mut mirror, _t2, _r2) = init_repo();
+    transfer_changes(&origin, &mirror, &orange_m); // superset of dev's
+
+    // Root → leaf.
+    let dev_out = mirror.apply_view_manifest(&dev_m).expect("apply dev");
+    assert_eq!(dev_out.replayed, 2);
+    assert_eq!(dev_out.already_present, 0);
+
+    let orange_out = mirror.apply_view_manifest(&orange_m).expect("apply orange");
+    assert_eq!(orange_out.replayed, 5);
+
+    // Identity is byte-exact on both views.
+    let dev_info = mirror.get_view_info("dev").unwrap();
+    assert_eq!(dev_info.scope, ViewScope::Shared);
+    assert_eq!(dev_info.parent_name, None);
+    assert_eq!(dev_info.change_count, 2);
+    assert_eq!(dev_info.state, dev_m.state);
+
+    let orange_info = mirror.get_view_info("orange").unwrap();
+    assert_eq!(orange_info.scope, ViewScope::Draft);
+    assert_eq!(orange_info.parent_name.as_deref(), Some("dev"));
+    assert_eq!(orange_info.change_count, 5);
+    assert_eq!(orange_info.own_change_count, 3, "fork point preserved");
+    assert_eq!(orange_info.state, orange_m.state);
+
+    // And the reconstructed log re-exports identically.
+    let re_exported = mirror.view_manifest("orange").unwrap();
+    assert_eq!(re_exported.changes, hashes);
+    assert_eq!(re_exported.to_text(), orange_m.to_text());
+}
+
+#[test]
+fn apply_is_idempotent_and_resumable() {
+    let (origin, _t1, _r1, _hashes) = build_origin();
+    let dev_m = origin.view_manifest("dev").unwrap();
+
+    let (mut mirror, _t2, _r2) = init_repo();
+    transfer_changes(&origin, &mirror, &dev_m);
+
+    mirror.apply_view_manifest(&dev_m).expect("first apply");
+
+    // Re-applying the identical manifest is a no-op (full prefix match).
+    let again = mirror.apply_view_manifest(&dev_m).expect("second apply");
+    assert_eq!(again.already_present, 2);
+    assert_eq!(again.replayed, 0);
+
+    // A shorter prefix (interrupted transfer) fast-forwards on re-apply.
+    let mut partial = dev_m.clone();
+    partial.changes.truncate(1);
+    partial.state = ViewManifest::fold(&partial.changes);
+    // Simulate: a fresh repo that only got the first change applied.
+    let (mut fresh, _t3, _r3) = init_repo();
+    transfer_changes(&origin, &fresh, &dev_m);
+    fresh.apply_view_manifest(&partial).expect("apply prefix");
+    let resumed = fresh.apply_view_manifest(&dev_m).expect("resume");
+    assert_eq!(resumed.already_present, 1);
+    assert_eq!(resumed.replayed, 1);
+    assert_eq!(fresh.get_view_info("dev").unwrap().state, dev_m.state);
+}
+
+#[test]
+fn apply_rejects_missing_changes() {
+    let (origin, _t1, _r1, _hashes) = build_origin();
+    let dev_m = origin.view_manifest("dev").unwrap();
+
+    let (mut mirror, _t2, _r2) = init_repo();
+    // No change files transferred.
+    let err = mirror.apply_view_manifest(&dev_m).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            RepositoryError::ManifestMissingChanges { count: 2, .. }
+        ),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn apply_rejects_missing_parent() {
+    let (origin, _t1, _r1, _hashes) = build_origin();
+    let mut orange_m = origin.view_manifest("orange").unwrap();
+    orange_m.parent = Some("no-such-view".to_string());
+
+    let (mut mirror, _t2, _r2) = init_repo();
+    transfer_changes(&origin, &mirror, &orange_m);
+    let err = mirror.apply_view_manifest(&orange_m).unwrap_err();
+    assert!(
+        matches!(err, RepositoryError::ManifestParentMissing { ref parent, .. }
+            if parent == "no-such-view"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn apply_rejects_divergent_log() {
+    let (origin, _t1, _r1, _hashes) = build_origin();
+    let dev_m = origin.view_manifest("dev").unwrap();
+
+    // The mirror's dev has its own unrelated change: not a prefix.
+    let (mut mirror, _t2, root) = init_repo();
+    write_and_add(&mirror, &root, "other.txt", "different history\n");
+    record(&mirror, "divergent");
+    transfer_changes(&origin, &mirror, &dev_m);
+
+    let err = mirror.apply_view_manifest(&dev_m).unwrap_err();
+    assert!(
+        matches!(err, RepositoryError::ManifestDiverged { at: 0, .. }),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn apply_rejects_identity_mismatch() {
+    let (origin, _t1, _r1, _hashes) = build_origin();
+    let mut dev_m = origin.view_manifest("dev").unwrap();
+
+    // Same name, but the manifest claims dev is a draft of something.
+    dev_m.scope = ViewScope::Draft;
+    dev_m.parent = Some("elsewhere".to_string());
+
+    let (mut mirror, _t2, _r2) = init_repo();
+    transfer_changes(&origin, &mirror, &dev_m);
+    let err = mirror.apply_view_manifest(&dev_m).unwrap_err();
+    assert!(
+        matches!(err, RepositoryError::ManifestIdentityMismatch { .. }),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn apply_rejects_tampered_state() {
+    let (origin, _t1, _r1, _hashes) = build_origin();
+    let mut dev_m = origin.view_manifest("dev").unwrap();
+    dev_m.state = Merkle::of(b"tampered");
+
+    let (mut mirror, _t2, _r2) = init_repo();
+    transfer_changes(&origin, &mirror, &dev_m);
+    let err = mirror.apply_view_manifest(&dev_m).unwrap_err();
+    assert!(matches!(err, RepositoryError::Manifest(_)), "got: {err}");
+}
+
+#[test]
+fn empty_view_manifest_declares_identity_only() {
+    let (origin, _t1, _r1, _hashes) = build_origin();
+    // A brand-new draft with no changes of its own... export and apply it.
+    let mut origin = origin;
+    origin.create_draft_view("empty-draft", "dev").unwrap();
+    let m = origin.view_manifest("empty-draft").unwrap();
+    assert!(m.changes.is_empty());
+    assert_eq!(m.state, Merkle::ZERO);
+
+    let (mut mirror, _t2, _r2) = init_repo();
+    let out = mirror.apply_view_manifest(&m).expect("apply empty draft");
+    assert_eq!(out.replayed, 0);
+
+    let info = mirror.get_view_info("empty-draft").unwrap();
+    assert_eq!(info.scope, ViewScope::Draft);
+    assert_eq!(info.parent_name.as_deref(), Some("dev"));
+    assert!(info.is_empty());
+}


### PR DESCRIPTION
This pull request introduces significant enhancements and refactors to the clone and push commands, focusing on view manifest support and identity-preserving synchronization. The changes improve correctness, robustness, and user experience for multi-view repositories, and update both internal logic and user-facing documentation. The most notable updates are grouped below.

### View Manifest Support and Helper Functions

* Added new helper functions in `clone/helpers.rs` for parsing, verifying, and ordering `ViewManifest` objects, deduplicating their change logs, and classifying inventory responses from remotes. This includes robust error handling and cycle detection in parent chains.
* Comprehensive tests were added to ensure correct manifest ordering, deduplication, error handling, and inventory classification.

### Clone and Push Command Refactoring

* Refactored the clone workflow to fetch and apply view manifests for the requested view and its parent chain, download only missing changes, and apply manifests root→leaf, ensuring the correct view hierarchy is reconstructed locally.
* Overhauled the push command to sync local views to the remote identity-preservingly via manifests, removing the old flattening logic. The new process builds the ancestor chain, enforces fast-forward rules, and declares manifests on the remote, ensuring the remote mirrors the local hierarchy. [[1]](diffhunk://#diff-181ec61bb912a1ef27f8a6dc0ea5e7817ba8e1ca1d320a651e79eeccdb85cc70L1-R45) [[2]](diffhunk://#diff-181ec61bb912a1ef27f8a6dc0ea5e7817ba8e1ca1d320a651e79eeccdb85cc70L37-R97)
* Updated push command options and output to reflect the new view-based sync model, including improved dry-run and error reporting for identity mismatches and unsupported servers. [[1]](diffhunk://#diff-181ec61bb912a1ef27f8a6dc0ea5e7817ba8e1ca1d320a651e79eeccdb85cc70L37-R97) [[2]](diffhunk://#diff-181ec61bb912a1ef27f8a6dc0ea5e7817ba8e1ca1d320a651e79eeccdb85cc70L83-R113)

### Documentation and Architecture Updates

* Updated module-level documentation for both clone and push commands to clearly document the new manifest-based workflows, error cases, and architectural diagrams. [[1]](diffhunk://#diff-181ec61bb912a1ef27f8a6dc0ea5e7817ba8e1ca1d320a651e79eeccdb85cc70L1-R45) [[2]](diffhunk://#diff-181ec61bb912a1ef27f8a6dc0ea5e7817ba8e1ca1d320a651e79eeccdb85cc70L95-R143)

### CLI Usability Improvements

* Added shell completion support for view names in the `view delete` command, improving CLI usability. [[1]](diffhunk://#diff-dc3b7cfbb74e2da8ab8f5e449095a450810fec489e69fe6b8495bdbb11dff4cbR41-R43) [[2]](diffhunk://#diff-dc3b7cfbb74e2da8ab8f5e449095a450810fec489e69fe6b8495bdbb11dff4cbL67-R70)