### PR TITLE
Update triage process to enable narrative creation

### DIFF
--- a/atomic-cli/src/commands/triage/mod.rs
+++ b/atomic-cli/src/commands/triage/mod.rs
@@ -59,6 +59,7 @@ pub enum TriageCommands {
     /// ```text
     /// atomic triage review feature --into dev
     /// atomic triage review feature --into dev --json
+    /// atomic triage review feature --into dev --walkthrough     # guided reading order
     /// atomic triage review feature --into dev --html            # write + open in browser
     /// atomic triage review feature --into dev --html --output review.html
     /// atomic triage review feature --into dev --html --no-open
@@ -216,6 +217,12 @@ pub struct TriageReview {
     #[arg(long)]
     pub json: bool,
 
+    /// Print the guided walkthrough: the candidate changes grouped into
+    /// ordered semantic layers (foundations first), with each layer's
+    /// rationale, files, and inspect commands. Bounded — never a diff dump.
+    #[arg(long)]
+    pub walkthrough: bool,
+
     /// Write a self-contained HTML report (inline CSS/JS, no external assets)
     /// to a file and open it in the default browser.
     #[arg(long)]
@@ -247,7 +254,8 @@ impl Command for TriageReview {
 
         let report = project::build_report(&repo, &self.feature, &self.into)?;
 
-        // Output selection precedence: attest > html > json > CLI dashboard.
+        // Output selection precedence:
+        // attest > html > json > walkthrough > CLI dashboard.
         if self.attest {
             let signed = output::attest_report(&report, self.identity.as_deref())?;
             println!("{}", serde_json::to_string_pretty(&signed).unwrap());
@@ -256,6 +264,8 @@ impl Command for TriageReview {
             write_and_open_html(&html, &report, self.output.as_deref(), !self.no_open)?;
         } else if self.json {
             println!("{}", serde_json::to_string_pretty(&report).unwrap());
+        } else if self.walkthrough {
+            output::print_walkthrough(&report);
         } else {
             output::print_report(&report);
         }

--- a/atomic-cli/src/commands/triage/model.rs
+++ b/atomic-cli/src/commands/triage/model.rs
@@ -77,6 +77,12 @@ pub struct TriageReport {
     pub intents: Vec<IntentReport>,
     pub changes: Vec<ChangeReport>,
     pub findings: Vec<Finding>,
+    /// The guided walkthrough: candidate modifications grouped into semantic
+    /// layers (module clusters), in reading order — foundations first. A pure,
+    /// deterministic projection of the pinned inputs; empty when the candidate
+    /// set modifies no files.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub walkthrough: Vec<WalkthroughLayer>,
 }
 
 /// The pinned inputs the report is a fact about (the evidence-bundle role).
@@ -191,6 +197,37 @@ pub struct ChangeReport {
     /// Compact provenance (session / agent / turn), best-effort; `None` if no
     /// provenance graph explains the change.
     pub provenance: Option<serde_json::Value>,
+}
+
+/// One semantic layer in the guided walkthrough: a cluster of modified files
+/// (a module), the tasks/criteria/changes that land there, and a deterministic
+/// prose rationale. The `Vec<WalkthroughLayer>` order on [`TriageReport`] IS
+/// the reading order (foundations first, entry points last).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WalkthroughLayer {
+    /// Stable layer id: `layer:<module>` (e.g. `layer:atomic-core/src/pristine`).
+    pub id: String,
+    /// Human title — the module path (or `(root)` for top-level files).
+    pub title: String,
+    /// Deterministic template prose explaining what this layer does and why it
+    /// reads at this position — assembled from task text, criteria, and change
+    /// messages. Never LLM-authored (the report must stay reproducible).
+    pub rationale: String,
+    /// Modified `file:<path>` node ids in this layer (keys into
+    /// `changes[].modifies` / `changes[].diff`).
+    pub files: Vec<String>,
+    /// Canonical ids of intent tasks whose `::file-ref` touches land here.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tasks: Vec<String>,
+    /// Acceptance-criterion ids those tasks satisfy.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub criteria: Vec<String>,
+    /// Candidate change hashes (base32) that modify files in this layer.
+    pub changes: Vec<String>,
+    /// Earlier layer ids this layer builds on (via `IMPORTS`/`INCLUDES` edges
+    /// between modified files) — why it reads after them.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub depends_on: Vec<String>,
 }
 
 /// A finding — the machine + human face of one issue.

--- a/atomic-cli/src/commands/triage/output.rs
+++ b/atomic-cli/src/commands/triage/output.rs
@@ -5,6 +5,8 @@
 //! line, the severity-sorted findings, and a compact per-intent view — never a
 //! diff dump.
 
+use std::collections::BTreeMap;
+
 use serde_json::Value;
 
 use atomic_canonical::proof::attest_value;
@@ -14,8 +16,8 @@ use crate::error::CliResult;
 use crate::output::{emphasis, hint, info};
 
 use super::model::{
-    ChangeReport, CriterionReport, Finding, IntentReport, TriageReport, Verdict, SEV_BLOCK,
-    SEV_INFO, SEV_WARN,
+    ChangeReport, CriterionReport, DiffFileView, Finding, IntentReport, TriageReport, Verdict,
+    WalkthroughLayer, SEV_BLOCK, SEV_INFO, SEV_WARN,
 };
 
 /// Render the report to stdout as the bounded human dashboard.
@@ -117,12 +119,120 @@ pub fn print_report(report: &TriageReport) {
         }
     }
 
-    // Drill-down pointer (JSON is the full worklist; keep the CLI bounded).
-    println!(
-        "\n{}",
-        hint("run with --json for the full worklist (findings, criteria, provenance)")
-    );
+    // Drill-down pointers (JSON is the full worklist; keep the CLI bounded).
+    if !report.walkthrough.is_empty() {
+        println!(
+            "\n{}",
+            hint(&format!(
+                "run with --walkthrough for the guided reading order ({} layer{})",
+                report.walkthrough.len(),
+                if report.walkthrough.len() == 1 {
+                    ""
+                } else {
+                    "s"
+                }
+            ))
+        );
+        println!(
+            "{}",
+            hint("run with --json for the full worklist (findings, criteria, provenance)")
+        );
+    } else {
+        println!(
+            "\n{}",
+            hint("run with --json for the full worklist (findings, criteria, provenance)")
+        );
+    }
     println!("{} {}", hint("ref"), hint(&report.reference));
+}
+
+// ── Walkthrough skin (bounded guided reading order) ──────────────────────
+
+/// Cap for inline path/change lists in the walkthrough skin — anything longer
+/// is elided with a count, keeping the output bounded on huge layers.
+const WALKTHROUGH_LIST_CAP: usize = 8;
+
+/// Comma-join up to [`WALKTHROUGH_LIST_CAP`] items, eliding the rest.
+fn capped_list(items: &[String]) -> String {
+    if items.len() <= WALKTHROUGH_LIST_CAP {
+        items.join(", ")
+    } else {
+        format!(
+            "{}, … and {} more",
+            items[..WALKTHROUGH_LIST_CAP].join(", "),
+            items.len() - WALKTHROUGH_LIST_CAP
+        )
+    }
+}
+
+/// Render the guided walkthrough as bounded text: a verdict line, then one
+/// numbered entry per layer — title, rationale, files, contributing changes
+/// with their inspect commands — never a hunk dump. The canonical section is
+/// rendered verbatim; nothing is re-derived here.
+pub fn walkthrough_text(report: &TriageReport) -> String {
+    let mut out = String::new();
+    let verdict_label = match report.verdict {
+        Verdict::Ready => info("READY").to_string(),
+        Verdict::Blocked => emphasis(crate::output::error("BLOCKED")).to_string(),
+        Verdict::Stale => crate::output::warning("STALE").to_string(),
+    };
+    out.push_str(&format!(
+        "{} {} \u{2192} {}   {}   ({} layer{}, {} change{})\n",
+        emphasis("walkthrough"),
+        report.inputs.feature,
+        report.inputs.target,
+        verdict_label,
+        report.walkthrough.len(),
+        if report.walkthrough.len() == 1 {
+            ""
+        } else {
+            "s"
+        },
+        report.summary.changes,
+        if report.summary.changes == 1 { "" } else { "s" },
+    ));
+
+    if report.walkthrough.is_empty() {
+        out.push_str("\n  no walkthrough: the candidate set modifies no files\n");
+        return out;
+    }
+
+    // The exact inspect command per contributing change, from the canonical
+    // change reports (no re-derivation).
+    let review_cmd: BTreeMap<&str, &str> = report
+        .changes
+        .iter()
+        .map(|c| (c.id.as_str(), c.review_command.as_str()))
+        .collect();
+
+    for (i, layer) in report.walkthrough.iter().enumerate() {
+        out.push_str(&format!("\n{}. {}\n", i + 1, emphasis(&layer.title)));
+        out.push_str(&format!("   {}\n", layer.rationale));
+        let files: Vec<String> = layer
+            .files
+            .iter()
+            .map(|f| f.strip_prefix("file:").unwrap_or(f).to_string())
+            .collect();
+        out.push_str(&format!("   files: {}\n", capped_list(&files)));
+        if !layer.criteria.is_empty() {
+            out.push_str(&format!("   criteria: {}\n", capped_list(&layer.criteria)));
+        }
+        for ch in &layer.changes {
+            let short: String = ch.chars().take(12).collect();
+            match review_cmd.get(ch.as_str()) {
+                Some(cmd) => out.push_str(&format!("   {short}  {}\n", hint(cmd))),
+                None => out.push_str(&format!("   {short}\n")),
+            }
+        }
+    }
+
+    out.push_str(&format!("\n{} {}\n", hint("ref"), hint(&report.reference)));
+    out
+}
+
+/// Print the guided walkthrough skin to stdout.
+pub fn print_walkthrough(report: &TriageReport) {
+    print!("{}", walkthrough_text(report));
 }
 
 /// Aggregate (additions, deletions) across a change's embedded diff.
@@ -258,6 +368,12 @@ pub fn render_html(report: &TriageReport) -> String {
         }
     }
     h.push_str("</section>\n");
