### PR TITLE
perf(init): avoid unrelated untracked scans

### DIFF
--- a/atomic-agent/src/record/mod.rs
+++ b/atomic-agent/src/record/mod.rs
@@ -361,6 +361,9 @@ pub fn record_turn(
         .view(options.session.view_name.clone())
         .apply_after_record(true)
         .save_to_store(true)
+        // The agent already discovered and added every untracked destination
+        // above, so a second raw-rename scan cannot find a move.
+        .detect_raw_renames(false)
         .sync_vault(false)
         .enrich_kg(false)
         .provenance(vec![provenance_entry])

--- a/atomic-cli/src/commands/git/import.rs
+++ b/atomic-cli/src/commands/git/import.rs
@@ -777,7 +777,10 @@ fn init_atomicignore_and_vault(
             atomic_repository::TrackingOptions::default(),
         );
         let header = atomic_core::change::ChangeHeader::new("Initialize repository");
-        match repo.record(header, atomic_repository::RecordOptions::default()) {
+        let options = atomic_repository::RecordOptions::new()
+            .add_path(".atomicignore")
+            .detect_raw_renames(false);
+        match repo.record(header, options) {
             Ok(_) => print_info("Recorded .atomicignore"),
             Err(atomic_repository::RecordError::NothingToRecord) => {}
             Err(e) => log::warn!("Failed to record .atomicignore: {}", e),
@@ -816,7 +819,10 @@ fn init_atomicignore_and_vault(
             }
 
             let header = atomic_core::change::ChangeHeader::new("Initialize vault");
-            match repo.record(header, atomic_repository::RecordOptions::default()) {
+            let options = atomic_repository::RecordOptions::new()
+                .add_path(".vault")
+                .detect_raw_renames(false);
+            match repo.record(header, options) {
                 Ok(_) => print_info("Recorded vault defaults"),
                 Err(atomic_repository::RecordError::NothingToRecord) => {}
                 Err(e) => log::warn!("Failed to record vault files: {}", e),

--- a/atomic-cli/src/commands/init.rs
+++ b/atomic-cli/src/commands/init.rs
@@ -588,7 +588,10 @@ impl Command for Init {
                 atomic_repository::TrackingOptions::default(),
             );
             let header = atomic_core::change::ChangeHeader::new("Initialize repository");
-            match repo.record(header, atomic_repository::RecordOptions::default()) {
+            let options = atomic_repository::RecordOptions::new()
+                .add_path(".atomicignore")
+                .detect_raw_renames(false);
+            match repo.record(header, options) {
                 Ok(_) => {}
                 Err(atomic_repository::RecordError::NothingToRecord) => {}
                 Err(e) => log::warn!("Failed to record .atomicignore: {}", e),
@@ -610,7 +613,10 @@ impl Command for Init {
 
             // Record vault files as their own change
             let header = atomic_core::change::ChangeHeader::new("Initialize vault");
-            match repo.record(header, atomic_repository::RecordOptions::default()) {
+            let options = atomic_repository::RecordOptions::new()
+                .add_path(".vault")
+                .detect_raw_renames(false);
+            match repo.record(header, options) {
                 Ok(outcome) => {
                     println!(
                         "Recorded vault defaults ({} files)",

--- a/atomic-cli/src/commands/vault/init.rs
+++ b/atomic-cli/src/commands/vault/init.rs
@@ -49,7 +49,10 @@ impl Command for Init {
 
         // Record vault files as their own change
         let header = atomic_core::change::ChangeHeader::new("Initialize vault");
-        match repo.record(header, atomic_repository::RecordOptions::default()) {
+        let options = atomic_repository::RecordOptions::new()
+            .add_path(".vault")
+            .detect_raw_renames(false);
+        match repo.record(header, options) {
             Ok(_) => print_success("Recorded vault defaults"),
             Err(atomic_repository::RecordError::NothingToRecord) => {}
             Err(e) => log::warn!("Failed to record vault files: {}", e),

--- a/atomic-repository/src/record/options.rs
+++ b/atomic-repository/src/record/options.rs
@@ -97,6 +97,13 @@ pub struct RecordOptions {
     /// resolved before it is baked into history. Set true to override (for
     /// the rare case where such lines are legitimate content).
     allow_conflict_markers: bool,
+
+    /// Whether to detect raw filesystem renames by matching deleted tracked
+    /// files with byte-identical untracked files.
+    ///
+    /// Defaults to `true`. Internal callers that already know every path they
+    /// intend to record may disable this to avoid an unrelated untracked scan.
+    detect_raw_renames: bool,
 }
 
 impl RecordOptions {
@@ -267,6 +274,19 @@ impl RecordOptions {
     #[must_use]
     pub fn get_allow_conflict_markers(&self) -> bool {
         self.allow_conflict_markers
+    }
+
+    /// Set whether raw filesystem renames should be detected.
+    #[must_use]
+    pub fn detect_raw_renames(mut self, detect: bool) -> Self {
+        self.detect_raw_renames = detect;
+        self
+    }
+
+    /// Get whether raw filesystem rename detection is enabled.
+    #[must_use]
+    pub fn get_detect_raw_renames(&self) -> bool {
+        self.detect_raw_renames
     }
 
     /// Set AI provenance information for this change.
@@ -450,6 +470,7 @@ impl Default for RecordOptions {
             enrich_kg: true,
             provenance: Vec::new(),
             allow_conflict_markers: false,
+            detect_raw_renames: true,
         }
     }
 }

--- a/atomic-repository/src/record/tests.rs
+++ b/atomic-repository/src/record/tests.rs
@@ -27,6 +27,7 @@ fn test_options_new_returns_defaults() {
     assert!(opts.get_message().is_none());
     assert!(opts.get_apply_after_record());
     assert!(opts.get_save_to_store());
+    assert!(opts.get_detect_raw_renames());
 }
 
 #[test]
@@ -115,6 +116,12 @@ fn test_options_apply_after_record() {
 fn test_options_save_to_store() {
     let opts = RecordOptions::new().save_to_store(false);
     assert!(!opts.get_save_to_store());
+}
+
+#[test]
+fn test_options_detect_raw_renames() {
+    let opts = RecordOptions::new().detect_raw_renames(false);
+    assert!(!opts.get_detect_raw_renames());
 }
 
 #[test]

--- a/atomic-repository/src/repository/record.rs
+++ b/atomic-repository/src/repository/record.rs
@@ -59,8 +59,14 @@ impl Repository {
 
         // Get repository status to find modified files
         let status_t0 = std::time::Instant::now();
+        let mut status_options = StatusOptions::default();
+        if !options.all() {
+            for path in options.get_paths() {
+                status_options = status_options.filter_path(std::path::PathBuf::from(path));
+            }
+        }
         let status = self
-            .status(StatusOptions::default())
+            .status_for_record(status_options, options.get_detect_raw_renames())
             .map_err(RecordError::Repository)?;
         if trace_record {
             eprintln!(
@@ -168,9 +174,11 @@ impl Repository {
         // as moves so the main loop skips deleting them.
         let mut renamed_from: std::collections::HashSet<String> = std::collections::HashSet::new();
         let mut rename_moves: Vec<(String, String, atomic_core::types::Inode)> = Vec::new();
-        {
-            // Candidate destinations: untracked files present on disk.
-            let mut untracked: Vec<(String, Vec<u8>)> = Vec::new();
+        if options.get_detect_raw_renames() {
+            // Candidate destinations: regular untracked files present on disk,
+            // bucketed by size so unrelated contents are never loaded.
+            let mut untracked_by_size: std::collections::BTreeMap<u64, Vec<String>> =
+                std::collections::BTreeMap::new();
             for e in status.entries() {
                 if e.status() != FileStatus::Untracked {
                     continue;
@@ -179,34 +187,52 @@ impl Repository {
                 if !options.should_include(&p) {
                     continue;
                 }
-                if let Ok(bytes) = std::fs::read(self.root.join(&p)) {
-                    untracked.push((p, bytes));
+                if let Ok(metadata) = std::fs::metadata(self.root.join(&p)) {
+                    if metadata.is_file() {
+                        untracked_by_size.entry(metadata.len()).or_default().push(p);
+                    }
                 }
             }
-            if !untracked.is_empty() {
-                let mut used_new: std::collections::HashSet<usize> =
+
+            for paths in untracked_by_size.values_mut() {
+                paths.sort();
+            }
+
+            if !untracked_by_size.is_empty() {
+                let mut used_new: std::collections::HashSet<String> =
                     std::collections::HashSet::new();
-                for f in &files_to_record {
-                    if f.status() != FileStatus::Deleted {
-                        continue;
-                    }
-                    if f.details().map(|d| d == "directory").unwrap_or(false) {
-                        continue; // directory renames are out of scope for Stage 1
-                    }
+                let mut deleted_candidates: Vec<&FileStatusEntry> = files_to_record
+                    .iter()
+                    .copied()
+                    .filter(|f| {
+                        f.status() == FileStatus::Deleted && f.details() != Some("directory")
+                    })
+                    .collect();
+                deleted_candidates.sort_by(|a, b| a.path().cmp(b.path()));
+
+                for f in deleted_candidates {
                     let old_path = f.path().to_string_lossy().to_string();
                     // The deleted file's content as the graph still holds it.
                     let old_bytes = match self.get_file_content(&old_path) {
                         Ok(Some(b)) => b,
                         _ => continue,
                     };
-                    // Pair with the first unused untracked file of identical bytes.
-                    let matched = untracked.iter().enumerate().find(|(i, (_, nb))| {
-                        !used_new.contains(i) && nb.len() == old_bytes.len() && **nb == old_bytes
-                    });
-                    let Some((idx, (new_path, _))) = matched else {
+                    let Some(candidates) = untracked_by_size.get(&(old_bytes.len() as u64)) else {
                         continue;
                     };
-                    let new_path = new_path.clone();
+                    // Pair with the first unused, same-sized destination whose
+                    // contents are byte-identical. Candidate order is stable.
+                    let matched = candidates.iter().find(|new_path| {
+                        if used_new.contains(*new_path) {
+                            return false;
+                        }
+                        std::fs::read(self.root.join(new_path))
+                            .map(|new_bytes| new_bytes == old_bytes)
+                            .unwrap_or(false)
+                    });
+                    let Some(new_path) = matched.cloned() else {
+                        continue;
+                    };
                     let inode = match f.inode() {
                         Some(ino) => ino,
                         None => match self.get_file_inode(&old_path) {
@@ -214,7 +240,7 @@ impl Repository {
                             _ => continue,
                         },
                     };
-                    used_new.insert(idx);
+                    used_new.insert(new_path.clone());
                     renamed_from.insert(old_path.clone());
                     rename_moves.push((old_path, new_path, inode));
                 }

--- a/atomic-repository/src/repository/status.rs
+++ b/atomic-repository/src/repository/status.rs
@@ -2,6 +2,13 @@ use std::collections::HashMap;
 
 use super::*;
 
+#[derive(Debug, Clone, Copy)]
+enum UntrackedScanPolicy {
+    Always,
+    Never,
+    WhenRegularFileDeleted,
+}
+
 impl Repository {
     // Status Methods
 
@@ -22,6 +29,34 @@ impl Repository {
     /// | 43,000 files | ~150s | <3s |
     /// | 80,000 files | ~150s | <5s |
     pub fn status(&self, options: StatusOptions) -> Result<RepositoryStatus, RepositoryError> {
+        self.status_inner(options, UntrackedScanPolicy::Always, true)
+    }
+
+    /// Compute status for recording without scanning unrelated untracked files.
+    ///
+    /// Raw rename detection is the only record stage that consumes untracked
+    /// entries. When it is enabled, defer the walk until the selected tracked
+    /// status contains a deleted regular file. Untracked content hashes are
+    /// also unnecessary because rename matching reads candidates on demand.
+    pub(crate) fn status_for_record(
+        &self,
+        options: StatusOptions,
+        detect_raw_renames: bool,
+    ) -> Result<RepositoryStatus, RepositoryError> {
+        let policy = if detect_raw_renames {
+            UntrackedScanPolicy::WhenRegularFileDeleted
+        } else {
+            UntrackedScanPolicy::Never
+        };
+        self.status_inner(options, policy, false)
+    }
+
+    fn status_inner(
+        &self,
+        options: StatusOptions,
+        untracked_policy: UntrackedScanPolicy,
+        hash_untracked: bool,
+    ) -> Result<RepositoryStatus, RepositoryError> {
         use std::time::SystemTime;
 
         let overall_start = std::time::Instant::now();
@@ -426,7 +461,21 @@ impl Repository {
         // Only do the expensive walkdir when the caller wants untracked
         // files.  The walk skips .atomic, .git, and ignored paths.
         let untracked_start = std::time::Instant::now();
-        if options.include_untracked {
+        let scan_untracked = options.include_untracked
+            && match untracked_policy {
+                UntrackedScanPolicy::Always => true,
+                UntrackedScanPolicy::Never => false,
+                UntrackedScanPolicy::WhenRegularFileDeleted => status
+                    .entries()
+                    .iter()
+                    .any(|e| e.status() == FileStatus::Deleted && e.details() != Some("directory")),
+            };
+        log::debug!(
+            "status: untracked policy={:?}, scan={}",
+            untracked_policy,
+            scan_untracked
+        );
+        if scan_untracked {
             let rules = if options.respect_ignore_files {
                 Some(self.ignore_rules())
             } else {
@@ -440,7 +489,7 @@ impl Repository {
             for path in working_files {
                 if !tracked_paths.contains(&path) {
                     let mut entry = FileStatusEntry::new(path.clone(), FileStatus::Untracked);
-                    if options.hash_contents {
+                    if hash_untracked && options.hash_contents {
                         let abs_path = self.root.join(&path);
                         if let Ok(hash) = hash_file_contents(&abs_path) {
                             entry.set_current_hash(hash);

--- a/atomic-repository/src/repository/tests/rename_tests.rs
+++ b/atomic-repository/src/repository/tests/rename_tests.rs
@@ -292,3 +292,38 @@ fn test_plain_delete_is_not_a_rename() {
     assert!(sawdel, "plain delete should still record as a FileDel");
     assert!(repo.get_file_inode("f.txt").unwrap().is_none());
 }
+
+/// Internal callers can explicitly disable raw rename detection when they
+/// already know every destination path. The tracked deletion must still be
+/// recorded, while the unrelated untracked file remains outside the change.
+#[test]
+fn test_raw_rename_detection_can_be_disabled() {
+    let (temp, repo) = create_temp_repo();
+    let old = temp.path().join("old.txt");
+
+    std::fs::write(&old, "same content\n").unwrap();
+    repo.add("old.txt", TrackingOptions::default()).unwrap();
+    record_all(&repo, "base").unwrap();
+
+    std::fs::rename(&old, temp.path().join("new.txt")).unwrap();
+    let outcome = repo
+        .record(
+            ChangeHeader::new("delete without rename detection"),
+            RecordOptions::new()
+                .with_all(true)
+                .detect_raw_renames(false),
+        )
+        .unwrap();
+
+    assert!(outcome
+        .change()
+        .hunks()
+        .iter()
+        .any(|op| matches!(op, GraphOp::FileDel { path, .. } if path == "old.txt")));
+    assert!(!outcome
+        .change()
+        .hunks()
+        .iter()
+        .any(|op| matches!(op, GraphOp::FileMove { .. })));
+    assert!(temp.path().join("new.txt").exists());
+}

--- a/atomic-repository/src/status.rs
+++ b/atomic-repository/src/status.rs
@@ -660,7 +660,7 @@ pub struct StatusOptions {
     /// If empty, all paths are checked.
     pub path_filters: Vec<PathBuf>,
 
-    /// Respect .gitignore and similar ignore files.
+    /// Respect Atomic ignore rules (`.atomicignore` and the global ignore file).
     ///
     /// Default: `true`
     pub respect_ignore_files: bool,
@@ -812,6 +812,17 @@ pub fn collect_working_copy_files_with_rules(
                 }
             }
 
+            // Prune directories that cannot contain a selected path. Without
+            // this check, a path-scoped status still traverses the entire
+            // working copy and only filters files after visiting them.
+            if !options.path_filters.is_empty() {
+                if let Ok(rel_path) = e.path().strip_prefix(root) {
+                    if !path_intersects_filters(rel_path, &options.path_filters) {
+                        return false;
+                    }
+                }
+            }
+
             // Check ignore rules if provided and not including ignored files
             if !options.include_ignored {
                 if let Some(rules) = rules {
@@ -838,14 +849,8 @@ pub fn collect_working_copy_files_with_rules(
         // Get path relative to root
         if let Ok(rel_path) = entry.path().strip_prefix(root) {
             // Check path filters if specified
-            if !options.path_filters.is_empty() {
-                let matches_filter = options
-                    .path_filters
-                    .iter()
-                    .any(|filter| rel_path.starts_with(filter) || filter.starts_with(rel_path));
-                if !matches_filter {
-                    continue;
-                }
+            if !path_intersects_filters(rel_path, &options.path_filters) {
+                continue;
             }
 
             // Normalize to forward slashes so paths match TREE entries
@@ -857,6 +862,19 @@ pub fn collect_working_copy_files_with_rules(
     }
 
     Ok(files)
+}
+
+fn path_intersects_filters(path: &Path, filters: &[PathBuf]) -> bool {
+    if filters.is_empty() {
+        return true;
+    }
+
+    let normalized_path = PathBuf::from(path.to_string_lossy().replace('\\', "/"));
+    filters.iter().any(|filter| {
+        let normalized_filter = PathBuf::from(filter.to_string_lossy().replace('\\', "/"));
+        normalized_path.starts_with(&normalized_filter)
+            || normalized_filter.starts_with(&normalized_path)
+    })
 }
 
 // Tests
@@ -1303,6 +1321,32 @@ mod tests {
         assert!(files.contains(&PathBuf::from("src/main.rs")));
         assert!(!files.contains(&PathBuf::from("tests/test.rs")));
         assert!(!files.contains(&PathBuf::from("README.md")));
+    }
+
+    #[test]
+    fn test_path_filters_keep_ancestors_and_prune_siblings() {
+        let filters = vec![PathBuf::from("src/nested/main.rs")];
+
+        assert!(path_intersects_filters(Path::new(""), &filters));
+        assert!(path_intersects_filters(Path::new("src"), &filters));
+        assert!(path_intersects_filters(Path::new("src/nested"), &filters));
+        assert!(path_intersects_filters(
+            Path::new("src/nested/main.rs"),
+            &filters
+        ));
+        assert!(!path_intersects_filters(Path::new("tests"), &filters));
+        assert!(!path_intersects_filters(Path::new("src/other"), &filters));
+    }
+
+    #[test]
+    fn test_path_filters_normalize_platform_separators() {
+        let filters = vec![PathBuf::from("src\\nested\\main.rs")];
+
+        assert!(path_intersects_filters(Path::new("src/nested"), &filters));
+        assert!(path_intersects_filters(
+            Path::new("src/nested/main.rs"),
+            &filters
+        ));
     }
 
     // StatusError Tests

--- a/tests/harness/31_init_lazy_untracked.sh
+++ b/tests/harness/31_init_lazy_untracked.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# 31_init_lazy_untracked.sh — initialization records must not scan unrelated
+# untracked files when their complete path set is already known.
+#
+# A FIFO makes this regression deterministic: the old implementation hashed
+# every untracked entry and blocked opening the FIFO for reading. The optimized
+# path never visits or reads it, so `atomic init` completes normally.
+
+HARNESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$HARNESS_DIR/helpers.sh"
+
+echo "${BOLD}init skips unrelated untracked content${RESET}"
+
+make_temp_repo init-lazy-untracked
+
+if ! command -v mkfifo >/dev/null 2>&1; then
+    skip_suite "mkfifo is unavailable"
+fi
+
+mkfifo unrelated.pipe
+
+INIT_STATUS=0
+atomic init >init.out 2>&1 &
+INIT_PID=$!
+
+# Keep the harness finite if this behavior regresses. Polling avoids relying on
+# GNU `timeout`, which is not installed by default on macOS.
+for _ in {1..100}; do
+    if ! kill -0 "$INIT_PID" 2>/dev/null; then
+        break
+    fi
+    sleep 0.1
+done
+
+if kill -0 "$INIT_PID" 2>/dev/null; then
+    kill "$INIT_PID" 2>/dev/null || true
+    wait "$INIT_PID" 2>/dev/null || true
+    _fail "atomic init completes without reading the FIFO" \
+        "initialization was still running after 10 seconds"
+else
+    wait "$INIT_PID" || INIT_STATUS=$?
+    if [[ "$INIT_STATUS" -eq 0 ]]; then
+        _pass "atomic init completes without reading the FIFO"
+    else
+        _fail "atomic init completes without reading the FIFO" \
+            "atomic init exited $INIT_STATUS: $(head -5 init.out)"
+    fi
+fi
+
+assert_dir_exists "repository metadata was initialized" .atomic
+assert_dir_exists "vault was initialized" .vault
+assert_output_contains "repository initialization remains a separate change" \
+    "Initialize repository" atomic log
+assert_output_contains "vault initialization remains a separate change" \
+    "Initialize vault" atomic log
+
+print_summary


### PR DESCRIPTION
## Why

`atomic init` records two small, known path sets, but each record previously performed a repository-wide untracked walk and hashed every untracked file. In large working copies this made initialization spend roughly 25 seconds in `untracked` twice.

## What changed

- Added a record-only untracked scan policy: skip the walk when raw rename detection is disabled, and defer it until a selected tracked regular file is actually deleted when rename detection is enabled.
- Kept public `status` behavior unchanged, including untracked hashing.
- Added an explicit `RecordOptions::detect_raw_renames` switch that defaults to `true`.
- Scoped init, vault init, Git import initialization, and agent recording to their known paths and disabled redundant raw rename detection.
- Pruned filesystem traversal outside path-filter ancestors.
- Made raw rename matching deterministic and cheaper by grouping regular-file candidates by size and reading only viable candidates on demand.
- Added focused unit/integration coverage and a FIFO-based harness that deterministically fails if init reads unrelated untracked content.

## Behavioral guarantees

- Normal record operations still detect raw renames by default.
- Rename matches remain byte-exact, one-to-one, deterministic, and preserve the original inode/history.
- Repository and vault initialization remain separate Atomic changes.
- Public status and Atomic ignore semantics are unchanged.

## Verification

- `cargo test --workspace`
- `cargo fmt --all -- --check`
- `cargo clippy -p atomic-repository --lib -- -D warnings`
- `cargo clippy -p atomic-agent --lib -- -D warnings`
- `cargo clippy -p atomic-cli --bin atomic -- -D warnings`
- Harness matrix: 26 suites passed, 1 storage suite skipped because its external server was unavailable, 0 failed
- New `31_init_lazy_untracked` harness: 5 passed, 0 failed

The broader `cargo clippy --workspace --all-targets --all-features -- -D warnings` reaches pre-existing warnings in `atomic-repository/src/repository/tests/merge_property_tests.rs`; all production targets touched here pass strict Clippy.
