### PR TITLE
patch theory in action

### DIFF
--- a/atomic-cli/src/commands/view/list.rs
+++ b/atomic-cli/src/commands/view/list.rs
@@ -273,7 +273,7 @@ impl Command for List {
                         // show total for root views.
                         let change_display = if info.parent_name.is_some() {
                             let own = info.own_change_count;
-                            let inherited = info.change_count.saturating_sub(info.own_change_count);
+                            let inherited = info.inherited_change_count;
                             if own == 1 {
                                 format!("({} change, {} inherited)", own, inherited)
                             } else {

--- a/atomic-cli/src/commands/view/mod.rs
+++ b/atomic-cli/src/commands/view/mod.rs
@@ -90,6 +90,7 @@ pub mod delete;
 pub mod list;
 pub mod new;
 pub mod promote;
+pub mod split;
 pub mod switch;
 
 use clap::Subcommand;
@@ -98,6 +99,7 @@ pub use delete::Delete;
 pub use list::List;
 pub use new::New;
 pub use promote::Promote;
+pub use split::Split;
 pub use switch::Switch;
 
 use crate::commands::Command;
@@ -139,6 +141,25 @@ pub enum ViewCommands {
     /// ```
     #[command(name = "create")]
     Create(New),
+
+    /// Split changes out of a view into a new draft view.
+    ///
+    /// Creates a new draft that forks from the source view, then removes the
+    /// chosen changes from the source. This is a pure metadata operation — no
+    /// changes are rewritten. Splitting from the middle is refused when a
+    /// change staying behind depends on one being removed, unless `--cascade`
+    /// is given.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// # Split two specific changes out of the current view
+    /// atomic view split wip ABCDEF12 34567890
+    ///
+    /// # Split the last 3 changes out of dev, previewing first
+    /// atomic view split wip --from dev --last 3 --dry-run
+    /// ```
+    Split(Split),
 
     /// Switch to a different view.
     ///
@@ -197,6 +218,7 @@ impl Command for View {
     fn run(&self) -> CliResult<()> {
         match &self.command {
             ViewCommands::Create(cmd) => cmd.run(),
+            ViewCommands::Split(cmd) => cmd.run(),
             ViewCommands::Switch(cmd) => cmd.run(),
             ViewCommands::Delete(cmd) => cmd.run(),
             ViewCommands::List(cmd) => cmd.run(),
@@ -217,6 +239,7 @@ mod tests {
         fn check_variant(cmd: &ViewCommands) -> &'static str {
             match cmd {
                 ViewCommands::Create(_) => "create",
+                ViewCommands::Split(_) => "split",
                 ViewCommands::Switch(_) => "switch",
                 ViewCommands::Delete(_) => "delete",
                 ViewCommands::List(_) => "list",

--- a/atomic-cli/src/commands/view/split.rs
+++ b/atomic-cli/src/commands/view/split.rs
@@ -1,0 +1,315 @@
+//! The `view split` command for extracting changes into a new draft view.
+//!
+//! A split creates a new **Draft** view that forks from a source view and then
+//! removes a chosen set of changes from that source. Because every change lives
+//! in the single canonical graph and a view is only a change-set *filter*, this
+//! is a pure metadata operation — no edges are copied and no new changes are
+//! created.
+//!
+//! After a split of `[3,4]` out of `dev = [1,2,3,4,5,6,7]`:
+//!
+//! - `dev` becomes `[1,2,5,6,7]`.
+//! - the new draft holds `{3,4}` in its own log and inherits the rest from
+//!   `dev`, so it sees the full pre-split state `[1..7]` — the snapshot you
+//!   keep iterating on.
+//!
+//! # Safety
+//!
+//! Splitting from the middle is refused when a change staying behind depends on
+//! one being removed (which would leave `dev` incoherent). Use `--cascade` to
+//! move those dependents along too, or `--dry-run` to preview the analysis.
+//!
+//! # Usage
+//!
+//! ```text
+//! atomic view split [OPTIONS] <NAME> [CHANGES]...
+//!
+//! Arguments:
+//!   <NAME>         Name of the new draft view
+//!   [CHANGES]...   Change hashes/prefixes to split out (or use --last)
+//!
+//! Options:
+//!       --from <VIEW>   Source view to split out of (default: current view)
+//!       --last <N>      Split the last N changes of the source view
+//!       --cascade       Also move changes that depend on the split-out set
+//!   -n, --dry-run       Preview the split without performing it
+//!   -s, --switch        Switch to the new draft after creating it
+//! ```
+
+use clap::Parser;
+use clap_complete::engine::ArgValueCompleter;
+
+use atomic_core::types::Base32;
+use atomic_repository::{Repository, SplitOptions};
+
+use crate::commands::complete::complete_view_names;
+use crate::commands::{find_repository_root, Command};
+use crate::error::{CliError, CliResult};
+use crate::output::view as style_view;
+use crate::output::{hash as style_hash, print_hint, print_info, print_success, print_warning};
+
+/// Split changes out of a view into a new draft view.
+#[derive(Parser, Debug, Default)]
+#[command(name = "split")]
+pub struct Split {
+    /// Name of the new draft view to create.
+    #[arg(value_name = "NAME")]
+    pub name: String,
+
+    /// Change hashes (or unambiguous prefixes) to split out.
+    ///
+    /// Mutually exclusive with `--last`.
+    #[arg(value_name = "CHANGES")]
+    pub changes: Vec<String>,
+
+    /// Source view to split out of. Defaults to the current view.
+    #[arg(long = "from", value_name = "VIEW", add = ArgValueCompleter::new(complete_view_names))]
+    pub from: Option<String>,
+
+    /// Split the last N changes of the source view instead of naming them.
+    #[arg(long = "last", value_name = "N", conflicts_with = "changes")]
+    pub last: Option<usize>,
+
+    /// Also move any changes that depend on the split-out set, rather than
+    /// refusing the split.
+    #[arg(long = "cascade")]
+    pub cascade: bool,
+
+    /// Preview what would be split without performing it.
+    #[arg(short = 'n', long = "dry-run")]
+    pub dry_run: bool,
+
+    /// Switch to the new draft view after creating it.
+    #[arg(short = 's', long = "switch")]
+    pub switch: bool,
+}
+
+impl Command for Split {
+    fn run(&self) -> CliResult<()> {
+        let repo_root = find_repository_root()?;
+        let mut repo = Repository::open(&repo_root).map_err(|e| match e {
+            atomic_repository::RepositoryError::NotFound { path } => CliError::RepositoryNotFound {
+                searched_path: path.into(),
+            },
+            other => CliError::Repository(other),
+        })?;
+
+        let from_view = self
+            .from
+            .clone()
+            .unwrap_or_else(|| repo.current_view().to_string());
+
+        // Resolve which changes to split: either an explicit list or --last N.
+        let change_hashes = self.resolve_changes(&repo, &from_view)?;
+
+        let options = SplitOptions {
+            target_view: self.name.clone(),
+            from_view: Some(from_view.clone()),
+            changes: change_hashes,
+            cascade: self.cascade,
+            dry_run: self.dry_run,
+            // When switching, the draft is materialized by the switch below, so
+            // there's no need to reconcile the source we're leaving. Otherwise,
+            // refresh the source's working copy in place.
+            materialize: !self.switch,
+        };
+
+        let outcome = repo.split_view(options).map_err(CliError::Repository)?;
+
+        // ── Dry run: report the analysis. ──
+        if outcome.was_dry_run {
+            print_info(&format!(
+                "Dry run: splitting {} change(s) out of {}",
+                outcome.requested.len(),
+                style_view(&outcome.from_view),
+            ));
+            for c in &outcome.requested {
+                println!("  requested  {}", style_hash(c.hash.to_base32()));
+            }
+            if outcome.blocked {
+                print_warning(&format!(
+                    "Blocked: {} change(s) remaining in '{}' depend on the split-out set:",
+                    outcome.dependents.len(),
+                    outcome.from_view,
+                ));
+                for c in &outcome.dependents {
+                    println!("  dependent  {}", style_hash(c.hash.to_base32()));
+                }
+                print_hint("Re-run with --cascade to move the dependents too.");
+            } else {
+                if !outcome.dependents.is_empty() {
+                    print_info(&format!(
+                        "{} dependent change(s) would be moved along (--cascade):",
+                        outcome.dependents.len(),
+                    ));
+                    for c in &outcome.dependents {
+                        println!("  dependent  {}", style_hash(c.hash.to_base32()));
+                    }
+                }
+                print_info(&format!(
+                    "Would create draft '{}' with {} change(s); '{}' would keep {} change(s).",
+                    self.name,
+                    outcome.moved.len(),
+                    outcome.from_view,
+                    outcome.source_change_count,
+                ));
+            }
+            return Ok(());
+        }
+
+        // ── Real split completed. ──
+        print_success(&format!(
+            "Split {} change(s) out of {} into draft {}",
+            outcome.moved.len(),
+            style_view(&outcome.from_view),
+            style_view(&self.name),
+        ));
+        if outcome.dependents.is_empty() {
+            for c in &outcome.moved {
+                println!("  moved  {}", style_hash(c.hash.to_base32()));
+            }
+        } else {
+            for c in &outcome.requested {
+                println!("  moved      {}", style_hash(c.hash.to_base32()));
+            }
+            for c in &outcome.dependents {
+                println!("  cascaded   {}", style_hash(c.hash.to_base32()));
+            }
+        }
+        print_info(&format!(
+            "'{}' now has {} change(s); draft '{}' has {} own change(s).",
+            outcome.from_view, outcome.source_change_count, self.name, outcome.target_change_count,
+        ));
+
+        if outcome.working_copy_updated && (outcome.files_written > 0 || outcome.files_removed > 0)
+        {
+            print_info(&format!(
+                "Working copy updated: {} file(s) refreshed, {} removed.",
+                outcome.files_written, outcome.files_removed,
+            ));
+        }
+
+        self.maybe_switch(&mut repo)
+    }
+}
+
+impl Split {
+    /// Resolve the set of change hashes to split, from either the explicit
+    /// positional list or `--last N`.
+    fn resolve_changes(
+        &self,
+        repo: &Repository,
+        from_view: &str,
+    ) -> CliResult<Vec<atomic_core::types::Hash>> {
+        use atomic_core::types::Hash;
+
+        if let Some(n) = self.last {
+            if n == 0 {
+                return Err(CliError::InvalidArgument {
+                    message: "--last must be greater than zero".to_string(),
+                });
+            }
+            let all = repo
+                .view_own_change_hashes(from_view)
+                .map_err(CliError::Repository)?;
+            if all.len() < n {
+                return Err(CliError::InvalidArgument {
+                    message: format!(
+                        "view '{}' has only {} change(s); cannot split the last {}",
+                        from_view,
+                        all.len(),
+                        n
+                    ),
+                });
+            }
+            return Ok(all[all.len() - n..].to_vec());
+        }
+
+        if self.changes.is_empty() {
+            return Err(CliError::InvalidArgument {
+                message: "specify one or more changes to split, or use --last <N>".to_string(),
+            });
+        }
+
+        let mut hashes = Vec::with_capacity(self.changes.len());
+        for spec in &self.changes {
+            let hash = if let Some(h) = Hash::from_base32(spec.as_bytes()) {
+                h
+            } else {
+                repo.find_change_by_prefix(spec)
+                    .map_err(CliError::Repository)?
+                    .ok_or_else(|| CliError::ChangeNotFound { hash: spec.clone() })?
+            };
+            hashes.push(hash);
+        }
+        Ok(hashes)
+    }
+
+    /// Optionally switch to the new draft view.
+    fn maybe_switch(&self, repo: &mut Repository) -> CliResult<()> {
+        if self.switch {
+            let result = repo.switch_view(&self.name).map_err(CliError::Repository)?;
+            print_success(&format!(
+                "Switched to view: {} ({} files updated)",
+                style_view(&self.name),
+                result.files_written,
+            ));
+        } else {
+            print_hint(&format!(
+                "Use 'atomic view switch {}' to switch to the new draft",
+                self.name
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn parses_name_and_changes() {
+        let cmd = Split::try_parse_from(["split", "wip", "ABCD", "EF12"]).unwrap();
+        assert_eq!(cmd.name, "wip");
+        assert_eq!(cmd.changes, vec!["ABCD".to_string(), "EF12".to_string()]);
+        assert!(cmd.last.is_none());
+        assert!(!cmd.cascade);
+        assert!(!cmd.dry_run);
+        assert!(!cmd.switch);
+    }
+
+    #[test]
+    fn parses_flags() {
+        let cmd = Split::try_parse_from([
+            "split",
+            "wip",
+            "--from",
+            "dev",
+            "--last",
+            "3",
+            "--cascade",
+            "--dry-run",
+            "--switch",
+        ])
+        .unwrap();
+        assert_eq!(cmd.name, "wip");
+        assert_eq!(cmd.from.as_deref(), Some("dev"));
+        assert_eq!(cmd.last, Some(3));
+        assert!(cmd.cascade);
+        assert!(cmd.dry_run);
+        assert!(cmd.switch);
+    }
+
+    #[test]
+    fn last_conflicts_with_explicit_changes() {
+        let err = Split::try_parse_from(["split", "wip", "ABCD", "--last", "2"]);
+        assert!(err.is_err(), "--last and explicit changes must conflict");
+    }
+
+    #[test]
+    fn name_is_required() {
+        assert!(Split::try_parse_from(["split"]).is_err());
+    }
+}

--- a/atomic-repository/src/error.rs
+++ b/atomic-repository/src/error.rs
@@ -39,6 +39,22 @@ pub enum RepositoryError {
     #[error("Cannot delete the current view '{name}'")]
     CannotDeleteCurrentView { name: String },
 
+    /// A change requested for a split is not present in the source view's
+    /// own change log (it may be inherited from a parent view).
+    #[error("Change {hash} is not in view '{view}'")]
+    ChangeNotInView { hash: String, view: String },
+
+    /// Splitting the requested changes would leave changes behind in the
+    /// source view that still depend on them. Re-run with cascade to move
+    /// the dependents too.
+    #[error(
+        "cannot split: {} change(s) remaining in '{view}' still depend on the changes being split \
+         (use --cascade to move them too): {}",
+        blocking.len(),
+        blocking.join(", ")
+    )]
+    ViewSplitHasDependents { view: String, blocking: Vec<String> },
+
     /// Working copy has uncommitted changes
     #[error("Working copy has uncommitted changes")]
     UncommittedChanges,
@@ -230,6 +246,8 @@ impl RepositoryError {
                 | RepositoryError::TagAlreadyExists { .. }
                 | RepositoryError::InvalidTagName { .. }
                 | RepositoryError::ViewAlreadyExists { .. }
+                | RepositoryError::ChangeNotInView { .. }
+                | RepositoryError::ViewSplitHasDependents { .. }
         )
     }
 

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -80,6 +80,7 @@ mod filter;
 mod materialize;
 mod sandbox;
 mod semantic_materialize;
+mod split;
 mod switch;
 mod views;
 
@@ -90,6 +91,7 @@ pub use filter::{
     expand_indexed_dependency_closure,
 };
 pub use sandbox::{SealOptions, SealResult, StageOptions, StageResult, SANDBOX_POINTER};
+pub use split::{SplitChange, SplitOptions, SplitOutcome};
 pub use views::{ManifestApplyOutcome, ViewInfo};
 
 // Re-import workspace helpers from `switch` so they are available to

--- a/atomic-repository/src/repository/split.rs
+++ b/atomic-repository/src/repository/split.rs
@@ -1,0 +1,503 @@
+//! Splitting changes out of a view into a new draft view.
+//!
+//! A **split** creates a new Draft view that forks from a source view and then
+//! removes a chosen set of changes from the source. Because every change lives
+//! in the single canonical `GRAPH` and a view is only a change-set *filter*,
+//! this is a pure metadata operation — no edges are copied and no new changes
+//! are created.
+//!
+//! # Semantics
+//!
+//! Given a source view `S = [1,2,3,4,5,6,7]` and a request to split out
+//! `{3,4}`, the result is:
+//!
+//! - `S` becomes `[1,2,5,6,7]` (the requested changes removed).
+//! - The new draft `D` is parented on `S` and holds `{3,4}` in its **own**
+//!   change log, so `D` sees `own{3,4} ∪ inherit(S)= [1..7]` — the full
+//!   pre-split state. `D` is the "escape pod" you keep iterating on while `S`
+//!   moves forward without the split-out work.
+//!
+//! # The dependency safety check
+//!
+//! Removing changes from the *middle* of a view is only coherent when nothing
+//! that stays behind depends on what leaves. We compute the **reverse-
+//! dependency closure** of the requested set within `S` using the indexed
+//! `REV_CHANGE_DEPS` table:
+//!
+//! - If the closure equals the requested set, the split is clean.
+//! - If the closure is larger, some remaining change depends on a requested
+//!   one. We refuse with [`RepositoryError::ViewSplitHasDependents`] unless
+//!   `cascade` is set, in which case the dependents are moved too.
+//!
+//! This guarantees `S` is always left in a coherent state: no change remaining
+//! in `S` references a change that was removed.
+
+use std::collections::{HashSet, VecDeque};
+
+use super::*;
+
+use atomic_core::pristine::{PristineError, ViewState};
+
+/// Remove now-empty parent directories of a just-deleted path, deepest-first.
+///
+/// `std::fs::remove_dir` only succeeds on empty directories, so this is safe:
+/// a directory that still holds files is left untouched.
+fn remove_empty_ancestors(root: &std::path::Path, removed_rel_path: &str) {
+    let mut ancestor = std::path::Path::new(removed_rel_path).parent();
+    while let Some(dir) = ancestor {
+        if dir.as_os_str().is_empty() || dir == std::path::Path::new(".") {
+            break;
+        }
+        let abs = root.join(dir);
+        if abs.is_dir() {
+            // Fails harmlessly if the directory is not empty.
+            if std::fs::remove_dir(&abs).is_err() {
+                break;
+            }
+        }
+        ancestor = dir.parent();
+    }
+}
+
+/// Options controlling a view split.
+#[derive(Debug, Clone)]
+pub struct SplitOptions {
+    /// Name of the new Draft view to create.
+    pub target_view: String,
+    /// Source view to split changes out of. `None` uses the current view.
+    pub from_view: Option<String>,
+    /// Changes to remove from the source and retain in the new draft.
+    pub changes: Vec<Hash>,
+    /// Also move any changes that depend on the requested set (their reverse-
+    /// dependency closure) instead of refusing the split.
+    pub cascade: bool,
+    /// Analyze only — report what would happen without mutating anything.
+    pub dry_run: bool,
+    /// Reconcile the working copy after the split.
+    ///
+    /// Only has an effect when splitting out of the **current** view: the
+    /// files touched by the removed changes are refreshed on disk — reverted
+    /// to the source's new state, or deleted if no longer present. When false
+    /// (the default), the working copy is left as-is and only the stale
+    /// `FILE_INDEX` entries are dropped so the next `status` recomputes.
+    pub materialize: bool,
+}
+
+impl SplitOptions {
+    /// Create options to split `changes` out of the current view into
+    /// `target_view`.
+    pub fn new(target_view: impl Into<String>, changes: Vec<Hash>) -> Self {
+        Self {
+            target_view: target_view.into(),
+            from_view: None,
+            changes,
+            cascade: false,
+            dry_run: false,
+            materialize: false,
+        }
+    }
+}
+
+/// A single change involved in a split, paired with its sequence in the source.
+#[derive(Debug, Clone)]
+pub struct SplitChange {
+    /// The change hash.
+    pub hash: Hash,
+    /// Its sequence number in the source view (pre-split).
+    pub sequence: u64,
+}
+
+/// The result of a split (or a dry-run preview of one).
+#[derive(Debug, Clone)]
+pub struct SplitOutcome {
+    /// Name of the new draft view.
+    pub target_view: String,
+    /// Name of the source view.
+    pub from_view: String,
+    /// Whether this was a dry run (no mutation performed).
+    pub was_dry_run: bool,
+    /// Whether the split was blocked by dependents (only possible when
+    /// `cascade` is false). When blocked, no mutation is performed.
+    pub blocked: bool,
+    /// The changes explicitly requested, in source-sequence order.
+    pub requested: Vec<SplitChange>,
+    /// Additional dependent changes in the reverse-dependency closure, in
+    /// source-sequence order. When `blocked`, these are the changes that
+    /// prevented the split; when moved (cascade), these came along.
+    pub dependents: Vec<SplitChange>,
+    /// The full set of changes moved into the draft (requested + dependents),
+    /// in source-sequence order. Empty when `blocked` or on a blocked dry run.
+    pub moved: Vec<SplitChange>,
+    /// Source view's own change count after the split (unchanged on dry run).
+    pub source_change_count: u64,
+    /// New draft's own change count after the split (0 on a blocked/dry run).
+    pub target_change_count: u64,
+    /// Whether the working copy was reconciled (only when `materialize` was
+    /// requested and the split was out of the current view).
+    pub working_copy_updated: bool,
+    /// Number of affected files rewritten in the working copy.
+    pub files_written: usize,
+    /// Number of affected files removed from the working copy.
+    pub files_removed: usize,
+}
+
+/// Analysis of a requested split against a source view.
+struct SplitAnalysis {
+    /// Requested changes, ordered by source sequence ascending.
+    requested: Vec<SplitChange>,
+    /// Reverse-dependency dependents (closure minus requested), ordered.
+    dependents: Vec<SplitChange>,
+    /// Full closure (requested + dependents), ordered ascending — the move set.
+    closure: Vec<SplitChange>,
+}
+
+/// Compute the reverse-dependency closure of `requested` within `source`.
+///
+/// Bounds are `T: ViewTxnT` (which requires `GraphTxnT`), so this works on both
+/// read and write transactions and can be reused for dry-run previews.
+fn analyze_split<T: ViewTxnT>(
+    txn: &T,
+    source: &ViewState,
+    requested: &[Hash],
+) -> Result<SplitAnalysis, RepositoryError> {
+    let db = |e: PristineError| RepositoryError::Database(e.to_string());
+
+    // Resolve each requested hash to an internal id and confirm it is in the
+    // source view's OWN change log.
+    let mut requested_ids: HashSet<NodeId> = HashSet::new();
+    let mut queue: VecDeque<(Hash, NodeId)> = VecDeque::new();
+    for hash in requested {
+        let id =
+            txn.get_internal(hash)
+                .map_err(db)?
+                .ok_or_else(|| RepositoryError::ChangeNotFound {
+                    hash: hash.to_base32(),
+                })?;
+        if txn.get_change_seq(source, id).map_err(db)?.is_none() {
+            return Err(RepositoryError::ChangeNotInView {
+                hash: hash.to_base32(),
+                view: source.name.clone(),
+            });
+        }
+        if requested_ids.insert(id) {
+            queue.push_back((*hash, id));
+        }
+    }
+
+    // BFS over reverse dependencies, staying inside the source view.
+    let mut closure_ids: HashSet<NodeId> = requested_ids.clone();
+    while let Some((hash, _id)) = queue.pop_front() {
+        let dependents = txn.get_rev_change_deps(&hash).map_err(db)?;
+        for dep_id in dependents {
+            // Only dependents that actually live in the source view matter;
+            // dependents in other views don't affect this view's coherence.
+            if txn.get_change_seq(source, dep_id).map_err(db)?.is_none() {
+                continue;
+            }
+            if closure_ids.insert(dep_id) {
+                let dep_hash = txn.get_external(dep_id).map_err(db)?.ok_or_else(|| {
+                    RepositoryError::ChangeNotFound {
+                        hash: format!("id={}", dep_id.0),
+                    }
+                })?;
+                queue.push_back((dep_hash, dep_id));
+            }
+        }
+    }
+
+    // Build ordered lists keyed by source sequence.
+    let ordered = |ids: &HashSet<NodeId>| -> Result<Vec<SplitChange>, RepositoryError> {
+        let mut v = Vec::with_capacity(ids.len());
+        for &id in ids {
+            let seq = txn
+                .get_change_seq(source, id)
+                .map_err(db)?
+                .expect("closure member is in source view");
+            let hash = txn.get_external(id).map_err(db)?.ok_or_else(|| {
+                RepositoryError::ChangeNotFound {
+                    hash: format!("id={}", id.0),
+                }
+            })?;
+            v.push(SplitChange {
+                hash,
+                sequence: seq,
+            });
+        }
+        v.sort_by_key(|c| c.sequence);
+        Ok(v)
+    };
+
+    let requested_ordered = ordered(&requested_ids)?;
+    let closure_ordered = ordered(&closure_ids)?;
+    let requested_hashes: HashSet<Hash> = requested_ordered.iter().map(|c| c.hash).collect();
+    let dependents: Vec<SplitChange> = closure_ordered
+        .iter()
+        .filter(|c| !requested_hashes.contains(&c.hash))
+        .cloned()
+        .collect();
+
+    Ok(SplitAnalysis {
+        requested: requested_ordered,
+        dependents,
+        closure: closure_ordered,
+    })
+}
+
+impl Repository {
+    /// Split a set of changes out of a view into a new Draft view.
+    ///
+    /// See the [module documentation](self) for the full semantics and the
+    /// dependency safety guarantee.
+    ///
+    /// # Errors
+    ///
+    /// - [`RepositoryError::ViewAlreadyExists`] if `target_view` exists.
+    /// - [`RepositoryError::ViewNotFound`] if the source view doesn't exist.
+    /// - [`RepositoryError::ChangeNotFound`] / [`RepositoryError::ChangeNotInView`]
+    ///   if a requested change is unknown or not in the source view's own log.
+    /// - [`RepositoryError::ViewSplitHasDependents`] if changes remaining in the
+    ///   source depend on the split-out set and `cascade` is not set.
+    pub fn split_view(&mut self, options: SplitOptions) -> Result<SplitOutcome, RepositoryError> {
+        let db = |e: PristineError| RepositoryError::Database(e.to_string());
+
+        let from_view_name = options
+            .from_view
+            .clone()
+            .unwrap_or_else(|| self.current_view.clone());
+
+        if options.changes.is_empty() {
+            return Err(RepositoryError::InvalidOperation {
+                message: "no changes specified to split".to_string(),
+            });
+        }
+
+        // ── Dry run: analyze against a read transaction, mutate nothing. ──
+        if options.dry_run {
+            let txn = self.pristine.read_txn().map_err(db)?;
+            let source = txn.get_view(&from_view_name).map_err(db)?.ok_or_else(|| {
+                RepositoryError::ViewNotFound {
+                    name: from_view_name.clone(),
+                }
+            })?;
+
+            if txn.get_view(&options.target_view).map_err(db)?.is_some() {
+                return Err(RepositoryError::ViewAlreadyExists {
+                    name: options.target_view.clone(),
+                });
+            }
+
+            let analysis = analyze_split(&txn, &source, &options.changes)?;
+            let blocked = !analysis.dependents.is_empty() && !options.cascade;
+            let moved = if blocked {
+                Vec::new()
+            } else {
+                analysis.closure.clone()
+            };
+            let target_change_count = moved.len() as u64;
+            let source_change_count = source.change_count.saturating_sub(moved.len() as u64);
+
+            return Ok(SplitOutcome {
+                target_view: options.target_view,
+                from_view: from_view_name,
+                was_dry_run: true,
+                blocked,
+                requested: analysis.requested,
+                dependents: analysis.dependents,
+                moved,
+                source_change_count,
+                target_change_count,
+                working_copy_updated: false,
+                files_written: 0,
+                files_removed: 0,
+            });
+        }
+
+        // ── Real split: analysis + mutation in one write transaction. ──
+        let mut txn = self.pristine.write_txn().map_err(db)?;
+
+        if txn.get_view(&options.target_view).map_err(db)?.is_some() {
+            return Err(RepositoryError::ViewAlreadyExists {
+                name: options.target_view.clone(),
+            });
+        }
+
+        let mut source = txn.get_view(&from_view_name).map_err(db)?.ok_or_else(|| {
+            RepositoryError::ViewNotFound {
+                name: from_view_name.clone(),
+            }
+        })?;
+        let source_id = source.id;
+
+        let analysis = analyze_split(&txn, &source, &options.changes)?;
+
+        // Enforce the dependency safety check *before* creating anything.
+        if !analysis.dependents.is_empty() && !options.cascade {
+            return Err(RepositoryError::ViewSplitHasDependents {
+                view: from_view_name,
+                blocking: analysis
+                    .dependents
+                    .iter()
+                    .map(|c| c.hash.to_base32())
+                    .collect(),
+            });
+        }
+
+        // The move set is the full reverse-dependency closure.
+        let move_set = &analysis.closure;
+
+        // Create the workspace dir (filesystem, idempotent) so the draft has a
+        // materialization target.
+        ensure_workspace_dir(&self.dot_dir, &options.target_view)?;
+
+        // Create the draft parented on the source view. It inherits the
+        // source's content through the parent chain; we give it its own
+        // references to the moved changes below.
+        let mut draft = txn
+            .create_view(&options.target_view, ViewScope::Draft, Some(source_id))
+            .map_err(db)?;
+
+        // Add moved changes to the draft's own log in dependency (ascending
+        // sequence) order.
+        for change in move_set.iter() {
+            let id = txn.get_internal(&change.hash).map_err(db)?.ok_or_else(|| {
+                RepositoryError::ChangeNotFound {
+                    hash: change.hash.to_base32(),
+                }
+            })?;
+            txn.put_change(&mut draft, id, &change.hash).map_err(db)?;
+        }
+
+        // Remove moved changes from the source view. `del_change` looks each
+        // change up by id (not by cached sequence) and recomputes the source's
+        // Merkle chain, so removal order doesn't affect correctness; we go
+        // descending to minimize sequence-shifting churn.
+        for change in move_set.iter().rev() {
+            let id = txn.get_internal(&change.hash).map_err(db)?.ok_or_else(|| {
+                RepositoryError::ChangeNotFound {
+                    hash: change.hash.to_base32(),
+                }
+            })?;
+            txn.del_change(&mut source, id, &change.hash).map_err(db)?;
+        }
+
+        txn.update_view(&draft).map_err(db)?;
+        txn.update_view(&source).map_err(db)?;
+
+        let source_change_count = source.change_count;
+        let target_change_count = draft.change_count;
+
+        txn.commit().map_err(db)?;
+
+        // Working-copy handling only concerns the current view (the only one
+        // materialized on disk). Splitting out of another view leaves the
+        // working copy untouched.
+        let mut working_copy_updated = false;
+        let mut files_written = 0usize;
+        let mut files_removed = 0usize;
+
+        if from_view_name == self.current_view {
+            // Collect the paths touched by the removed changes.
+            let mut affected: Vec<String> = Vec::new();
+            for change in move_set.iter() {
+                if let Ok(loaded) = self.load_change(&change.hash) {
+                    for op in loaded.hunks() {
+                        if let Some(p) = op.path() {
+                            let p = p.to_string();
+                            if !affected.contains(&p) {
+                                affected.push(p);
+                            }
+                        }
+                    }
+                }
+            }
+
+            if options.materialize {
+                // Reconcile the working copy to the source's new state. A
+                // removed change may *delete* a file (no remaining change keeps
+                // it alive) or *revert* its content (an earlier change still
+                // owns it), so we split affected paths by post-split
+                // visibility and handle each accordingly.
+                let post_visible = self.visible_file_paths(&self.current_view)?;
+                let mut to_remove: Vec<String> = Vec::new();
+                let mut to_write: std::collections::HashSet<String> =
+                    std::collections::HashSet::new();
+                for p in &affected {
+                    if post_visible.contains(p) {
+                        to_write.insert(p.clone());
+                    } else {
+                        to_remove.push(p.clone());
+                    }
+                }
+
+                for p in &to_remove {
+                    let abs = self.root.join(p);
+                    if abs.is_file() {
+                        let _ = std::fs::remove_file(&abs);
+                        remove_empty_ancestors(&self.root, p);
+                    }
+                }
+                if !to_remove.is_empty() {
+                    let refs: Vec<&str> = to_remove.iter().map(|s| s.as_str()).collect();
+                    let _ = self.del_file_index_batch(&refs);
+                    files_removed = to_remove.len();
+                }
+
+                if !to_write.is_empty() {
+                    let n = to_write.len();
+                    self.materialize_paths(to_write)?;
+                    files_written = n;
+                }
+
+                working_copy_updated = true;
+            } else if !affected.is_empty() {
+                // Conservative default: don't touch the working copy; just drop
+                // the stale FILE_INDEX entries so `status` recomputes.
+                let refs: Vec<&str> = affected.iter().map(|s| s.as_str()).collect();
+                let _ = self.del_file_index_batch(&refs);
+            }
+        }
+
+        Ok(SplitOutcome {
+            target_view: options.target_view,
+            from_view: from_view_name,
+            was_dry_run: false,
+            blocked: false,
+            requested: analysis.requested,
+            dependents: analysis.dependents,
+            moved: analysis.closure,
+            source_change_count,
+            target_change_count,
+            working_copy_updated,
+            files_written,
+            files_removed,
+        })
+    }
+
+    /// Return the source view's own change hashes in sequence order.
+    ///
+    /// Used by the CLI to resolve `--last N` into concrete change hashes. Only
+    /// the view's own log is returned (inherited changes are excluded), which
+    /// matches what [`split_view`](Self::split_view) can operate on.
+    pub fn view_own_change_hashes(&self, view_name: &str) -> Result<Vec<Hash>, RepositoryError> {
+        let db = |e: PristineError| RepositoryError::Database(e.to_string());
+        let txn = self.pristine.read_txn().map_err(db)?;
+        let view =
+            txn.get_view(view_name)
+                .map_err(db)?
+                .ok_or_else(|| RepositoryError::ViewNotFound {
+                    name: view_name.to_string(),
+                })?;
+
+        let mut out = Vec::new();
+        for item in txn.iter_changes(&view, 0).map_err(db)? {
+            let (_seq, id, _merkle) = item.map_err(db)?;
+            let hash = txn.get_external(id).map_err(db)?.ok_or_else(|| {
+                RepositoryError::ChangeNotFound {
+                    hash: format!("id={}", id.0),
+                }
+            })?;
+            out.push(hash);
+        }
+        Ok(out)
+    }
+}

--- a/atomic-repository/src/repository/split.rs
+++ b/atomic-repository/src/repository/split.rs
@@ -246,8 +246,11 @@ fn analyze_split<T: ViewTxnT>(
 impl Repository {
     /// Split a set of changes out of a view into a new Draft view.
     ///
-    /// See the [module documentation](self) for the full semantics and the
-    /// dependency safety guarantee.
+    /// This is a pure metadata operation guarded by a reverse-dependency
+    /// check: a change cannot leave the source while another change that stays
+    /// behind still depends on it, unless `cascade` moves the dependents too.
+    /// See [`SplitOptions`] for the options and [`SplitOutcome`] for the
+    /// result.
     ///
     /// # Errors
     ///

--- a/atomic-repository/src/repository/views.rs
+++ b/atomic-repository/src/repository/views.rs
@@ -15,12 +15,20 @@ pub struct ViewInfo {
     pub name: String,
     /// The current Merkle state (hash of all inserted changes)
     pub state: Merkle,
-    /// Total number of changes in this view's VIEW_CHANGES
-    /// (includes inherited changes for draft views).
+    /// Number of entries in this view's own VIEW_CHANGES log.
+    ///
+    /// This is the length of the view's own change sequence and is used to
+    /// resolve change references (e.g. `@`, `@~1`). It is NOT the total
+    /// effective change count for a draft — inherited changes are not stored
+    /// in this view's log.
     pub change_count: u64,
-    /// Number of changes unique to this view (not in the parent).
-    /// For shared views or views without a parent, this equals `change_count`.
+    /// Number of this view's own changes that are unique to it (not visible
+    /// through the parent chain). For shared views or views without a parent,
+    /// this equals `change_count`.
     pub own_change_count: u64,
+    /// Number of changes this view inherits through its parent chain. Zero for
+    /// views without a parent.
+    pub inherited_change_count: u64,
     /// View scope (Draft or Shared)
     pub scope: ViewScope,
     /// Parent view name, if any
@@ -518,23 +526,26 @@ impl Repository {
                 name: name.to_string(),
             })?;
 
-        // Resolve parent name and compute own change count.
-        let (parent_name, parent_change_count) = if let Some(parent_id) = view.parent {
-            match txn
-                .get_view_by_id(parent_id)
-                .map_err(|e| RepositoryError::Database(e.to_string()))?
-            {
-                Some(p) => (Some(p.name), p.change_count),
-                None => (None, 0),
+        // Resolve parent name and compute own/inherited change counts by
+        // actual graph membership rather than by assuming the own log is a
+        // superset of the parent (which only holds for `create_view_from`
+        // drafts, not for record- or split-created drafts).
+        let (parent_name, own_change_count, inherited_change_count) = match view.parent {
+            Some(parent_id) => {
+                match txn
+                    .get_view_by_id(parent_id)
+                    .map_err(|e| RepositoryError::Database(e.to_string()))?
+                {
+                    Some(parent) => {
+                        let parent_visible = collect_visible_change_ids(&txn, &parent)?;
+                        let own_ids = collect_view_change_ids(&txn, &view)?;
+                        let own = own_ids.difference(&parent_visible).count() as u64;
+                        (Some(parent.name), own, parent_visible.len() as u64)
+                    }
+                    None => (None, view.change_count, 0),
+                }
             }
-        } else {
-            (None, 0)
-        };
-
-        let own_change_count = if view.parent.is_some() {
-            view.change_count.saturating_sub(parent_change_count)
-        } else {
-            view.change_count
+            None => (None, view.change_count, 0),
         };
 
         Ok(ViewInfo {
@@ -542,6 +553,7 @@ impl Repository {
             state: view.state,
             change_count: view.change_count,
             own_change_count,
+            inherited_change_count,
             scope: view.kind,
             parent_name,
         })

--- a/atomic-repository/tests/view_split_test.rs
+++ b/atomic-repository/tests/view_split_test.rs
@@ -1,0 +1,250 @@
+//! Integration tests for `Repository::split_view`.
+//!
+//! A split forks a new Draft view off a source view and removes a chosen set
+//! of changes from the source. It is a pure metadata operation guarded by a
+//! reverse-dependency safety check: a change cannot be removed from the source
+//! while something remaining there still depends on it (unless `--cascade`).
+
+use std::fs;
+use std::path::Path;
+
+use atomic_core::change::{Author, ChangeHeader};
+use atomic_core::pristine::ViewScope;
+use atomic_core::types::{Base32, Hash};
+use atomic_repository::history::HistoryOptions;
+use atomic_repository::{RecordOptions, Repository, SplitOptions};
+use tempfile::TempDir;
+
+fn add_file(repo: &Repository, repo_path: &Path, name: &str, content: &str) {
+    fs::write(repo_path.join(name), content).expect("write file");
+    repo.add(name, Default::default()).expect("add file");
+}
+
+fn write_only(repo_path: &Path, name: &str, content: &str) {
+    fs::write(repo_path.join(name), content).expect("write file");
+}
+
+fn record(repo: &Repository, message: &str) -> Hash {
+    let header = ChangeHeader::builder()
+        .message(message)
+        .author(Author::new("Test", Some("test@example.com")))
+        .build();
+    *repo
+        .record(header, RecordOptions::default())
+        .expect("record")
+        .hash()
+}
+
+fn log_hashes(repo: &Repository, view: &str) -> Vec<Hash> {
+    repo.log(HistoryOptions::default().view(view))
+        .expect("log")
+        .into_iter()
+        .map(|e| e.hash)
+        .collect()
+}
+
+/// Splitting independent changes out of the middle of a view is clean: the
+/// source keeps the survivors, the draft owns the extracted changes.
+#[test]
+fn split_independent_middle_changes() {
+    let temp = TempDir::new().unwrap();
+    let repo_path = temp.path().to_path_buf();
+    let mut repo = Repository::init(&repo_path).expect("init");
+    let source = repo.current_view().to_string();
+
+    // Four independent changes (separate files).
+    add_file(&repo, &repo_path, "a.txt", "A\n");
+    let a = record(&repo, "add a");
+    add_file(&repo, &repo_path, "b.txt", "B\n");
+    let b = record(&repo, "add b");
+    add_file(&repo, &repo_path, "c.txt", "C\n");
+    let c = record(&repo, "add c");
+    add_file(&repo, &repo_path, "d.txt", "D\n");
+    let d = record(&repo, "add d");
+
+    assert_eq!(log_hashes(&repo, &source), vec![a, b, c, d]);
+
+    // Split out the middle two.
+    let outcome = repo
+        .split_view(SplitOptions::new("wip", vec![b, c]))
+        .expect("split");
+
+    assert!(!outcome.blocked);
+    assert!(outcome.dependents.is_empty(), "no dependents expected");
+    assert_eq!(outcome.moved.len(), 2);
+    assert_eq!(outcome.source_change_count, 2);
+    assert_eq!(outcome.target_change_count, 2);
+
+    // Source keeps the survivors in order.
+    assert_eq!(log_hashes(&repo, &source), vec![a, d]);
+
+    // Draft owns exactly the extracted changes.
+    assert_eq!(log_hashes(&repo, "wip"), vec![b, c]);
+
+    // Draft is a Draft parented on the source, and sees the full pre-split
+    // state through inheritance.
+    let info = repo.get_view_info("wip").expect("view info");
+    assert_eq!(info.scope, ViewScope::Draft);
+    assert_eq!(info.parent_name.as_deref(), Some(source.as_str()));
+
+    let effective: Vec<Hash> = repo
+        .effective_history(Some("wip"))
+        .expect("effective history")
+        .into_iter()
+        .map(|e| e.hash)
+        .collect();
+    let mut all = effective.clone();
+    all.sort();
+    let mut expected = vec![a, b, c, d];
+    expected.sort();
+    assert_eq!(all, expected, "draft should see all four changes");
+}
+
+/// A change that a remaining change depends on cannot be split out without
+/// `--cascade`; the operation is refused and nothing is mutated.
+#[test]
+fn split_blocked_by_dependent() {
+    let temp = TempDir::new().unwrap();
+    let repo_path = temp.path().to_path_buf();
+    let mut repo = Repository::init(&repo_path).expect("init");
+    let source = repo.current_view().to_string();
+
+    // c2 edits the line c1 introduced, so c2 depends on c1.
+    add_file(&repo, &repo_path, "f.txt", "hello\n");
+    let c1 = record(&repo, "create f");
+    write_only(&repo_path, "f.txt", "HELLO\n");
+    let c2 = record(&repo, "edit f");
+
+    assert_eq!(log_hashes(&repo, &source), vec![c1, c2]);
+
+    // Dry run reports the block without mutating.
+    let preview = repo
+        .split_view(SplitOptions {
+            target_view: "wip".to_string(),
+            from_view: None,
+            changes: vec![c1],
+            cascade: false,
+            dry_run: true,
+            materialize: false,
+        })
+        .expect("dry run ok");
+    assert!(preview.blocked, "dry run should report blocked");
+    assert_eq!(preview.dependents.len(), 1);
+    assert_eq!(preview.dependents[0].hash, c2);
+    assert!(preview.moved.is_empty());
+
+    // Real attempt errors.
+    let err = repo
+        .split_view(SplitOptions::new("wip", vec![c1]))
+        .expect_err("should be blocked");
+    match err {
+        atomic_repository::RepositoryError::ViewSplitHasDependents { blocking, .. } => {
+            assert_eq!(blocking, vec![c2.to_base32()]);
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+
+    // Nothing was created or removed.
+    assert!(!repo.view_exists("wip").expect("view_exists"));
+    assert_eq!(log_hashes(&repo, &source), vec![c1, c2]);
+}
+
+/// With `--cascade`, the dependent is moved along with the requested change.
+#[test]
+fn split_cascade_moves_dependents() {
+    let temp = TempDir::new().unwrap();
+    let repo_path = temp.path().to_path_buf();
+    let mut repo = Repository::init(&repo_path).expect("init");
+    let source = repo.current_view().to_string();
+
+    add_file(&repo, &repo_path, "f.txt", "hello\n");
+    let c1 = record(&repo, "create f");
+    write_only(&repo_path, "f.txt", "HELLO\n");
+    let c2 = record(&repo, "edit f");
+
+    let outcome = repo
+        .split_view(SplitOptions {
+            target_view: "wip".to_string(),
+            from_view: Some(source.clone()),
+            changes: vec![c1],
+            cascade: true,
+            dry_run: false,
+            materialize: false,
+        })
+        .expect("cascade split");
+
+    assert!(!outcome.blocked);
+    assert_eq!(outcome.requested.len(), 1);
+    assert_eq!(outcome.dependents.len(), 1);
+    assert_eq!(outcome.dependents[0].hash, c2);
+    assert_eq!(outcome.moved.len(), 2);
+
+    // Both changes moved into the draft; source is now empty.
+    assert_eq!(log_hashes(&repo, &source), Vec::<Hash>::new());
+    assert_eq!(log_hashes(&repo, "wip"), vec![c1, c2]);
+}
+
+/// With `materialize`, splitting out of the current view reconciles the working
+/// copy: a file whose only change left is deleted, and a reverted file's
+/// content is rewritten to the source's new state.
+#[test]
+fn split_materialize_reconciles_working_copy() {
+    let temp = TempDir::new().unwrap();
+    let repo_path = temp.path().to_path_buf();
+    let mut repo = Repository::init(&repo_path).expect("init");
+    let source = repo.current_view().to_string();
+
+    // g.txt is created then edited: create g (v1) <- edit g (v2). Independent
+    // file h.txt is created once.
+    add_file(&repo, &repo_path, "g.txt", "v1\n");
+    let _cg = record(&repo, "create g");
+    write_only(&repo_path, "g.txt", "v2\n");
+    let edit_g = record(&repo, "edit g");
+    add_file(&repo, &repo_path, "h.txt", "H\n");
+    let create_h = record(&repo, "create h");
+
+    // Split out `edit g` (revert g.txt) and `create h` (delete h.txt).
+    let outcome = repo
+        .split_view(SplitOptions {
+            target_view: "wip".to_string(),
+            from_view: Some(source.clone()),
+            changes: vec![edit_g, create_h],
+            cascade: false,
+            dry_run: false,
+            materialize: true,
+        })
+        .expect("materialize split");
+
+    assert!(outcome.working_copy_updated);
+    assert_eq!(outcome.files_removed, 1, "h.txt removed");
+    assert_eq!(outcome.files_written, 1, "g.txt reverted");
+
+    // h.txt is gone; g.txt reverted to v1.
+    assert!(!repo_path.join("h.txt").exists(), "h.txt should be deleted");
+    assert_eq!(
+        fs::read_to_string(repo_path.join("g.txt")).expect("read g"),
+        "v1\n",
+        "g.txt should be reverted to the pre-edit content"
+    );
+}
+
+/// Requesting a change that isn't in the source view is a clear error.
+#[test]
+fn split_rejects_change_not_in_view() {
+    let temp = TempDir::new().unwrap();
+    let repo_path = temp.path().to_path_buf();
+    let mut repo = Repository::init(&repo_path).expect("init");
+
+    add_file(&repo, &repo_path, "a.txt", "A\n");
+    let _a = record(&repo, "add a");
+
+    // A hash that was never recorded.
+    let phantom = Hash::of(b"nope");
+    let err = repo
+        .split_view(SplitOptions::new("wip", vec![phantom]))
+        .expect_err("should reject unknown change");
+    assert!(matches!(
+        err,
+        atomic_repository::RepositoryError::ChangeNotFound { .. }
+    ));
+}


### PR DESCRIPTION
This pull request introduces a new `atomic view split` command to the CLI, allowing users to extract specific changes from an existing view into a new draft view as a pure metadata operation. It also refines the internal representation of view change counts to distinguish between own, unique, and inherited changes, and adds supporting error types and plumbing in the repository layer.

**New feature: View splitting**

* Added a new `view split` command (`atomic-cli/src/commands/view/split.rs`) that lets users split selected changes out of a source view into a new draft view, with options for cascading dependents, dry-run previews, and automatic switching.
* Wired the new `Split` command into the CLI interface and command dispatch, including documentation, argument parsing, and test coverage. [[1]](diffhunk://#diff-6b480193868b4dc09e7a572ddcfdd85f8e2132a915b604e23f96e33bcbfee169R93) [[2]](diffhunk://#diff-6b480193868b4dc09e7a572ddcfdd85f8e2132a915b604e23f96e33bcbfee169R102) [[3]](diffhunk://#diff-6b480193868b4dc09e7a572ddcfdd85f8e2132a915b604e23f96e33bcbfee169R145-R163) [[4]](diffhunk://#diff-6b480193868b4dc09e7a572ddcfdd85f8e2132a915b604e23f96e33bcbfee169R221) [[5]](diffhunk://#diff-6b480193868b4dc09e7a572ddcfdd85f8e2132a915b604e23f96e33bcbfee169R242)

**Repository and data model improvements**

* Updated the `ViewInfo` struct to clearly separate `change_count` (own log entries), `own_change_count` (unique to this view), and `inherited_change_count` (from parent views), and changed the logic to compute these counts based on actual graph membership. [[1]](diffhunk://#diff-b93addb9a8518cd8c35a48345d4edf76fcf7a4b27e2cc19ad429a819c2083c9cL18-R31) [[2]](diffhunk://#diff-b93addb9a8518cd8c35a48345d4edf76fcf7a4b27e2cc19ad429a819c2083c9cL521-R556)
* Adjusted the list command output to use the new `inherited_change_count` field for clarity.

**Error handling enhancements**

* Added new repository error types for split operations: `ChangeNotInView` (when a requested change is not in the source view) and `ViewSplitHasDependents` (when a split would leave dependents behind), and marked them as user-facing. [[1]](diffhunk://#diff-143f8112fb7a8eae3bd4014132ce62bb0f4676bd5c5973cbe0813eda8542743fR42-R57) [[2]](diffhunk://#diff-143f8112fb7a8eae3bd4014132ce62bb0f4676bd5c5973cbe0813eda8542743fR249-R250)

**Repository API and plumbing**

* Introduced new types and functions for split operations (`SplitOptions`, `SplitOutcome`, `SplitChange`) and exposed them via the repository module. [[1]](diffhunk://#diff-e6fb908e7852ab01ffc10ccdb8b3030ec546e76a3fcc56d8316e0114b20faf67R83) [[2]](diffhunk://#diff-e6fb908e7852ab01ffc10ccdb8b3030ec546e76a3fcc56d8316e0114b20faf67R94)

These changes collectively enable safe, user-friendly splitting of changes between views, with robust error handling and improved clarity in view change statistics.