### PR TITLE
fix: report oversized files as a user error

### DIFF
--- a/atomic-cli/src/commands/record/command.rs
+++ b/atomic-cli/src/commands/record/command.rs
@@ -56,31 +56,54 @@ impl Command for Record {
             }
         }
 
-        // Record the changes
-        let outcome = repo.record(header, options).map_err(|e| match e {
-            atomic_repository::record::RecordError::NothingToRecord => CliError::NothingToRecord,
-            atomic_repository::record::RecordError::NoFilesMatched => CliError::NothingToRecord,
-            atomic_repository::record::RecordError::FileNotFound { path } => {
-                CliError::FileNotFound {
+        // Record the changes.
+        //
+        // This match is deliberately exhaustive: no `_ =>` arm. The catch-all
+        // it replaces routed everything unlisted into `CliError::Internal`,
+        // which tells the user "this appears to be a bug, please report it"
+        // and exits 128 — so every new `RecordError` variant silently
+        // defaulted to accusing Atomic of a bug. `FileTooLarge` reached users
+        // that way. Keeping the match exhaustive makes the compiler demand a
+        // classification decision for each variant added from here on.
+        let outcome = repo.record(header, options).map_err(|e| {
+            use atomic_repository::record::RecordError as RE;
+            match e {
+                RE::NothingToRecord | RE::NoFilesMatched => CliError::NothingToRecord,
+                RE::FileNotFound { path } => CliError::FileNotFound {
                     path: PathBuf::from(path),
-                }
-            }
-            atomic_repository::record::RecordError::FileNotTracked { path } => {
-                CliError::FileNotTracked {
+                },
+                RE::FileNotTracked { path } => CliError::FileNotTracked {
                     path: PathBuf::from(path),
+                },
+                // Refusing to bake an unresolved merge into history is the
+                // documented behavior, not a bug — keep it out of the
+                // Internal bucket so it neither tells the user to file an
+                // issue nor exits 128.
+                RE::ConflictMarkersPresent { path, line } => {
+                    CliError::ConflictMarkers { path, line }
                 }
+                RE::UnresolvedConflicts => CliError::Conflict {
+                    description: "the working copy has unresolved conflicts".to_string(),
+                },
+                // Almost always a build artifact or dependency cache that
+                // should have been ignored. The user can fix it three ways,
+                // all named in the error's suggestion.
+                RE::FileTooLarge { path, size, limit } => {
+                    CliError::FileTooLarge { path, size, limit }
+                }
+                // A bad `--message`/`--author` is a usage error, not a bug.
+                RE::InvalidHeader { reason } => CliError::InvalidArgument { message: reason },
+                // Unreadable file, full disk, bad permissions: the
+                // environment failed, not Atomic.
+                RE::Io(err) => CliError::Io(err),
+                RE::Repository(err) => CliError::Repository(err),
+                // Genuine internal failures: the change graph or the store
+                // itself misbehaved. These are the ones worth a bug report.
+                other @ (RE::Globalize(_)
+                | RE::Assembly(_)
+                | RE::ChangeStore(_)
+                | RE::Database(_)) => CliError::Internal(anyhow::anyhow!("{}", other)),
             }
-            // Refusing to bake an unresolved merge into history is the
-            // documented behavior, not a bug — keep it out of the
-            // Internal bucket so it neither tells the user to file an
-            // issue nor exits 128.
-            atomic_repository::record::RecordError::ConflictMarkersPresent { path, line } => {
-                CliError::ConflictMarkers { path, line }
-            }
-            atomic_repository::record::RecordError::UnresolvedConflicts => CliError::Conflict {
-                description: "the working copy has unresolved conflicts".to_string(),
-            },
-            other => CliError::Internal(anyhow::anyhow!("{}", other)),
         })?;
 
         // Display result

--- a/atomic-cli/src/error.rs
+++ b/atomic-cli/src/error.rs
@@ -265,6 +265,27 @@ pub enum CliError {
         line: u32,
     },
 
+    /// A file exceeded the maximum size `record` will take.
+    ///
+    /// Expected and user-fixable: the file is nearly always a build artifact
+    /// or dependency cache that should be ignored rather than versioned, and
+    /// the limit itself is adjustable. Sizes are rendered in human units
+    /// because a bare byte count tells the user nothing about how far over
+    /// the limit they are.
+    #[error(
+        "{path} is {} (limit: {})",
+        crate::commands::format_size(*size),
+        crate::commands::format_size(*limit)
+    )]
+    FileTooLarge {
+        /// Repository-relative path of the oversized file.
+        path: String,
+        /// Actual size of the file in bytes.
+        size: u64,
+        /// The configured limit in bytes.
+        limit: u64,
+    },
+
     // Identity Errors
     /// The specified identity doesn't exist.
     ///
@@ -483,6 +504,7 @@ impl CliError {
                 | Self::MissingDependency { .. }
                 | Self::Conflict { .. }
                 | Self::ConflictMarkers { .. }
+                | Self::FileTooLarge { .. }
                 | Self::IdentityNotFound(_)
                 | Self::IdentityAlreadyExists(_)
                 | Self::RemoteNotFound { .. }
@@ -578,6 +600,9 @@ impl CliError {
             Self::ConflictMarkers { .. } => Some(
                 "Edit the file to remove the '>>>>>>>' / '=======' / '<<<<<<<' lines and keep the content you want, then record again. Run 'atomic conflicts' to list every conflict, or pass '--allow-conflict-markers' if the markers are legitimate content.",
             ),
+            Self::FileTooLarge { .. } => Some(
+                "If this is build output or a dependency cache, add it to '.atomicignore' (or your '.gitignore') and record again. To record everything else and leave oversized files out, use 'atomic record --skip-binary'. To raise the ceiling instead, use 'atomic record --max-size <bytes>'.",
+            ),
             Self::Cancelled => None,
             Self::InvalidArgument { .. } => {
                 Some("Run 'atomic <command> --help' for usage information.")
@@ -635,6 +660,7 @@ impl CliError {
             | Self::MissingDependency { .. }
             | Self::Conflict { .. }
             | Self::ConflictMarkers { .. }
+            | Self::FileTooLarge { .. }
             | Self::IdentityNotFound(_)
             | Self::IdentityAlreadyExists(_) => 3,
 
@@ -876,6 +902,60 @@ mod tests {
     fn test_cancelled_no_suggestion() {
         let err = CliError::Cancelled;
         assert!(err.suggestion().is_none());
+    }
+
+    // -------------------------------------------------------------------------
+    // FileTooLarge
+    //
+    // Regression: `atomic record` in a Next.js project hit an 11 MB turbopack
+    // cache file and reported "Internal error … This appears to be a bug,
+    // please report it", exiting 128. It is neither internal nor a bug.
+    // -------------------------------------------------------------------------
+
+    fn oversized() -> CliError {
+        CliError::FileTooLarge {
+            path: ".next/dev/cache/turbopack/v16.2.10/00000012.sst".into(),
+            size: 11_290_117,
+            limit: 10 * 1024 * 1024,
+        }
+    }
+
+    #[test]
+    fn test_file_too_large_display_uses_human_units() {
+        let msg = oversized().to_string();
+        assert!(msg.contains("00000012.sst"), "message was: {msg}");
+        assert!(msg.contains("10.8 MiB"), "actual size unreadable: {msg}");
+        assert!(msg.contains("10.0 MiB"), "limit unreadable: {msg}");
+        assert!(
+            !msg.contains("11290117"),
+            "raw byte counts should not reach the user: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_file_too_large_is_not_reported_as_a_bug() {
+        let err = oversized();
+        assert!(err.is_user_fixable());
+        assert!(!err.is_internal());
+        assert_eq!(err.exit_code(), 3);
+        assert_ne!(err.exit_code(), 128);
+
+        let suggestion = err.suggestion().expect("needs an actionable hint");
+        assert!(
+            !suggestion.contains("github.com"),
+            "must not ask the user to file an issue: {suggestion}"
+        );
+    }
+
+    #[test]
+    fn test_file_too_large_suggestion_names_every_escape_hatch() {
+        let suggestion = oversized().suggestion().unwrap();
+        for expected in [".atomicignore", "--skip-binary", "--max-size"] {
+            assert!(
+                suggestion.contains(expected),
+                "hint omits {expected}: {suggestion}"
+            );
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/atomic-repository/src/ignore.rs
+++ b/atomic-repository/src/ignore.rs
@@ -1,8 +1,9 @@
 //! Ignore pattern matching for Atomic VCS
 //!
-//! This module parses and applies `.atomicignore` patterns using gitignore syntax.
-//! It supports both global ignore rules (from `~/.config/atomic/ignore`) and
-//! repository-local rules (from `.atomicignore` in the repository root).
+//! This module parses and applies ignore patterns using gitignore syntax.
+//! It supports global ignore rules (from `~/.config/atomic/ignore`) and
+//! repository-local rules from `.gitignore`, `.ignore`, and `.atomicignore`
+//! at the repository root.
 //!
 //! # Pattern Syntax
 //!
@@ -18,8 +19,11 @@
 //!
 //! # Priority
 //!
-//! Local `.atomicignore` rules take precedence over global rules.
-//! Within each file, later rules override earlier ones.
+//! Repository-local rules take precedence over global rules. Among the local
+//! files the order is `.gitignore` < `.ignore` < `.atomicignore`, so Atomic's
+//! own file has the final say and a `!pattern` there can re-include something
+//! the project's `.gitignore` excludes. Within each file, later rules override
+//! earlier ones.
 //!
 //! # Example
 //!
@@ -63,7 +67,8 @@ pub enum IgnoreError {
 ///
 /// This struct aggregates ignore patterns from:
 /// - Global config: `~/.config/atomic/ignore`
-/// - Repository-local: `.atomicignore` in repository root
+/// - Repository-local: `.gitignore`, `.ignore`, and `.atomicignore` in the
+///   repository root
 ///
 /// # Example
 ///
@@ -87,7 +92,7 @@ pub enum IgnoreError {
 pub struct IgnoreRules {
     /// Global ignore rules from ~/.config/atomic/ignore
     global: Option<Gitignore>,
-    /// Repository-level rules from .atomicignore
+    /// Repository-level rules from .gitignore, .ignore, and .atomicignore
     local: Option<Gitignore>,
     /// Repository root path (for relative path resolution)
     repo_root: std::path::PathBuf,
@@ -96,8 +101,20 @@ pub struct IgnoreRules {
 impl IgnoreRules {
     /// Load ignore rules for a repository.
     ///
-    /// This loads rules from both global and local ignore files.
-    /// Missing files are silently ignored (not an error).
+    /// This loads rules from the global ignore file and from the repository's
+    /// `.gitignore`, `.ignore`, and `.atomicignore`. Missing files are
+    /// silently ignored (not an error).
+    ///
+    /// Honoring `.gitignore` matters because it is what virtually every
+    /// project already uses to exclude build artifacts. Without it a first
+    /// `atomic record` in, say, a Next.js repository walks straight into
+    /// `.next/` and trips over multi-megabyte bundler caches that were never
+    /// meant to be versioned.
+    ///
+    /// These rules govern *discovery* of new paths — `status` listing
+    /// untracked files, `add` picking up a directory. A file that is already
+    /// tracked stays tracked and keeps being recorded even if a pattern later
+    /// starts matching it, mirroring Git's behavior.
     ///
     /// # Arguments
     ///
@@ -118,24 +135,12 @@ impl IgnoreRules {
 
     /// Load ignore rules for knowledge-graph enrichment.
     ///
-    /// Like [`load`](Self::load), but the repository-local rules are built
-    /// from `.atomicignore`, `.gitignore`, and `.ignore` (in that order, so
-    /// later files take precedence on conflicting patterns). This lets
-    /// `atomic query enrich` skip build artifacts and dependencies that those
-    /// files exclude (e.g. `node_modules/`, `dist/`, `target/`) instead of
-    /// creating knowledge-graph nodes for them.
-    ///
-    /// Only the files at the repository root are consulted; nested ignore
-    /// files in subdirectories are not (matching the existing `.atomicignore`
-    /// behavior of [`load`](Self::load)).
+    /// Identical to [`load`](Self::load) — both read the same set of local
+    /// ignore files. Kept as a distinct entry point because enrichment and
+    /// content search additionally filter out Atomic-internal paths such as
+    /// `.vault`, and because the call sites read more clearly for it.
     pub fn load_for_enrichment(repo_root: &Path) -> Self {
-        let global = load_global_ignore();
-        let local = load_local_enrichment_ignore(repo_root);
-        Self {
-            global,
-            local,
-            repo_root: repo_root.to_path_buf(),
-        }
+        Self::load(repo_root)
     }
 
     /// Create an empty IgnoreRules (ignores nothing except built-in patterns).
@@ -356,49 +361,29 @@ fn load_global_ignore() -> Option<Gitignore> {
     }
 }
 
-/// Load repository-local ignore rules from .atomicignore
-fn load_local_ignore(repo_root: &Path) -> Option<Gitignore> {
-    let ignore_path = repo_root.join(".atomicignore");
-
-    if ignore_path.exists() {
-        let mut builder = GitignoreBuilder::new(repo_root);
-        // builder.add() returns Option<Error> - log if there's an issue
-        if let Some(err) = builder.add(&ignore_path) {
-            log::warn!(
-                "Failed to parse .atomicignore at {}: {}",
-                ignore_path.display(),
-                err
-            );
-            return None;
-        }
-        match builder.build() {
-            Ok(gitignore) => Some(gitignore),
-            Err(err) => {
-                log::warn!(
-                    "Failed to build ignore rules from {}: {}",
-                    ignore_path.display(),
-                    err
-                );
-                None
-            }
-        }
-    } else {
-        None
-    }
-}
-
-/// Load repository-local ignore rules for enrichment from `.atomicignore`,
-/// `.gitignore`, and `.ignore` at the repository root.
+/// Repository-local ignore files, lowest precedence first.
 ///
-/// All existing files are merged into a single matcher. Later files take
-/// precedence on conflicting patterns (`.atomicignore` < `.gitignore` <
-/// `.ignore`), following the `ignore` crate's last-match-wins semantics.
-/// Returns `None` when none of the files exist or all fail to parse.
-fn load_local_enrichment_ignore(repo_root: &Path) -> Option<Gitignore> {
+/// `.atomicignore` comes last so it wins on conflicting patterns: it is
+/// Atomic's own file, and a `!pattern` there must be able to re-include
+/// something the project's `.gitignore` excludes.
+const LOCAL_IGNORE_FILES: [&str; 3] = [".gitignore", ".ignore", ".atomicignore"];
+
+/// Load repository-local ignore rules from `.gitignore`, `.ignore`, and
+/// `.atomicignore` at the repository root.
+///
+/// All existing files are merged into a single matcher following the `ignore`
+/// crate's last-match-wins semantics, so the order in [`LOCAL_IGNORE_FILES`]
+/// is also the precedence order. A file that fails to parse is skipped with a
+/// warning rather than discarding the rules that did load. Returns `None` when
+/// none of the files exist or all fail to parse.
+///
+/// Only the files at the repository root are consulted; nested ignore files in
+/// subdirectories are not.
+fn load_local_ignore(repo_root: &Path) -> Option<Gitignore> {
     let mut builder = GitignoreBuilder::new(repo_root);
     let mut added = false;
 
-    for name in [".atomicignore", ".gitignore", ".ignore"] {
+    for name in LOCAL_IGNORE_FILES {
         let ignore_path = repo_root.join(name);
         if !ignore_path.exists() {
             continue;
@@ -423,7 +408,7 @@ fn load_local_enrichment_ignore(repo_root: &Path) -> Option<Gitignore> {
         Ok(gitignore) => Some(gitignore),
         Err(err) => {
             log::warn!(
-                "Failed to build enrichment ignore rules for {}: {}",
+                "Failed to build ignore rules for {}: {}",
                 repo_root.display(),
                 err
             );
@@ -521,15 +506,83 @@ mod tests {
     }
 
     #[test]
-    fn test_load_for_enrichment_load_does_not_read_gitignore() {
-        // The general-purpose `load` must remain `.atomicignore`-only so that
-        // enabling gitignore semantics for enrichment does not silently change
-        // VCS-wide behavior (status, tracking, switch).
+    fn test_load_reads_gitignore() {
+        // `load` is the VCS-wide matcher (status, tracking, switch). It must
+        // honor `.gitignore`, because that is the file every project already
+        // uses to exclude build output — and without it `record` walks into
+        // those directories and fails on artifacts nobody meant to version.
         let temp = TempDir::new().unwrap();
         std::fs::write(temp.path().join(".gitignore"), "node_modules/\n").unwrap();
 
         let rules = IgnoreRules::load(temp.path());
-        assert!(!rules.is_ignored(Path::new("node_modules/pkg/index.js"), false));
+        assert!(rules.is_ignored(Path::new("node_modules/pkg/index.js"), false));
+    }
+
+    #[test]
+    fn test_load_reads_dot_ignore() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(temp.path().join(".ignore"), "scratch/\n").unwrap();
+
+        let rules = IgnoreRules::load(temp.path());
+        assert!(rules.is_ignored(Path::new("scratch/tmp.txt"), false));
+    }
+
+    #[test]
+    fn test_load_honors_all_three_local_files() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(temp.path().join(".atomicignore"), "dist/\n").unwrap();
+        std::fs::write(temp.path().join(".gitignore"), "node_modules/\n").unwrap();
+        std::fs::write(temp.path().join(".ignore"), "scratch/\n").unwrap();
+
+        let rules = IgnoreRules::load(temp.path());
+
+        assert!(rules.is_ignored(Path::new("dist/index.js"), false));
+        assert!(rules.is_ignored(Path::new("node_modules/typescript/lib.d.ts"), false));
+        assert!(rules.is_ignored(Path::new("scratch/tmp.txt"), false));
+        assert!(!rules.is_ignored(Path::new("src/index.ts"), false));
+    }
+
+    #[test]
+    fn test_atomicignore_overrides_gitignore() {
+        // `.atomicignore` is loaded last, so a negation there re-includes a
+        // path the project's `.gitignore` excludes. Without this precedence
+        // there would be no way to version a generated file that Git skips.
+        let temp = TempDir::new().unwrap();
+        std::fs::write(temp.path().join(".gitignore"), "dist/\n").unwrap();
+        std::fs::write(temp.path().join(".atomicignore"), "!dist/\n").unwrap();
+
+        let rules = IgnoreRules::load(temp.path());
+        assert!(!rules.is_ignored(Path::new("dist"), true));
+    }
+
+    #[test]
+    fn test_load_skips_unreadable_file_without_losing_others() {
+        // A `.gitignore` that is a directory cannot be parsed. The rules from
+        // the files that did load must survive.
+        let temp = TempDir::new().unwrap();
+        std::fs::create_dir(temp.path().join(".gitignore")).unwrap();
+        std::fs::write(temp.path().join(".atomicignore"), "dist/\n").unwrap();
+
+        let rules = IgnoreRules::load(temp.path());
+        assert!(rules.is_ignored(Path::new("dist/index.js"), false));
+    }
+
+    #[test]
+    fn test_nextjs_build_cache_is_ignored_via_gitignore() {
+        // Regression: `atomic record` in a Next.js project aborted on
+        // `.next/dev/cache/turbopack/*.sst` because `.next/` was never
+        // ignored, even though the project's `.gitignore` excludes it.
+        let temp = TempDir::new().unwrap();
+        std::fs::write(temp.path().join(".gitignore"), "/.next/\n/node_modules\n").unwrap();
+
+        let rules = IgnoreRules::load(temp.path());
+
+        assert!(rules.is_ignored(Path::new(".next"), true));
+        assert!(rules.is_ignored(
+            Path::new(".next/dev/cache/turbopack/v16.2.10/00000012.sst"),
+            false
+        ));
+        assert!(!rules.is_ignored(Path::new("src/app/page.tsx"), false));
     }
 
     #[test]

--- a/tests/harness/31_record_oversized_file.sh
+++ b/tests/harness/31_record_oversized_file.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# chmod +x tests/harness/31_record_oversized_file.sh
+#
+# 31_record_oversized_file.sh — build output stays out of `record`, and an
+# oversized file that *is* tracked is reported as a USER error.
+#
+# The reported symptom was a first `atomic record` in a Next.js project:
+#
+#   ✗ Internal error: File too large: .next/dev/cache/turbopack/…/00000012.sst
+#     (11290117 bytes, limit: 10485760)
+#   Hint: This appears to be a bug. Please report it at <issues URL>
+#
+# Two separate defects, both pinned here:
+#
+#   1. `.next/` was walked at all. IgnoreRules::load read only `.atomicignore`,
+#      never `.gitignore` — so every Node/Rust/Python project handed `record`
+#      its build artifacts, and one of them happened to exceed the limit.
+#
+#   2. When an oversized file does reach `record`, the failure was misreported.
+#      `RecordError::FileTooLarge` had no arm in the record command's error
+#      mapping and fell through to `other => CliError::Internal`, which renders
+#      "Internal error:", appends the bug-report hint, and exits 128 — the code
+#      error.rs reserves for actual bugs. This is the same catch-all that
+#      swallowed ConflictMarkersPresent (see 30_record_conflict_refusal.sh);
+#      that fix added an arm, this one removes the catch-all.
+
+HARNESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$HARNESS_DIR/helpers.sh"
+
+echo "${BOLD}record ignores build output and reports oversized files as user errors${RESET}"
+
+# 11290117 bytes — the size from the original report, just over the 10 MiB limit.
+OVERSIZED_BYTES=11290117
+
+make_oversized_file() {
+    local path="$1"
+    mkdir -p "$(dirname "$path")"
+    # Sparse allocation: instant, and no multi-megabyte fixture in the repo.
+    dd if=/dev/zero of="$path" bs=1 count=0 seek="$OVERSIZED_BYTES" 2>/dev/null
+}
+
+# ── 1 · .gitignore keeps build output out of record ─────────────────────────
+
+begin_section ".gitignore is honored, so build output never reaches record"
+
+make_temp_repo record-oversized
+init_repo
+
+printf '/.next/\n/node_modules\n' > .gitignore
+create_file src/app/page.tsx 'export default function Page() { return null }'
+create_file package.json '{"name":"next-app"}'
+make_oversized_file .next/dev/cache/turbopack/v16.2.10/00000012.sst
+
+assert_status_no_entry "the build cache is not offered as untracked" ".next"
+assert_status_contains "source files still are"                      "src/app/page.tsx"
+
+add_files . >/dev/null
+assert_success "record succeeds despite the oversized build artifact" \
+    atomic record -m "First change with Atomic"
+
+# The whole point: the artifact must not be in history.
+assert_output_contains     "source files were recorded"   "page.tsx" atomic change
+assert_output_not_contains "the build cache was not recorded" ".next" atomic change
+
+# ── 2 · .atomicignore still wins over .gitignore ────────────────────────────
+#
+# .atomicignore is loaded last so a negation there can re-include something the
+# project's .gitignore excludes. Without this there would be no way to version
+# a generated file that Git skips.
+
+begin_section ".atomicignore overrides .gitignore"
+
+make_temp_repo record-oversized-override
+init_repo
+
+printf 'dist/\n'  >  .gitignore
+printf '!dist/\n' >> .atomicignore
+create_file dist/bundle.js 'built'
+
+assert_status_contains "'!dist/' in .atomicignore re-includes the path" "dist/bundle.js"
+
+# ── 3 · a tracked oversized file is a USER error, not an internal one ───────
+#
+# These are the assertions that would have caught the misclassification.
+
+begin_section "an oversized file is classified as a user error"
+
+make_temp_repo record-oversized-tracked
+init_repo
+
+create_file README.md 'hello'
+make_oversized_file dataset.bin
+add_files . >/dev/null
+
+assert_failure "record fails on the oversized file" \
+    atomic record -m "should be refused"
+
+assert_output_not_contains "not reported as an internal error" \
+    "Internal error" atomic record -m "should be refused"
+assert_output_not_contains "does not tell the user to file a bug" \
+    "Please report it" atomic record -m "should be refused"
+
+# Sizes must be human-readable; a raw byte count says nothing about how far
+# over the limit the file is.
+assert_output_contains "names the file"        "dataset.bin" atomic record -m "should be refused"
+assert_output_contains "size in human units"   "10.8 MiB"    atomic record -m "should be refused"
+assert_output_contains "limit in human units"  "10.0 MiB"    atomic record -m "should be refused"
+assert_output_not_contains "no raw byte counts" \
+    "$OVERSIZED_BYTES" atomic record -m "should be refused"
+
+# Exit code: must be a user/data error, never 128.
+# NB: the harness runs under `set -e`, so capture the status without letting
+# the expected failure abort the suite.
+RECORD_EXIT=0
+atomic record -m "should be refused" >/dev/null 2>&1 || RECORD_EXIT=$?
+if [[ "$RECORD_EXIT" -ne 0 && "$RECORD_EXIT" -ne 128 ]]; then
+    _pass "exit code is a user error ($RECORD_EXIT), not 128"
+else
+    _fail "exit code is a user error, not 128" \
+        "expected non-zero and != 128, got $RECORD_EXIT"
+fi
+
+# ── 4 · the hint names escape hatches that actually work ────────────────────
+#
+# NB: leading '--' is dropped from the needles on purpose — assert_output_contains
+# passes them straight to `grep -F`, which would parse '--skip-binary' as an option.
+
+begin_section "the suggested escape hatches work"
+
+assert_output_contains "hint mentions .atomicignore" \
+    ".atomicignore" atomic record -m "should be refused"
+assert_output_contains "hint mentions skip-binary" \
+    "skip-binary"   atomic record -m "should be refused"
+assert_output_contains "hint mentions max-size" \
+    "max-size"      atomic record -m "should be refused"
+
+assert_success "--skip-binary records everything else" \
+    atomic record -m "skip the big one" --skip-binary
+
+# README.md went in; dataset.bin did not.
+assert_output_contains "the small file was recorded" \
+    "README.md" atomic change
+assert_output_not_contains "the oversized file was skipped" \
+    "dataset.bin" atomic change
+
+# ── 5 · --max-size moves the ceiling in both directions ─────────────────────
+#
+# Deliberately exercised against a *small* file. Proving the flag is wired only
+# needs the ceiling to move relative to the file; using a genuinely oversized
+# one would mean recording 10+ MiB through the tokenizer, which dominated this
+# suite's runtime for no extra coverage. Section 3 already pins the real
+# 11 MB case against the default limit.
+
+begin_section "--max-size moves the ceiling in both directions"
+
+make_temp_repo record-oversized-maxsize
+init_repo
+
+create_file notes.txt 'a few hundred bytes would be plenty here'
+add_files . >/dev/null
+
+assert_failure "a lowered --max-size refuses a small file" \
+    atomic record -m "should be refused" --max-size 8
+assert_output_contains "and reports it the same way" \
+    "notes.txt" atomic record -m "should be refused" --max-size 8
+assert_success "a raised --max-size accepts it" \
+    atomic record -m "raised ceiling" --max-size 100000
+
+print_summary


### PR DESCRIPTION
## What broke

A first `atomic record` in a Next.js project:

```
✗ Internal error: File too large: .next/dev/cache/turbopack/v16.2.10/00000012.sst (11290117 bytes, limit: 10485760)

Hint: This appears to be a bug. Please report it at: https://github.com/atomicdotdev/atomic/issues
```

It is not a bug, and the file should never have been looked at.

## Why

**`.next/` was walked at all.** `IgnoreRules::load` read only `.atomicignore`. Every Node/Rust/Python project therefore handed `record` its build artifacts, and one of them happened to exceed the 10 MiB limit. The `.gitignore`-aware loader already existed next door — `load_for_enrichment` used it — but the VCS path never called it.

**The failure was misreported.** `RecordError::FileTooLarge` had no arm in the record command's error mapping, so it fell through to `other => CliError::Internal`: "Internal error:", a bug-report hint, and exit 128 — the code `error.rs` reserves for actual bugs. The message also printed raw byte counts, which say nothing about how far over the limit you are.

This is the same catch-all that swallowed `ConflictMarkersPresent` in #160. That fix added an arm; the catch-all stayed, so the next variant fell through it.

## What changed

- `IgnoreRules::load` reads `.gitignore`, `.ignore`, and `.atomicignore`. `.atomicignore` is loaded last, so `!pattern` there can re-include something the project's `.gitignore` excludes. A file that fails to parse is skipped without discarding the rules that did load.
- `CliError::FileTooLarge` — exit 3, human-readable sizes, and a hint naming the three real fixes (`.atomicignore`, `--skip-binary`, `--max-size`).
- The `other =>` catch-all is gone. The match is exhaustive, so every new `RecordError` variant now needs a deliberate classification. Three more variants that were also being reported as bugs are now routed properly: `InvalidHeader` → usage error, `Io` → environment, `Repository` → repository error. Only `Globalize`/`Assembly`/`ChangeStore`/`Database` remain internal.

## Scope note for review

`switch.rs` uses the same `ignore_rules()` to decide what gets shelved per view, so the wider ignore set now shelves `.gitignore`'d paths too. Right for `node_modules/` and `.next/`; worth a look for `.env`, which many projects gitignore. Not a new category — the `atomic init -k node` template already lists `.env` — but the blast radius is larger. Happy to add `.env` to `DEFAULT_EXPOSE` if that's the call.

Deliberately **not** included: changing the default from hard-fail to skip, decoupling large-file skipping from `--skip-binary` (an `.sst` is not a "binary" problem), and adding `.next/`/`.turbo/`/`.nuxt/` to the `init` node template.

## Testing

- `31_record_oversized_file.sh` — 23 assertions covering both defects, the `.atomicignore` override, all three escape hatches, and that the exit code is never 128. Runs in ~5s.
- 8 new unit tests (5 in `ignore.rs`, 3 in `error.rs`).
- Full suites green: `atomic-repository` 886 passed, `atomic-cli` 1797 passed. Harness suites 01–04, 21, 22, 29–31 all pass. `clippy --workspace -- -D warnings` and `RUSTDOCFLAGS=-Dwarnings cargo doc` clean.
- Verified end-to-end against a reconstructed repro: the original command now succeeds and records 3 files, with `.next/` absent from history.

One existing test was inverted: `test_load_for_enrichment_load_does_not_read_gitignore` asserted that `load` must *not* read `.gitignore`, to avoid changing VCS-wide behavior. That is the behavior this PR deliberately changes, so it is now `test_load_reads_gitignore` with the reasoning written out.