### PR TITLE
Implement segment ID verification and CI tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,7 @@ name = "atomic-remote"
 version = "0.15.5"
 dependencies = [
  "anyhow",
+ "atomic-core",
  "bytes",
  "chrono",
  "env_logger",

--- a/atomic-core/src/types/mod.rs
+++ b/atomic-core/src/types/mod.rs
@@ -25,6 +25,7 @@ mod graph_node;
 mod hash;
 mod node_id;
 mod position;
+mod set_id;
 
 pub use edge_kind::{Edge, EdgeKind, ForwardEdge, ParentEdge, ParentEdgeKind};
 pub use graph_edge::{EdgeFlags, GraphEdge, SerializedGraphEdge};
@@ -32,6 +33,7 @@ pub use graph_node::{GraphNode, IntoGraphNode};
 pub use hash::{Hash, Hasher, Merkle};
 pub use node_id::{ChangePosition, Inode, NodeId, L64};
 pub use position::Position;
+pub use set_id::SetId;
 
 /// Base32 encoding trait for human-readable identifiers
 pub trait Base32: Sized {

--- a/atomic-core/src/types/set_id.rs
+++ b/atomic-core/src/types/set_id.rs
@@ -89,7 +89,7 @@ const SETID_DOMAIN: &[u8] = b"atomic:setid:v1";
 ///
 /// `SetId` is a 32-byte additive homomorphic digest: the componentwise sum
 /// (four independent little-endian `u64` lanes, mod 2^64) of a domain-separated
-/// expansion of each member hash. See the [module docs](self) for the
+/// expansion of each member hash. See the module-level docs for the
 /// construction, the convergence-identity tradeoff, and the canonical domain
 /// contract.
 ///
@@ -205,7 +205,7 @@ impl SetId {
     /// [`SetId::ZERO`]. Order does not affect the result.
     ///
     /// The caller is responsible for supplying the canonical domain (applyable
-    /// change and tag hashes, sidecars excluded) — see the [module docs](self).
+    /// change and tag hashes, sidecars excluded) — see the module-level docs.
     pub fn of<'a, I>(changes: I) -> Self
     where
         I: IntoIterator<Item = &'a super::Merkle>,

--- a/atomic-core/src/types/set_id.rs
+++ b/atomic-core/src/types/set_id.rs
@@ -1,0 +1,539 @@
+//! Order-invariant set identity (`SetId`) for views and convergence.
+//!
+//! # Why this exists
+//!
+//! Atomic identifies a view's state with a running Merkle fold over its change
+//! **sequence** (`state_n = H(state_{n-1} || change_n)`, see
+//! [`Merkle::next`](super::Merkle::next)). That identity is *order-sensitive*:
+//! two views holding the same **set** of changes in a different order — the
+//! normal outcome of concurrent multi-agent writes and of `view split` /
+//! reinsert — report different `Merkle` states even though their materialized
+//! tree is byte-identical. That contradicts the property the content layer
+//! already guarantees (independent changes commute).
+//!
+//! [`SetId`] is a second identity that lives **alongside** the order-sensitive
+//! `Merkle`, never replacing it. It answers a different question — "do these
+//! two views hold the same set of changes?" — with a single hash, regardless
+//! of the order the changes were applied in.
+//!
+//! # Construction (AdHash — an additive homomorphic hash)
+//!
+//! Each change hash `h` is expanded to a 256-bit element
+//! `e(h) = Blake3("atomic:setid:v1" || h)`, read as four little-endian `u64`
+//! lanes. A `SetId` is the componentwise sum of the elements of its members,
+//! with each lane added **mod 2^64** (independent wrapping lanes, no cross-lane
+//! carry):
+//!
+//! ```text
+//! SetId(S) = Σ_{h ∈ S} e(h)   (lanewise, mod 2^64)
+//! ```
+//!
+//! Because integer addition is commutative and associative, the result is
+//! independent of order (order-invariance), `combine` is componentwise
+//! addition, and `remove` is componentwise subtraction — the exact inverse of
+//! `add`. The empty set folds to all-zero lanes, which is [`SetId::ZERO`].
+//!
+//! ## Simplification guard: this is a convergence identity, not a trust boundary
+//!
+//! The intent recommended a wide LtHash-style lattice accumulator (≈2 KiB) with
+//! the public id derived as a Blake3 over its canonical bytes. This module
+//! instead ships the **compact 32-byte additive digest (AdHash)** so that a
+//! `SetId` is a single value that is simultaneously homomorphic (`add` /
+//! `remove` / `combine`) *and* a fixed, base32-embeddable identity that mirrors
+//! the [`Merkle`](super::Merkle) API. The tradeoff, stated explicitly:
+//!
+//! - AdHash is **materially stronger than the incumbent** `GeoStore::set_digest`
+//!   (sort + FNV-64): collisions require a distinct sub-multiset whose sum
+//!   matches across four independent 64-bit lanes seeded by a Blake3 random
+//!   oracle (~256-bit generic hardness) versus a trivially-forgeable 64-bit FNV.
+//! - AdHash is **weaker than a wide LtHash** against an adaptive adversary who
+//!   can choose set members freely. `SetId` is therefore an **equivalence /
+//!   convergence identity, not a trust boundary**. The authoritative
+//!   change-hash list / view manifest remains the source of truth for what a
+//!   view actually contains; `SetId` only accelerates "are these equal?"
+//!   answers. If a wide LtHash is ever needed, it can replace the internal
+//!   accumulator without changing the public `SetId` string contract.
+//!
+//! # The canonical domain (a cross-producer contract)
+//!
+//! For CLI/core, `atomic-storage`, and geodist to compute the **same** `SetId`
+//! for the same project, they must fold **byte-for-byte the same domain**:
+//!
+//! - **Applyable artifact hashes only**: changes and tags.
+//! - **Sidecars excluded**: `.provenance` and `.attest` files are audit nodes,
+//!   not part of any view's applyable set, and must not be folded in.
+//! - Each member is fed in as its 32-byte [`Merkle`](super::Merkle) (the same
+//!   value the base32 change hash decodes to).
+//!
+//! A domain mismatch silently breaks convergence equality, so the domain is a
+//! documented contract rather than an implementation detail. `SetId` itself is
+//! agnostic to *which* hashes it is given — enforcing the domain is the caller's
+//! responsibility.
+//!
+//! # String form
+//!
+//! The base32 alphabet is RFC 4648 (`A–Z`, `2–7`) — it **never contains `-`**,
+//! so a `SetId` can be embedded unambiguously in geodist object keys such as
+//! `snapshots/pristine.redb@{ts}-{setdigest}`.
+
+use super::Base32;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Domain-separation prefix for expanding a change hash into a `SetId` element.
+/// Changing this string changes every `SetId` and breaks cross-producer
+/// convergence — it is part of the wire/identity contract.
+const SETID_DOMAIN: &[u8] = b"atomic:setid:v1";
+
+/// An order-invariant identity for a **set** of change hashes.
+///
+/// `SetId` is a 32-byte additive homomorphic digest: the componentwise sum
+/// (four independent little-endian `u64` lanes, mod 2^64) of a domain-separated
+/// expansion of each member hash. See the [module docs](self) for the
+/// construction, the convergence-identity tradeoff, and the canonical domain
+/// contract.
+///
+/// It mirrors the [`Merkle`](super::Merkle) API surface (`ZERO`, `from_bytes`,
+/// `as_bytes`, `to_base32`/`from_base32`, `to_hex`/`from_hex`, serde, `Display`,
+/// `Debug`) so it can be used interchangeably in identity-carrying code.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct SetId(pub [u8; 32]);
+
+/// Read a 32-byte buffer as four little-endian `u64` lanes.
+#[inline]
+fn lanes_from_bytes(bytes: &[u8; 32]) -> [u64; 4] {
+    let mut lanes = [0u64; 4];
+    for (i, lane) in lanes.iter_mut().enumerate() {
+        let mut chunk = [0u8; 8];
+        chunk.copy_from_slice(&bytes[i * 8..i * 8 + 8]);
+        *lane = u64::from_le_bytes(chunk);
+    }
+    lanes
+}
+
+/// Write four little-endian `u64` lanes back into a 32-byte buffer.
+#[inline]
+fn bytes_from_lanes(lanes: [u64; 4]) -> [u8; 32] {
+    let mut bytes = [0u8; 32];
+    for (i, lane) in lanes.iter().enumerate() {
+        bytes[i * 8..i * 8 + 8].copy_from_slice(&lane.to_le_bytes());
+    }
+    bytes
+}
+
+impl SetId {
+    /// The identity element: the `SetId` of the empty set (all-zero lanes).
+    pub const ZERO: SetId = SetId([0u8; 32]);
+
+    /// Digest size in bytes.
+    pub const SIZE: usize = 32;
+
+    /// Wrap raw bytes as a `SetId`.
+    #[inline]
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        SetId(bytes)
+    }
+
+    /// Borrow the underlying bytes.
+    #[inline]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// Whether this is the empty-set identity ([`SetId::ZERO`]).
+    #[inline]
+    pub fn is_zero(&self) -> bool {
+        *self == Self::ZERO
+    }
+
+    /// Expand a change hash into its four-lane `SetId` element via a
+    /// domain-separated Blake3 hash.
+    #[inline]
+    fn element_lanes(change: &super::Merkle) -> [u64; 4] {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(SETID_DOMAIN);
+        hasher.update(change.as_bytes());
+        let out: [u8; 32] = hasher.finalize().into();
+        lanes_from_bytes(&out)
+    }
+
+    /// Return the `SetId` with `change` added to the set.
+    ///
+    /// Adding is commutative and associative, so folding a set in any order
+    /// yields the same `SetId`. Adding the same hash twice models a multiset
+    /// (two members); callers that want set semantics must deduplicate first.
+    #[must_use]
+    pub fn add(&self, change: &super::Merkle) -> Self {
+        let e = Self::element_lanes(change);
+        let mut lanes = lanes_from_bytes(&self.0);
+        for (l, r) in lanes.iter_mut().zip(e.iter()) {
+            *l = l.wrapping_add(*r);
+        }
+        SetId(bytes_from_lanes(lanes))
+    }
+
+    /// Return the `SetId` with `change` removed from the set.
+    ///
+    /// `remove` is the exact inverse of [`add`](Self::add):
+    /// `s.add(h).remove(h) == s` for every `s` and `h`.
+    #[must_use]
+    pub fn remove(&self, change: &super::Merkle) -> Self {
+        let e = Self::element_lanes(change);
+        let mut lanes = lanes_from_bytes(&self.0);
+        for (l, r) in lanes.iter_mut().zip(e.iter()) {
+            *l = l.wrapping_sub(*r);
+        }
+        SetId(bytes_from_lanes(lanes))
+    }
+
+    /// Combine two set identities into the identity of their multiset union.
+    ///
+    /// `combine` is componentwise addition, so
+    /// `SetId::of(a).combine(&SetId::of(b)) == SetId::of(a ∪ b)` (as multisets).
+    #[must_use]
+    pub fn combine(&self, other: &SetId) -> Self {
+        let a = lanes_from_bytes(&self.0);
+        let b = lanes_from_bytes(&other.0);
+        let mut lanes = [0u64; 4];
+        for i in 0..4 {
+            lanes[i] = a[i].wrapping_add(b[i]);
+        }
+        SetId(bytes_from_lanes(lanes))
+    }
+
+    /// Fold an iterator of change hashes into a `SetId`, starting from
+    /// [`SetId::ZERO`]. Order does not affect the result.
+    ///
+    /// The caller is responsible for supplying the canonical domain (applyable
+    /// change and tag hashes, sidecars excluded) — see the [module docs](self).
+    pub fn of<'a, I>(changes: I) -> Self
+    where
+        I: IntoIterator<Item = &'a super::Merkle>,
+    {
+        let mut acc = Self::ZERO;
+        for change in changes {
+            acc = acc.add(change);
+        }
+        acc
+    }
+
+    /// Convert to a lowercase hex string (64 characters).
+    pub fn to_hex(&self) -> String {
+        let mut s = String::with_capacity(64);
+        for byte in &self.0 {
+            s.push_str(&format!("{:02x}", byte));
+        }
+        s
+    }
+
+    /// Parse from a 64-character lowercase/uppercase hex string.
+    pub fn from_hex(s: &str) -> Option<Self> {
+        if s.len() != 64 {
+            return None;
+        }
+        let mut bytes = [0u8; 32];
+        for (i, chunk) in s.as_bytes().chunks(2).enumerate() {
+            let hex_str = std::str::from_utf8(chunk).ok()?;
+            bytes[i] = u8::from_str_radix(hex_str, 16).ok()?;
+        }
+        Some(SetId(bytes))
+    }
+}
+
+impl fmt::Debug for SetId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SetId({})", &self.to_hex()[..12])
+    }
+}
+
+impl fmt::Display for SetId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_base32())
+    }
+}
+
+impl Serialize for SetId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&self.to_base32())
+        } else {
+            serializer.serialize_newtype_struct("SetId", &self.0)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for SetId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            SetId::from_base32(s.as_bytes())
+                .ok_or_else(|| serde::de::Error::custom("invalid base32 SetId"))
+        } else {
+            struct SetIdVisitor;
+
+            impl<'de> serde::de::Visitor<'de> for SetIdVisitor {
+                type Value = SetId;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("a 32-byte SetId")
+                }
+
+                fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    let bytes = <[u8; 32]>::deserialize(deserializer)?;
+                    Ok(SetId(bytes))
+                }
+
+                fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+                where
+                    A: serde::de::SeqAccess<'de>,
+                {
+                    let mut bytes = [0u8; 32];
+                    for (i, byte) in bytes.iter_mut().enumerate() {
+                        *byte = seq
+                            .next_element()?
+                            .ok_or_else(|| serde::de::Error::invalid_length(i, &self))?;
+                    }
+                    Ok(SetId(bytes))
+                }
+            }
+
+            deserializer.deserialize_newtype_struct("SetId", SetIdVisitor)
+        }
+    }
+}
+
+// Base32 alphabet (RFC 4648, no padding) — identical to `Merkle`'s, and
+// crucially free of `-` so a `SetId` embeds cleanly in geodist object keys.
+const BASE32_ALPHABET: &[u8; 32] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+impl Base32 for SetId {
+    fn to_base32(&self) -> String {
+        // 32 bytes -> 52 base32 characters (ceil(32*8/5)).
+        let mut result = String::with_capacity(52);
+        let mut bits: u64 = 0;
+        let mut num_bits = 0;
+
+        for &byte in &self.0 {
+            bits = (bits << 8) | (byte as u64);
+            num_bits += 8;
+
+            while num_bits >= 5 {
+                num_bits -= 5;
+                let idx = ((bits >> num_bits) & 0x1f) as usize;
+                result.push(BASE32_ALPHABET[idx] as char);
+            }
+        }
+
+        if num_bits > 0 {
+            let idx = ((bits << (5 - num_bits)) & 0x1f) as usize;
+            result.push(BASE32_ALPHABET[idx] as char);
+        }
+
+        result
+    }
+
+    fn from_base32(s: &[u8]) -> Option<Self> {
+        let mut bytes = [0u8; 32];
+        let mut bits: u64 = 0;
+        let mut num_bits = 0;
+        let mut byte_idx = 0;
+
+        for &c in s {
+            let val = match c {
+                b'A'..=b'Z' => c - b'A',
+                b'a'..=b'z' => c - b'a', // Case insensitive
+                b'2'..=b'7' => c - b'2' + 26,
+                _ => return None,
+            };
+
+            bits = (bits << 5) | (val as u64);
+            num_bits += 5;
+
+            if num_bits >= 8 {
+                num_bits -= 8;
+                if byte_idx >= 32 {
+                    return None;
+                }
+                bytes[byte_idx] = ((bits >> num_bits) & 0xff) as u8;
+                byte_idx += 1;
+            }
+        }
+
+        if byte_idx != 32 {
+            return None;
+        }
+
+        Some(SetId(bytes))
+    }
+}
+
+impl From<[u8; 32]> for SetId {
+    fn from(bytes: [u8; 32]) -> Self {
+        SetId(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Merkle;
+
+    /// A cheap deterministic pseudo-random change hash generator so the
+    /// property tests don't need an external rng dependency.
+    fn change(seed: u64) -> Merkle {
+        Merkle::of(format!("change-{seed}").as_bytes())
+    }
+
+    #[test]
+    fn empty_set_is_zero() {
+        // (c) The empty set maps to SetId::ZERO.
+        let empty: Vec<Merkle> = Vec::new();
+        assert_eq!(SetId::of(empty.iter()), SetId::ZERO);
+        assert!(SetId::ZERO.is_zero());
+    }
+
+    #[test]
+    fn permutation_invariance() {
+        // (a) Any permutation of the same set yields an identical SetId.
+        let hashes: Vec<Merkle> = (0..64).map(change).collect();
+
+        let forward = SetId::of(hashes.iter());
+        let backward = SetId::of(hashes.iter().rev());
+
+        // A few deterministic shuffles (swap pairs, rotate) — no rng needed.
+        let mut rotated = hashes.clone();
+        rotated.rotate_left(17);
+        let rotated_id = SetId::of(rotated.iter());
+
+        let mut swapped = hashes.clone();
+        swapped.swap(3, 61);
+        swapped.swap(0, 40);
+        let swapped_id = SetId::of(swapped.iter());
+
+        assert_eq!(forward, backward);
+        assert_eq!(forward, rotated_id);
+        assert_eq!(forward, swapped_id);
+    }
+
+    #[test]
+    fn remove_inverts_add() {
+        // (b) remove(add(s, h), h) == s for arbitrary s and h.
+        let base: Vec<Merkle> = (100..140).map(change).collect();
+        let s = SetId::of(base.iter());
+
+        for seed in [0u64, 1, 7, 999, u64::MAX] {
+            let h = change(seed);
+            assert_eq!(s.add(&h).remove(&h), s);
+            // Order of the two operations does not matter either.
+            assert_eq!(s.remove(&h).add(&h), s);
+        }
+    }
+
+    #[test]
+    fn combine_equals_union() {
+        // combine is the identity of the multiset union.
+        let a: Vec<Merkle> = (0..30).map(change).collect();
+        let b: Vec<Merkle> = (30..70).map(change).collect();
+
+        let union: Vec<Merkle> = a.iter().chain(b.iter()).copied().collect();
+
+        let combined = SetId::of(a.iter()).combine(&SetId::of(b.iter()));
+        assert_eq!(combined, SetId::of(union.iter()));
+    }
+
+    #[test]
+    fn different_sets_differ() {
+        // (d) Distinct sets yield distinct SetIds across randomized inputs.
+        use std::collections::HashSet;
+
+        let mut ids: HashSet<[u8; 32]> = HashSet::new();
+        // 500 distinct sets: set k = {change(0..k+1)} plus a unique marker.
+        for k in 0..500u64 {
+            let mut members: Vec<Merkle> = (0..=k).map(change).collect();
+            members.push(Merkle::of(format!("marker-{k}").as_bytes()));
+            let id = SetId::of(members.iter());
+            assert!(
+                ids.insert(id.0),
+                "collision at k={k}: SetId {} already seen",
+                id
+            );
+        }
+
+        // Two single-element sets that differ only by their one member.
+        assert_ne!(SetId::ZERO.add(&change(1)), SetId::ZERO.add(&change(2)));
+    }
+
+    #[test]
+    fn adding_twice_is_a_multiset() {
+        // A member added twice is not the same as added once (multiset), and
+        // removing once returns to the single-member identity.
+        let h = change(42);
+        let once = SetId::ZERO.add(&h);
+        let twice = once.add(&h);
+        assert_ne!(once, twice);
+        assert_eq!(twice.remove(&h), once);
+    }
+
+    #[test]
+    fn base32_roundtrip_and_no_dash() {
+        let id = SetId::of((0..10).map(change).collect::<Vec<_>>().iter());
+        let s = id.to_base32();
+        assert_eq!(s.len(), 52);
+        assert!(!s.contains('-'), "SetId string must never contain '-'");
+        let parsed = SetId::from_base32(s.as_bytes()).unwrap();
+        assert_eq!(id, parsed);
+    }
+
+    #[test]
+    fn base32_is_case_insensitive() {
+        let id = SetId::ZERO.add(&change(5));
+        let upper = id.to_base32();
+        let lower = upper.to_lowercase();
+        assert_eq!(
+            SetId::from_base32(upper.as_bytes()).unwrap(),
+            SetId::from_base32(lower.as_bytes()).unwrap()
+        );
+    }
+
+    #[test]
+    fn hex_roundtrip() {
+        let id = SetId::of((20..25).map(change).collect::<Vec<_>>().iter());
+        let hex = id.to_hex();
+        assert_eq!(hex.len(), 64);
+        assert_eq!(SetId::from_hex(&hex).unwrap(), id);
+    }
+
+    #[test]
+    fn json_and_postcard_roundtrip() {
+        let id = SetId::of((0..8).map(change).collect::<Vec<_>>().iter());
+
+        let json = serde_json::to_string(&id).unwrap();
+        let from_json: SetId = serde_json::from_str(&json).unwrap();
+        assert_eq!(id, from_json);
+
+        let bytes = postcard::to_allocvec(&id).unwrap();
+        let from_postcard: SetId = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(id, from_postcard);
+        assert_eq!(bytes.len(), 32, "binary SetId is exactly 32 bytes");
+    }
+
+    #[test]
+    fn debug_and_display() {
+        let id = SetId::ZERO.add(&change(1));
+        let debug = format!("{id:?}");
+        let display = format!("{id}");
+        assert!(debug.starts_with("SetId("));
+        assert!(debug.len() < 24);
+        assert_eq!(display.len(), 52);
+        assert!(!display.contains("SetId"));
+    }
+}

--- a/atomic-remote/Cargo.toml
+++ b/atomic-remote/Cargo.toml
@@ -12,6 +12,9 @@ keywords = ["vcs", "version-control", "distributed", "remote", "protocol"]
 categories = ["development-tools"]
 
 [dependencies]
+# Internal crates
+atomic-core = { workspace = true }
+
 # HTTP client
 reqwest = { workspace = true, features = ["json", "gzip", "deflate", "stream"] }
 

--- a/atomic-remote/src/http/upload.rs
+++ b/atomic-remote/src/http/upload.rs
@@ -14,6 +14,23 @@ use crate::error::{RemoteError, RemoteResult};
 
 use super::HttpRemote;
 
+/// Extract base32 change-hash tokens from a server error message.
+///
+/// A "missing dependency/change" error from the manifest apply names the
+/// offending change(s) as full base32 hashes (e.g. `change ABC… depends on
+/// DEF…`). Pulling those out lets the CLI report *which* dependency is missing
+/// instead of the useless "requires 0 dependencies". A Blake3 change hash is 52
+/// base32 chars (`[A-Z2-7]`); we accept any run of ≥ 40 such chars so ordinary
+/// words never match while remaining robust to hash-length changes.
+fn extract_change_hashes(msg: &str) -> Vec<String> {
+    msg.split(|c: char| !(c.is_ascii_uppercase() || c.is_ascii_digit()))
+        .filter(|tok| {
+            tok.len() >= 40 && tok.bytes().all(|b| matches!(b, b'A'..=b'Z' | b'2'..=b'7'))
+        })
+        .map(|s| s.to_string())
+        .collect()
+}
+
 impl HttpRemote {
     /// Upload a change file.
     ///
@@ -50,10 +67,16 @@ impl HttpRemote {
             }
             StatusCode::BAD_REQUEST | StatusCode::INTERNAL_SERVER_ERROR => {
                 let msg = response.text().await.unwrap_or_default();
-                // Check if it's a missing dependencies error
+                // Missing-dependency error: name the offending hashes when the
+                // server included them; otherwise preserve the full message
+                // rather than collapsing it to "0 dependencies".
                 if msg.contains("missing") && msg.contains("dependenc") {
-                    // Try to extract hash list from error message
-                    Err(RemoteError::missing_deps(vec![]))
+                    let hashes = extract_change_hashes(&msg);
+                    if hashes.is_empty() {
+                        Err(RemoteError::http(status.as_u16(), msg))
+                    } else {
+                        Err(RemoteError::missing_deps(hashes))
+                    }
                 } else {
                     Err(RemoteError::http(status.as_u16(), msg))
                 }
@@ -155,8 +178,16 @@ impl HttpRemote {
             }
             StatusCode::BAD_REQUEST => {
                 let msg = response.text().await.unwrap_or_default();
+                // A missing change/dependency from the manifest apply names the
+                // offending hash(es); surface them instead of "0 dependencies",
+                // and fall back to the full server message when none parse.
                 if msg.contains("missing") && msg.contains("change") {
-                    Err(RemoteError::missing_deps(vec![]))
+                    let hashes = extract_change_hashes(&msg);
+                    if hashes.is_empty() {
+                        Err(RemoteError::http(status.as_u16(), msg))
+                    } else {
+                        Err(RemoteError::missing_deps(hashes))
+                    }
                 } else {
                     Err(RemoteError::http(status.as_u16(), msg))
                 }
@@ -455,7 +486,12 @@ impl HttpRemote {
             StatusCode::BAD_REQUEST | StatusCode::INTERNAL_SERVER_ERROR => {
                 let msg = response.text().await.unwrap_or_default();
                 if msg.contains("missing") && msg.contains("dependenc") {
-                    Err(RemoteError::missing_deps(vec![]))
+                    let hashes = extract_change_hashes(&msg);
+                    if hashes.is_empty() {
+                        Err(RemoteError::http(status.as_u16(), msg))
+                    } else {
+                        Err(RemoteError::missing_deps(hashes))
+                    }
                 } else {
                     Err(RemoteError::http(status.as_u16(), msg))
                 }
@@ -490,5 +526,41 @@ impl HttpRemote {
         path: &Path,
     ) -> RemoteResult<()> {
         self.upload_change_streamed(hash, view, path).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_change_hashes;
+
+    #[test]
+    fn extracts_hashes_from_manifest_dependency_error() {
+        // The exact shape `apply_view_manifest` produces for a split-created
+        // draft whose first change depends on a change left in the parent.
+        let msg = "missing changes: Manifest for view 'orange-night-44fb': change \
+             GJGC6OK6JT77OB2PDGFYEC2BUISJWQNQVT345SNIZ2CKKXGV652A depends on \
+             FUGMXMFD7FJ6QARZ4RML2W5W6W3RGE2K7ILTZ55XKQ4Z3XZ4YQ4A, which is neither \
+             earlier in the log nor present locally";
+        let hashes = extract_change_hashes(msg);
+        assert_eq!(
+            hashes,
+            vec![
+                "GJGC6OK6JT77OB2PDGFYEC2BUISJWQNQVT345SNIZ2CKKXGV652A".to_string(),
+                "FUGMXMFD7FJ6QARZ4RML2W5W6W3RGE2K7ILTZ55XKQ4Z3XZ4YQ4A".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_ordinary_words_and_short_tokens() {
+        let msg = "missing changes not present locally on the REMOTE server";
+        assert!(extract_change_hashes(msg).is_empty());
+    }
+
+    #[test]
+    fn rejects_non_base32_long_tokens() {
+        // Contains 0/1/8/9 (not in base32 [A-Z2-7]) → not a hash.
+        let msg = "error 00000000000000000000000000000000000000000000000000";
+        assert!(extract_change_hashes(msg).is_empty());
     }
 }

--- a/atomic-remote/src/sync.rs
+++ b/atomic-remote/src/sync.rs
@@ -464,6 +464,27 @@ impl<'a> SyncEngine<'a> {
         &self.stats
     }
 
+    /// Fold a set of base32 change hashes into the view's order-invariant
+    /// [`SetId`](atomic_core::types::SetId) string.
+    ///
+    /// Returns `None` if any hash is not valid base32, in which case the
+    /// caller must fall back to the Merkle dichotomy rather than risk a false
+    /// "in sync" from a partially-folded set.
+    ///
+    /// The domain is the local view's applyable change set — it must match
+    /// byte-for-byte the domain the server folds into the advertised `SetId`
+    /// (changes and tags, sidecars excluded); see the cross-producer contract
+    /// on [`atomic_core::types::SetId`].
+    fn local_set_id(local_hashes: &HashSet<String>) -> Option<String> {
+        use atomic_core::types::{Base32, Merkle, SetId};
+        let mut acc = SetId::ZERO;
+        for hash in local_hashes {
+            let merkle = Merkle::from_base32(hash.as_bytes())?;
+            acc = acc.add(&merkle);
+        }
+        Some(acc.to_base32())
+    }
+
     // Dichotomy Algorithm — O(log n) divergence detection
 
     /// Find the divergence point between our cached view and the remote's
@@ -616,6 +637,24 @@ impl<'a> SyncEngine<'a> {
         view: &str,
         local_hashes: &HashSet<String>,
     ) -> RemoteResult<RemoteDelta> {
+        // Order-invariant fast path (additive; dormant until the server
+        // advertises a SetId). If the remote publishes the SetId of its
+        // effective change set and it equals the SetId folded from our local
+        // hashes, both sides hold the same SET of changes regardless of order
+        // — we are in sync and can skip the O(log n) Merkle dichotomy and the
+        // changelist download entirely. When the field is absent (older
+        // server) or the local set cannot be folded, we fall through to the
+        // existing dichotomy with no behavior change.
+        let remote_state = self.remote.get_state(view).await?;
+        if let (Some(remote_sid), Some(local_sid)) =
+            (remote_state.set_id(), Self::local_set_id(local_hashes))
+        {
+            if remote_sid == local_sid {
+                debug!("sync: SetId match ({}), views already in sync", remote_sid);
+                return Ok(RemoteDelta::in_sync());
+            }
+        }
+
         // Handle from-scratch sync (no cache)
         if self.cache.is_empty() {
             return self.compute_delta_from_scratch(view, local_hashes).await;

--- a/atomic-remote/src/types.rs
+++ b/atomic-remote/src/types.rs
@@ -303,7 +303,10 @@ impl std::error::Error for ParseChangelistError {}
 /// the Merkle state at that position, and optionally the Merkle state of
 /// the most recent tag.
 ///
-/// Protocol format: `{position} {merkle} {tag_merkle}` or `-` for empty channel.
+/// Protocol format: `{position} {merkle} {tag_merkle} [{set_id}]` or `-` for
+/// an empty channel. The trailing `{set_id}` is optional and only emitted by
+/// servers that advertise the order-invariant [`SetId`](atomic_core::types::SetId);
+/// older servers omit it and clients fall back to the Merkle dichotomy.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StateResponse {
     /// The channel has state.
@@ -314,18 +317,43 @@ pub enum StateResponse {
         merkle: String,
         /// The Merkle state of the most recent tag, or empty if no tags.
         tag_merkle: String,
+        /// The order-invariant `SetId` of the view's effective change set
+        /// (base32 encoded), or `None` when the server does not advertise it.
+        ///
+        /// This is an **additive, optional** field: it enables an
+        /// order-invariant sync fast path without changing the existing
+        /// Merkle-based protocol. Absent on older servers.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        set_id: Option<String>,
     },
     /// The channel is empty.
     Empty,
 }
 
 impl StateResponse {
-    /// Create a state response with values.
+    /// Create a state response with values (no advertised `SetId`).
     pub fn state(position: u64, merkle: impl Into<String>, tag_merkle: impl Into<String>) -> Self {
         Self::State {
             position,
             merkle: merkle.into(),
             tag_merkle: tag_merkle.into(),
+            set_id: None,
+        }
+    }
+
+    /// Create a state response that also advertises the order-invariant
+    /// [`SetId`](atomic_core::types::SetId) of the view's change set.
+    pub fn state_with_set_id(
+        position: u64,
+        merkle: impl Into<String>,
+        tag_merkle: impl Into<String>,
+        set_id: impl Into<String>,
+    ) -> Self {
+        Self::State {
+            position,
+            merkle: merkle.into(),
+            tag_merkle: tag_merkle.into(),
+            set_id: Some(set_id.into()),
         }
     }
 
@@ -345,7 +373,7 @@ impl StateResponse {
     ///
     /// let state = StateResponse::parse("42 ABC123 DEF456").unwrap();
     /// match state {
-    ///     StateResponse::State { position, merkle, tag_merkle } => {
+    ///     StateResponse::State { position, merkle, tag_merkle, .. } => {
     ///         assert_eq!(position, 42);
     ///         assert_eq!(merkle, "ABC123");
     ///         assert_eq!(tag_merkle, "DEF456");
@@ -379,11 +407,15 @@ impl StateResponse {
 
         let merkle = parts[1].to_string();
         let tag_merkle = parts[2].to_string();
+        // Optional 4th token: the order-invariant SetId. Absent on older
+        // servers, which emit only three tokens.
+        let set_id = parts.get(3).map(|s| s.to_string());
 
         Ok(Self::State {
             position,
             merkle,
             tag_merkle,
+            set_id,
         })
     }
 
@@ -416,6 +448,15 @@ impl StateResponse {
         }
     }
 
+    /// Get the advertised order-invariant `SetId` (base32), if the server
+    /// provided one.
+    pub fn set_id(&self) -> Option<&str> {
+        match self {
+            Self::State { set_id, .. } => set_id.as_deref(),
+            Self::Empty => None,
+        }
+    }
+
     /// Format this response as a protocol line.
     pub fn to_protocol_line(&self) -> String {
         match self {
@@ -423,7 +464,11 @@ impl StateResponse {
                 position,
                 merkle,
                 tag_merkle,
-            } => format!("{} {} {}", position, merkle, tag_merkle),
+                set_id,
+            } => match set_id {
+                Some(sid) => format!("{} {} {} {}", position, merkle, tag_merkle, sid),
+                None => format!("{} {} {}", position, merkle, tag_merkle),
+            },
             Self::Empty => "-".to_string(),
         }
     }
@@ -795,6 +840,7 @@ mod tests {
                 position,
                 merkle,
                 tag_merkle,
+                ..
             } => {
                 assert_eq!(position, 42);
                 assert_eq!(merkle, "ABC123");
@@ -839,6 +885,46 @@ mod tests {
 
         let empty = StateResponse::empty();
         assert_eq!(empty.to_protocol_line(), "-");
+    }
+
+    #[test]
+    fn test_state_response_set_id_optional() {
+        // No SetId: three-token line, set_id() is None (older server).
+        let without = StateResponse::state(42, "ABC", "DEF");
+        assert_eq!(without.set_id(), None);
+        assert_eq!(without.to_protocol_line(), "42 ABC DEF");
+
+        // With SetId: four-token line, round-trips and set_id() is Some.
+        let with = StateResponse::state_with_set_id(42, "ABC", "DEF", "SID32");
+        assert_eq!(with.set_id(), Some("SID32"));
+        assert_eq!(with.to_protocol_line(), "42 ABC DEF SID32");
+        assert_eq!(
+            StateResponse::parse("42 ABC DEF SID32").unwrap(),
+            with,
+            "the optional SetId token round-trips through parse"
+        );
+    }
+
+    #[test]
+    fn test_state_response_parse_ignores_missing_set_id() {
+        // A legacy three-token line parses to set_id = None (backward compat).
+        let parsed = StateResponse::parse("7 MERK TAG").unwrap();
+        assert_eq!(parsed.set_id(), None);
+    }
+
+    #[test]
+    fn test_state_response_set_id_json_backward_compat() {
+        // Older JSON without `set_id` deserializes (serde default = None).
+        let legacy = r#"{"State":{"position":1,"merkle":"M","tag_merkle":"T"}}"#;
+        let parsed: StateResponse = serde_json::from_str(legacy).unwrap();
+        assert_eq!(parsed.set_id(), None);
+
+        // And a None set_id is skipped on serialize (no `set_id` key emitted).
+        let json = serde_json::to_string(&StateResponse::state(1, "M", "T")).unwrap();
+        assert!(
+            !json.contains("set_id"),
+            "None set_id must not be serialized"
+        );
     }
 
     #[test]

--- a/atomic-repository/src/repository/filter.rs
+++ b/atomic-repository/src/repository/filter.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use atomic_core::types::SetId;
+
 /// Collect all change `NodeId`s inserted into a view into a `HashSet`.
 ///
 /// This is the canonical helper for building a **change filter** — the set
@@ -116,6 +118,74 @@ pub fn collect_visible_change_ids_with_deps<T: ViewTxnT>(
     let mut ids = collect_visible_change_ids(txn, view)?;
     expand_indexed_dependency_closure(txn, &mut ids)?;
     Ok(ids)
+}
+
+/// Fold a view's **effective visible change set** into an order-invariant
+/// [`SetId`].
+///
+/// The identity is derived on demand (never stored) by mapping every visible
+/// change `NodeId` — the view's own changes plus everything inherited through
+/// its parent chain, exactly as [`collect_visible_change_ids`] computes it —
+/// back to its external [`Merkle`](atomic_core::types::Merkle) hash and folding
+/// those hashes into a `SetId`.
+///
+/// Because `SetId` is order-invariant, the arbitrary iteration order of the
+/// underlying `HashSet` does not affect the result: two views holding the same
+/// set of changes in any order (e.g. before and after a `view split` +
+/// reinsert) yield the **same** `SetId`, even though their order-sensitive
+/// `Merkle` states legitimately differ.
+///
+/// # Domain
+///
+/// This folds the view's applyable **change** set. Sidecars
+/// (`.provenance`/`.attest`) are never part of `VIEW_CHANGES` and so are
+/// naturally excluded — matching the canonical cross-producer domain documented
+/// on [`atomic_core::types::SetId`].
+///
+/// # Complexity
+///
+/// O(C) in the number of visible changes: one pass to collect the ids and one
+/// external-hash lookup per change.
+pub fn view_set_id<T: ViewTxnT + GraphTxnT>(
+    txn: &T,
+    view: &atomic_core::pristine::ViewState,
+) -> Result<SetId, RepositoryError> {
+    let ids = collect_visible_change_ids(txn, view)?;
+    let mut acc = SetId::ZERO;
+    for id in ids {
+        let hash = txn
+            .get_external(id)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+            .ok_or_else(|| {
+                RepositoryError::Database(format!("change {} has no external hash", id.0))
+            })?;
+        acc = acc.add(&hash);
+    }
+    Ok(acc)
+}
+
+impl Repository {
+    /// Derive the order-invariant [`SetId`] of a view's effective visible
+    /// change set.
+    ///
+    /// This is the content identity that answers "do these two views hold the
+    /// same set of changes?" regardless of the order the changes were applied
+    /// in — the property the order-sensitive `Merkle` state cannot provide. See
+    /// [`view_set_id`] and [`atomic_core::types::SetId`] for the construction,
+    /// the domain contract, and the convergence-identity tradeoff.
+    pub fn view_set_id(&self, name: &str) -> Result<SetId, RepositoryError> {
+        let txn = self
+            .pristine
+            .read_txn()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        let view = txn
+            .get_view(name)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+            .ok_or_else(|| RepositoryError::ViewNotFound {
+                name: name.to_string(),
+            })?;
+        view_set_id(&txn, &view)
+    }
 }
 
 /// Expand `ids` in-place using the pristine change dependency index only.

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -88,7 +88,7 @@ mod views;
 // use `use super::*;` continue to resolve them at `crate::repository::…`.
 pub use filter::{
     collect_view_change_ids, collect_visible_change_ids, collect_visible_change_ids_with_deps,
-    expand_indexed_dependency_closure,
+    expand_indexed_dependency_closure, view_set_id,
 };
 pub use sandbox::{SealOptions, SealResult, StageOptions, StageResult, SANDBOX_POINTER};
 pub use split::{SplitChange, SplitOptions, SplitOutcome};

--- a/atomic-repository/tests/view_setid_test.rs
+++ b/atomic-repository/tests/view_setid_test.rs
@@ -1,0 +1,91 @@
+//! Integration test for the order-invariant view [`SetId`]
+//! (`Repository::view_set_id`, intent ATOM::norman::10, AC-3).
+//!
+//! Proves the payoff: splitting changes out of a view and reinserting them
+//! returns the view to the SAME `SetId` it started with (identity round-trips
+//! home), while the order-sensitive `Merkle` state legitimately differs.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use atomic_core::change::{Author, ChangeHeader};
+use atomic_core::types::{Hash, SetId};
+use atomic_repository::{InsertOptions, RecordOptions, Repository, SplitOptions};
+use tempfile::TempDir;
+
+fn init_repo() -> (Repository, TempDir, PathBuf) {
+    let temp = TempDir::new().expect("temp dir");
+    let path = temp.path().to_path_buf();
+    let repo = Repository::init(&path).expect("init repository");
+    (repo, temp, path)
+}
+
+fn write_and_add(repo: &Repository, root: &Path, name: &str, content: &str) {
+    fs::write(root.join(name), content).expect("write file");
+    repo.add(name, Default::default()).expect("add file");
+}
+
+fn record(repo: &Repository, message: &str) -> Hash {
+    let header = ChangeHeader::builder()
+        .message(message)
+        .author(Author::new("Test", Some("test@example.com")))
+        .build();
+    *repo
+        .record(header, RecordOptions::default())
+        .expect("record")
+        .hash()
+}
+
+#[test]
+fn view_set_id_round_trips_home_after_split_and_reinsert() {
+    let (mut repo, _temp, root) = init_repo();
+    let dev = repo.current_view().to_string();
+
+    // Three independent changes (distinct files → no dependencies), so the
+    // middle one can be split out and reinserted at the tail, reordering the
+    // log without violating any dependency.
+    write_and_add(&repo, &root, "a.txt", "alpha\n");
+    let _c1 = record(&repo, "add a");
+    write_and_add(&repo, &root, "b.txt", "bravo\n");
+    let c2 = record(&repo, "add b");
+    write_and_add(&repo, &root, "c.txt", "charlie\n");
+    let _c3 = record(&repo, "add c");
+
+    let set_before = repo.view_set_id(&dev).expect("set id before");
+    let merkle_before = repo.get_view_info(&dev).expect("info before").state;
+    assert_ne!(
+        set_before,
+        SetId::ZERO,
+        "non-empty view has a non-zero SetId"
+    );
+
+    // Split the middle change out into a draft. dev is now {a, c}.
+    repo.split_view(SplitOptions::new("escape", vec![c2]))
+        .expect("split c2 into escape");
+
+    let set_after_split = repo.view_set_id(&dev).expect("set id after split");
+    assert_ne!(
+        set_after_split, set_before,
+        "removing a change must change the view's SetId"
+    );
+
+    // Reinsert the split-out change back into dev. Its edges are already in the
+    // global graph, so this is a metadata append at the tail: dev's log becomes
+    // {a, c, b} — the same SET as before, in a DIFFERENT order.
+    repo.insert_change(&c2, InsertOptions::default().view(&dev))
+        .expect("reinsert c2 into dev");
+
+    let set_after = repo.view_set_id(&dev).expect("set id after reinsert");
+    let merkle_after = repo.get_view_info(&dev).expect("info after").state;
+
+    // The order-invariant identity returns home...
+    assert_eq!(
+        set_after, set_before,
+        "SetId must round-trip home: same set of changes ⇒ same SetId"
+    );
+    // ...while the order-sensitive Merkle legitimately differs (reordered log).
+    assert_ne!(
+        merkle_after, merkle_before,
+        "Merkle is order-sensitive and must differ after reordering the log"
+    );
+}


### PR DESCRIPTION
This pull request introduces a new order-invariant content identity for views, called `SetId`, across the repository and remote sync protocol. This enables a fast path for determining if two views hold the same set of changes, regardless of their order, improving synchronization efficiency and reliability. The changes are backward-compatible: the new `SetId` field is optional and only used when both client and server support it. The pull request also improves error reporting when dependencies are missing and adds comprehensive tests for the new logic.

**Order-invariant view identity and sync improvements:**

- Added the `SetId` type to `atomic-core` and exposed it for use in other crates, enabling order-invariant content identity for change sets.
- Implemented functions in `atomic-repository` to compute a view's `SetId` by folding the set of visible changes' hashes, and exposed this via the `Repository` API. [[1]](diffhunk://#diff-ce5feaedb31436a624c2ef767408656cd7eb7bc6d7a99946b02441bfa3bf13d9R3-R4) [[2]](diffhunk://#diff-ce5feaedb31436a624c2ef767408656cd7eb7bc6d7a99946b02441bfa3bf13d9R123-R190) [[3]](diffhunk://#diff-e6fb908e7852ab01ffc10ccdb8b3030ec546e76a3fcc56d8316e0114b20faf67L91-R91)
- Extended the remote sync protocol (`StateResponse`) to optionally include a `set_id` field, with full backward compatibility for older servers and clients. Parsing, serialization, and tests were updated accordingly. [[1]](diffhunk://#diff-0202506a9b174d0ac5a2f5f4d76e48cdf27c0423c5e14807c77ded974f2fed22L306-R309) [[2]](diffhunk://#diff-0202506a9b174d0ac5a2f5f4d76e48cdf27c0423c5e14807c77ded974f2fed22R320-R356) [[3]](diffhunk://#diff-0202506a9b174d0ac5a2f5f4d76e48cdf27c0423c5e14807c77ded974f2fed22L348-R376) [[4]](diffhunk://#diff-0202506a9b174d0ac5a2f5f4d76e48cdf27c0423c5e14807c77ded974f2fed22R410-R418) [[5]](diffhunk://#diff-0202506a9b174d0ac5a2f5f4d76e48cdf27c0423c5e14807c77ded974f2fed22R451-R471) [[6]](diffhunk://#diff-0202506a9b174d0ac5a2f5f4d76e48cdf27c0423c5e14807c77ded974f2fed22R843) [[7]](diffhunk://#diff-0202506a9b174d0ac5a2f5f4d76e48cdf27c0423c5e14807c77ded974f2fed22R890-R929)
- Updated the sync engine to use the new `SetId` for a fast path: if the local and remote `SetId` match, the views are declared in sync without further computation. [[1]](diffhunk://#diff-979bdd7becbf8003770c16971c24ce34419791616536901c8d6a000e6c6b9940R467-R487) [[2]](diffhunk://#diff-979bdd7becbf8003770c16971c24ce34419791616536901c8d6a000e6c6b9940R640-R657)

**Error handling and diagnostics:**

- Improved missing dependency error reporting: when the server reports missing change dependencies, the client now extracts and surfaces the offending change hashes, making errors more actionable. Added a utility for extracting base32 hashes and tests for its correctness. [[1]](diffhunk://#diff-5c2c711ab34c6fb3b84268b49ad21941d1788473be87b6e0b9e941a3124b9427R17-R33) [[2]](diffhunk://#diff-5c2c711ab34c6fb3b84268b49ad21941d1788473be87b6e0b9e941a3124b9427L53-R79) [[3]](diffhunk://#diff-5c2c711ab34c6fb3b84268b49ad21941d1788473be87b6e0b9e941a3124b9427R181-R190) [[4]](diffhunk://#diff-5c2c711ab34c6fb3b84268b49ad21941d1788473be87b6e0b9e941a3124b9427L458-R494) [[5]](diffhunk://#diff-5c2c711ab34c6fb3b84268b49ad21941d1788473be87b6e0b9e941a3124b9427R531-R566)

**Dependency and project organization:**

- Added `atomic-core` as an explicit dependency in `atomic-remote` for internal crate access.