+
+    // Walkthrough — the guided chapter tour (only when the projection produced
+    // layers). Rendered verbatim from the canonical section.
+    if !report.walkthrough.is_empty() {
+        h.push_str(&render_walkthrough(report));
+    }
 
     // Intents.
     h.push_str("<section id=\"intents\">\n<h2>Intents</h2>\n");
@@ -449,32 +565,7 @@ fn render_change(c: &ChangeReport) -> String {
     ));
     // The real code-review surface: inline, color-coded unified diff.
     for f in &c.diff {
-        s.push_str(&format!(
-            "<div class=\"diff-file\"><span class=\"diff-path\">{}</span> <span class=\"diff-status {}\">{}</span></div>\n",
-            html_escape(&f.path),
-            html_escape(&f.status),
-            html_escape(&f.status)
-        ));
-        s.push_str("<pre class=\"diff\">");
-        for hunk in &f.hunks {
-            s.push_str(&format!(
-                "<div class=\"hunk-header\">{}</div>",
-                html_escape(&hunk.header)
-            ));
-            for line in &hunk.lines {
-                let cls = match line.tag.as_str() {
-                    "+" => "add",
-                    "-" => "del",
-                    _ => "ctx",
-                };
-                s.push_str(&format!(
-                    "<div class=\"line {cls}\">{}{}</div>",
-                    html_escape(&line.tag),
-                    html_escape(&line.content)
-                ));
-            }
-        }
-        s.push_str("</pre>\n");
+        s.push_str(&render_diff_file(f));
     }
     if !c.blast_radius.is_empty() {
         s.push_str(&format!(
@@ -488,6 +579,147 @@ fn render_change(c: &ChangeReport) -> String {
     }
     s.push_str("</details>\n");
     s
+}
+
+/// One file's color-coded unified diff — shared by the per-change view and the
+/// walkthrough chapters, so both render diffs identically.
+fn render_diff_file(f: &DiffFileView) -> String {
+    let mut s = String::new();
+    s.push_str(&format!(
+        "<div class=\"diff-file\"><span class=\"diff-path\">{}</span> <span class=\"diff-status {}\">{}</span></div>\n",
+        html_escape(&f.path),
+        html_escape(&f.status),
+        html_escape(&f.status)
+    ));
+    s.push_str("<pre class=\"diff\">");
+    for hunk in &f.hunks {
+        s.push_str(&format!(
+            "<div class=\"hunk-header\">{}</div>",
+            html_escape(&hunk.header)
+        ));
+        for line in &hunk.lines {
+            let cls = match line.tag.as_str() {
+                "+" => "add",
+                "-" => "del",
+                _ => "ctx",
+            };
+            s.push_str(&format!(
+                "<div class=\"line {cls}\">{}{}</div>",
+                html_escape(&line.tag),
+                html_escape(&line.content)
+            ));
+        }
+    }
+    s.push_str("</pre>\n");
+    s
+}
+
+/// The walkthrough section: a reading-order nav plus one numbered collapsible
+/// chapter per layer (first chapter open). Each chapter shows the canonical
+/// rationale, its tasks/criteria, `depends_on` anchor links to earlier
+/// chapters, and the per-file diffs scoped to that layer's files.
+fn render_walkthrough(report: &TriageReport) -> String {
+    // layer id → (1-based chapter number, title) for depends_on anchors.
+    let chapter_of: BTreeMap<&str, (usize, &str)> = report
+        .walkthrough
+        .iter()
+        .enumerate()
+        .map(|(i, l)| (l.id.as_str(), (i + 1, l.title.as_str())))
+        .collect();
+
+    let mut h = String::new();
+    h.push_str("<section id=\"walkthrough\">\n<h2>Walkthrough</h2>\n");
+    h.push_str("<p class=\"tour-intro\">Guided reading order — foundations first.</p>\n");
+
+    // Reading-order nav.
+    h.push_str("<ol class=\"toc\">\n");
+    for (i, layer) in report.walkthrough.iter().enumerate() {
+        h.push_str(&format!(
+            "<li><a href=\"#chapter-{}\">{}</a></li>\n",
+            i + 1,
+            html_escape(&layer.title)
+        ));
+    }
+    h.push_str("</ol>\n");
+
+    for (i, layer) in report.walkthrough.iter().enumerate() {
+        let n = i + 1;
+        let open = if i == 0 { " open" } else { "" };
+        h.push_str(&format!(
+            "<details class=\"chapter\" id=\"chapter-{n}\"{open}>\n"
+        ));
+        h.push_str(&format!(
+            "<summary><span class=\"chapter-num\">{n}</span> <span class=\"chapter-title\">{}</span> <span class=\"stat\">{} file(s) · {} change(s)</span></summary>\n",
+            html_escape(&layer.title),
+            layer.files.len(),
+            layer.changes.len()
+        ));
+        h.push_str(&format!(
+            "<p class=\"rationale\">{}</p>\n",
+            html_escape(&layer.rationale)
+        ));
+
+        // depends_on → anchor links to the chapters this one builds on.
+        if !layer.depends_on.is_empty() {
+            h.push_str("<div class=\"chapter-deps\">builds on: ");
+            let mut first = true;
+            for dep in &layer.depends_on {
+                if !first {
+                    h.push_str(" · ");
+                }
+                first = false;
+                match chapter_of.get(dep.as_str()) {
+                    Some((dn, title)) => h.push_str(&format!(
+                        "<a href=\"#chapter-{dn}\">{dn}. {}</a>",
+                        html_escape(title)
+                    )),
+                    // A dep outside the rendered set (defensive): plain text.
+                    None => h.push_str(&html_escape(dep)),
+                }
+            }
+            h.push_str("</div>\n");
+        }
+
+        if !layer.tasks.is_empty() {
+            h.push_str(&format!(
+                "<div class=\"chapter-meta\">tasks: <code>{}</code></div>\n",
+                html_escape(&layer.tasks.join(", "))
+            ));
+        }
+        if !layer.criteria.is_empty() {
+            h.push_str(&format!(
+                "<div class=\"chapter-meta\">criteria: <code>{}</code></div>\n",
+                html_escape(&layer.criteria.join(", "))
+            ));
+        }
+
+        // The layer's code: per-file diffs scoped to this chapter's files,
+        // pulled from the contributing changes' canonical diffs.
+        let layer_paths: std::collections::HashSet<&str> = layer
+            .files
+            .iter()
+            .map(|f| f.strip_prefix("file:").unwrap_or(f))
+            .collect();
+        for ch_id in &layer.changes {
+            let Some(change) = report.changes.iter().find(|c| &c.id == ch_id) else {
+                continue;
+            };
+            let short: String = ch_id.chars().take(12).collect();
+            for f in &change.diff {
+                if layer_paths.contains(f.path.as_str()) {
+                    h.push_str(&format!(
+                        "<div class=\"chapter-change\">from <code>{}</code></div>\n",
+                        html_escape(&short)
+                    ));
+                    h.push_str(&render_diff_file(f));
+                }
+            }
+        }
+
+        h.push_str("</details>\n");
+    }
+    h.push_str("</section>\n");
+    h
 }
 
 /// HTML-escape the five significant characters so no interpolated string can
@@ -616,7 +848,111 @@ mod tests {
                 "reaches <script>alert(1)</script> & <b>bold</b>",
             )
             .with_query("atomic vault query neighbors change:HASH1 -d 2 --json")],
+            walkthrough: vec![
+                WalkthroughLayer {
+                    id: "layer:src".to_string(),
+                    title: "src".to_string(),
+                    rationale: "reads <first> & foremost".to_string(),
+                    files: vec!["file:src/<a>.rs".to_string()],
+                    tasks: vec!["urn:atomic:task:T-1".to_string()],
+                    criteria: vec!["urn:atomic:ac:DEMO-A-1".to_string()],
+                    changes: vec!["HASH1".to_string()],
+                    depends_on: vec![],
+                },
+                WalkthroughLayer {
+                    id: "layer:cli".to_string(),
+                    title: "cli".to_string(),
+                    rationale: "the entry point".to_string(),
+                    files: vec!["file:cli/main.rs".to_string()],
+                    tasks: vec![],
+                    criteria: vec![],
+                    changes: vec!["HASH1".to_string()],
+                    depends_on: vec!["layer:src".to_string()],
+                },
+            ],
         }
+    }
+
+    /// The text walkthrough skin lists layers in canonical order with their
+    /// rationale, files, and inspect commands — and never dumps diff hunks.
+    #[test]
+    fn walkthrough_text_is_ordered_and_bounded() {
+        let report = sample_report();
+        let text = walkthrough_text(&report);
+
+        // Numbered entries in canonical (reading) order.
+        let pos_src = text.find("1. ").expect("first chapter");
+        let pos_cli = text.find("2. ").expect("second chapter");
+        assert!(pos_src < pos_cli);
+        assert!(text.contains("src"));
+        assert!(text.contains("cli"));
+
+        // Canonical rationale rendered verbatim; files stripped of the
+        // `file:` prefix; the exact inspect command from the change report.
+        assert!(text.contains("reads <first> & foremost"));
+        assert!(text.contains("files: src/<a>.rs"));
+        assert!(text.contains("criteria: urn:atomic:ac:DEMO-A-1"));
+        assert!(text.contains("atomic change HASH1 --show-hunks"));
+
+        // Bounded: no diff content lines leak into the text skin.
+        assert!(!text.contains("let x = <old> & 1;"));
+        assert!(!text.contains("let x = <new> & 2;"));
+
+        // The reproducible reference closes the view.
+        assert!(text.contains("urn:atomic:triage:abc123"));
+    }
+
+    /// A list longer than the cap is elided with a count.
+    #[test]
+    fn walkthrough_capped_list_elides() {
+        let items: Vec<String> = (0..12).map(|i| format!("f{i}")).collect();
+        let s = capped_list(&items);
+        assert!(s.contains("f0") && s.contains("f7"));
+        assert!(!s.contains("f8"));
+        assert!(s.contains("and 4 more"));
+
+        let short: Vec<String> = vec!["a".to_string(), "b".to_string()];
+        assert_eq!(capped_list(&short), "a, b");
+    }
+
+    /// The HTML chapter tour: nav anchors, numbered chapters (first open),
+    /// depends_on links, escaped rationale, and layer-scoped diffs.
+    #[test]
+    fn render_html_walkthrough_chapter_tour() {
+        let html = render_html(&sample_report());
+
+        // Section + reading-order nav.
+        assert!(html.contains("<section id=\"walkthrough\">"));
+        assert!(html.contains("<a href=\"#chapter-1\">src</a>"));
+        assert!(html.contains("<a href=\"#chapter-2\">cli</a>"));
+
+        // First chapter open, second closed.
+        assert!(html.contains("<details class=\"chapter\" id=\"chapter-1\" open>"));
+        assert!(html.contains("<details class=\"chapter\" id=\"chapter-2\">"));
+
+        // depends_on renders as an anchor back to the earlier chapter.
+        assert!(html.contains("builds on: <a href=\"#chapter-1\">1. src</a>"));
+
+        // Rationale is escaped.
+        assert!(html.contains("reads &lt;first&gt; &amp; foremost"));
+        assert!(!html.contains("reads <first>"));
+
+        // Chapter 1 embeds the layer-scoped diff (src/<a>.rs from HASH1);
+        // chapter 2's files match no diff, so it embeds none. The chapter
+        // diff is attributed to its change.
+        assert!(html.contains("<div class=\"chapter-change\">from <code>HASH1</code></div>"));
+        let chapter2_pos = html.find("id=\"chapter-2\"").unwrap();
+        let after_chapter2 = &html[chapter2_pos
+            ..html
+                .find("</section>\n<section id=\"intents\">")
+                .unwrap_or(html.len())];
+        assert!(
+            !after_chapter2.contains("chapter-change"),
+            "chapter 2 has no matching diff files, so no scoped diff"
+        );
+
+        // Still self-contained.
+        assert!(!html.contains("http://") && !html.contains("https://"));
     }
 
     #[test]
@@ -782,4 +1118,18 @@ pre.diff .line{white-space:pre-wrap;word-break:break-word}
 pre.diff .line.add{background:rgba(46,160,67,.18);color:#7ee787}
 pre.diff .line.del{background:rgba(248,81,73,.18);color:#ffa198}
 pre.diff .line.ctx{color:#c9d1d9}
-.empty{color:#666;font-style:italic}"#;
+.empty{color:#666;font-style:italic}
+.tour-intro{color:#555;font-style:italic;margin:6px 0}
+ol.toc{margin:8px 0;padding-left:22px}
+ol.toc a{color:#1662c4;text-decoration:none}
+ol.toc a:hover{text-decoration:underline}
+details.chapter{background:#fff;border:1px solid #e2e4e8;border-radius:6px;padding:10px 12px;margin:10px 0}
+details.chapter summary{cursor:pointer;font-weight:600}
+.chapter-num{display:inline-block;min-width:22px;height:22px;line-height:22px;text-align:center;background:#1a1a1a;color:#fff;border-radius:11px;font-size:12px}
+.chapter-title{margin-left:4px}
+.rationale{color:#333;margin:8px 0 4px}
+.chapter-deps{font-size:13px;color:#555;margin:2px 0}
+.chapter-deps a{color:#1662c4;text-decoration:none}
+.chapter-deps a:hover{text-decoration:underline}
+.chapter-meta{font-size:13px;color:#555;margin:2px 0}
+.chapter-change{font-size:12px;color:#555;margin-top:8px}"#;

--- a/atomic-cli/src/commands/triage/project.rs
+++ b/atomic-cli/src/commands/triage/project.rs
@@ -122,6 +122,14 @@ pub fn build_report(
     // Entities defined in each candidate's modified files (parallel to
     // `change_reports`) — the seeds for the blast-radius walk below.
     let mut change_entities: Vec<Vec<String>> = Vec::new();
+    // Walkthrough facts, collected in the same KG passes (no extra queries):
+    // path → module (PART_OF) and file → file dependency edges (IMPORTS/
+    // INCLUDES). Best-effort — empty on an unenriched KG.
+    let mut file_module: BTreeMap<String, String> = BTreeMap::new();
+    let mut file_deps: BTreeSet<(String, String)> = BTreeSet::new();
+    // Task facts from reached intents (id, text, touches, satisfies), in
+    // intent-id order — the walkthrough's narrative inputs.
+    let mut task_facts: Vec<TaskFact> = Vec::new();
 
     for full in &set.only_in_feature {
         let hash = Hash::from_base32(full.as_bytes());
@@ -175,6 +183,7 @@ pub fn build_report(
             let Ok(fsub) = repo.vault_kg_neighbors(file_id, 1) else {
                 continue;
             };
+            let path = file_id.strip_prefix("file:").unwrap_or(file_id);
             for e in &fsub.edges {
                 if e.to_id == *file_id && kind_is(&e.kind, edge_kind::TOUCHES) {
                     covered = true;
@@ -182,6 +191,22 @@ pub fn build_report(
                 }
                 if e.from_id == *file_id && kind_is(&e.kind, edge_kind::DEFINES) {
                     entities.push(e.to_id.clone());
+                }
+                // Walkthrough facts on the same depth-1 neighborhood: the
+                // file's module (PART_OF) and its outgoing file dependencies
+                // (IMPORTS / INCLUDES) — the layer-ordering signal.
+                if e.from_id == *file_id && kind_is(&e.kind, edge_kind::PART_OF) {
+                    if let Some(module) = e.to_id.strip_prefix("module:") {
+                        file_module.insert(path.to_string(), module.to_string());
+                    }
+                }
+                if e.from_id == *file_id
+                    && (kind_is(&e.kind, edge_kind::IMPORTS)
+                        || kind_is(&e.kind, edge_kind::INCLUDES))
+                {
+                    if let Some(target) = e.to_id.strip_prefix("file:") {
+                        file_deps.insert((path.to_string(), target.to_string()));
+                    }
                 }
             }
         }
@@ -491,6 +516,18 @@ pub fn build_report(
                     );
                 }
 
+                // Task facts for the walkthrough: intent iteration order is a
+                // BTreeMap key walk and tasks keep their directive order, so
+                // this collection is deterministic.
+                for t in &node.has_task {
+                    task_facts.push(TaskFact {
+                        id: t.id.clone(),
+                        text: t.text.clone(),
+                        touches: t.touches_file.clone(),
+                        satisfies: t.satisfies.as_slice().to_vec(),
+                    });
+                }
+
                 let gate_violations: Vec<String> =
                     report.results.iter().map(|v| v.message.clone()).collect();
 
@@ -731,6 +768,20 @@ pub fn build_report(
     };
     let reference = triage_reference(&pins);
 
+    // 12. The guided walkthrough — a pure projection of facts already in hand
+    //     (no further repo access). Candidate order comes from the set itself.
+    let change_paths: Vec<(String, Vec<String>)> = set
+        .only_in_feature
+        .iter()
+        .map(|h| {
+            (
+                h.clone(),
+                change_raw_paths.get(h).cloned().unwrap_or_default(),
+            )
+        })
+        .collect();
+    let walkthrough = build_walkthrough(&change_paths, &file_module, &file_deps, &task_facts);
+
     Ok(TriageReport {
         reference,
         verdict,
@@ -746,7 +797,185 @@ pub fn build_report(
         intents: intent_reports,
         changes: change_reports,
         findings,
+        walkthrough,
     })
+}
+
+// ── The guided walkthrough (semantic layers) ─────────────────────────────
+
+/// The narrative-relevant slice of a reached intent's task: id, text, the
+/// paths its `::file-ref`s touch, and the criteria it satisfies.
+#[derive(Debug, Clone)]
+pub(crate) struct TaskFact {
+    pub id: String,
+    pub text: String,
+    pub touches: Vec<String>,
+    pub satisfies: Vec<String>,
+}
+
+/// A modified path's layer key: its KG module (`PART_OF`) when enriched,
+/// otherwise its parent directory (`(root)` for top-level files). Purely
+/// path-derived in the fallback, so unenriched repos still get a walkthrough.
+fn layer_key(path: &str, file_module: &BTreeMap<String, String>) -> String {
+    if let Some(module) = file_module.get(path) {
+        return module.clone();
+    }
+    match path.rsplit_once('/') {
+        Some((dir, _)) => dir.to_string(),
+        None => "(root)".to_string(),
+    }
+}
+
+/// First non-empty line of a task's directive body, trimmed — the walkthrough
+/// narrates with headlines, not whole bodies.
+fn task_headline(text: &str) -> &str {
+    text.lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("")
+}
+
+/// Group the candidate modifications into ordered semantic layers.
+///
+/// Pure and deterministic: clusters modified paths by [`layer_key`], orders
+/// clusters foundations-first by a Kahn toposort over the module-level
+/// projection of `file_deps` (a layer that is imported reads before its
+/// importer), breaking ties — and cycles — lexicographically, then attaches
+/// the tasks, criteria, and changes that land in each layer plus a template
+/// prose rationale. No repo access; every input is already pinned by the
+/// report.
+pub(crate) fn build_walkthrough(
+    change_paths: &[(String, Vec<String>)],
+    file_module: &BTreeMap<String, String>,
+    file_deps: &BTreeSet<(String, String)>,
+    task_facts: &[TaskFact],
+) -> Vec<WalkthroughLayer> {
+    // 1. Cluster: layer key → sorted modified paths; path → layer key.
+    let mut layer_files: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let mut path_layer: BTreeMap<String, String> = BTreeMap::new();
+    for (_, paths) in change_paths {
+        for p in paths {
+            let key = layer_key(p, file_module);
+            layer_files
+                .entry(key.clone())
+                .or_default()
+                .insert(p.clone());
+            path_layer.insert(p.clone(), key);
+        }
+    }
+    if layer_files.is_empty() {
+        return Vec::new();
+    }
+
+    // 2. Order: project file → file dependencies onto layers. `a imports b`
+    //    means b is more foundational, so the reading-order edge is b → a.
+    //    Only edges where BOTH ends are modified files count — the walkthrough
+    //    orders the change-set, not the whole codebase.
+    let mut reads_after: BTreeMap<String, BTreeSet<String>> = BTreeMap::new(); // layer → layers it builds on
+    for (from, to) in file_deps {
+        let (Some(from_layer), Some(to_layer)) = (path_layer.get(from), path_layer.get(to)) else {
+            continue;
+        };
+        if from_layer != to_layer {
+            reads_after
+                .entry(from_layer.clone())
+                .or_default()
+                .insert(to_layer.clone());
+        }
+    }
+
+    // Kahn's algorithm over the layer set, always taking the lexicographically
+    // smallest ready layer. A dependency cycle leaves layers with unresolved
+    // in-edges; they are appended in lexicographic order (deterministic, and
+    // their `depends_on` still names the relationship for the reader).
+    let mut remaining: BTreeSet<String> = layer_files.keys().cloned().collect();
+    let mut ordered: Vec<String> = Vec::new();
+    while !remaining.is_empty() {
+        let next = remaining
+            .iter()
+            .find(|l| {
+                reads_after
+                    .get(*l)
+                    .map(|deps| deps.iter().all(|d| !remaining.contains(d)))
+                    .unwrap_or(true)
+            })
+            .or_else(|| remaining.iter().next()) // cycle: break it lexicographically
+            .cloned()
+            .expect("remaining is non-empty");
+        remaining.remove(&next);
+        ordered.push(next);
+    }
+
+    // 3. Attach facts and narrate each layer.
+    ordered
+        .into_iter()
+        .map(|key| {
+            let files_set = &layer_files[&key];
+            let files: Vec<String> = files_set.iter().map(|p| format!("file:{p}")).collect();
+
+            // Candidate changes that modify a file in this layer (candidate order).
+            let changes: Vec<String> = change_paths
+                .iter()
+                .filter(|(_, paths)| paths.iter().any(|p| files_set.contains(p)))
+                .map(|(h, _)| h.clone())
+                .collect();
+
+            // Tasks whose touches land here (collection order = intent order),
+            // and the criteria they satisfy (sorted, deduped).
+            let mut tasks: Vec<String> = Vec::new();
+            let mut criteria: BTreeSet<String> = BTreeSet::new();
+            let mut headlines: Vec<String> = Vec::new();
+            for tf in task_facts {
+                if tf.touches.iter().any(|p| files_set.contains(p)) {
+                    tasks.push(tf.id.clone());
+                    criteria.extend(tf.satisfies.iter().cloned());
+                    let h = task_headline(&tf.text);
+                    if !h.is_empty() {
+                        headlines.push(h.to_string());
+                    }
+                }
+            }
+
+            let depends_on: Vec<String> = reads_after
+                .get(&key)
+                .map(|deps| deps.iter().map(|d| format!("layer:{d}")).collect())
+                .unwrap_or_default();
+
+            // Deterministic template prose — facts only, no generation.
+            let mut rationale = format!(
+                "{} file(s) in {} modified by {} change(s).",
+                files.len(),
+                key,
+                changes.len()
+            );
+            if !depends_on.is_empty() {
+                rationale.push_str(&format!(
+                    " Builds on {} — read those first.",
+                    depends_on
+                        .iter()
+                        .map(|d| d.strip_prefix("layer:").unwrap_or(d))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+            if headlines.is_empty() {
+                rationale.push_str(" No intent task touches this layer's files.");
+            } else {
+                rationale.push_str(&format!(" Motivated by: {}.", headlines.join("; ")));
+            }
+
+            WalkthroughLayer {
+                id: format!("layer:{key}"),
+                title: key,
+                rationale,
+                files,
+                tasks,
+                criteria: criteria.into_iter().collect(),
+                changes,
+                depends_on,
+            }
+        })
+        .collect()
 }
 
 fn coverage_label(cov: &atomic_repository::Coverage) -> &'static str {
@@ -1481,6 +1710,15 @@ Edit bar.
             "expected an added line with 'feature edit': {:?}",
             dfv.hunks
         );
+
+        // End-to-end walkthrough wiring: with no KG enrichment, the modified
+        // file clusters into its parent-directory layer, carrying the change.
+        assert_eq!(report.walkthrough.len(), 1, "one modified dir → one layer");
+        let layer = &report.walkthrough[0];
+        assert_eq!(layer.id, "layer:src");
+        assert_eq!(layer.files, vec!["file:src/foo.rs"]);
+        assert_eq!(layer.changes, vec![hash.clone()]);
+        assert!(layer.depends_on.is_empty());
     }
 
     const WORK_AUTHOR: &str = "did:atomic:alice";
@@ -1651,5 +1889,160 @@ Reviewed A independently.
         let f = unreviewed_findings(&report, &a_id);
         assert_eq!(f.len(), 1, "an in-flight review must not clear the gate");
         assert!(f[0].message.contains("self-authored or not yet done"));
+    }
+
+    // ── build_walkthrough (pure projection) ───────────────────────────────
+
+    fn tf(id: &str, text: &str, touches: &[&str], satisfies: &[&str]) -> TaskFact {
+        TaskFact {
+            id: id.to_string(),
+            text: text.to_string(),
+            touches: touches.iter().map(|s| s.to_string()).collect(),
+            satisfies: satisfies.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn cp(hash: &str, paths: &[&str]) -> (String, Vec<String>) {
+        (
+            hash.to_string(),
+            paths.iter().map(|s| s.to_string()).collect(),
+        )
+    }
+
+    /// With no KG at all (no PART_OF, no IMPORTS), files cluster by parent
+    /// directory, top-level files land in `(root)`, and layers order
+    /// lexicographically (stable fallback).
+    #[test]
+    fn walkthrough_falls_back_to_path_clustering() {
+        let changes = vec![cp(
+            "HASH1",
+            &["src/storage/tables.rs", "src/cli/main.rs", "README.md"],
+        )];
+        let layers = build_walkthrough(&changes, &BTreeMap::new(), &BTreeSet::new(), &[]);
+
+        let ids: Vec<&str> = layers.iter().map(|l| l.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["layer:(root)", "layer:src/cli", "layer:src/storage"]
+        );
+
+        let root = &layers[0];
+        assert_eq!(root.files, vec!["file:README.md"]);
+        assert_eq!(root.changes, vec!["HASH1"]);
+        assert!(root.depends_on.is_empty());
+        assert!(root.rationale.contains("No intent task touches"));
+    }
+
+    /// An IMPORTS edge between modified files orders the imported (foundation)
+    /// layer before the importing (entry-point) layer, overriding lexicographic
+    /// order, and records the relationship in `depends_on`.
+    #[test]
+    fn walkthrough_orders_foundations_first() {
+        // "app" sorts before "zcore", but app/main.rs imports zcore/lib.rs —
+        // so zcore must read first.
+        let changes = vec![cp("HASH1", &["app/main.rs", "zcore/lib.rs"])];
+        let mut deps = BTreeSet::new();
+        deps.insert(("app/main.rs".to_string(), "zcore/lib.rs".to_string()));
+
+        let layers = build_walkthrough(&changes, &BTreeMap::new(), &deps, &[]);
+        let ids: Vec<&str> = layers.iter().map(|l| l.id.as_str()).collect();
+        assert_eq!(ids, vec!["layer:zcore", "layer:app"]);
+
+        assert!(layers[0].depends_on.is_empty());
+        assert_eq!(layers[1].depends_on, vec!["layer:zcore"]);
+        assert!(layers[1].rationale.contains("Builds on zcore"));
+    }
+
+    /// A dependency edge to a file OUTSIDE the change-set must not order (the
+    /// walkthrough orders the candidate set, not the whole codebase), and a
+    /// cycle between layers still yields every layer, deterministically.
+    #[test]
+    fn walkthrough_ignores_external_deps_and_survives_cycles() {
+        let changes = vec![cp("HASH1", &["a/x.rs", "b/y.rs"])];
+        let mut deps = BTreeSet::new();
+        // External target: no ordering effect.
+        deps.insert(("a/x.rs".to_string(), "vendor/z.rs".to_string()));
+        // Cycle: a → b and b → a.
+        deps.insert(("a/x.rs".to_string(), "b/y.rs".to_string()));
+        deps.insert(("b/y.rs".to_string(), "a/x.rs".to_string()));
+
+        let layers = build_walkthrough(&changes, &BTreeMap::new(), &deps, &[]);
+        let ids: Vec<&str> = layers.iter().map(|l| l.id.as_str()).collect();
+        // Cycle broken lexicographically; both layers present.
+        assert_eq!(ids, vec!["layer:a", "layer:b"]);
+        // The cyclic relationship is still visible to the reader.
+        assert_eq!(layers[0].depends_on, vec!["layer:b"]);
+        assert_eq!(layers[1].depends_on, vec!["layer:a"]);
+    }
+
+    /// PART_OF module membership beats the path fallback, and tasks/criteria
+    /// attach to the layer their touched files land in — with the task's
+    /// headline in the rationale.
+    #[test]
+    fn walkthrough_uses_modules_and_attaches_tasks() {
+        let changes = vec![
+            cp("HASH1", &["crates/store/src/tables.rs"]),
+            cp("HASH2", &["crates/cli/src/run.rs"]),
+        ];
+        let mut modules = BTreeMap::new();
+        modules.insert(
+            "crates/store/src/tables.rs".to_string(),
+            "store".to_string(),
+        );
+        modules.insert("crates/cli/src/run.rs".to_string(), "cli".to_string());
+
+        let tasks = vec![
+            tf(
+                "urn:atomic:task:T-1",
+                "Add the VIEW_CHANGES filter\nmore detail here",
+                &["crates/store/src/tables.rs"],
+                &["T-ac-1"],
+            ),
+            tf(
+                "urn:atomic:task:T-2",
+                "Wire the CLI flag",
+                &["crates/cli/src/run.rs"],
+                &["T-ac-1", "T-ac-2"],
+            ),
+        ];
+
+        let layers = build_walkthrough(&changes, &modules, &BTreeSet::new(), &tasks);
+        assert_eq!(layers.len(), 2);
+
+        let store = layers.iter().find(|l| l.id == "layer:store").unwrap();
+        assert_eq!(store.tasks, vec!["urn:atomic:task:T-1"]);
+        assert_eq!(store.criteria, vec!["T-ac-1"]);
+        assert_eq!(store.changes, vec!["HASH1"]);
+        assert!(store.rationale.contains("Add the VIEW_CHANGES filter"));
+        assert!(!store.rationale.contains("more detail here"));
+
+        let cli = layers.iter().find(|l| l.id == "layer:cli").unwrap();
+        assert_eq!(cli.tasks, vec!["urn:atomic:task:T-2"]);
+        assert_eq!(cli.criteria, vec!["T-ac-1", "T-ac-2"]);
+        assert_eq!(cli.changes, vec!["HASH2"]);
+    }
+
+    /// The projection is a pure function: identical inputs → identical output,
+    /// and an empty candidate set → empty walkthrough.
+    #[test]
+    fn walkthrough_is_deterministic_and_empty_on_no_files() {
+        assert!(
+            build_walkthrough(&[], &BTreeMap::new(), &BTreeSet::new(), &[]).is_empty(),
+            "no modified files → no walkthrough"
+        );
+
+        let changes = vec![cp("HASH1", &["m/a.rs", "n/b.rs"]), cp("HASH2", &["m/c.rs"])];
+        let mut deps = BTreeSet::new();
+        deps.insert(("n/b.rs".to_string(), "m/a.rs".to_string()));
+        let tasks = vec![tf("urn:atomic:task:T-1", "do it", &["m/a.rs"], &["T-ac-1"])];
+
+        let a = build_walkthrough(&changes, &BTreeMap::new(), &deps, &tasks);
+        let b = build_walkthrough(&changes, &BTreeMap::new(), &deps, &tasks);
+        assert_eq!(a, b);
+
+        // And the reading order is foundations-first: m (imported by n) → n.
+        let ids: Vec<&str> = a.iter().map(|l| l.id.as_str()).collect();
+        assert_eq!(ids, vec!["layer:m", "layer:n"]);
+        assert_eq!(a[0].changes, vec!["HASH1", "HASH2"]);
     }
 }

--- a/docs/triage.md
+++ b/docs/triage.md
@@ -352,6 +352,8 @@ TriageReport
     id, authored_by, diff_ref, files[], blast_radius[], closure_baggage, provenance{turn,session,memories}
   findings[]     (= "failures", also mirrored inline, severity-sorted)
     code, severity, focus, message, suggested_query, remedy
+  walkthrough[]  (= the guided reading order, foundations first)
+    id, title, rationale, files[], tasks[], criteria[], changes[], depends_on[]
 ```
 
 ### Skins and scale
@@ -366,16 +368,26 @@ review yields the same three-line verdict as a 4-change one.
 | **JSON** | streamable, paginated worklist | agent pages through it | the review skill |
 | **attested export** | signed frozen bytes (opt-in) | — | portability / compliance |
 
-Drill-down: `atomic triage feature --into dev [--finding block | --intent <ref> | --change <hash> | --html]`.
+Drill-down: `atomic triage feature --into dev [--finding block | --intent <ref> | --change <hash> | --walkthrough | --html]`.
 
 Shipped: `--json` (the agent worklist), the bounded CLI dashboard (default),
-`--html` (a self-contained, dependency-free document — inline CSS/JS, no CDN,
-verdict banner, severity-filterable finding cards, collapsible per-intent
-`<details>`, and the full report embedded as a JSON island), and `--attest`
+`--walkthrough` (the guided reading order: the report's `walkthrough` section
+— candidate modifications clustered into semantic layers by module, ordered
+foundations-first by import/include direction — as bounded text, one numbered
+entry per layer with rationale, files, and inspect commands, never a diff
+dump), `--html` (a self-contained, dependency-free document — inline CSS/JS,
+no CDN, verdict banner, severity-filterable finding cards, collapsible
+per-intent `<details>`, an ordered walkthrough chapter tour — reading-order
+nav, numbered collapsible chapters with `depends_on` anchors and layer-scoped
+diffs — and the full report embedded as a JSON island), and `--attest`
 (the signed frozen export: the report Value plus an `eddsa-jcs-2022` Data
-Integrity `proof`, alongside the content-addressed `reference`). A richer
-severity-colored node-link graph view (reusing the `query graph` machinery, once
-de-CDN'd) remains a future enhancement over the current structured document.
+Integrity `proof`, alongside the content-addressed `reference`). The
+walkthrough is a pure, deterministic projection built from facts already in
+the report (KG `PART_OF` modules with a parent-directory fallback,
+`IMPORTS`/`INCLUDES` ordering, task/criterion joins) — never LLM-authored, so
+the attested export stays reproducible. A richer severity-colored node-link
+graph view (reusing the `query graph` machinery, once de-CDN'd) remains a
+future enhancement over the current structured document.
 
 ## Finding taxonomy (closed set)
 


### PR DESCRIPTION
This pull request introduces a new "guided walkthrough" feature to the triage review command, providing a structured, bounded, and reproducible reading order for code review. The walkthrough groups candidate changes into semantic layers (modules), each with rationale, files, tasks, criteria, and change commands, and is available in both CLI and HTML outputs. The implementation includes new data structures, CLI options, output rendering logic, and comprehensive tests.

**Guided Walkthrough Feature:**

- Added a `--walkthrough` flag to the `triage review` command, enabling output of a guided, layer-by-layer reading order for candidate changes, ordered from foundations to entry points. This output is bounded and never dumps raw diffs. [[1]](diffhunk://#diff-b40f8dff0fa5d2b8ac12407c38cd44586e9c347e5601289b694f29a2e70a8de2R62) [[2]](diffhunk://#diff-b40f8dff0fa5d2b8ac12407c38cd44586e9c347e5601289b694f29a2e70a8de2R220-R225) [[3]](diffhunk://#diff-b40f8dff0fa5d2b8ac12407c38cd44586e9c347e5601289b694f29a2e70a8de2L250-R258) [[4]](diffhunk://#diff-b40f8dff0fa5d2b8ac12407c38cd44586e9c347e5601289b694f29a2e70a8de2R267-R268)

- Extended the `TriageReport` model with a `walkthrough` field containing a list of `WalkthroughLayer` structs, each representing a semantic layer (module) with rationale, files, tasks, criteria, contributing changes, and dependencies. [[1]](diffhunk://#diff-51004ebbb8d9c15eccc24edf47fc6aad31f30c8000ca9e3300eef320dd15cbe4R80-R85) [[2]](diffhunk://#diff-51004ebbb8d9c15eccc24edf47fc6aad31f30c8000ca9e3300eef320dd15cbe4R202-R232)

**CLI and Output Enhancements:**

- Implemented CLI output logic for the walkthrough, including a new `print_walkthrough` function and a bounded, readable text format that never exposes raw diff hunks. The CLI dashboard now also hints at the walkthrough when available.

- Added HTML rendering for the walkthrough, including a reading-order navigation, collapsible chapters per layer, rationale, tasks, criteria, dependency anchors, and layer-scoped diffs. Styling for the walkthrough is included in the HTML CSS. [[1]](diffhunk://#diff-35155e055620594e954cd4ee4183412ada4575b9179d1b6ac54b52f9f982fa2cR372-R377) [[2]](diffhunk://#diff-35155e055620594e954cd4ee4183412ada4575b9179d1b6ac54b52f9f982fa2cR568-R587) [[3]](diffhunk://#diff-35155e055620594e954cd4ee4183412ada4575b9179d1b6ac54b52f9f982fa2cR614-R722) [[4]](diffhunk://#diff-35155e055620594e954cd4ee4183412ada4575b9179d1b6ac54b52f9f982fa2cL785-R1135)

**Testing and Robustness:**

- Added comprehensive tests to ensure the walkthrough is ordered, bounded, and rendered correctly in both text and HTML formats, including checks for rationale, file lists, inspect commands, and HTML escaping.