### PR TITLE
Follow Git default branch naming and update openchamber -f option

### DIFF
--- a/atomic-agent/src/turn/orchestrator/mod.rs
+++ b/atomic-agent/src/turn/orchestrator/mod.rs
@@ -67,6 +67,19 @@ mod turn;
 #[cfg(test)]
 mod tests;
 
+/// True if a `try_lock*` error means the file lock is currently held by another
+/// process, rather than a genuine I/O failure.
+///
+/// On Unix a contended non-blocking lock surfaces as `WouldBlock`, but on
+/// Windows the OS returns `ERROR_LOCK_VIOLATION` (code 33), which maps to
+/// `ErrorKind::Uncategorized` rather than `WouldBlock`. Comparing the raw OS
+/// error against `fs2::lock_contended_error()` handles both platforms.
+pub(crate) fn is_lock_contended(e: &std::io::Error) -> bool {
+    e.kind() == std::io::ErrorKind::WouldBlock
+        || (e.raw_os_error().is_some()
+            && e.raw_os_error() == fs2::lock_contended_error().raw_os_error())
+}
+
 use std::path::{Path, PathBuf};
 
 use crate::error::AgentResult;

--- a/atomic-agent/src/turn/orchestrator/provenance.rs
+++ b/atomic-agent/src/turn/orchestrator/provenance.rs
@@ -80,7 +80,7 @@ impl TurnOrchestrator {
         };
 
         if let Err(e) = lock_file.try_lock_exclusive() {
-            if e.kind() == std::io::ErrorKind::WouldBlock {
+            if super::is_lock_contended(&e) {
                 log::warn!(
                     "Provenance accumulator for session {} is already locked; skipping best-effort provenance update",
                     session_id,
@@ -158,7 +158,7 @@ impl TurnOrchestrator {
         };
 
         if let Err(e) = lock_file.try_lock_exclusive() {
-            if e.kind() == std::io::ErrorKind::WouldBlock {
+            if super::is_lock_contended(&e) {
                 log::warn!(
                     "Provenance accumulator for session {} is already locked; skipping save",
                     session_id,

--- a/atomic-agent/src/turn/orchestrator/turn.rs
+++ b/atomic-agent/src/turn/orchestrator/turn.rs
@@ -485,7 +485,7 @@ impl TurnOrchestrator {
 
         match file.try_lock_exclusive() {
             Ok(()) => TurnEndLock::Acquired(TurnEndLockGuard { file }),
-            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => TurnEndLock::Busy,
+            Err(e) if super::is_lock_contended(&e) => TurnEndLock::Busy,
             Err(e) => {
                 log::warn!(
                     "Failed to acquire turn-end lock for session {}: {}",

--- a/atomic-cli/src/commands/change/command.rs
+++ b/atomic-cli/src/commands/change/command.rs
@@ -658,10 +658,24 @@ impl ChangeCmd {
         change: &Change,
         hash: &Hash,
         sequence: Option<u64>,
+        ledger: Vec<JsonChangeLedger>,
     ) -> String {
-        let json_change = JsonChange::from_change_with_provenance(change, hash, sequence);
+        let json_change =
+            JsonChange::from_change_with_provenance(change, hash, sequence).with_ledger(ledger);
         serde_json::to_string_pretty(&json_change)
             .unwrap_or_else(|e| format!("{{\"error\": \"Failed to serialize: {}\"}}", e))
+    }
+
+    /// Load the change ledger(s) — the causal decision graph(s) from the
+    /// `.provenance` file — for JSON output. Mirrors the `=== Change Ledger ===`
+    /// section of the default text format. Missing/corrupt provenance is
+    /// non-fatal: the ledger simply stays empty (and is omitted from the JSON).
+    fn load_json_ledger(&self, hash: &Hash, repo: &Repository) -> Vec<JsonChangeLedger> {
+        repo.find_provenance_for_change(hash)
+            .unwrap_or_default()
+            .iter()
+            .map(|(graph_hash, graph)| JsonChangeLedger::from_graph(graph_hash, graph))
+            .collect()
     }
 
     /// Print the change in the configured format.
@@ -669,7 +683,10 @@ impl ChangeCmd {
         let output = match self.format {
             ChangeFormat::Default => self.format_default(change, hash, sequence, repo),
             ChangeFormat::Short => self.format_short(change, hash, sequence),
-            ChangeFormat::Json => self.format_json(change, hash, sequence),
+            ChangeFormat::Json => {
+                let ledger = self.load_json_ledger(hash, repo);
+                self.format_json(change, hash, sequence, ledger)
+            }
         };
         print!("{}", output);
     }

--- a/atomic-cli/src/commands/change/mod.rs
+++ b/atomic-cli/src/commands/change/mod.rs
@@ -68,9 +68,24 @@
 //!   "timestamp": "2024-01-15T15:30:45Z",
 //!   "dependencies": ["DEF987...", "GHI111..."],
 //!   "hunks": [...],
-//!   "provenance": null
+//!   "provenance": null,
+//!   "ledger": [
+//!     {
+//!       "graph_hash": "...",
+//!       "session_id": "...",
+//!       "agent_name": "opencode",
+//!       "node_count": 12,
+//!       "edge_count": 11,
+//!       "nodes": [{"id": "...", "kind": "goal", "summary": "..."}],
+//!       "edges": [{"from": "...", "to": "...", "kind": "led_to"}]
+//!     }
+//!   ]
 //! }
 //! ```
+//!
+//! The `ledger` array carries the causal decision graph(s) explaining the
+//! change (the machine-readable form of the `=== Change Ledger ===` text
+//! section). It is omitted entirely when no provenance graph is recorded.
 //!
 //! # Change Identification
 //!

--- a/atomic-cli/src/commands/change/tests.rs
+++ b/atomic-cli/src/commands/change/tests.rs
@@ -509,7 +509,7 @@ mod tests {
         let cmd = ChangeCmd::new();
         let change = create_test_change();
         let hash = Hash::of(b"test");
-        let output = cmd.format_json(&change, &hash, Some(10));
+        let output = cmd.format_json(&change, &hash, Some(10), Vec::new());
 
         let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
         assert_eq!(parsed["message"], "Test change message");
@@ -521,7 +521,7 @@ mod tests {
         let cmd = ChangeCmd::new();
         let change = create_test_change();
         let hash = Hash::of(b"test");
-        let output = cmd.format_json(&change, &hash, None);
+        let output = cmd.format_json(&change, &hash, None, Vec::new());
 
         let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
         assert!(parsed.get("sequence").is_none() || parsed["sequence"].is_null());
@@ -842,6 +842,94 @@ mod tests {
     }
 
     #[test]
+    fn test_format_json_includes_change_ledger() {
+        use atomic_core::change::provenance_graph::{
+            ProvenanceEdge, ProvenanceEdgeKind, ProvenanceNode, ProvenanceNodeKind,
+        };
+        use atomic_core::change::ProvenanceGraphBuilder;
+
+        let goal = ProvenanceNode {
+            id: "sess1-0".into(),
+            kind: ProvenanceNodeKind::Goal,
+            timestamp: 1000,
+            summary: "Add JSON ledger export".into(),
+            detail: Some(r#"{"intent":"export ledger"}"#.into()),
+            change_hash: None,
+            tool_name: None,
+            tool_call_id: None,
+            duration_ms: None,
+            classified: false,
+            confidence: None,
+            consolidated_from: Vec::new(),
+        };
+        let commit = ProvenanceNode {
+            id: "sess1-1".into(),
+            kind: ProvenanceNodeKind::Commitment,
+            timestamp: 2000,
+            summary: "Edit types.rs".into(),
+            detail: None,
+            change_hash: None,
+            tool_name: Some("edit".into()),
+            tool_call_id: Some("call-1".into()),
+            duration_ms: Some(150),
+            classified: false,
+            confidence: None,
+            consolidated_from: Vec::new(),
+        };
+        let graph = ProvenanceGraphBuilder::new("sess1", "opencode")
+            .agent_display_name("OpenCode")
+            .agent_vendor("anthropic")
+            .timestamp(42)
+            .add_node(goal)
+            .add_node(commit)
+            .add_edge(ProvenanceEdge {
+                from: "sess1-0".into(),
+                to: "sess1-1".into(),
+                kind: ProvenanceEdgeKind::CommittedVia,
+            })
+            .build();
+
+        let graph_hash = Hash::of(b"graph");
+        let ledger = vec![JsonChangeLedger::from_graph(&graph_hash, &graph)];
+
+        let cmd = ChangeCmd::new();
+        let change = create_test_change();
+        let hash = Hash::of(b"test");
+        let output = cmd.format_json(&change, &hash, Some(1), ledger);
+
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        let ledgers = parsed["ledger"].as_array().expect("ledger array present");
+        assert_eq!(ledgers.len(), 1);
+        let l = &ledgers[0];
+        assert_eq!(l["session_id"], "sess1");
+        assert_eq!(l["agent_name"], "opencode");
+        assert_eq!(l["agent_display_name"], "OpenCode");
+        assert_eq!(l["node_count"], 2);
+        assert_eq!(l["edge_count"], 1);
+        assert_eq!(l["nodes"][0]["kind"], "goal");
+        // detail is parsed into a JSON object, not left as a string.
+        assert_eq!(l["nodes"][0]["detail"]["intent"], "export ledger");
+        assert_eq!(l["nodes"][1]["kind"], "commitment");
+        assert_eq!(l["nodes"][1]["tool_name"], "edit");
+        assert_eq!(l["nodes"][1]["duration_ms"], 150);
+        assert_eq!(l["edges"][0]["from"], "sess1-0");
+        assert_eq!(l["edges"][0]["to"], "sess1-1");
+        assert_eq!(l["edges"][0]["kind"], "committed_via");
+    }
+
+    #[test]
+    fn test_format_json_omits_ledger_when_empty() {
+        let cmd = ChangeCmd::new();
+        let change = create_test_change();
+        let hash = Hash::of(b"test");
+        let output = cmd.format_json(&change, &hash, Some(1), Vec::new());
+
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        // Empty ledger is omitted entirely (skip_serializing_if).
+        assert!(parsed.get("ledger").is_none());
+    }
+
+    #[test]
     fn test_format_json_with_dependencies() {
         let cmd = ChangeCmd::new();
         let dep_hash = Hash::of(b"dependency");
@@ -854,7 +942,7 @@ mod tests {
             vec![dep_hash],
         );
         let hash = Hash::of(b"main change");
-        let output = cmd.format_json(&change, &hash, None);
+        let output = cmd.format_json(&change, &hash, None, Vec::new());
 
         let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
         assert!(parsed["dependencies"].is_array());

--- a/atomic-cli/src/commands/change/types.rs
+++ b/atomic-cli/src/commands/change/types.rs
@@ -242,6 +242,13 @@ pub struct JsonChange {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unhashed: Option<serde_json::Value>,
 
+    /// Change ledger(s): the causal decision graph(s) explaining this change,
+    /// loaded from the `.provenance` file. Empty when no provenance graph is
+    /// recorded for the change. This is the machine-readable equivalent of the
+    /// `=== Change Ledger ===` section in the default text output.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub ledger: Vec<JsonChangeLedger>,
+
     /// Sequence number in the current view (if known).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sequence: Option<u64>,
@@ -278,6 +285,7 @@ impl JsonChange {
             has_provenance: change.has_provenance(),
             provenance: None,
             unhashed: change.unhashed.clone(),
+            ledger: Vec::new(),
             sequence,
         }
     }
@@ -293,6 +301,166 @@ impl JsonChange {
             json.provenance = Some(JsonProvenance::from(prov));
         }
         json
+    }
+
+    /// Attach the change ledger(s) (causal decision graph) to this JSON change.
+    ///
+    /// Consumes and returns `self` so it can be chained after construction.
+    pub fn with_ledger(mut self, ledger: Vec<JsonChangeLedger>) -> Self {
+        self.ledger = ledger;
+        self
+    }
+}
+
+/// JSON representation of a change ledger (one provenance/decision graph).
+///
+/// Mirrors [`atomic_core::change::ProvenanceGraph`] but flattens node/edge
+/// kinds to their stable snake_case labels and encodes hashes as Base32 so the
+/// output is stable and self-describing for external tooling.
+#[derive(Debug, Clone, Serialize)]
+pub struct JsonChangeLedger {
+    /// Base32 hash of the provenance graph itself.
+    pub graph_hash: String,
+    /// Session identifier linking graphs within the same session.
+    pub session_id: String,
+    /// Agent registry key (e.g. "claude-code", "opencode").
+    pub agent_name: String,
+    /// Human-readable agent name (e.g. "Claude Code").
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub agent_display_name: String,
+    /// AI vendor (e.g. "anthropic", "openai").
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub agent_vendor: String,
+    /// Graph creation timestamp (Unix epoch seconds).
+    pub timestamp: i64,
+    /// Schema profile identifier (e.g. "sherpa-trace/1.0.0"), when present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    /// Vault work-item/intent ID governing this turn, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plan_id: Option<String>,
+    /// Number of nodes in the decision graph.
+    pub node_count: usize,
+    /// Number of causal edges in the decision graph.
+    pub edge_count: usize,
+    /// Number of changes this graph explains.
+    pub change_count: usize,
+    /// Base32 hashes of the changes this graph explains.
+    pub changes_explained: Vec<String>,
+    /// Base32 hash of the previous graph in this session chain, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous: Option<String>,
+    /// The typed nodes in the decision DAG.
+    pub nodes: Vec<JsonLedgerNode>,
+    /// The causal edges between nodes.
+    pub edges: Vec<JsonLedgerEdge>,
+}
+
+/// JSON representation of a single provenance graph node.
+#[derive(Debug, Clone, Serialize)]
+pub struct JsonLedgerNode {
+    /// Unique node identifier within the graph.
+    pub id: String,
+    /// Node kind label (snake_case: "goal", "exploration", "commitment", ...).
+    pub kind: String,
+    /// When this activity occurred (Unix epoch milliseconds).
+    pub timestamp: i64,
+    /// One-line human-readable summary.
+    pub summary: String,
+    /// Kind-specific structured detail. Parsed to JSON when it is valid JSON,
+    /// otherwise carried as a raw string.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<serde_json::Value>,
+    /// Base32 hash of the change this node produced, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub change_hash: Option<String>,
+    /// Tool name that produced this node.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+    /// Tool call ID for correlating pre/post pairs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+    /// Duration of the tool call in milliseconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    /// Whether the classifier consolidated this node.
+    pub classified: bool,
+    /// Classifier confidence (0.0–1.0).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f32>,
+    /// IDs of raw tool-call nodes this decision consolidates.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub consolidated_from: Vec<String>,
+}
+
+/// JSON representation of a causal edge between two provenance nodes.
+#[derive(Debug, Clone, Serialize)]
+pub struct JsonLedgerEdge {
+    /// Source node ID (the cause).
+    pub from: String,
+    /// Target node ID (the effect).
+    pub to: String,
+    /// Edge kind label (snake_case: "led_to", "explored_via", ...).
+    pub kind: String,
+}
+
+impl JsonChangeLedger {
+    /// Build a JSON ledger from a provenance graph and its content hash.
+    pub fn from_graph(graph_hash: &Hash, graph: &atomic_core::change::ProvenanceGraph) -> Self {
+        Self {
+            graph_hash: graph_hash.to_base32(),
+            session_id: graph.session_id.clone(),
+            agent_name: graph.agent_name.clone(),
+            agent_display_name: graph.agent_display_name.clone(),
+            agent_vendor: graph.agent_vendor.clone(),
+            timestamp: graph.timestamp,
+            profile: graph.profile.clone(),
+            plan_id: graph.plan_id.clone(),
+            node_count: graph.node_count(),
+            edge_count: graph.edge_count(),
+            change_count: graph.change_count(),
+            changes_explained: graph
+                .changes_explained
+                .iter()
+                .map(|h| h.to_base32())
+                .collect(),
+            previous: graph.previous.as_ref().map(|h| h.to_base32()),
+            nodes: graph.nodes.iter().map(JsonLedgerNode::from).collect(),
+            edges: graph.edges.iter().map(JsonLedgerEdge::from).collect(),
+        }
+    }
+}
+
+impl From<&atomic_core::change::provenance_graph::ProvenanceNode> for JsonLedgerNode {
+    fn from(node: &atomic_core::change::provenance_graph::ProvenanceNode) -> Self {
+        let detail = node.detail.as_ref().map(|d| {
+            serde_json::from_str::<serde_json::Value>(d)
+                .unwrap_or_else(|_| serde_json::Value::String(d.clone()))
+        });
+        Self {
+            id: node.id.clone(),
+            kind: node.kind.to_string(),
+            timestamp: node.timestamp,
+            summary: node.summary.clone(),
+            detail,
+            change_hash: node.change_hash.as_ref().map(|h| h.to_base32()),
+            tool_name: node.tool_name.clone(),
+            tool_call_id: node.tool_call_id.clone(),
+            duration_ms: node.duration_ms,
+            classified: node.classified,
+            confidence: node.confidence,
+            consolidated_from: node.consolidated_from.clone(),
+        }
+    }
+}
+
+impl From<&atomic_core::change::provenance_graph::ProvenanceEdge> for JsonLedgerEdge {
+    fn from(edge: &atomic_core::change::provenance_graph::ProvenanceEdge) -> Self {
+        Self {
+            from: edge.from.clone(),
+            to: edge.to.clone(),
+            kind: edge.kind.to_string(),
+        }
     }
 }
 

--- a/atomic-cli/src/commands/git/hooks.rs
+++ b/atomic-cli/src/commands/git/hooks.rs
@@ -1,9 +1,11 @@
 //! Git hook installer for automatic Atomic sync.
 //!
-//! Installs `post-commit`, `post-merge`, and `post-rewrite` hooks that
-//! call `atomic git import --incremental` after each git operation.
-//! The import is idempotent — if a commit is already indexed in
-//! GIT_SHA_INDEX, it's skipped.
+//! Installs `post-commit`, `post-merge`, and `post-rewrite` hooks that call
+//! `atomic git import --incremental` after each git operation (idempotent — an
+//! already-indexed commit is skipped), plus a **warn-only** `post-checkout`
+//! hook that flags when git HEAD has moved to a branch that no longer matches
+//! the current Atomic view, pointing the user at the resync command. The
+//! warn hook mutates nothing (SPEC-single-materializer-validator.md §5.4).
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -17,12 +19,26 @@ use crate::output::{print_info, print_warning};
 const MARKER_BEGIN: &str = "# atomic:git:begin";
 const MARKER_END: &str = "# atomic:git:end";
 
-/// The hook script body inserted between markers.
+/// The import hook body inserted between markers on write hooks.
 /// Fails silently (|| true) so git operations never break.
 const HOOK_BODY: &str = r#"atomic git import --incremental 2>/dev/null || true"#;
 
-/// The three hooks we install.
-const HOOK_NAMES: &[&str] = &["post-commit", "post-merge", "post-rewrite"];
+/// Warn-only `post-checkout` body (SPEC §5.4): if git HEAD moved to a branch
+/// that differs from the current Atomic view, print a resync hint. It mutates
+/// nothing — no switch, no import, no commit — and only acts on branch
+/// checkouts (`$3 == 1`), not file checkouts.
+const SYNC_WARN_BODY: &str = r#"if [ "$3" = "1" ]; then b=$(git symbolic-ref --short HEAD 2>/dev/null); v=$(tr -d '[:space:]' < .atomic/current_view 2>/dev/null); if [ -n "$b" ] && [ -n "$v" ] && [ "$b" != "$v" ]; then echo "atomic: git is on '$b' but the Atomic view is '$v'; run 'atomic view switch $b' to resync (or 'atomic git import' to onboard git-side work)." >&2; fi; fi"#;
+
+/// The hooks we install. `post-checkout` is warn-only; the rest run import.
+const HOOK_NAMES: &[&str] = &["post-commit", "post-merge", "post-rewrite", "post-checkout"];
+
+/// The hook-script body for a given hook name.
+fn body_for_hook(name: &str) -> &'static str {
+    match name {
+        "post-checkout" => SYNC_WARN_BODY,
+        _ => HOOK_BODY,
+    }
+}
 
 /// Manage Git hooks for automatic Atomic sync.
 #[derive(Debug, Args)]
@@ -134,8 +150,13 @@ fn install_single_hook(path: &Path, _name: &str) -> Result<bool, std::io::Error>
         return Ok(false);
     }
 
-    // Build the section to append
-    let section = format!("\n{}\n{}\n{}\n", MARKER_BEGIN, HOOK_BODY, MARKER_END);
+    // Build the section to append (body depends on which hook this is).
+    let section = format!(
+        "\n{}\n{}\n{}\n",
+        MARKER_BEGIN,
+        body_for_hook(_name),
+        MARKER_END
+    );
 
     let new_content = if existing.is_empty() {
         format!("#!/bin/sh\n{}", section)

--- a/atomic-cli/src/commands/git/import.rs
+++ b/atomic-cli/src/commands/git/import.rs
@@ -37,7 +37,10 @@ use git2::{Repository as GitRepository, Sort};
 
 use atomic_repository::Repository;
 
-use super::parallel::{ParallelImportOptions, ParallelImporter};
+use super::parallel::{
+    forecast_commit_kind, incremental_import_skips, ForecastKind, ParallelImportOptions,
+    ParallelImporter,
+};
 use crate::commands::{find_repository_root, Command};
 use crate::error::{CliError, CliResult};
 use crate::output::{print_hint, print_info, print_success, print_warning};
@@ -273,10 +276,15 @@ impl Import {
     /// The states let the importer skip commits created by `atomic git
     /// push`: such a commit trailers the view state it represents, and if
     /// that state is already known the commit adds nothing.
+    ///
+    /// `repair_index` controls the best-effort Git SHA index repair. Real
+    /// imports pass `true`; the `--dry-run` forecast passes `false` so it can
+    /// compute markers against a read-only handle without writing anything.
     fn get_incremental_markers(
         &self,
         repo: &Repository,
         view_name: &str,
+        repair_index: bool,
     ) -> CliResult<(HashSet<String>, HashSet<atomic_core::types::Merkle>)> {
         use atomic_repository::HistoryOptions;
 
@@ -310,16 +318,37 @@ impl Import {
             }
         }
 
+        // Inserted squashes (SPEC §4) write no change record, so their git SHA
+        // isn't reachable via change `unhashed` metadata. The ReviewGate tag on
+        // the target view owns that provenance — scan tags for `git.sha` so a
+        // re-import recognises the squash as already imported and skips it.
+        if let Ok(tags) = repo.list_tags_for_view(view_name) {
+            for tag in tags {
+                if let Some(sha) = tag
+                    .metadata
+                    .as_ref()
+                    .and_then(|m| m.get("git"))
+                    .and_then(|g| g.get("sha"))
+                    .and_then(|v| v.as_str())
+                {
+                    shas.insert(sha.to_string());
+                }
+            }
+        }
+
         // Repair the acceleration index while scanning older repositories.
         // The explicit target-view history is authoritative; index repair is
         // best-effort and batched so a no-op sync never commits once per
-        // historical Git change.
-        if let Err(error) = repo.index_git_shas(&index_repairs) {
-            log::warn!(
-                "Failed to repair Git SHA index for view '{}': {}",
-                view_name,
-                error
-            );
+        // historical Git change. Skipped for dry-run forecasts, which must not
+        // write to the repository.
+        if repair_index {
+            if let Err(error) = repo.index_git_shas(&index_repairs) {
+                log::warn!(
+                    "Failed to repair Git SHA index for view '{}': {}",
+                    view_name,
+                    error
+                );
+            }
         }
 
         Ok((shas, states))
@@ -365,12 +394,19 @@ impl Import {
         })
     }
 
-    /// Count commits for dry-run mode.
+    /// Count the commits a real import would create, for dry-run mode.
+    ///
+    /// In incremental mode this applies the exact same skip rules as the real
+    /// import — already-imported SHAs and self-pushed commits whose view state
+    /// is already present — via [`incremental_import_skips`], so the forecast
+    /// matches what the import would actually bring in.
     fn count_commits(
         &self,
         git_repo: &GitRepository,
         head_oid: git2::Oid,
         imported_shas: &HashSet<String>,
+        known_states: &HashSet<atomic_core::types::Merkle>,
+        target_view: &str,
         mainline_only: bool,
     ) -> CliResult<usize> {
         let mut revwalk = git_repo.revwalk().map_err(|e| CliError::GitError {
@@ -401,14 +437,119 @@ impl Import {
                 message: format!("Revwalk error: {}", e),
             })?;
 
-            if self.incremental && imported_shas.contains(&oid.to_string()) {
-                continue;
+            if self.incremental {
+                let sha = oid.to_string();
+                let commit = git_repo.find_commit(oid).map_err(|e| CliError::GitError {
+                    message: format!("Failed to load commit {}: {}", sha, e),
+                })?;
+                let message = commit.message().unwrap_or("");
+                if incremental_import_skips(&sha, message, imported_shas, target_view, known_states)
+                {
+                    continue;
+                }
             }
 
             count += 1;
         }
 
         Ok(count)
+    }
+
+    /// Classify the commits an incremental import would bring in and print a
+    /// per-shape recommendation (SPEC §4.4). Purely advisory — writes nothing.
+    fn print_forecast_recommendations(
+        &self,
+        git_repo: &GitRepository,
+        head_oid: git2::Oid,
+        imported_shas: &HashSet<String>,
+        known_states: &HashSet<atomic_core::types::Merkle>,
+        target_view: &str,
+        repo: Option<&Repository>,
+    ) -> CliResult<()> {
+        use atomic_core::types::{Base32, Hash};
+
+        let mut revwalk = git_repo.revwalk().map_err(|e| CliError::GitError {
+            message: format!("Failed to create revwalk: {}", e),
+        })?;
+        revwalk.push(head_oid).map_err(|e| CliError::GitError {
+            message: format!("Failed to push HEAD to revwalk: {}", e),
+        })?;
+        if !self.all_branches {
+            revwalk
+                .simplify_first_parent()
+                .map_err(|e| CliError::GitError {
+                    message: format!("Failed to simplify revwalk: {}", e),
+                })?;
+        }
+        revwalk
+            .set_sorting(Sort::TOPOLOGICAL | Sort::REVERSE)
+            .map_err(|e| CliError::GitError {
+                message: format!("Failed to set sorting: {}", e),
+            })?;
+
+        let mut insertable = 0usize;
+        let mut missing = 0usize;
+        let mut merges = 0usize;
+        let mut normal = 0usize;
+
+        for oid_result in revwalk {
+            let oid = oid_result.map_err(|e| CliError::GitError {
+                message: format!("Revwalk error: {}", e),
+            })?;
+            let sha = oid.to_string();
+            let commit = git_repo.find_commit(oid).map_err(|e| CliError::GitError {
+                message: format!("Failed to load commit {}: {}", sha, e),
+            })?;
+            let message = commit.message().unwrap_or("");
+            if incremental_import_skips(&sha, message, imported_shas, target_view, known_states) {
+                continue;
+            }
+            let is_merge = commit.parent_count() > 1;
+            let records_present = |h: &str| {
+                repo.map(|r| {
+                    Hash::from_base32(h.as_bytes())
+                        .map(|hash| r.has_change(&hash))
+                        .unwrap_or(false)
+                })
+                .unwrap_or(false)
+            };
+            match forecast_commit_kind(message, is_merge, records_present) {
+                ForecastKind::SquashInsertable { count, pr } => {
+                    insertable += 1;
+                    let label = pr
+                        .map(|n| format!("PR #{}", n))
+                        .unwrap_or_else(|| "squash".to_string());
+                    print_info(&format!(
+                        "  squash ({}) — atomic headers present, {} record{} available: \
+                         will insert into '{}' and tag the aggregate",
+                        label,
+                        count,
+                        if count == 1 { "" } else { "s" },
+                        target_view
+                    ));
+                }
+                ForecastKind::SquashRecordsMissing { count } => {
+                    missing += 1;
+                    print_info(&format!(
+                        "  squash — atomic headers present but {} record{} missing locally: \
+                         run `atomic pull`, then re-import",
+                        count,
+                        if count == 1 { "" } else { "s" }
+                    ));
+                }
+                ForecastKind::Merge => merges += 1,
+                ForecastKind::Normal => normal += 1,
+            }
+        }
+
+        if normal > 0 && insertable == 0 && missing == 0 && merges == 0 {
+            print_info(
+                "  git-authored commits (no atomic headers): a normal import will \
+                 record them as changes",
+            );
+        }
+
+        Ok(())
     }
 }
 
@@ -434,19 +575,57 @@ impl Command for Import {
                 vec![self.branch.clone().unwrap_or(default_branch)]
             };
 
+            // For an incremental forecast, open the existing Atomic repo
+            // read-only so we can subtract what each branch's view already
+            // contains. A fresh (not-yet-initialized) repo has nothing
+            // imported, so the forecast is the full history — which is correct.
+            let repo = if self.incremental && workdir.join(".atomic").join("pristine.redb").exists()
+            {
+                Repository::open_readonly(workdir).ok()
+            } else {
+                None
+            };
+
             for branch_name in &branches {
                 if let Ok(reference) = git_repo.find_branch(branch_name, git2::BranchType::Local) {
                     if let Some(target) = reference.get().target() {
+                        // Compute the same incremental markers the real import
+                        // would use for this branch's view (without repairing
+                        // the index — a dry run writes nothing).
+                        let (imported_shas, known_states) = match &repo {
+                            Some(repo) if repo.view_exists(branch_name).unwrap_or(false) => {
+                                self.get_incremental_markers(repo, branch_name, false)?
+                            }
+                            _ => (HashSet::new(), HashSet::new()),
+                        };
+
                         let count = self.count_commits(
                             &git_repo,
                             target,
-                            &HashSet::new(),
+                            &imported_shas,
+                            &known_states,
+                            branch_name,
                             !self.all_branches,
                         )?;
                         print_info(&format!(
-                            "Would import {} commits from branch '{}'",
-                            count, branch_name
+                            "Would import {} commit{} from branch '{}'",
+                            count,
+                            if count == 1 { "" } else { "s" },
+                            branch_name
                         ));
+
+                        // Router (SPEC §4.4): classify the incoming commits and
+                        // recommend the right path for each shape.
+                        if self.incremental && count > 0 {
+                            self.print_forecast_recommendations(
+                                &git_repo,
+                                target,
+                                &imported_shas,
+                                &known_states,
+                                branch_name,
+                                repo.as_ref(),
+                            )?;
+                        }
                     }
                 }
             }
@@ -512,7 +691,7 @@ impl Command for Import {
                 }
 
                 let (imported_shas, known_states) = if self.incremental {
-                    self.get_incremental_markers(&repo, &branch_name)?
+                    self.get_incremental_markers(&repo, &branch_name, true)?
                 } else {
                     (HashSet::new(), HashSet::new())
                 };
@@ -617,7 +796,7 @@ impl Command for Import {
             }
 
             let (imported_shas, known_states) = if self.incremental {
-                self.get_incremental_markers(&repo, &branch_name)?
+                self.get_incremental_markers(&repo, &branch_name, true)?
             } else {
                 (HashSet::new(), HashSet::new())
             };

--- a/atomic-cli/src/commands/git/import.rs
+++ b/atomic-cli/src/commands/git/import.rs
@@ -458,6 +458,10 @@ impl Command for Import {
             print_info("Configured Git to ignore Atomic local state.");
         }
 
+        // Determine Git's default branch up front so a fresh Atomic repo can
+        // adopt it as its default view (rather than the generic `dev` view).
+        let default_branch = self.get_default_branch(&git_repo)?;
+
         // Check if Atomic repository exists in THIS directory (not parent dirs).
         // Don't use find_repository_root() — it walks up and might find
         // ~/.atomic/ (global config dir) which isn't a repo.
@@ -465,8 +469,14 @@ impl Command for Import {
         let mut repo = if repo_exists {
             Repository::open(workdir).map_err(|e| CliError::Internal(e.into()))?
         } else {
-            print_info("Initializing Atomic repository...");
-            Repository::init(workdir).map_err(|e| CliError::Internal(e.into()))?
+            print_info(&format!(
+                "Initializing Atomic repository (default view '{}')...",
+                default_branch
+            ));
+            // Seed the default view with Git's default branch name so Atomic's
+            // shared view matches the project's Git default branch.
+            Repository::init_with_view(workdir, &default_branch)
+                .map_err(|e| CliError::Internal(e.into()))?
         };
 
         let original_view = repo.current_view().to_string();
@@ -482,9 +492,6 @@ impl Command for Import {
                  Pass --with-crdt to pre-materialize token-level blame/diff for imported history.",
             );
         }
-
-        // Determine which branches to import
-        let default_branch = self.get_default_branch(&git_repo)?;
 
         if self.all_branches {
             // Import all branches

--- a/atomic-cli/src/commands/git/import.rs
+++ b/atomic-cli/src/commands/git/import.rs
@@ -169,7 +169,7 @@ struct BranchImportMode {
     preserve_working_copy: bool,
 }
 
-fn ensure_git_shadow_excludes(git_dir: &Path) -> CliResult<bool> {
+pub(crate) fn ensure_git_shadow_excludes(git_dir: &Path) -> CliResult<bool> {
     let info_dir = git_dir.join("info");
     std::fs::create_dir_all(&info_dir)?;
 

--- a/atomic-cli/src/commands/git/mod.rs
+++ b/atomic-cli/src/commands/git/mod.rs
@@ -58,6 +58,7 @@ pub mod hooks;
 pub mod import;
 pub mod parallel;
 pub mod push;
+pub(crate) mod shadow;
 
 use clap::Subcommand;
 

--- a/atomic-cli/src/commands/git/parallel.rs
+++ b/atomic-cli/src/commands/git/parallel.rs
@@ -102,6 +102,12 @@ pub struct ImportStats {
     /// Commits skipped because they were created by `atomic git push` and
     /// the view already contains the state they reference.
     pub self_push_skipped: usize,
+    /// Squash commits represented by inserting their original change records
+    /// into the target view instead of writing a new squash change (SPEC §4).
+    pub squash_inserted: usize,
+    /// Atomic-origin squash commits skipped because their originals were not
+    /// present locally, or inserting them diverged from the git tree (SPEC §5).
+    pub squash_skipped: usize,
     /// Time spent in Phase 1 (parsing).
     pub phase1_duration: std::time::Duration,
     /// Time spent in Phase 2 (writing).
@@ -169,8 +175,46 @@ fn should_skip_self_push(parsed: &ParsedCommit, options: &ParallelImportOptions)
     }
     match &parsed.push_trailer {
         Some(trailer) => {
-            trailer.view == options.target_view && options.known_states.contains(&trailer.state)
+            self_push_state_known(trailer, &options.target_view, &options.known_states)
         }
+        None => false,
+    }
+}
+
+/// The self-push rule in one place: a commit created by `atomic git push`
+/// carries the target view's Merkle state, so if that view already has the
+/// state, the commit adds nothing. Shared by [`should_skip_self_push`] and
+/// [`incremental_import_skips`] so the real import and the `--dry-run` forecast
+/// can never disagree on it.
+fn self_push_state_known(
+    trailer: &PushTrailer,
+    target_view: &str,
+    known_states: &HashSet<Merkle>,
+) -> bool {
+    trailer.view == target_view && known_states.contains(&trailer.state)
+}
+
+/// Whether an incremental import would skip the git commit identified by `sha`
+/// with the given commit `message`, for a target view that already contains
+/// `imported_shas` and `known_states`.
+///
+/// This mirrors exactly what the real importer does — the SHA skip in
+/// `collect_commit_oids` (already-imported commits) plus the self-push skip in
+/// `phase2_write` (commits whose carried view state is already present). It is
+/// the single source of truth used by `atomic git import --dry-run` to forecast
+/// the real import count. Callers must only invoke it for incremental imports.
+pub(crate) fn incremental_import_skips(
+    sha: &str,
+    message: &str,
+    imported_shas: &HashSet<String>,
+    target_view: &str,
+    known_states: &HashSet<Merkle>,
+) -> bool {
+    if imported_shas.contains(sha) {
+        return true;
+    }
+    match parse_push_trailer(message) {
+        Some(trailer) => self_push_state_known(&trailer, target_view, known_states),
         None => false,
     }
 }
@@ -2281,10 +2325,14 @@ impl ParallelImporter {
             stats.empty_commits += write_stats.empty_commits;
             stats.merge_commits += write_stats.merge_commits;
             stats.self_push_skipped += write_stats.self_push_skipped;
+            stats.squash_inserted += write_stats.squash_inserted;
+            stats.squash_skipped += write_stats.squash_skipped;
             stats.files_processed += write_stats.files_processed;
 
-            commits_written +=
-                write_stats.changes_written + write_stats.empty_commits + write_stats.merge_commits;
+            commits_written += write_stats.changes_written
+                + write_stats.empty_commits
+                + write_stats.merge_commits
+                + write_stats.squash_inserted;
             all_imported_commits.extend(batch_imported);
 
             let total_elapsed = import_start.elapsed();
@@ -2611,6 +2659,27 @@ impl ParallelImporter {
                 continue;
             }
 
+            // Squash → insert (SPEC §4): an atomic-origin squash-merge is
+            // represented by inserting its original change records into the
+            // target view, not by writing a new squash change. Only attempted
+            // on incremental imports (the git-shadow-sync workflow), where the
+            // originals already exist in the graph.
+            if self.options.incremental {
+                match self.try_squash_insert(repo, parsed)? {
+                    SquashDecision::Inserted(info) => {
+                        stats.squash_inserted += 1;
+                        stats.files_processed += parsed.files.len();
+                        imported_commits.push(info);
+                        continue;
+                    }
+                    SquashDecision::Skipped => {
+                        stats.squash_skipped += 1;
+                        continue;
+                    }
+                    SquashDecision::NotSquash => {}
+                }
+            }
+
             // Progress reporting with per-batch timing
             if total > 100 && idx % 100 == 0 {
                 if idx == 0 {
@@ -2686,6 +2755,142 @@ impl ParallelImporter {
         }
 
         Ok((stats, imported_commits))
+    }
+
+    /// Attempt to represent an atomic-origin squash commit by inserting its
+    /// original change records into the target view instead of writing a new
+    /// squash change (SPEC §4). Verifies that the insert reproduces the git
+    /// tree for the touched paths; on divergence or missing originals it rolls
+    /// back and skips the commit (SPEC §5, decision D1-A).
+    fn try_squash_insert(
+        &self,
+        repo: &mut Repository,
+        parsed: &ParsedCommit,
+    ) -> CliResult<SquashDecision> {
+        use atomic_repository::InsertOptions;
+
+        // Merges are handled by the normal path + the phase-3 merge tag.
+        if parsed.is_merge {
+            return Ok(SquashDecision::NotSquash);
+        }
+
+        // Must carry Atomic-Changes trailers to be an atomic-origin squash.
+        let message = parsed.full_message();
+        let original_hashes = match parse_atomic_changes_trailer(&message) {
+            Some(h) => h,
+            None => return Ok(SquashDecision::NotSquash),
+        };
+        let pr_number = parse_pr_number(&message);
+
+        // Resolve every original to a Hash and confirm it exists locally. A
+        // missing original means we cannot reconstruct the aggregate — skip and
+        // advise `atomic pull` rather than fabricate a squash change (SPEC §5).
+        let mut parsed_hashes: Vec<ContentHash> = Vec::with_capacity(original_hashes.len());
+        for h in &original_hashes {
+            match ContentHash::from_base32(h.as_bytes()) {
+                Some(hash) if repo.has_change(&hash) => parsed_hashes.push(hash),
+                _ => {
+                    print_warning(&format!(
+                        "Squash {} references change {} which is not present locally; \
+                         skipping (run `atomic pull` to fetch it, then re-import).",
+                        parsed.short_sha, h
+                    ));
+                    return Ok(SquashDecision::Skipped);
+                }
+            }
+        }
+
+        let target = self.options.target_view.clone();
+
+        // Insert the originals (with dependency closure) into the target view.
+        // Track exactly which changes we newly added, for rollback on divergence.
+        let mut newly_applied: Vec<ContentHash> = Vec::new();
+        for hash in &parsed_hashes {
+            let options = InsertOptions::default()
+                .view(target.clone())
+                .apply_deps(true);
+            match repo.insert_change_rec(hash, options) {
+                Ok(outcome) => {
+                    newly_applied.extend(outcome.stats.applied_hashes.iter().copied());
+                }
+                Err(e) => {
+                    print_warning(&format!(
+                        "Squash {}: failed to insert original {}: {}; skipping.",
+                        parsed.short_sha,
+                        &hash.to_base32()[..12],
+                        e
+                    ));
+                    rollback_inserts(repo, &target, &newly_applied);
+                    return Ok(SquashDecision::Skipped);
+                }
+            }
+        }
+
+        // Verify the insert reproduces the git tree for every touched path
+        // (SPEC §5 / D1-A). Divergence means a human resolved a conflict in the
+        // PR; we must not silently desync the shared view from git.
+        if !self.squash_insert_matches_tree(repo, parsed, &target) {
+            print_warning(&format!(
+                "Squash {}: inserting its originals diverges from the git tree \
+                 (manual conflict resolution?); skipping. The shared view was \
+                 left unchanged.",
+                parsed.short_sha
+            ));
+            rollback_inserts(repo, &target, &newly_applied);
+            return Ok(SquashDecision::Skipped);
+        }
+
+        // Anchor the git SHA to the tip original so re-imports resolve it and
+        // `atomic change <sha>` works; the ReviewGate tag owns full provenance.
+        let tip = parsed_hashes.last().copied().unwrap_or(ContentHash::ZERO);
+        if tip != ContentHash::ZERO {
+            let _ = repo.index_git_sha(&parsed.git_sha, &tip);
+        }
+
+        Ok(SquashDecision::Inserted(ImportedCommitInfo {
+            git_sha: parsed.git_sha.clone(),
+            short_sha: parsed.short_sha.clone(),
+            atomic_hash: tip,
+            is_merge: false,
+            message,
+            squash_insert: Some(SquashInsert {
+                original_hashes,
+                pr_number,
+            }),
+        }))
+    }
+
+    /// Whether the target view's materialized content for every path the squash
+    /// touches matches the git tree recorded in `parsed`.
+    fn squash_insert_matches_tree(
+        &self,
+        repo: &Repository,
+        parsed: &ParsedCommit,
+        target: &str,
+    ) -> bool {
+        for file in &parsed.files {
+            match file.operation {
+                FileOperation::Deleted => {
+                    // The path must be absent (or empty) in the target view.
+                    if let Ok(Some(content)) = repo.get_file_content_on_view(&file.path, target) {
+                        if !content.is_empty() {
+                            return false;
+                        }
+                    }
+                }
+                _ => {
+                    let expected = match &file.new_content {
+                        Some(c) => c,
+                        None => continue,
+                    };
+                    match repo.get_file_content_on_view(&file.path, target) {
+                        Ok(Some(actual)) if &actual == expected => {}
+                        _ => return false,
+                    }
+                }
+            }
+        }
+        true
     }
 
     /// Write a single commit to the repository.
@@ -2827,6 +3032,7 @@ impl ParallelImporter {
                 atomic_hash: write_outcome.hash,
                 is_merge: parsed.is_merge,
                 message: parsed.full_message(),
+                squash_insert: None,
             });
         }
 
@@ -3303,6 +3509,7 @@ impl ParallelImporter {
             atomic_hash: write_outcome.hash,
             is_merge: parsed.is_merge,
             message: parsed.full_message(),
+            squash_insert: None,
         })
     }
 
@@ -3346,6 +3553,7 @@ impl ParallelImporter {
             atomic_hash: write_outcome.hash,
             is_merge: parsed.is_merge,
             message: parsed.full_message(),
+            squash_insert: None,
         })
     }
 
@@ -3418,6 +3626,47 @@ impl ParallelImporter {
         let mut stats = ClassificationStats::default();
 
         for info in imported {
+            // Squash represented by inserted originals (SPEC §4): tag the
+            // aggregate over those records rather than re-classifying from the
+            // message. The originals are already live in the target view.
+            if let Some(sq) = &info.squash_insert {
+                stats.squashes += 1;
+                let tag_name = if let Some(pr) = sq.pr_number {
+                    format!("pr-{}", pr)
+                } else {
+                    format!("squash-{}", info.short_sha)
+                };
+                let from = sq.original_hashes.first();
+                let to = sq.original_hashes.last();
+                let metadata = serde_json::json!({
+                    "git": {
+                        "sha": info.git_sha,
+                        "merge_strategy": "squash",
+                        "pr_number": sq.pr_number,
+                    },
+                    "changes": {
+                        "original_hashes": sq.original_hashes,
+                        "from": from,
+                        "to": to,
+                        "count": sq.original_hashes.len(),
+                        "inserted": true,
+                    }
+                });
+                if let Err(e) = repo.create_tag_with_metadata(
+                    &tag_name,
+                    Some(&format!("Squash merge {} (inserted)", info.short_sha)),
+                    TagKind::ReviewGate,
+                    Some(metadata),
+                ) {
+                    log::warn!(
+                        "Failed to create aggregate ReviewGate tag for squash {}: {}",
+                        info.short_sha,
+                        e
+                    );
+                }
+                continue;
+            }
+
             let classification = classify_commit(info);
             match classification {
                 CommitClassification::Normal => {
@@ -3495,7 +3744,9 @@ impl ParallelImporter {
         let actual = stats.changes_written
             + stats.empty_commits
             + stats.merge_commits
-            + stats.self_push_skipped;
+            + stats.self_push_skipped
+            + stats.squash_inserted
+            + stats.squash_skipped;
 
         if actual != expected {
             return Err(CliError::GitError {
@@ -3521,6 +3772,10 @@ struct WriteStats {
     empty_commits: usize,
     merge_commits: usize,
     self_push_skipped: usize,
+    /// Squash commits handled by inserting their originals (SPEC §4).
+    squash_inserted: usize,
+    /// Atomic-origin squash commits skipped (missing originals or divergence).
+    squash_skipped: usize,
     files_processed: usize,
 }
 
@@ -3537,6 +3792,31 @@ struct ImportedCommitInfo {
     is_merge: bool,
     /// The commit message (for squash detection).
     message: String,
+    /// Set when this squash was represented by inserting its original change
+    /// records into the target view (SPEC §4) rather than writing a new change.
+    /// Phase 3 turns this into an aggregate ReviewGate tag.
+    squash_insert: Option<SquashInsert>,
+}
+
+/// Provenance for a squash represented by inserting its originals (SPEC §4).
+#[derive(Debug, Clone)]
+struct SquashInsert {
+    /// The original change hashes named in the squash's trailers, trailer order.
+    original_hashes: Vec<String>,
+    /// PR/MR number parsed from the squash subject, if any.
+    pr_number: Option<u32>,
+}
+
+/// Outcome of attempting the squash → insert path in Phase 2 (SPEC §4/§5).
+enum SquashDecision {
+    /// Handled by inserting the originals; carries the info for tagging.
+    Inserted(ImportedCommitInfo),
+    /// An atomic-origin squash we could not insert (originals missing, or the
+    /// insert diverged from the git tree). The commit is left unimported so a
+    /// later run can complete it; caller warns and advises.
+    Skipped,
+    /// Not an insertable atomic squash — fall through to the normal write path.
+    NotSquash,
 }
 
 /// Classification of a commit detected during post-import analysis.
@@ -3561,6 +3841,66 @@ struct ClassificationStats {
 // ═══════════════════════════════════════════════════════════════════════
 // Commit Classification
 // ═══════════════════════════════════════════════════════════════════════
+
+/// Dry-run classification of an incoming commit, used by the `--dry-run` router
+/// to recommend the right import path (SPEC §4.4).
+pub(crate) enum ForecastKind {
+    /// Git-authored content with no atomic provenance.
+    Normal,
+    /// Multi-parent merge commit.
+    Merge,
+    /// Atomic-origin squash whose originals are all present — insertable.
+    SquashInsertable { count: usize, pr: Option<u32> },
+    /// Atomic-origin squash missing ≥ 1 original locally — needs `atomic pull`.
+    SquashRecordsMissing { count: usize },
+}
+
+/// Classify an incoming git commit for the `--dry-run` forecast (SPEC §4.4).
+///
+/// `records_present(hash)` reports whether a named original change hash exists
+/// locally; callers wire it to `Repository::has_change`.
+pub(crate) fn forecast_commit_kind(
+    message: &str,
+    is_merge: bool,
+    records_present: impl Fn(&str) -> bool,
+) -> ForecastKind {
+    if is_merge {
+        return ForecastKind::Merge;
+    }
+    match parse_atomic_changes_trailer(message) {
+        Some(hashes) => {
+            if hashes.iter().all(|h| records_present(h)) {
+                ForecastKind::SquashInsertable {
+                    count: hashes.len(),
+                    pr: parse_pr_number(message),
+                }
+            } else {
+                ForecastKind::SquashRecordsMissing {
+                    count: hashes.len(),
+                }
+            }
+        }
+        None => ForecastKind::Normal,
+    }
+}
+
+/// Remove change refs a failed squash-insert added to `view`, newest first, so
+/// a divergent or partial insert leaves the shared view exactly as it was
+/// (SPEC §5 / D1-A). Best-effort: rollback failures are logged, not fatal.
+fn rollback_inserts(repo: &Repository, view: &str, applied: &[ContentHash]) {
+    use atomic_repository::UnrecordOptions;
+    for hash in applied.iter().rev() {
+        let options = UnrecordOptions::default().view(view.to_string());
+        if let Err(e) = repo.unrecord(hash, options) {
+            print_warning(&format!(
+                "Failed to roll back inserted change {} from '{}': {}",
+                &hash.to_base32()[..12],
+                view,
+                e
+            ));
+        }
+    }
+}
 
 /// Classify an imported commit as normal, merge, or squash.
 fn classify_commit(info: &ImportedCommitInfo) -> CommitClassification {
@@ -3589,22 +3929,48 @@ fn classify_commit(info: &ImportedCommitInfo) -> CommitClassification {
     CommitClassification::Normal
 }
 
-/// Parse "Atomic-Changes: HASH1, HASH2, ..." from a commit message.
+/// Split the value of a single `Atomic-Changes:` trailer (the text after the
+/// colon) into individual, non-empty change hashes.
+fn split_atomic_changes_value(value: &str) -> impl Iterator<Item = String> + '_ {
+    value
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Parse **every** `Atomic-Changes:` trailer in a commit message.
+///
+/// A GitHub (or GitLab/Azure) squash-merge concatenates the bodies of all
+/// squashed commits, so a single squash commit legitimately carries
+/// **multiple** `Atomic-Changes:` blocks — one per materialization commit. We
+/// accumulate hashes across every block, de-duplicated with first-seen order
+/// preserved, so the ReviewGate links back to the *full* set of original
+/// changes rather than just the first block.
+///
+/// This differs deliberately from [`parse_push_trailer`], which inspects only
+/// the message's final paragraph. That function answers "did *I* just push this
+/// exact view state?", where only the trailing self-push block is
+/// authoritative; this function answers "which original changes does this
+/// squash represent?", where every block counts. They share the low-level
+/// [`split_atomic_changes_value`] splitter but must keep these distinct
+/// notions of which trailers are relevant.
 fn parse_atomic_changes_trailer(message: &str) -> Option<Vec<String>> {
+    let mut all: Vec<String> = Vec::new();
     for line in message.lines() {
         let line = line.trim();
         if let Some(rest) = line.strip_prefix("Atomic-Changes:") {
-            let hashes: Vec<String> = rest
-                .split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
-            if !hashes.is_empty() {
-                return Some(hashes);
+            for hash in split_atomic_changes_value(rest) {
+                if !all.contains(&hash) {
+                    all.push(hash);
+                }
             }
         }
     }
-    None
+    if all.is_empty() {
+        None
+    } else {
+        Some(all)
+    }
 }
 
 /// Parse a PR/MR number from a commit message.
@@ -3866,7 +4232,10 @@ fn parse_push_trailer(message: &str) -> Option<PushTrailer> {
         } else if let Some(value) = line.strip_prefix("Atomic-State:") {
             state = Merkle::from_base32(value.trim().as_bytes());
         } else if line.starts_with("Atomic-Changes:") {
-            // Optional trailer; not needed for self-push detection.
+            // Optional trailer; not needed for self-push detection (we only
+            // care about view + state here). The authoritative collection of
+            // these hashes for ReviewGate provenance happens in
+            // `parse_atomic_changes_trailer`, which scans the whole message.
         } else {
             // Non-trailer content in the final paragraph — not a commit
             // produced by `atomic git push`.
@@ -4354,6 +4723,66 @@ mod tests {
     }
 
     #[test]
+    fn test_incremental_import_skips() {
+        let (state_b32, state) = test_state();
+        let self_push_msg = format!(
+            "feat: test\n\nAtomic-View: main\nAtomic-State: {}",
+            state_b32
+        );
+        let plain_msg = "feat: ordinary human commit";
+
+        let mut imported = HashSet::new();
+        imported.insert("already-imported-sha".to_string());
+        let mut known_states = HashSet::new();
+        known_states.insert(state);
+
+        // Already-imported SHA is skipped regardless of message.
+        assert!(incremental_import_skips(
+            "already-imported-sha",
+            plain_msg,
+            &imported,
+            "main",
+            &known_states,
+        ));
+
+        // Self-push commit whose state is already in the target view is skipped.
+        assert!(incremental_import_skips(
+            "new-sha",
+            &self_push_msg,
+            &imported,
+            "main",
+            &known_states,
+        ));
+
+        // Self-push commit for a DIFFERENT view is not skipped.
+        assert!(!incremental_import_skips(
+            "new-sha",
+            &self_push_msg,
+            &imported,
+            "dev",
+            &known_states,
+        ));
+
+        // Self-push commit whose state is unknown is not skipped.
+        assert!(!incremental_import_skips(
+            "new-sha",
+            &self_push_msg,
+            &imported,
+            "main",
+            &HashSet::new(),
+        ));
+
+        // An ordinary new commit is imported (not skipped).
+        assert!(!incremental_import_skips(
+            "new-sha",
+            plain_msg,
+            &imported,
+            "main",
+            &known_states,
+        ));
+    }
+
+    #[test]
     fn test_file_operation_equality() {
         assert_eq!(FileOperation::Added, FileOperation::Added);
         assert_ne!(FileOperation::Added, FileOperation::Modified);
@@ -4473,6 +4902,7 @@ mod tests {
             atomic_hash: ContentHash::ZERO,
             is_merge,
             message: message.to_string(),
+            squash_insert: None,
         }
     }
 
@@ -4561,6 +4991,76 @@ mod tests {
     #[test]
     fn test_parse_atomic_changes_trailer_none() {
         assert_eq!(parse_atomic_changes_trailer("normal commit"), None);
+    }
+
+    #[test]
+    fn test_parse_atomic_changes_trailer_collects_all_blocks() {
+        // A GitHub squash-merge concatenates every squashed commit body, so the
+        // message carries multiple `Atomic-Changes:` blocks. All must survive.
+        let msg = "\
+squash (#2)
+
+* materialize
+Atomic-View: a
+Atomic-State: S1
+Atomic-Changes: AAA, BBB
+
+* materialize
+Atomic-View: b
+Atomic-State: S2
+Atomic-Changes: CCC
+
+Atomic-Changes: DDD, EEE
+";
+        let hashes = parse_atomic_changes_trailer(msg).expect("should parse");
+        assert_eq!(hashes, vec!["AAA", "BBB", "CCC", "DDD", "EEE"]);
+    }
+
+    #[test]
+    fn test_parse_atomic_changes_trailer_dedups_preserving_order() {
+        // The tip work can repeat a hash already listed in an earlier block;
+        // de-duplicate while keeping first-seen order.
+        let msg = "\
+squash (#3)
+
+Atomic-Changes: AAA, BBB
+Atomic-Changes: BBB, CCC, AAA
+";
+        let hashes = parse_atomic_changes_trailer(msg).expect("should parse");
+        assert_eq!(hashes, vec!["AAA", "BBB", "CCC"]);
+    }
+
+    #[test]
+    fn test_classify_squash_collects_all_trailer_blocks() {
+        // End-to-end through classify_commit: the squash ReviewGate must record
+        // every original hash, not just the first block's.
+        let msg = "\
+Materialize session view (#7)
+
+* chore(atomic): materialize
+Atomic-View: old-forest-591e
+Atomic-State: S1
+Atomic-Changes: FIRSTHASH
+
+* chore(atomic): materialize
+Atomic-View: calm-violet-8d7f
+Atomic-State: S2
+Atomic-Changes: SECONDHASH, THIRDHASH
+";
+        let info = test_info(msg, false);
+        match classify_commit(&info) {
+            CommitClassification::Squash {
+                original_hashes,
+                pr_number,
+            } => {
+                assert_eq!(
+                    original_hashes,
+                    vec!["FIRSTHASH", "SECONDHASH", "THIRDHASH"]
+                );
+                assert_eq!(pr_number, Some(7));
+            }
+            other => panic!("expected Squash, got {:?}", other),
+        }
     }
 
     #[test]

--- a/atomic-cli/src/commands/git/push.rs
+++ b/atomic-cli/src/commands/git/push.rs
@@ -5,7 +5,6 @@
 //! pushes to the remote.
 
 use std::io::IsTerminal;
-use std::path::Path;
 
 use clap::Args;
 use git2::Repository as GitRepository;
@@ -82,27 +81,6 @@ impl Default for Push {
     }
 }
 
-/// Append a `shadow-conflict` entry to `.atomic/hook-errors.log` so a
-/// non-interactive shadow push that aborts on conflict markers leaves a durable,
-/// greppable trail instead of failing silently. Best-effort: log I/O errors are
-/// ignored (the push already fails loudly via its return value).
-fn append_shadow_conflict_log(repo_root: &Path, view: &str, file: &str, line: u32) {
-    use std::io::Write;
-    let log_path = repo_root.join(".atomic").join("hook-errors.log");
-    let entry = format!(
-        "{} shadow-conflict view={} file={} line={}\n",
-        chrono::Utc::now().to_rfc3339(),
-        view,
-        file,
-        line
-    );
-    let _ = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&log_path)
-        .and_then(|mut f| f.write_all(entry.as_bytes()));
-}
-
 impl Command for Push {
     fn run(&self) -> CliResult<()> {
         // Find and open the Atomic repository
@@ -116,6 +94,16 @@ impl Command for Push {
 
         // Get current view name for trailers
         let current_view = repo.current_view().to_string();
+
+        // Serialize the shadow-commit pipeline (SPEC §4.3): acquire the
+        // repo-scoped lock OUTERMOST, before any staging or git mutation. If
+        // another shadow materialize/commit is in flight this is a logged no-op
+        // — the in-flight operation owns this commit. Held for the whole run.
+        let _shadow_lock =
+            match super::shadow::acquire_shadow_lock(&repo, &repo_root, &current_view)? {
+                Some(guard) => guard,
+                None => return Ok(()),
+            };
 
         // Resolve the git branch this push targets. Explicit `--branch` wins;
         // otherwise a draft view maps to a git branch named after the view so
@@ -153,65 +141,61 @@ impl Command for Push {
         // Atomic-State to locate our position in the view's history.
         let last_pushed_state = self.find_last_pushed_state(&git_repo, &current_view);
         let start_idx = match &last_pushed_state {
-            Some(state) => history
-                .iter()
-                .position(|e| &e.state == state)
-                .map(|i| i + 1)
-                .unwrap_or(0),
+            Some(state) => match history.iter().position(|e| &e.state == state) {
+                // Fast-forward: the branch's last published state is in the
+                // view's recorded lineage. Push the changes recorded since.
+                Some(i) => i + 1,
+                // Validator Rule V3 (SPEC §6.3): the branch's last published
+                // state is NOT in this view's lineage — genuine drift (e.g. the
+                // branch was reset, or published from a foreign view/state).
+                // Refuse with **no bypass**; reconcile-then-push.
+                None => {
+                    if !std::io::stderr().is_terminal() {
+                        super::shadow::append_shadow_validate_log(
+                            &repo_root,
+                            "V3",
+                            &current_view,
+                            &format!(
+                                "branch state {} not in view lineage",
+                                &state.to_base32()[..12.min(state.to_base32().len())]
+                            ),
+                        );
+                    }
+                    print_warning(&format!(
+                        "Refusing to shadow-commit: git branch's last published state is \
+                         not in view '{}' history (drift).",
+                        current_view
+                    ));
+                    return Err(CliError::GitError {
+                        message: format!(
+                            "git shadow drift (V3): the branch was last published from a \
+                             state view '{}' cannot reach. Reconcile first, then re-push — \
+                             `git reset --hard` the branch to its last coherent shadow \
+                             commit, or `atomic git import` to onboard the git-side work. \
+                             No commit was created.",
+                            current_view
+                        ),
+                    });
+                }
+            },
+            // First publish for this view/branch — nothing to drift from.
             None => 0,
         };
         let new_history = &history[start_idx..];
         let new_count = new_history.len();
 
-        // Conflict-marker guard (SPEC: shadow materialization must never commit
-        // unresolved markers). Runs BEFORE staging/tree/commit and shares the
-        // exact detector `atomic record` uses, so the two paths cannot disagree.
-        if !self.allow_conflict_markers {
-            if let Some((path, line)) = repo
-                .first_working_copy_conflict_marker()
-                .map_err(CliError::Repository)?
-            {
-                // Non-interactive (hook) contexts get a durable audit entry so a
-                // background materialization cannot fail silently.
-                if !std::io::stderr().is_terminal() {
-                    append_shadow_conflict_log(&repo_root, &current_view, &path, line);
-                }
-                print_warning(&format!(
-                    "Refusing to commit '{}': unresolved conflict marker at line {}.",
-                    path, line
-                ));
-                return Err(CliError::GitError {
-                    message: format!(
-                        "'{}' still contains conflict markers at line {} — resolve the \
-                         conflict (remove the >>>>>>> / ======= / <<<<<<< lines), or pass \
-                         --allow-conflict-markers to override. No commit was created.",
-                        path, line
-                    ),
-                });
-            }
-        }
-
-        // Stage everything: git add -A (add_all + update_all handles new files and deletions)
-        let mut index = git_repo.index().map_err(|e| CliError::GitError {
-            message: format!("Failed to open git index: {}", e),
-        })?;
-        index
-            .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
-            .map_err(|e| CliError::GitError {
-                message: format!("Failed to stage files: {}", e),
-            })?;
-        index
-            .update_all(["*"].iter(), None)
-            .map_err(|e| CliError::GitError {
-                message: format!("Failed to update index: {}", e),
-            })?;
-        index.write().map_err(|e| CliError::GitError {
-            message: format!("Failed to write index: {}", e),
-        })?;
-
-        let tree_oid = index.write_tree().map_err(|e| CliError::GitError {
-            message: format!("Failed to write tree: {}", e),
-        })?;
+        // Single shadow-commit pipeline (SPEC §5.2): stage the working copy and
+        // run the pre-commit Validator (V1 markers, V4 provenance) before a tree
+        // is produced. `git push` and the turn-end hook both go through this;
+        // there is no independent `add_all`/`write_tree` here. Any rule failure
+        // aborts atomically (index restored from HEAD, nothing committed).
+        let tree_oid = super::shadow::stage_and_validate_tree(
+            &repo,
+            &git_repo,
+            &repo_root,
+            &current_view,
+            self.allow_conflict_markers,
+        )?;
         let tree = git_repo
             .find_tree(tree_oid)
             .map_err(|e| CliError::GitError {

--- a/atomic-cli/src/commands/git/push.rs
+++ b/atomic-cli/src/commands/git/push.rs
@@ -4,6 +4,9 @@
 //! `git add -A`, commits with Atomic provenance trailers, and optionally
 //! pushes to the remote.
 
+use std::io::IsTerminal;
+use std::path::Path;
+
 use clap::Args;
 use git2::Repository as GitRepository;
 
@@ -59,6 +62,12 @@ pub struct Push {
     /// current view's state to a PR branch).
     #[arg(long, short = 'b', value_name = "BRANCH")]
     pub branch: Option<String>,
+
+    /// Commit even if the working copy still contains unresolved conflict
+    /// markers. Off by default, mirroring `atomic record`; the shadow-sync
+    /// turn-end hook must never pass this.
+    #[arg(long = "allow-conflict-markers")]
+    pub allow_conflict_markers: bool,
 }
 
 impl Default for Push {
@@ -68,8 +77,30 @@ impl Default for Push {
             no_push: false,
             remote: "origin".to_string(),
             branch: None,
+            allow_conflict_markers: false,
         }
     }
+}
+
+/// Append a `shadow-conflict` entry to `.atomic/hook-errors.log` so a
+/// non-interactive shadow push that aborts on conflict markers leaves a durable,
+/// greppable trail instead of failing silently. Best-effort: log I/O errors are
+/// ignored (the push already fails loudly via its return value).
+fn append_shadow_conflict_log(repo_root: &Path, view: &str, file: &str, line: u32) {
+    use std::io::Write;
+    let log_path = repo_root.join(".atomic").join("hook-errors.log");
+    let entry = format!(
+        "{} shadow-conflict view={} file={} line={}\n",
+        chrono::Utc::now().to_rfc3339(),
+        view,
+        file,
+        line
+    );
+    let _ = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .and_then(|mut f| f.write_all(entry.as_bytes()));
 }
 
 impl Command for Push {
@@ -131,6 +162,34 @@ impl Command for Push {
         };
         let new_history = &history[start_idx..];
         let new_count = new_history.len();
+
+        // Conflict-marker guard (SPEC: shadow materialization must never commit
+        // unresolved markers). Runs BEFORE staging/tree/commit and shares the
+        // exact detector `atomic record` uses, so the two paths cannot disagree.
+        if !self.allow_conflict_markers {
+            if let Some((path, line)) = repo
+                .first_working_copy_conflict_marker()
+                .map_err(CliError::Repository)?
+            {
+                // Non-interactive (hook) contexts get a durable audit entry so a
+                // background materialization cannot fail silently.
+                if !std::io::stderr().is_terminal() {
+                    append_shadow_conflict_log(&repo_root, &current_view, &path, line);
+                }
+                print_warning(&format!(
+                    "Refusing to commit '{}': unresolved conflict marker at line {}.",
+                    path, line
+                ));
+                return Err(CliError::GitError {
+                    message: format!(
+                        "'{}' still contains conflict markers at line {} — resolve the \
+                         conflict (remove the >>>>>>> / ======= / <<<<<<< lines), or pass \
+                         --allow-conflict-markers to override. No commit was created.",
+                        path, line
+                    ),
+                });
+            }
+        }
 
         // Stage everything: git add -A (add_all + update_all handles new files and deletions)
         let mut index = git_repo.index().map_err(|e| CliError::GitError {
@@ -541,6 +600,7 @@ mod tests {
             no_push: true,
             remote: "upstream".to_string(),
             branch: Some("pr-branch".to_string()),
+            allow_conflict_markers: false,
         };
         assert_eq!(push.message.as_deref(), Some("custom message"));
         assert!(push.no_push);

--- a/atomic-cli/src/commands/git/shadow.rs
+++ b/atomic-cli/src/commands/git/shadow.rs
@@ -1,0 +1,435 @@
+//! The shadow-commit pipeline — the single path that stages a shadow commit and
+//! runs the pre-commit Validator before a git tree is produced.
+//!
+//! Per `SPEC-single-materializer-validator.md` (§5), exactly one code path may
+//! stage the shadow working copy and hand a candidate to the Validator.
+//! `atomic git push` and the turn-end hook both go through
+//! [`stage_and_validate_tree`], so no other path independently
+//! `git add -A`/`write_tree`s the tree. Any Validator rule failure aborts
+//! atomically: the git index is restored from HEAD and nothing is committed.
+//!
+//! Validator rules enforced here (pre-commit):
+//! - **V1** — no unresolved conflict markers (shares `record`'s detector).
+//! - **V4** — no git-excluded provenance path (`.atomic/`, `.vault/`,
+//!   `.atomicignore`) is ever staged.
+//!
+//! V2 (tree↔view coherence) and V3 (git↔state agreement) are added here in later
+//! phases, ahead of `write_tree`, so every shadow commit passes the same gate.
+
+use std::io::IsTerminal;
+use std::path::Path;
+
+use git2::Repository as GitRepository;
+
+use atomic_repository::Repository;
+
+use crate::error::{CliError, CliResult};
+use crate::output::{print_info, print_warning};
+
+/// After an `atomic view switch`, point the git shadow's HEAD at the branch that
+/// mirrors the new view (Direction A of §5.4 — "git shadows Atomic"). Atomic is
+/// upstream, so it drives the downstream git shadow's branch selection.
+///
+/// This is a **ref move**, never a `git checkout`: it updates HEAD (and realigns
+/// the index to the new branch's tree) but never re-renders the working copy,
+/// which Atomic just materialized. It is **best-effort** — any git error is a
+/// warning, never a failure of the view switch — and a **no-op** outside a
+/// shadow-sync repo or when HEAD is already on the branch.
+pub(crate) fn sync_git_head_to_view(repo_root: &Path, view: &str) {
+    let git_repo = match GitRepository::discover(repo_root) {
+        Ok(r) => r,
+        Err(_) => return, // not a git repo — nothing to shadow
+    };
+    // Only touch git in repos where shadow sync is actually established.
+    if !shadow_sync_active(&git_repo) {
+        return;
+    }
+
+    let branch_ref = format!("refs/heads/{}", view);
+
+    // Idempotent: already on the mirror branch (no loop, no churn).
+    if git_repo
+        .head()
+        .ok()
+        .and_then(|h| h.name().map(str::to_owned))
+        .as_deref()
+        == Some(branch_ref.as_str())
+    {
+        return;
+    }
+
+    // Create the mirror branch at the current commit if it doesn't exist yet
+    // (a new draft view branches from wherever HEAD currently points).
+    if git_repo.find_reference(&branch_ref).is_err() {
+        match git_repo.head().and_then(|h| h.peel_to_commit()) {
+            Ok(commit) => {
+                if let Err(e) = git_repo.branch(view, &commit, false) {
+                    print_warning(&format!(
+                        "Could not create git branch '{}' to mirror the view: {}",
+                        view, e
+                    ));
+                    return;
+                }
+            }
+            // Unborn HEAD / no commits yet — nothing to anchor a branch to.
+            Err(_) => return,
+        }
+    }
+
+    // Move HEAD to the mirror branch WITHOUT touching the working copy, then
+    // realign the index to the new branch tip so `git status` cleanly shows the
+    // view's content as the delta the next shadow push will commit.
+    if let Err(e) = git_repo.set_head(&branch_ref) {
+        print_warning(&format!(
+            "Could not point git HEAD at branch '{}': {}",
+            view, e
+        ));
+        return;
+    }
+    restore_index_from_head(&git_repo);
+    print_info(&format!("git shadow now tracks branch '{}'.", view));
+}
+
+/// Whether git shadow sync is established for this repo (the `.git/info/exclude`
+/// carries Atomic's shadow patterns, written by import/push). Used to gate the
+/// view-switch git-follow so we never touch HEAD in a plain (non-shadow) repo.
+fn shadow_sync_active(git_repo: &GitRepository) -> bool {
+    let exclude = git_repo.path().join("info").join("exclude");
+    std::fs::read_to_string(exclude)
+        .map(|c| c.lines().any(|l| l.trim() == "/.atomic/"))
+        .unwrap_or(false)
+}
+
+/// Acquire the repo-scoped shadow-commit lock, or return `None` (a no-op skip)
+/// if a shadow materialize/commit is already in flight (SPEC §4.3 / Principle 5).
+///
+/// Non-blocking: rather than queueing (which would hang a turn-end hook), the
+/// contended case is a logged no-op — the in-flight operation owns this commit.
+/// The returned guard must be held for the whole stage → validate → commit
+/// sequence; dropping it releases the lock. Acquire it **outermost**, before any
+/// staging or DB write.
+pub(crate) fn acquire_shadow_lock(
+    repo: &Repository,
+    repo_root: &Path,
+    view: &str,
+) -> CliResult<Option<std::fs::File>> {
+    match repo
+        .try_lock_shadow_commit()
+        .map_err(CliError::Repository)?
+    {
+        Some(guard) => Ok(Some(guard)),
+        None => {
+            if std::io::stderr().is_terminal() {
+                print_info("Another shadow materialize is in flight; skipping this push.");
+            } else {
+                append_shadow_log(
+                    repo_root,
+                    "shadow-lock:contended",
+                    view,
+                    "another shadow materialize in flight",
+                );
+            }
+            Ok(None)
+        }
+    }
+}
+
+/// Stage the current working copy for a shadow commit, run the pre-commit
+/// Validator, and return the candidate git tree OID.
+///
+/// This is the sole shadow-commit staging path (SPEC §5.2). On any Validator
+/// failure it aborts atomically — the index is restored from HEAD so git is left
+/// byte-identical — and returns an error naming the failing rule.
+pub(crate) fn stage_and_validate_tree(
+    repo: &Repository,
+    git_repo: &GitRepository,
+    repo_root: &Path,
+    view: &str,
+    allow_conflict_markers: bool,
+) -> CliResult<git2::Oid> {
+    // ── Rule V1 — no unresolved conflict markers ────────────────────────────
+    // Shares `atomic record`'s detector so the two paths cannot disagree.
+    if !allow_conflict_markers {
+        if let Some((path, line)) = repo
+            .first_working_copy_conflict_marker()
+            .map_err(CliError::Repository)?
+        {
+            if !std::io::stderr().is_terminal() {
+                append_shadow_validate_log(
+                    repo_root,
+                    "V1",
+                    view,
+                    &format!("file={} line={}", path, line),
+                );
+            }
+            print_warning(&format!(
+                "Refusing to commit '{}': unresolved conflict marker at line {}.",
+                path, line
+            ));
+            return Err(CliError::GitError {
+                message: format!(
+                    "'{}' still contains conflict markers at line {} — resolve the \
+                     conflict (remove the >>>>>>> / ======= / <<<<<<< lines), or pass \
+                     --allow-conflict-markers to override. No commit was created.",
+                    path, line
+                ),
+            });
+        }
+    }
+
+    // Prevention: make sure git is configured to exclude Atomic's shadow /
+    // provenance paths before staging, so `git add -A` never picks them up.
+    // Best-effort (an unwritable .git/info is caught by the V4 guard below).
+    let _ = super::import::ensure_git_shadow_excludes(git_repo.path());
+
+    // Stage everything: git add -A (add_all + update_all handles new files and
+    // deletions).
+    let mut index = git_repo.index().map_err(|e| CliError::GitError {
+        message: format!("Failed to open git index: {}", e),
+    })?;
+    index
+        .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+        .map_err(|e| CliError::GitError {
+            message: format!("Failed to stage files: {}", e),
+        })?;
+    index
+        .update_all(["*"].iter(), None)
+        .map_err(|e| CliError::GitError {
+            message: format!("Failed to update index: {}", e),
+        })?;
+    index.write().map_err(|e| CliError::GitError {
+        message: format!("Failed to write index: {}", e),
+    })?;
+
+    // ── Rule V4 — no provenance / excluded path may be staged ───────────────
+    if let Some(bad) = first_forbidden_shadow_path(&index) {
+        restore_index_from_head(git_repo);
+        if !std::io::stderr().is_terminal() {
+            append_shadow_validate_log(repo_root, "V4", view, &format!("path={}", bad));
+        }
+        print_warning(&format!(
+            "Refusing to shadow-commit: provenance/excluded path '{}' was staged.",
+            bad
+        ));
+        return Err(CliError::GitError {
+            message: format!(
+                "'{}' is a git-excluded Atomic shadow path (.atomic/, .vault/, \
+                 .atomicignore) and must never be committed to git. Aborting; no \
+                 commit was created and the index was restored. Ensure \
+                 `.git/info/exclude` carries the Atomic shadow patterns.",
+                bad
+            ),
+        });
+    }
+
+    let tree_oid = index.write_tree().map_err(|e| CliError::GitError {
+        message: format!("Failed to write tree: {}", e),
+    })?;
+
+    // ── Rule V2 — tree ↔ view coherence (SPEC §6.2) ─────────────────────────
+    // The staged tree must correspond to what the current view materializes.
+    // Cost-safe / incremental: only paths that differ between the candidate
+    // tree and git HEAD are checked, each against the view's recorded content.
+    if let Some((path, reason)) = first_incoherent_path(repo, git_repo, tree_oid, view)? {
+        restore_index_from_head(git_repo);
+        if !std::io::stderr().is_terminal() {
+            append_shadow_validate_log(
+                repo_root,
+                "V2",
+                view,
+                &format!("path={} reason={}", path, reason),
+            );
+        }
+        print_warning(&format!(
+            "Refusing to shadow-commit: '{}' {} (SPEC V2).",
+            path, reason
+        ));
+        return Err(CliError::GitError {
+            message: format!(
+                "'{}' {} — the working copy diverges from the current view '{}'. Record \
+                 your changes (or reconcile the view) so the shadow tree matches the \
+                 recorded state. No commit was created.",
+                path, reason, view
+            ),
+        });
+    }
+
+    Ok(tree_oid)
+}
+
+/// Return the first changed path whose staged content does not correspond to the
+/// current view's recorded content, as `(path, reason)`, or `None` if the
+/// candidate tree is coherent with the view (Rule V2, SPEC §6.2).
+///
+/// Only paths that differ between the candidate tree and git HEAD are examined
+/// (the incremental form), so the check costs one `get_file_content_on_view` per
+/// changed path rather than a full-view materialize. Provenance / excluded paths
+/// are skipped — Rule V4 owns them.
+fn first_incoherent_path(
+    repo: &Repository,
+    git_repo: &GitRepository,
+    candidate_tree_oid: git2::Oid,
+    view: &str,
+) -> CliResult<Option<(String, String)>> {
+    let candidate_tree =
+        git_repo
+            .find_tree(candidate_tree_oid)
+            .map_err(|e| CliError::GitError {
+                message: format!("Failed to load candidate tree: {}", e),
+            })?;
+    let head_tree = git_repo
+        .head()
+        .ok()
+        .and_then(|h| h.peel_to_commit().ok())
+        .and_then(|c| c.tree().ok());
+
+    let diff = git_repo
+        .diff_tree_to_tree(head_tree.as_ref(), Some(&candidate_tree), None)
+        .map_err(|e| CliError::GitError {
+            message: format!("Failed to diff candidate tree: {}", e),
+        })?;
+
+    for delta in diff.deltas() {
+        let (path, in_candidate) = match delta.status() {
+            git2::Delta::Deleted => match delta.old_file().path().and_then(|p| p.to_str()) {
+                Some(p) => (p.to_string(), false),
+                None => continue,
+            },
+            _ => match delta.new_file().path().and_then(|p| p.to_str()) {
+                Some(p) => (p.to_string(), true),
+                None => continue,
+            },
+        };
+
+        // Rule V4 owns provenance / git-excluded paths; V2 ignores them.
+        if is_forbidden_shadow_path(&path) {
+            continue;
+        }
+
+        let view_content = repo
+            .get_file_content_on_view(&path, view)
+            .map_err(CliError::Repository)?;
+
+        if in_candidate {
+            // The staged blob must equal what the view materializes for this path.
+            let staged = git_repo.find_blob(delta.new_file().id()).ok();
+            match (
+                staged.as_ref().map(|b| b.content()),
+                view_content.as_deref(),
+            ) {
+                (Some(s), Some(v)) if s == v => {}
+                (Some(_), Some(_)) => {
+                    return Ok(Some((
+                        path,
+                        "staged content differs from the view's recorded content".to_string(),
+                    )));
+                }
+                (Some(_), None) => {
+                    return Ok(Some((
+                        path,
+                        "is not recorded by the view (record it first)".to_string(),
+                    )));
+                }
+                // Non-blob entries (submodules/symlinks) carry no textual
+                // content to reconcile; leave them to git's own handling.
+                (None, _) => {}
+            }
+        } else if view_content.is_some() {
+            // The path was dropped from the tree, but the view still records it:
+            // the candidate omits a change the view accounts for.
+            return Ok(Some((
+                path,
+                "is still recorded by the view but missing from the tree".to_string(),
+            )));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Append a `shadow-validate:<rule>` entry to `.atomic/hook-errors.log` (SPEC
+/// §6.5) so a non-interactive shadow push that a Validator rule aborts leaves a
+/// durable, greppable trail instead of failing silently.
+pub(crate) fn append_shadow_validate_log(repo_root: &Path, rule: &str, view: &str, detail: &str) {
+    append_shadow_log(
+        repo_root,
+        &format!("shadow-validate:{}", rule),
+        view,
+        detail,
+    );
+}
+
+/// Append one tagged `.atomic/hook-errors.log` line. Best-effort: log I/O errors
+/// are ignored (the operation already surfaces its own outcome).
+fn append_shadow_log(repo_root: &Path, tag: &str, view: &str, detail: &str) {
+    use std::io::Write;
+    let log_path = repo_root.join(".atomic").join("hook-errors.log");
+    let entry = format!(
+        "{} {} view={} {}\n",
+        chrono::Utc::now().to_rfc3339(),
+        tag,
+        view,
+        detail
+    );
+    let _ = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .and_then(|mut f| f.write_all(entry.as_bytes()));
+}
+
+/// Return the first staged index path that is a git-excluded shadow / provenance
+/// path (`.atomic/`, `.vault/`, or `.atomicignore`), or `None` if the candidate
+/// is clean. Validator Rule V4 (SPEC §6.4): these paths must never enter a git
+/// commit — `.vault` (intents/memories/attestations) and `.atomic` (the change
+/// graph) are git-excluded and unbacked; committing or reconciling them risks
+/// the provenance layer.
+fn first_forbidden_shadow_path(index: &git2::Index) -> Option<String> {
+    index.iter().find_map(|entry| {
+        let path = String::from_utf8_lossy(&entry.path).into_owned();
+        is_forbidden_shadow_path(&path).then_some(path)
+    })
+}
+
+/// Whether `path` (a repo-relative git path) is a git-excluded Atomic shadow /
+/// provenance path that Rule V4 forbids from any shadow commit.
+fn is_forbidden_shadow_path(path: &str) -> bool {
+    path == ".atomicignore" || path.starts_with(".atomic/") || path.starts_with(".vault/")
+}
+
+/// Discard a candidate staging by restoring the git index from HEAD's tree,
+/// leaving git byte-identical to its pre-operation state (the working copy is
+/// never touched). Best-effort.
+fn restore_index_from_head(git_repo: &GitRepository) {
+    if let Ok(tree) = git_repo
+        .head()
+        .and_then(|h| h.peel_to_commit())
+        .and_then(|c| c.tree())
+    {
+        if let Ok(mut index) = git_repo.index() {
+            let _ = index.read_tree(&tree);
+            let _ = index.write();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_forbidden_shadow_path as forbidden;
+
+    #[test]
+    fn forbids_provenance_and_excluded_paths() {
+        assert!(forbidden(".atomicignore"));
+        assert!(forbidden(".atomic/pristine.redb"));
+        assert!(forbidden(".vault/intents/foo.md"));
+    }
+
+    #[test]
+    fn allows_ordinary_source_paths() {
+        assert!(!forbidden("src/main.rs"));
+        assert!(!forbidden("README.md"));
+        // A file that merely *contains* the substring is not forbidden.
+        assert!(!forbidden("docs/.atomicignore.md"));
+        assert!(!forbidden("my.vault/keep.txt"));
+    }
+}

--- a/atomic-cli/src/commands/tag/show.rs
+++ b/atomic-cli/src/commands/tag/show.rs
@@ -33,8 +33,8 @@
 
 use clap::Parser;
 
-use atomic_core::types::Base32;
-use atomic_repository::Repository;
+use atomic_core::types::{Base32, Hash};
+use atomic_repository::{Repository, TagKind};
 
 use crate::commands::{find_repository_root, Command};
 use crate::error::{CliError, CliResult};
@@ -123,7 +123,11 @@ impl Command for Show {
                 }
 
                 if let Some(ref metadata) = tag.metadata {
-                    println!("{}: {}", emphasis("Metadata"), metadata);
+                    if tag.kind == TagKind::ReviewGate {
+                        render_review_gate_metadata(&repo, metadata);
+                    } else {
+                        println!("{}: {}", emphasis("Metadata"), metadata);
+                    }
                 }
 
                 Ok(())
@@ -137,6 +141,96 @@ impl Command for Show {
                     ))
                 );
                 Ok(())
+            }
+        }
+    }
+}
+
+/// Render `ReviewGate` tag metadata as a readable provenance block.
+///
+/// Only lines whose underlying data is present are printed. All lookups are
+/// defensive against absent fields, matching the extensible metadata shape.
+fn render_review_gate_metadata(repo: &Repository, metadata: &serde_json::Value) {
+    // Git provenance line: "Git: <merge_strategy> <sha> (PR #<n>)"
+    if let Some(git) = metadata.get("git") {
+        let sha = git.get("sha").and_then(|v| v.as_str());
+        let strategy = git.get("merge_strategy").and_then(|v| v.as_str());
+        if sha.is_some() || strategy.is_some() {
+            let mut line = String::new();
+            if let Some(strategy) = strategy {
+                line.push_str(strategy);
+            }
+            if let Some(sha) = sha {
+                if !line.is_empty() {
+                    line.push(' ');
+                }
+                line.push_str(sha);
+            }
+            if let Some(pr) = git.get("pr_number").and_then(|v| v.as_u64()) {
+                line.push_str(&format!(" (PR #{})", pr));
+            }
+            println!("{}: {}", emphasis("Git"), line);
+        }
+    }
+
+    let changes = metadata.get("changes");
+    let original = changes
+        .and_then(|c| c.get("original_hashes"))
+        .and_then(|v| v.as_array());
+
+    // Aggregate line.
+    if let Some(changes) = changes {
+        let from = changes.get("from").and_then(|v| v.as_str());
+        let to = changes.get("to").and_then(|v| v.as_str());
+        let count = changes.get("count").and_then(|v| v.as_u64());
+        let inserted = changes
+            .get("inserted")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        if let (Some(from), Some(to)) = (from, to) {
+            let count_val = count
+                .map(|c| c as usize)
+                .or_else(|| original.map(|a| a.len()))
+                .unwrap_or(0);
+            let inserted_suffix = if inserted { ", inserted" } else { "" };
+            println!(
+                "{}: {} \u{2026} {}  ({} records{})",
+                emphasis("Aggregate"),
+                from,
+                to,
+                count_val,
+                inserted_suffix
+            );
+        } else if let Some(original) = original {
+            let count_val = count.map(|c| c as usize).unwrap_or(original.len());
+            println!("{}: {} records", emphasis("Aggregate"), count_val);
+        }
+    }
+
+    // Per-record presence and view membership.
+    if let Some(original) = original {
+        if !original.is_empty() {
+            println!("{}:", emphasis("Records"));
+            for entry in original {
+                let Some(s) = entry.as_str() else { continue };
+                match Hash::from_base32(s.as_bytes()) {
+                    Some(hash) => {
+                        let present = repo.has_change(&hash);
+                        let mark = if present { "\u{2713}" } else { "\u{2717}" };
+                        let status = if present { "present" } else { "missing" };
+                        let views = repo.views_containing_change(&hash).unwrap_or_default();
+                        let views_suffix = if views.is_empty() {
+                            String::new()
+                        } else {
+                            format!("  ({})", views.join(", "))
+                        };
+                        println!("  {} {}  {}{}", mark, s, status, views_suffix);
+                    }
+                    None => {
+                        println!("  {}", s);
+                    }
+                }
             }
         }
     }

--- a/atomic-cli/src/commands/view/switch.rs
+++ b/atomic-cli/src/commands/view/switch.rs
@@ -183,6 +183,11 @@ impl Command for Switch {
             ),
         );
 
+        // git shadows Atomic: point the git shadow's HEAD at the mirror branch
+        // for the new view (Direction A, §5.4). Best-effort ref move, no-op
+        // outside a shadow-sync repo — never fails the switch.
+        crate::commands::git::shadow::sync_git_head_to_view(&repo_root, name);
+
         if result.has_conflicts() {
             crate::output::print_warning(&format!(
                 "{} conflicts detected",

--- a/atomic-repository/src/repository/materialize.rs
+++ b/atomic-repository/src/repository/materialize.rs
@@ -20,6 +20,44 @@ pub(crate) fn first_conflict_marker_line(content: &[u8]) -> Option<u32> {
     None
 }
 
+impl Repository {
+    /// Return the first working-copy file that still contains an unresolved
+    /// conflict marker, as `(path, 1-based line)`, or `None` if the working
+    /// copy is clean.
+    ///
+    /// This scans the same status entries `record` guards on
+    /// (Added / Modified / Conflicted) with the same detector
+    /// ([`first_conflict_marker_line`]), so `atomic record` and
+    /// `atomic git push` agree on what counts as a conflicted working copy
+    /// (SPEC §5.4). It is the shared guard that stops any automated commit path
+    /// — including shadow materialization — from baking markers into history.
+    pub fn first_working_copy_conflict_marker(
+        &self,
+    ) -> Result<Option<(String, u32)>, RepositoryError> {
+        let status = self.status(StatusOptions::default())?;
+        for entry in status.entries() {
+            let is_directory = entry.details().map(|d| d == "directory").unwrap_or(false);
+            if is_directory {
+                continue;
+            }
+            if !matches!(
+                entry.status(),
+                FileStatus::Added | FileStatus::Modified | FileStatus::Conflicted
+            ) {
+                continue;
+            }
+            let path = entry.path().to_string_lossy().to_string();
+            let full_path = self.root.join(&path);
+            if let Ok(content) = std::fs::read(&full_path) {
+                if let Some(line) = first_conflict_marker_line(&content) {
+                    return Ok(Some((path, line)));
+                }
+            }
+        }
+        Ok(None)
+    }
+}
+
 /// Render a name conflict: two or more inodes are alive at the same path on
 /// this view, so instead of silently emitting whichever inode `TREE` happened
 /// to keep, wrap every side's materialized content in conflict markers.
@@ -945,5 +983,35 @@ impl Repository {
         self.populate_file_index(&result);
 
         Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod conflict_marker_tests {
+    use super::first_conflict_marker_line;
+
+    #[test]
+    fn detects_numbered_start_marker_at_line_start() {
+        let content = b"const shared = 1;\n>>>>>>> 1\nconst a = 2;\n======= 1 [C2YTBAHQ]\nconst b = 3;\n<<<<<<< 1\n";
+        assert_eq!(first_conflict_marker_line(content), Some(2));
+    }
+
+    #[test]
+    fn ignores_separator_or_content_that_only_appears_mid_line() {
+        // A legitimate line that merely contains `=======` (e.g. a Markdown
+        // rule or a comment) must not be misdetected — only a `>>>>>>>` at
+        // line start counts.
+        let content = b"let divider = \"=======\";\nfn eq() { a ======= b }\n";
+        assert_eq!(first_conflict_marker_line(content), None);
+    }
+
+    #[test]
+    fn clean_content_has_no_marker() {
+        assert_eq!(first_conflict_marker_line(b"fn main() {}\n"), None);
+    }
+
+    #[test]
+    fn binary_content_carries_no_marker() {
+        assert_eq!(first_conflict_marker_line(&[0xff, 0xfe, 0x00, 0x01]), None);
     }
 }

--- a/atomic-repository/src/repository/materialize.rs
+++ b/atomic-repository/src/repository/materialize.rs
@@ -31,6 +31,29 @@ impl Repository {
     /// `atomic git push` agree on what counts as a conflicted working copy
     /// (SPEC §5.4). It is the shared guard that stops any automated commit path
     /// — including shadow materialization — from baking markers into history.
+    /// Try to acquire the repo-scoped shadow-commit lock **without blocking**.
+    ///
+    /// Returns `Some(guard)` if acquired (the lock is held until the returned
+    /// file is dropped), or `None` if another shadow materialize/commit is
+    /// already in flight. This serializes the single shadow-commit pipeline
+    /// (SPEC §4.3 / Principle 5) so concurrent hooks/commands never interleave
+    /// partial staging. It is a distinct lock from the deferred-tree alignment
+    /// lock and is meant to be taken **outermost**, before any DB write txn.
+    pub fn try_lock_shadow_commit(&self) -> Result<Option<std::fs::File>, RepositoryError> {
+        use fs2::FileExt;
+        let lock = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(self.dot_dir.join("shadow-commit.lock"))?;
+        match lock.try_lock_exclusive() {
+            Ok(()) => Ok(Some(lock)),
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
+            Err(e) => Err(RepositoryError::Io(e)),
+        }
+    }
+
     pub fn first_working_copy_conflict_marker(
         &self,
     ) -> Result<Option<(String, u32)>, RepositoryError> {

--- a/atomic-repository/src/repository/materialize.rs
+++ b/atomic-repository/src/repository/materialize.rs
@@ -20,6 +20,19 @@ pub(crate) fn first_conflict_marker_line(content: &[u8]) -> Option<u32> {
     None
 }
 
+/// True if a `try_lock*` error means the lock is currently held by someone else
+/// (as opposed to a genuine I/O failure).
+///
+/// On Unix a contended non-blocking lock surfaces as `WouldBlock`, but on
+/// Windows the OS returns `ERROR_LOCK_VIOLATION` (code 33), which maps to
+/// `ErrorKind::Uncategorized` rather than `WouldBlock`. Comparing the raw OS
+/// error against `fs2::lock_contended_error()` handles both platforms.
+pub(crate) fn is_lock_contended(e: &std::io::Error) -> bool {
+    e.kind() == std::io::ErrorKind::WouldBlock
+        || (e.raw_os_error().is_some()
+            && e.raw_os_error() == fs2::lock_contended_error().raw_os_error())
+}
+
 impl Repository {
     /// Return the first working-copy file that still contains an unresolved
     /// conflict marker, as `(path, 1-based line)`, or `None` if the working
@@ -49,7 +62,7 @@ impl Repository {
             .open(self.dot_dir.join("shadow-commit.lock"))?;
         match lock.try_lock_exclusive() {
             Ok(()) => Ok(Some(lock)),
-            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
+            Err(e) if is_lock_contended(&e) => Ok(None),
             Err(e) => Err(RepositoryError::Io(e)),
         }
     }

--- a/atomic-repository/src/repository/materialize.rs
+++ b/atomic-repository/src/repository/materialize.rs
@@ -27,7 +27,7 @@ impl Repository {
     ///
     /// This scans the same status entries `record` guards on
     /// (Added / Modified / Conflicted) with the same detector
-    /// ([`first_conflict_marker_line`]), so `atomic record` and
+    /// (`first_conflict_marker_line`), so `atomic record` and
     /// `atomic git push` agree on what counts as a conflicted working copy
     /// (SPEC §5.4). It is the shared guard that stops any automated commit path
     /// — including shadow materialization — from baking markers into history.

--- a/atomic-repository/src/repository/mod.rs
+++ b/atomic-repository/src/repository/mod.rs
@@ -240,6 +240,32 @@ impl Repository {
     /// - The directory cannot be created
     /// - The database cannot be initialized
     pub fn init<P: AsRef<Path>>(path: P) -> Result<Self, RepositoryError> {
+        Self::init_with_view(path, DEFAULT_VIEW)
+    }
+
+    /// Initialize a new repository whose default view has the given name.
+    ///
+    /// Behaves like [`Repository::init`], but the initial shared root view —
+    /// and the config's `[view] default` — is `view_name` instead of
+    /// [`DEFAULT_VIEW`]. This is used by `atomic git import` so the imported
+    /// repository's default view matches the Git default branch rather than
+    /// leaving an unused `dev` view behind.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The directory to initialize as a repository
+    /// * `view_name` - The name of the initial shared root view
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - A repository already exists at the path
+    /// - The directory cannot be created
+    /// - The database cannot be initialized
+    pub fn init_with_view<P: AsRef<Path>>(
+        path: P,
+        view_name: &str,
+    ) -> Result<Self, RepositoryError> {
         let root = path.as_ref().to_path_buf();
         let dot_dir = root.join(DOT_DIR);
 
@@ -263,7 +289,7 @@ impl Repository {
 [view]
 default = "{}"
 "#,
-            DEFAULT_VIEW
+            view_name
         );
         std::fs::write(&config_path, initial_config)?;
 
@@ -282,25 +308,32 @@ default = "{}"
             let mut txn = pristine
                 .write_txn()
                 .map_err(|e| RepositoryError::Database(e.to_string()))?;
-            txn.open_or_create_view(DEFAULT_VIEW)
+            txn.open_or_create_view(view_name)
                 .map_err(|e| RepositoryError::Database(e.to_string()))?;
             txn.commit()
                 .map_err(|e| RepositoryError::Database(e.to_string()))?;
         }
-        ensure_workspace_dir(&dot_dir, DEFAULT_VIEW)?;
+        ensure_workspace_dir(&dot_dir, view_name)?;
 
         // Initialize the change store
         let change_store = ChangeStore::new(dot_dir.join("changes"), DEFAULT_CACHE_CAPACITY)
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
-        Ok(Self {
+        let repository = Self {
             root,
             dot_dir,
-            current_view: DEFAULT_VIEW.to_string(),
+            current_view: view_name.to_string(),
             pristine,
             change_store,
             is_sandbox: false,
-        })
+        };
+
+        // Persist the current-view pointer so reopening resolves this view.
+        // `read_current_view` only falls back to `DEFAULT_STACK` ("dev") when
+        // the pointer file is absent, so a custom initial view must be written.
+        repository.write_current_view(view_name)?;
+
+        Ok(repository)
     }
 
     /// Open an existing repository.

--- a/atomic-repository/src/repository/tests/mod.rs
+++ b/atomic-repository/src/repository/tests/mod.rs
@@ -17,6 +17,7 @@ mod merge_property_tests;
 mod record_duplication_tests;
 mod record_tests;
 mod rename_tests;
+mod shadow_lock_tests;
 mod status_tests;
 
 mod tracking_tests;

--- a/atomic-repository/src/repository/tests/shadow_lock_tests.rs
+++ b/atomic-repository/src/repository/tests/shadow_lock_tests.rs
@@ -1,0 +1,32 @@
+use super::*;
+
+/// The repo-scoped shadow-commit lock is exclusive and non-blocking: while a
+/// guard is held, a second `try_lock` reports contention (`None`); once the
+/// guard is dropped the lock is available again. This is the serialization
+/// primitive behind the single shadow-commit pipeline (SPEC §4.3 / Phase 3).
+#[test]
+fn shadow_commit_lock_is_exclusive_and_non_blocking() {
+    let (_temp_dir, repo) = create_temp_repo();
+
+    let first = repo
+        .try_lock_shadow_commit()
+        .expect("lock op should not error");
+    assert!(first.is_some(), "first acquire should succeed");
+
+    // A second attempt while the first guard is held must report contention,
+    // not block or double-acquire.
+    let second = repo
+        .try_lock_shadow_commit()
+        .expect("lock op should not error");
+    assert!(
+        second.is_none(),
+        "second acquire while held must be contended"
+    );
+
+    // Release and re-acquire.
+    drop(first);
+    let third = repo
+        .try_lock_shadow_commit()
+        .expect("lock op should not error");
+    assert!(third.is_some(), "acquire after release should succeed");
+}

--- a/atomic-repository/src/repository/tests/view_tests.rs
+++ b/atomic-repository/src/repository/tests/view_tests.rs
@@ -73,6 +73,32 @@ fn test_default_view_name() {
 }
 
 #[test]
+fn test_init_with_view_uses_custom_default_view() {
+    // `git import` seeds the default view with the Git default branch name so
+    // Atomic's shared view matches the project's Git default branch instead of
+    // leaving an unused `dev` view behind.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo = Repository::init_with_view(temp_dir.path(), "main").unwrap();
+
+    // The current (and only) view is the custom one.
+    assert_eq!(repo.current_view(), "main");
+
+    let views = repo.list_views().unwrap();
+    assert_eq!(views, vec!["main".to_string()]);
+    assert!(!views.contains(&"dev".to_string()));
+
+    // The config's default view matches too.
+    let config = std::fs::read_to_string(temp_dir.path().join(".atomic/config.toml")).unwrap();
+    assert!(config.contains("default = \"main\""));
+
+    // Reopening resolves the same current view.
+    let root = repo.root().to_path_buf();
+    drop(repo);
+    let reopened = Repository::open(&root).unwrap();
+    assert_eq!(reopened.current_view(), "main");
+}
+
+#[test]
 fn test_delete_view() {
     use atomic_core::pristine::{MutTxnT, ViewScope, ViewTxnT};
     let (_temp_dir, mut repo) = create_temp_repo();

--- a/atomic-repository/src/repository/views.rs
+++ b/atomic-repository/src/repository/views.rs
@@ -365,6 +365,44 @@ impl Repository {
             .map_err(|e| RepositoryError::Database(e.to_string()))
     }
 
+    /// Return the names of all views whose change-set references `hash`.
+    pub fn views_containing_change(&self, hash: &Hash) -> Result<Vec<String>, RepositoryError> {
+        let txn = self
+            .pristine
+            .read_txn()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        let change_id = match txn
+            .get_internal(hash)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+        {
+            Some(id) => id,
+            None => return Ok(vec![]),
+        };
+
+        let mut names = Vec::new();
+        for name in txn
+            .list_views()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+        {
+            let view = match txn
+                .get_view(&name)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?
+            {
+                Some(view) => view,
+                None => continue,
+            };
+            if txn
+                .get_change_seq(&view, change_id)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?
+                .is_some()
+            {
+                names.push(name);
+            }
+        }
+        Ok(names)
+    }
+
     /// Check if a view exists.
     ///
     /// # Arguments

--- a/docs/BUG-review-gate-original-hashes.md
+++ b/docs/BUG-review-gate-original-hashes.md
@@ -1,0 +1,190 @@
+# Bug: ReviewGate `original_hashes` captures only the first `Atomic-Changes` trailer on squash imports
+
+## Summary
+
+When `atomic git import` classifies a GitHub squash-merge commit that
+collapsed a **multi-commit** shadow branch, the resulting `ReviewGate` tag
+records only **one** original change hash instead of all of them. The
+granular provenance link from the shared view back to the original per-turn
+changes is therefore incomplete.
+
+Root cause: `parse_atomic_changes_trailer` returns on the **first**
+`Atomic-Changes:` line it encounters, but a squashed commit body legitimately
+contains **many** `Atomic-Changes:` lines (one per squashed materialization
+commit).
+
+- **Version:** atomic 0.15.6
+- **Component:** `atomic-cli` git import classifier
+- **Impact:** silent, partial provenance loss on the target view (no error,
+  data on disk is fine — only the ReviewGate → originals link is truncated)
+
+## Environment
+
+- atomic 0.15.6
+- Repo running git-shadow-sync (both `.git/` and `.atomic/`), squash-merge
+  workflow on GitHub.
+
+## Reproduction
+
+1. Shadow branch accumulates several materialization commits, each carrying its
+   own `Atomic-View` / `Atomic-State` / `Atomic-Changes` trailer block.
+2. Squash-merge the branch on GitHub. GitHub concatenates every squashed
+   commit's body, so the resulting merge commit contains **multiple**
+   `Atomic-Changes:` lines, e.g.:
+
+   ```
+   Materialize session view for git shadow sync snapshots (#2)
+
+   * chore(atomic): materialize session view for git shadow sync
+   Atomic-View: old-forest-591e
+   Atomic-State: NKEJLUQB6ZOP...
+   Atomic-Changes: 3FYFZISLWHD5ENCMB34H32MX7V3RMIXNTH6MEMSVLKEBSKDSJAFA
+
+   * chore(atomic): materialize session view for git shadow sync
+   Atomic-View: calm-violet-8d7f
+   Atomic-State: VXJOHMJMCNM6...
+   Atomic-Changes: TDD7KBU7RWXAZ5MHBNJLP3LDQZSD65TDSSZ5DXNPTWBUWV4EXRBQ
+
+   ... (several more Atomic-Changes lines) ...
+
+   Atomic-Changes: KBDY3IYTUXPAQINT2K4FOW37FW4GLAXPCWOQIQ5NK4D5LWMS4KMQ, EQU5BW25HXOY3A5VCIMNSYKREXF4LP2MTIH32WL72TI75UQ2S4TQ
+   ```
+
+3. On the correct branch, run:
+
+   ```
+   atomic git import --incremental --branch main
+   ```
+
+4. Inspect the ReviewGate (from the `main` view):
+
+   ```
+   atomic view switch main
+   atomic tag show pr-2
+   ```
+
+## Observed
+
+```
+Tag: pr-2
+View: main
+Message: Squash merge 97ccfe6d
+Kind: review-gate
+Metadata: {"changes":{"original_hashes":["3FYFZISLWHD5ENCMB34H32MX7V3RMIXNTH6MEMSVLKEBSKDSJAFA"]},
+           "git":{"merge_strategy":"squash","pr_number":2,"sha":"97ccfe6d..."}}
+```
+
+`original_hashes` contains a single hash — the **first** `Atomic-Changes` entry
+in the commit body (from `old-forest-591e`). All later `Atomic-Changes` lines,
+including the tip work `KBDY3IYTUXPA...` / `EQU5BW25HXOY...`, are dropped.
+
+## Expected
+
+`original_hashes` should contain **every** hash across **all** `Atomic-Changes:`
+lines in the squash body, so the ReviewGate links back to the full set of
+original changes the squash represents.
+
+## Root cause
+
+`atomic-cli/src/commands/git/parallel.rs`, `parse_atomic_changes_trailer`
+(around line 3631):
+
+```rust
+fn parse_atomic_changes_trailer(message: &str) -> Option<Vec<String>> {
+    for line in message.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("Atomic-Changes:") {
+            let hashes: Vec<String> = rest
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+            if !hashes.is_empty() {
+                return Some(hashes);   // <-- returns on the FIRST trailer line
+            }
+        }
+    }
+    None
+}
+```
+
+It returns as soon as one non-empty `Atomic-Changes:` line is parsed, so only
+the first block's hashes survive. `classify_commit` (line ~3611) then stores
+that partial list as the squash's `original_hashes`, and
+`classify_and_tag_imports` (line ~3502) writes it into the ReviewGate metadata.
+
+Note the sibling parser `parse_push_trailer` (line ~3895) already handles the
+squash shape differently — it reads only the *last paragraph* to avoid embedded
+trailers. The two parsers disagree about which `Atomic-Changes` block is
+authoritative, which is worth reconciling as part of the fix.
+
+## Suggested fix
+
+Accumulate across all `Atomic-Changes:` lines instead of returning on the
+first:
+
+```rust
+fn parse_atomic_changes_trailer(message: &str) -> Option<Vec<String>> {
+    let mut all: Vec<String> = Vec::new();
+    for line in message.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("Atomic-Changes:") {
+            all.extend(
+                rest.split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty()),
+            );
+        }
+    }
+    // Optionally de-duplicate while preserving order if the same hash can
+    // appear across blocks.
+    if all.is_empty() {
+        None
+    } else {
+        Some(all)
+    }
+}
+```
+
+Decisions for the maintainer:
+- Whether to de-duplicate hashes that repeat across blocks.
+- Whether to preserve order (first-seen) or sort.
+- Whether `parse_atomic_changes_trailer` and `parse_push_trailer` should share
+  a single trailer-extraction routine so their notions of "which trailers
+  count" stay consistent for squash commits.
+
+## Suggested test
+
+Add a unit test alongside the existing `test_parse_push_trailer_*` tests that
+feeds a multi-block squash body and asserts all hashes are collected:
+
+```rust
+#[test]
+fn test_parse_atomic_changes_trailer_collects_all_blocks() {
+    let msg = "\
+squash (#2)
+
+* materialize
+Atomic-View: a
+Atomic-State: S1
+Atomic-Changes: AAA, BBB
+
+* materialize
+Atomic-View: b
+Atomic-State: S2
+Atomic-Changes: CCC
+";
+    let hashes = parse_atomic_changes_trailer(msg).expect("should parse");
+    assert_eq!(hashes, vec!["AAA", "BBB", "CCC"]);
+}
+```
+
+## Impact / workaround
+
+- No data loss: the original changes still exist in the graph and remain
+  reachable by hash; only the ReviewGate → originals link is truncated.
+- Workaround until fixed: do **not** delete the source draft views after a
+  multi-commit squash import, so the full provenance stays reachable through
+  the views. Re-running the import after the fix would need to rebuild the
+  ReviewGate metadata (retroactive repair of existing tags is a separate
+  question worth calling out).

--- a/docs/SPEC-review-gate-insert-originals.md
+++ b/docs/SPEC-review-gate-insert-originals.md
@@ -1,0 +1,339 @@
+# Spec: Squash imports insert originals as records and represent the squash as a tag
+
+**Status:** Draft for review
+**Component:** `atomic-cli` git import (classifier, write pipeline, dry-run) +
+`atomic-repository` insert/tags
+**Related:** `BUG-review-gate-original-hashes.md` (prerequisite, already fixed)
+**Version target:** atomic 0.15.x
+
+---
+
+## 1. Problem
+
+In the git-shadow-sync workflow, developer work is recorded as granular
+per-turn Atomic **change records** in a **draft** view, materialized to a git
+shadow branch, and squash-merged onto `main` on GitHub. When we re-import that
+squash with:
+
+```
+atomic git import --incremental --branch main
+```
+
+the importer today **writes a brand-new squashed change record** into `main`
+and attaches a `ReviewGate` tag whose metadata lists the original change hashes.
+
+Two problems follow:
+
+1. **Provenance depends on keeping draft views.** The original per-turn records
+   are only referenced by the (disposable) draft view. The ReviewGate metadata
+   names them by hash, but nothing in a *synced* view references them, so:
+   - A default clone of `main` downloads only main's manifest changes (the
+     squashed record), not the originals — the ReviewGate hashes dangle
+     (`clone/command.rs:679`, `change_union`).
+   - Deleting the draft views severs the only live reference to the granular
+     history.
+
+2. **`main` holds a re-derived squash, not the real records.** The squashed
+   record is a fresh re-derivation of content that already exists in the graph
+   as the originals. Blame/diff/provenance on `main` sees one opaque squash
+   instead of the actual per-turn records.
+
+### What we want
+
+- Deleting draft views must be safe — no provenance loss.
+- `main` should reference the **original per-turn change records** so they are
+  cloned with `main` and remain queryable in the graph.
+- The squash is represented as an **atomic tag** (the ReviewGate) whose payload
+  is the **union/aggregate** of those records — `[first … last]`. **A squash
+  never becomes an atomic change record** (except the one non-atomic case in
+  §5).
+- No corruption of `atomic git import --incremental --branch main`.
+- `main` materializes to exactly the git squash's tree.
+
+---
+
+## 2. Two entity kinds — the squash is a tag, not a change
+
+Atomic has two distinct first-class entity kinds, both registered in the
+identity layer (INTERNAL / EXTERNAL / NODE_TYPES):
+
+- **Change record** (`NODE_TYPES` = change). Carries graph ops; participates in
+  `VIEW_CHANGES` and therefore in materialization.
+- **Tag** (`NODE_TYPES` = TAG; `TagRecord` in `TAG_RECORDS`). Carries a `state`
+  Merkle, `sequence`, `change_hash`, `kind`, and extensible `metadata`. Travels
+  over sync (`save_synced_tag`; pull replicates tags).
+
+The **originals are change records.** The **squash is a tag.** The ReviewGate
+tag's payload is the union of the inserted records.
+
+```
+originals (in draft) ──insert──▶ change records live in shared view
+                                 (materializable, cloneable, blameable)
+
+squash commit        ──────────▶ atomic TAG (ReviewGate) = union[first … last]
+                                 (NOT a change record)
+```
+
+### Why insert is cheap and non-destructive (ambient graph model)
+
+All edges from all views live in one canonical `GRAPH`. A view is a change-set
+**filter**. The originals' edges are already in `GRAPH` (recorded in the draft),
+so `insert_change_rec(hash, view=main)` (`insert.rs:1969`) only adds change refs
+(+ their transitive dependency closure, in dependency order) to main's
+`VIEW_CHANGES`. O(1) metadata per change, no edge copying, no content rewrite.
+
+### Materialization
+
+The **tag does not materialize anything.** `main` materializes from the change
+records in its filter, so inserting the originals is what puts the files on
+disk (`repo.materialize()`, `import.rs:611`). Because the originals are exactly
+the changes that produced the shadow-branch tip, materialized `main` equals the
+squash's git tree (in the shadow-sync model, where Atomic drives git). The tag
+sits on top purely as the aggregate marker / git↔atomic link.
+
+> Rejected alternative — *consolidating tag*: a Pijul-style tag that snapshots
+> state so `main` need not carry the individual records. Not chosen: tags here
+> carry a `state` but materialization still walks `VIEW_CHANGES`, and keeping
+> the individual records is the whole point (blame/provenance). Revisit only if
+> record-count in `main` becomes a scaling problem.
+
+---
+
+## 3. Current pipeline (what happens today)
+
+```
+phase 1  parse commits (parallel)
+phase 2  write_commit(...)  — parallel.rs:2733
+         └─ EVERY non-skipped commit → a NEW change record in target view
+            (self-push commits skipped: should_skip_self_push, :2647)
+phase 3  classify_and_tag_imports(...) — parallel.rs:3449
+         ├─ Normal  → no tag
+         ├─ Merge   → ReviewGate "merge-<sha>"
+         └─ Squash  → ReviewGate "pr-<n>"/"squash-<sha>" with
+                       metadata.changes.original_hashes
+phase 3  phase3_finalize(...) — parallel.rs:3530
+         └─ asserts commits_parsed == changes_written + empty + merge
+                                        + self_push_skipped
+final    repo.materialize() — import.rs:611
+```
+
+`classify_commit` (`:3604`) already separates squash-with-`Atomic-Changes`
+(originals populated — now the *full* set after the prerequisite bug fix) from a
+plain forge squash (originals empty). The corruption to avoid: inserting the
+originals **and** writing the squash record → `main` holds both.
+
+---
+
+## 4. Proposed design
+
+### 4.1 Squash → insert records + create aggregate tag
+
+In phase 2, classify the commit before writing. When it is a **Squash whose
+every `original_hash` exists locally** (`repo.has_change`):
+
+1. **Do not** `write_commit` it (write no change record for the squash).
+2. For each `original_hash`, in trailer order, `insert_change_rec(hash,
+   InsertOptions::default().view(target_view))`. Deps pulled automatically in
+   dependency order; re-inserting an already-present record is a no-op.
+3. Record the git SHA as imported (git SHA index + incremental markers) so a
+   re-run of `--incremental` skips it (`incremental_import_skips`, `:200`).
+4. Flag the `ImportedCommitInfo` as `SquashInserted` so phase 3 creates the
+   aggregate tag and counts it in a new `squash_inserted` bucket for
+   `phase3_finalize`.
+
+### 4.2 The ReviewGate tag as aggregate
+
+The ordered `original_hashes` already encode `[first … last]`. Add explicit
+convenience fields:
+
+```json
+{
+  "git": { "sha": "...", "merge_strategy": "squash", "pr_number": 2 },
+  "changes": {
+    "original_hashes": ["AAA", "BBB", "CCC", "DDD", "EEE"],
+    "from": "AAA",
+    "to":   "EEE",
+    "count": 5,
+    "inserted": true
+  }
+}
+```
+
+`inserted: true` ⇒ the records are live in this view. (`inserted` is only ever
+`false` for the non-atomic change-record case in §5; a squash tag is otherwise
+always backed by inserted records.)
+
+### 4.3 `atomic tag show` provenance UX (independent, low-risk)
+
+Render a ReviewGate readably instead of raw JSON:
+
+```
+Tag: pr-2
+View: main
+Kind: review-gate
+Git: squash 97ccfe6d (PR #2)
+Aggregate: AAA … EEE  (5 records, inserted)
+Records:
+  ✓ AAA  present  (main)
+  ✓ BBB  present  (main)
+  ...
+```
+
+Needs a small repo helper `views_containing_change(hash) -> Vec<String>`
+(read txn → `get_internal` → per view `get_change_seq`). Ships regardless of the
+insert work and directly serves "let me query the graph for provenance."
+
+### 4.4 Dry-run as router
+
+`--dry-run` today only counts (`import.rs:492`: "Would import N commits…"). It
+runs the real incremental skip rules but does no classification. Extend it to
+classify each incoming commit and route the user:
+
+```
+Would import 1 commit from branch 'main':
+  1 squash (PR #2) — atomic headers present, 5 records available
+    → will insert 5 records into 'main' and tag pr-2 (aggregate AAA…EEE)
+```
+
+Three-way routing table:
+
+| Dry-run detects | Recommendation | Result in `main` |
+|---|---|---|
+| Squash **with** atomic headers, records present | proceed with `--incremental` | insert records + aggregate **tag** |
+| **No** atomic headers (git-authored) | `git pull && atomic git import` (normal path) | ordinary **change record(s)** — legitimate new non-atomic content |
+| Atomic headers, records **missing locally** | `atomic pull` first, then re-import | insert once records are present |
+
+The middle row is the **only** sanctioned path where a squash yields a change
+record, and only because the content genuinely originated on the git side with
+no atomic provenance to preserve.
+
+---
+
+## 5. Fallback = skip + advise (never fabricate a squash record)
+
+Because a squash is a tag, the old "write the squash as a change record"
+fallback is gone. The two non-happy paths:
+
+1. **Atomic headers present, but ≥1 named record missing locally.** We cannot
+   union records that don't exist, and we must not invent one. → **Skip the
+   commit** (leave its git SHA unimported so a later run completes it) and warn,
+   naming the missing hashes, recommending **`atomic pull`**. A `git pull` does
+   *not* help here — git carries no atomic change records.
+
+2. **No atomic headers at all (git-authored squash/commit).** Genuinely new
+   non-atomic content with no records to union. → Handled by the **normal
+   import path** (writes ordinary change records), surfaced by the dry-run
+   router as `git pull && atomic git import`. This is the lone legitimate
+   change-record outcome.
+
+Partial presence (some records present, some not) is treated as case 1 — do not
+insert a partial set.
+
+---
+
+## 6. Decisions
+
+### D1. Divergence handling (the one open decision)
+
+If a human hand-resolved a conflict in the GitHub PR UI, the squash's git tree
+won't equal the sum of the originals, so inserting them would leave `main`'s
+materialized files different from git's `main`.
+
+- **(A) Verify + skip (safer).** After inserting, compare the materialized tree
+  for the touched paths against the git commit's tree. On mismatch, roll back
+  the insert (`del_view_changes` on the added refs) and **skip + advise** (as
+  §5) rather than corrupt `main`. `main` can never silently desync from git.
+- **(B) Trust the invariant (simpler).** Always insert when records are
+  present; no tree comparison. Correct as long as nobody hand-resolves in the
+  GitHub UI.
+
+*Recommendation:* A. Note the fallback under A is skip+advise, **not** writing a
+squash change record.
+
+### D2. Dependency-closure scope
+
+`insert_change_rec` pulls the transitive closure. A PR branch based on `dev`
+(not `main`) drags dev-only deps into `main`. Consistent with git (a squash of a
+dev-based branch onto main includes dev's diff), but confirm this is desired vs.
+erroring when the closure exceeds the declared trailer set.
+
+### D3. What the squash git SHA maps to
+
+Options: the resulting view state (Merkle), the last inserted record, or the
+ReviewGate tag entity. Affects `atomic change <git-sha>` lookups and re-import
+dedup. *Recommendation:* map the SHA to the resulting state and let the
+ReviewGate tag own the git provenance.
+
+### D4. Retroactive repair
+
+Pre-existing ReviewGate tags reference truncated/absent originals and point at a
+squash *record*. Rebuilding them (insert records, convert to aggregate tag,
+remove the squash record) is a separate `atomic git reclassify`-style tool.
+*Recommendation:* defer; confirm.
+
+### D5. Merge (non-squash) commits
+
+Out of scope; keep current `merge-<sha>` ReviewGate behavior. Confirm.
+
+---
+
+## 7. Edge cases
+
+- **Idempotent re-import:** git SHA recorded so `--incremental` skips it;
+  re-inserting the same records is a no-op (insert dedupes against
+  `VIEW_CHANGES`).
+- **Ordering:** insert in dependency order (handled by `insert_change_rec`);
+  preserve trailer order for the aggregate `from`/`to`.
+- **Draft view deletion after insert:** safe — records stay alive because
+  `main` references them; only orphaned edges are GC'd.
+- **Empty squash** (no file changes): keep current no-op handling.
+- **Tag naming collision** (`pr-<n>` already exists from a prior import):
+  overwrite vs. error — decide (recommend overwrite with a warning, since a
+  re-squash of the same PR is legitimate).
+
+---
+
+## 8. Testing
+
+Unit (prerequisite — already landed):
+- `parse_atomic_changes_trailer` collects all blocks, dedupes, preserves order.
+- `classify_commit` surfaces the full `original_hashes`.
+
+New integration tests:
+- Record N per-turn records in a draft; materialize to a git shadow branch;
+  squash-merge; `import --incremental --branch main`; assert:
+  - `main`'s `VIEW_CHANGES` contains all N originals, and **no** squash record.
+  - `repo.materialize()` of `main` == git squash tree.
+  - ReviewGate `pr-<n>` has `inserted: true`, `from`/`to`/`count`, full list.
+  - Deleting the draft leaves `main` materializable and originals present.
+- **Missing records:** headers present, a record absent → commit skipped, SHA
+  not marked imported, warning names the hash, recommends `atomic pull`.
+- **No headers:** git-authored commit → normal change record written (unchanged
+  path); dry-run router recommends `git pull && atomic git import`.
+- **Divergence (decision A):** synthesize a squash tree differing from the
+  records → insert rolled back, commit skipped, `main` unchanged.
+- **Dry-run classification:** each row of the §4.4 table produces the right
+  recommendation string.
+- `phase3_finalize` accounting holds with the `squash_inserted` bucket.
+
+---
+
+## 9. Rollout / compatibility
+
+- Local-only change to `atomic-cli` import + `atomic-repository`. No push/pull
+  wire-format change, so no `atomic-storage` `X-Atomic-Min-Version` bump
+  required (unless a future server-side reclassify is added).
+- ReviewGate metadata gains additive fields (`from`/`to`/`count`/`inserted`);
+  older readers ignore unknown keys.
+- Behavior change is gated on "squash with all records present"; git-authored
+  and non-atomic imports are unaffected.
+
+---
+
+## 10. Open items for reviewer
+
+1. **D1** — verify+skip (A) or trust-and-insert (B)? (Primary; determines size
+   and risk.)
+2. D2 dependency-closure semantics, D3 SHA mapping, D4 retroactive repair, D5
+   merges, and the §7 tag-naming-collision policy — each has a recommended
+   default; confirm or override inline.

--- a/docs/SPEC-shadow-push-conflict-markers.md
+++ b/docs/SPEC-shadow-push-conflict-markers.md
@@ -1,0 +1,213 @@
+# Spec: Shadow git-push must never commit unresolved conflict markers
+
+- **Status:** Proposed
+- **Severity:** Critical (silent working-tree corruption committed to git branches)
+- **Component:** `atomic-cli` git-shadow-sync (`atomic git push` materialization) +
+  cross-view materialization
+- **Version observed:** atomic 0.15.6
+- **Related:** `BUG-review-gate-original-hashes.md` (the parser bug is a
+  downstream symptom; this is the root-cause class)
+
+---
+
+## 1. Problem statement
+
+In a git-shadow-sync repository, the turn-end hook materializes the current
+Atomic view into a git commit via `atomic git push --no-push`. When a
+view's working copy contains **unresolved conflict markers** (produced by
+cross-view materialization of conflicting changes), the shadow push commits
+those markers verbatim into git. The result is git branches whose source files
+contain lines like:
+
+```
+>>>>>>> 1
+  onOpenRemoteUpdate: () => void;
+======= 1 [C2YTBAHQ]
+  remoteUpdateError: string | null;
+======= 1 [UDILON2P]
+};
+<<<<<<< 1
+```
+
+These branches do not compile, are indistinguishable from real work in git
+history, and silently diverge the git tree from any coherent Atomic state. In
+the observed incident this corrupted **53+ source files** across an entire
+application (`App.tsx`, `Header.tsx`, `ModelControls.tsx`, `useConfigStore.ts`,
+etc.), produced broken draft branches, and — because the hook keeps
+re-materializing — repeatedly re-committed the corruption onto `main` after
+each `git reset --hard` (commit `6e7b4e92`-style re-drift).
+
+## 2. Why this is the true root cause
+
+Several confusing downstream symptoms all trace to this one behavior:
+
+- `atomic git import` refusing with *"inserting its originals diverges from the
+  git tree"* — the git tree contained committed conflict markers, so it could
+  never match a clean Atomic insert.
+- Draft branches that "conflict with main" — they carry committed markers.
+- The re-materialization loop that re-dirtied `main` after every reset.
+
+Fixing the ReviewGate trailer parser (companion report) does not address this;
+it only makes provenance links complete once the tree is clean. **This spec is
+the corruption source.**
+
+## 3. Root cause in code
+
+Two guards exist for `atomic record`, but the shadow push bypasses both.
+
+### 3.1 `atomic record` already rejects conflict markers (the correct precedent)
+
+- `atomic-repository/src/record/options.rs:93-99` — `allow_conflict_markers`
+  option, **defaults to `false`**.
+- `atomic-repository/src/record/mod.rs:148-154` — recording a file that still
+  contains conflict markers is an error:
+  `"{path} still contains conflict markers at line {line} (resolve the
+  conflict, or pass --allow-conflict-markers to override)"`.
+- `atomic-cli/src/error.rs:260` / `:601` — CLI surfaces this and instructs the
+  user to remove `>>>>>>>` / `=======` / `<<<<<<<` lines.
+
+So the record path treats markers as a hard stop unless explicitly overridden.
+
+### 3.2 `atomic git push` (shadow materialization) has NO such guard
+
+`atomic-cli/src/commands/git/push.rs:135-160` stages and trees the working copy
+directly, with no conflict-marker inspection:
+
+```rust
+// Stage everything: git add -A
+index.add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)?;
+index.update_all(["*"].iter(), None)?;
+index.write()?;
+let tree_oid = index.write_tree()?;   // <-- whatever is on disk, markers included
+let tree = git_repo.find_tree(tree_oid)?;
+```
+
+The subsequent commit (push.rs, later in `run`) records this tree with the
+`Atomic-View` / `Atomic-State` / `Atomic-Changes` trailers. **Nothing between
+`add_all` and the commit checks whether any staged file contains conflict
+markers.** The only skip condition is "tree identical to HEAD" (push.rs:169-188)
+— which does not fire when the drifted, marker-laden tree genuinely differs
+from HEAD.
+
+### 3.3 Upstream: cross-view materialization emits the markers
+
+Materialization is *allowed* to write conflict markers for human resolution
+(by design):
+
+- `atomic-core/src/apply/conflict.rs:15` — "Allowing output with conflict
+  markers for human resolution".
+- `atomic-core/src/merge/engine.rs:41`, `atomic-core/src/merge/resolved.rs:52`,
+  `atomic-core/src/output/alive/order.rs:44` — SCC/cyclic conflicts are written
+  with markers.
+- `atomic-repository/src/archive.rs:64` — same marker convention.
+
+The markers themselves are legitimate (they are how Atomic asks a human to
+resolve a conflict). The defect is that an **automated background commit path**
+(the shadow hook) treats a working copy that is *pending human conflict
+resolution* as if it were a clean, commit-ready snapshot.
+
+## 4. Marker format to detect
+
+Atomic's conflict markers are numbered and change-hash-tagged (not classic git
+3-way markers):
+
+```
+>>>>>>> <N>
+=======  <N> [<CHANGE_HASH_BASE32>]
+<<<<<<< <N>
+```
+
+Detection must match `>>>>>>>`, `<<<<<<<`, and `======= N [hash]` at
+line-start. The record-path detector (`record/mod.rs`) already locates these
+"at line {line}"; the shadow push must reuse the **same** detector so the two
+paths cannot disagree.
+
+## 5. Required behavior
+
+### 5.1 Invariant
+
+> The shadow materialization path (`atomic git push`, including `--no-push`)
+> MUST NOT create a git commit from a working copy that contains unresolved
+> conflict markers, unless conflict-marker commits are explicitly enabled.
+
+### 5.2 Default behavior on markers detected
+
+1. **Do not stage, tree, or commit.** Abort the push before `write_tree`.
+2. Exit non-zero with a clear, actionable message naming the first conflicted
+   file and line, and instructing the user to resolve markers then re-run.
+3. When invoked from the turn-end hook (non-interactive), **log to
+   `.atomic/hook-errors.log`** with a distinct tag (e.g. `shadow-conflict`) and
+   leave both git and the working copy untouched. The hook must surface a
+   visible warning, not fail silently.
+4. Leave `git status` and `atomic status` exactly as they were (no partial
+   stage, no partial commit).
+
+### 5.3 Explicit override
+
+Provide an opt-in flag mirroring record's `--allow-conflict-markers` (e.g.
+`atomic git push --allow-conflict-markers`) for the rare case where markers are
+legitimate file content. Default is `false`. The hook MUST NOT pass this flag.
+
+### 5.4 Consistency requirement
+
+`atomic git push` and `atomic record` MUST share one conflict-marker detector
+and one default policy. It is a defect for `record` to reject markers while
+`git push` commits them.
+
+## 6. Acceptance criteria
+
+- [ ] With a view whose working copy contains conflict markers,
+      `atomic git push --no-push` creates **no** commit, exits non-zero, and
+      names the conflicted file + line.
+- [ ] The turn-end hook, on the same state, records a `shadow-conflict` entry in
+      `.atomic/hook-errors.log`, creates no commit, and mutates neither git nor
+      the working copy.
+- [ ] `atomic git push --allow-conflict-markers` still commits (explicit
+      override only).
+- [ ] A clean working copy (no markers) pushes exactly as before — no
+      regression to the normal shadow loop.
+- [ ] `atomic record` and `atomic git push` produce identical marker detection
+      (same file/line reported) for the same working copy.
+- [ ] Reproduction from the incident: a cross-view materialization that writes
+      markers to 50+ files does not result in any of those files being committed
+      by the shadow hook.
+
+## 7. Test plan
+
+Unit:
+- Marker detector: numbered/hash-tagged markers (`>>>>>>> 1`,
+  `======= 1 [ABC123]`, `<<<<<<< 1`) at line start are detected; legitimate
+  content containing `=======` mid-line is not misdetected.
+- `push::run` aborts before `write_tree` when detector returns a hit.
+
+Integration:
+- Materialize a synthetic conflict (two views editing the same span, cross-view
+  insert) so the working copy gains markers; assert `atomic git push --no-push`
+  makes no commit and the tree/HEAD are unchanged.
+- Assert `--allow-conflict-markers` path does commit.
+- Assert hook path writes `shadow-conflict` to the error log and is idempotent
+  (re-running does not accumulate commits).
+
+## 8. Risks / non-goals
+
+- **Non-goal:** changing whether cross-view materialization *emits* markers.
+  Markers-for-human-resolution is intended; this spec only stops the automated
+  commit of them.
+- **Risk:** a stricter push could block a user mid-flow if a view legitimately
+  contains `=======`-like content; the shared detector + `--allow-conflict-markers`
+  override mitigates this, matching existing `record` behavior.
+- **Migration:** existing branches already polluted with markers are out of
+  scope; they are cleaned up by discarding the affected draft branches/views and
+  resetting git to the last clean published state.
+
+## 9. Incident evidence (for the fix author)
+
+- Corrupted working-tree sample (Header.tsx) showing `>>>>>>> 1` /
+  `======= 1 [C2YTBAHQ]` / `<<<<<<< 1` with scrambled field order.
+- 53+ source files carried markers on the draft-view chain
+  (`git grep -lE '^(>>>>>>> [0-9]|<<<<<<< [0-9]|======= [0-9] \[)'`).
+- Shadow materialization commits (`chore(atomic): materialize session view for
+  git shadow sync`, e.g. `6e7b4e92`, `76f295ca`) committed these files with
+  full `Atomic-View`/`Atomic-State`/`Atomic-Changes` trailers.
+- `atomic git import` later refused with *"inserting its originals diverges from
+  the git tree ... skipping"* — a direct consequence of the committed markers.

--- a/docs/SPEC-single-materializer-validator.md
+++ b/docs/SPEC-single-materializer-validator.md
@@ -1,0 +1,401 @@
+# Architecture Spec: Single Shadow-Commit Pipeline + Validator for Git Shadow Sync
+
+- **Status:** Proposed (governing architecture) — *revised, phased*
+- **Severity:** Critical — addresses a bug *class*, not a single defect
+- **Component:** `atomic-cli` git-shadow-sync (materialization, `atomic git push`,
+  `atomic view switch`, `atomic git import`, turn-end hooks)
+- **Version observed:** atomic 0.15.6
+- **Subsumes:**
+  - `SPEC-shadow-push-conflict-markers.md` → Validator **Rule V1** (already implemented)
+  - `BUG-review-gate-original-hashes.md` → made non-load-bearing by V2 (parser already fixed)
+- **Revision note:** This version reframes the original "single Materializer" as a
+  **single shadow-commit pipeline** (the renderer is already centralized), tightens
+  **V3** to an ancestor-based, false-positive-safe rule, records the **current code
+  reality**, and lays out a **phased plan** where each phase ships independently.
+
+---
+
+## 1. Thesis
+
+When git shadow sync is enabled, the path that turns a view into a git commit
+MUST be governed by:
+
+1. a **single shadow-commit pipeline** — the sole path permitted to stage and
+   create a shadow commit (render-if-needed → validate → stage tracked-only →
+   candidate → commit), and
+2. a **secondary Validator** — an independent gate that must pass before the
+   commit is finalized, or the operation aborts and mutates nothing.
+
+The graph→disk **renderer already exists and is shared** (`Repository::materialize*`);
+the defect is that `atomic git push` stages disk→git **independently** of it, with
+no validation, and turn-end hooks race that path on their own schedule.
+
+## 2. Motivating incident (evidence)
+
+A single git-shadow session degenerated into hours of unrecoverable state. The
+distinct, uncoordinated writers observed:
+
+| Writer | What it did | File/behavior |
+|---|---|---|
+| Cross-view materialization | Wrote unresolved conflict markers to 53+ files | `atomic-core` merge/output emits `>>>>>>> N` / `======= N [HASH]` / `<<<<<<< N` |
+| `atomic git push` (shadow hook) | `git add -A` + commit of whatever was on disk, no validation | `push.rs` stages/trees with no coherence check |
+| `atomic view switch --force` | Materialized a drifted view over a clean tree | `switch.rs` force path |
+| `atomic git import` | Applied a squash whose tree didn't match the view; later refused | `git/import.rs`, `parallel.rs` |
+| Turn-end hook | Re-materialized/committed on its own schedule, recreating drift after each `git reset` | hook-driven `atomic git push --no-push` |
+
+Consequences: broken git branches carrying conflict markers, a materialization
+loop that re-dirtied `main` after every reset, an import that could never
+reconcile, and finally deletion of `.atomic`/`.vault` — **losing all authored
+intents, memories, attestations, and the change graph** (git-excluded, no
+backup). git survived only because it was the one anchor no shadow writer was
+allowed to rewrite remotely.
+
+**Common cause:** many writers, zero validators, no single owner of "the correct
+working-copy state right now," and no protection for the unbacked provenance store.
+
+## 3. Current state (what the code actually does)
+
+Grounded map, so this spec builds on reality rather than a strawman:
+
+| Concern | Today | Gap |
+|---|---|---|
+| Graph→disk renderer | **Centralized** in `Repository::materialize*` (`atomic-repository/src/repository/materialize.rs:274+`); used by `switch_view` (`switch.rs:91`) and `import`. | None — keep it. |
+| Shadow-commit staging | **Independent** in `atomic-cli/src/commands/git/push.rs` (`git add -A` → `write_tree` → commit) on whatever is on disk; no re-materialize, historically no validation. | The core hole. |
+| Validator | **Rule V1 only** — `Repository::first_working_copy_conflict_marker` guards `push` before staging (shares `record`'s detector). | V2/V3/V4 missing. |
+| Proto-V2 | `parallel.rs::squash_insert_matches_tree` does a **post-hoc** touched-path tree↔view check + rollback during import. | Promote to a **pre-commit** invariant. |
+| Serialization lock | **Primitive exists**: `deferred_tree.rs:554 lock_deferred_tree_alignment` (advisory `fs2::FileExt::lock_exclusive` on a `.atomic/*.lock`). | Not applied to the commit pipeline. |
+| Excluded paths | `ensure_git_shadow_excludes` (`import.rs:172`) git-excludes `.atomic/` etc. | Not *asserted* pre-commit (V4). |
+| Provenance protection | **None.** | The catastrophic gap (§2, §10). |
+
+## 4. Principles
+
+1. **Single commit pipeline.** Exactly one path stages and creates a shadow
+   commit. `git push` and hooks delegate to it; it renders via the existing
+   `Repository::materialize*` when needed. It never independently `git add -A`.
+2. **Validate before persist.** No shadow commit is created until the Validator
+   affirms coherence. Failure aborts with no mutation.
+3. **git is the durable anchor; provenance is precious and unbacked.** The
+   working copy and shadow commits are reconstructable; `.vault` and `.atomic`
+   are NOT. The architecture must never risk provenance to fix a tree.
+4. **No silent success on failure.** A failed validate surfaces (non-zero
+   interactively; `.atomic/hook-errors.log` with a distinct tag non-interactively)
+   and leaves git + working copy + graph untouched.
+5. **Serialized, not raced.** Only one shadow materialize/commit is in flight per
+   repo; concurrent hooks/commands queue or no-op, never interleave.
+6. **One authority; policy over mirroring.** Direction matters: **git shadows
+   Atomic**, not the reverse. Atomic is the upstream **source of truth** for
+   content and provenance; git is the **downstream shadow** — generated from
+   Atomic (materialize/push) and serving as the durable published anchor. Poking
+   the shadow (raw `git checkout`/`reset`/…) must never drive the source of
+   truth; the next Atomic materialize regenerates the shadow. The Atomic view is
+   the single authority for working-copy content. Rather than intercept every git command
+   that moves HEAD or the tree — an unbounded surface (`checkout`, `reset`,
+   `merge`, `rebase`, `cherry-pick`, `revert`, `stash pop`, `pull`, `am`,
+   `switch`, `restore`…) — shadow-sync relies on (a) **policy/documentation**:
+   prefer `atomic` commands over raw git, and (b) the **Validator as backstop**:
+   raw git that desyncs the tree simply makes the next shadow push refuse
+   (V1/V2/V3) with a reconcile hint. Safety comes from *refusing incoherent
+   commits*, not from mirroring git. Full bidirectional HEAD coupling is a
+   **non-goal** (see §5.4).
+
+## 5. The shadow-commit pipeline (sole committer)
+
+### 5.1 Responsibilities
+- **Render-if-needed:** ensure the working copy reflects the target view via
+  `Repository::materialize*` (it does not re-implement rendering).
+- **Validate:** run all Validator rules on the *candidate* (staged tree +
+  `Atomic-View`/`Atomic-State`/`Atomic-Changes` trailers).
+- **Stage tracked-only:** stage precisely the view's tracked paths, honoring
+  git-excluded shadow paths (`.atomic/`, `.vault/`, `.atomicignore`).
+- **Commit** only after the Validator passes.
+
+### 5.2 Required consolidations
+- `atomic git push` MUST call the pipeline instead of its own
+  `add_all`/`write_tree` block. That block is deleted.
+- Turn-end hooks invoke only the pipeline; they never stage/commit directly.
+- `atomic view switch` (incl. `--force`) keeps using `Repository::materialize*`
+  for rendering, but MUST detect when git HEAD moved out from under Atomic (an
+  external `git checkout`) and MUST NOT materialize a **conflicting** view over
+  that tree without reconciliation — it never silently produces a mixed tree.
+  Concretely: before materializing, if git HEAD's `Atomic-State` is not in the
+  target view's lineage (the V3 predicate), refuse with a reconcile hint rather
+  than overwriting. This is the root-cause guard for the git-checkout → switch
+  collision (§6.3); V1/V2 remain the push-time backstop.
+- `atomic git import`'s materialize step already uses the shared renderer; once
+  V2 is a pre-commit invariant, its post-hoc "diverges from git tree" refusal is
+  simplified to lean on V2.
+
+### 5.3 Concurrency (lock ordering matters)
+- A repo-scoped advisory lock (reuse the `deferred_tree.rs` pattern) guards the
+  pipeline. It is acquired **outermost** — before any DB write txn or the
+  deferred-tree alignment lock — to avoid deadlock.
+- A second materialize request while one runs **queues or no-ops** with a logged
+  reason; it never partially stages.
+
+### 5.4 Policy over coupling (why we do **not** mirror git)
+
+**Direction:** git shadows Atomic. Atomic is upstream (source of truth); git is
+the downstream shadow, generated from Atomic. So there is no symmetric “both
+drive each other” to build in the first place — work flows Atomic → git, and the
+sole, *deliberate* git → Atomic bridge is `atomic git import` (onboarding
+genuinely-new git-authored history), never automatic.
+
+Full bidirectional binding — make `atomic view switch` move git HEAD *and* make
+every `git checkout`/`reset`/`merge`/`rebase`/… move the Atomic view — was
+considered and **rejected as a non-goal**. It also has the direction backwards:
+letting a raw git command drive the Atomic view would make the shadow rewrite its
+source of truth. Reacting to git correctly means
+defending the entire git command surface (anything that moves HEAD or the tree),
+plus loop-prevention and clobber-avoidance on each. That is a large, fragile
+attack surface for a convenience.
+
+Instead, shadow-sync takes the cheaper, safer path:
+
+1. **Policy / documentation (primary).** In a shadow-sync repo, prefer `atomic`
+   commands over raw git: `atomic view switch` (not `git checkout`), `atomic git
+   import` to bring in external git commits, `atomic git push` to publish. This
+   is already the rule for agents (`atomic-opencode/AGENTS.md`: “never use `git`
+   for repository operations”); document it for humans in the shadow-sync guide.
+2. **Validator backstop (guarantee).** Policy is advisory, so the *guarantee*
+   lives in the Validator: if a user does use raw git and desyncs the working
+   copy, the next shadow push **refuses** (V1 markers / V2 tree↔view / V3
+   lineage) with a reconcile hint (`atomic git import`, or `git reset` to the
+   last coherent shadow commit). Raw git can inconvenience the *local* working
+   copy; it cannot corrupt shared history, because incoherent state is never
+   committed. This is why documentation is *sufficient* rather than reckless.
+3. **Optional advisory hook (nicety, not coupling).** At most, an installed git
+   `post-checkout`/`post-merge` hook that **only warns** — e.g. “git HEAD is now
+   `A` but the Atomic view is `B`; run `atomic view switch A` (or `atomic git
+   import`) to resync”. Warn-only means no mutation, no loops, no data-loss risk,
+   and a bounded surface. It never switches, imports, or commits on its own.
+
+**Direction A is implemented (the correct, in-our-control half).** `atomic view
+switch` moves the git shadow's HEAD to the mirror branch by a **ref move** —
+`set_head` + index realign, never a `git checkout`/re-render, so it can't refuse
+or revert Atomic's authoritative content. It is best-effort, gated to shadow-sync
+repos (excludes present), idempotent (no-op when already on the branch), and
+creates the mirror branch if absent. *(Done: `git/shadow.rs::sync_git_head_to_view`,
+called from `view/switch.rs`; harness `37_shadow_view_branch_follow.sh`.)*
+Note: running the real `git checkout` was rejected — when Atomic is ahead of the
+git branch (the normal state before push) it would either refuse or, with `-f`,
+revert to the stale git tree, discarding Atomic's un-pushed content (shadow
+overwriting source). The ref move avoids both.
+
+The reverse (`git checkout` ⇒ Atomic follows) remains a **non-goal** — that is
+the shadow driving the source, and reacting to it means the whole git surface.
+The safety mechanism is still the Validator (§6) plus provenance protection
+(Rule V4), never the coupling.
+
+## 6. The Validator (secondary gate)
+
+Runs on the candidate; any failure ⇒ abort, log, no mutation.
+
+### 6.1 Rule V1 — No unresolved conflict markers  *(implemented)*
+No staged file may contain `>>>>>>> N` / `======= N [HASH]` / `<<<<<<< N`.
+Reuses the **same** detector as `atomic record`
+(`first_conflict_marker_line`), so record and shadow-push never disagree.
+Override: `--allow-conflict-markers` (never passed by hooks). *(Done: `push.rs`
++ harness `33_shadow_push_conflict_markers.sh`.)*
+
+### 6.2 Rule V2 — Tree ↔ view coherence  *(incremental form)*
+The staged tree MUST correspond to the target view's recorded change set, over
+git-tracked paths only (exclude `.atomic/`, `.vault/`, `.atomicignore`).
+**Cost-safe implementation:** do **not** re-materialize the whole view and diff
+the tree (O(tree)). Instead, for each path that differs between the staged tree
+and git HEAD, compare the staged bytes to the view's materialized content for
+that path (`get_file_content_on_view`). A mismatch, an unaccounted-for path, or
+a view-recorded change absent from the tree fails V2. This lifts the existing
+`squash_insert_matches_tree` check to a general pre-commit invariant.
+
+### 6.3 Rule V3 — git ↔ Atomic state agreement  *(implemented; no bypass; advance = reconcile)*
+Purpose: stop a **drifted** view from being shadow-committed over an unrelated
+git HEAD (the "drifted `main`" failure) and — critically — stop the *external*
+materializer, `git checkout`, from silently poisoning a shadow commit.
+
+**The external-materializer hazard.** `git checkout <branch>` is a working-copy
+writer Atomic does not control. After a checkout, the working copy and git HEAD
+reflect branch A; a subsequent `atomic view switch B` materializes view B over
+that tree, leaving a **mixed** working copy (view-B tracked files + branch-A-only
+files, or per-path drift where the two disagree). This is the two-materializer
+collision this whole architecture exists to prevent.
+
+**What already catches it at push time (defense in depth, already shipped):**
+- Any branch-A file not in view B is staged but absent from the view ⇒ **V2**
+  fails ("not recorded by the view").
+- Any conflict markers left by materialization ⇒ **V1** fails.
+So the *default* push path already refuses the mixed tree. V3 adds the one signal
+V1/V2 can't see: the git HEAD **lineage** itself.
+
+**V3 definition (cheap lineage-membership, no tree diff):**
+- Let `HEAD_state` = the `Atomic-State` trailer of the most recent shadow commit
+  on the target branch whose `Atomic-View` matches the target view
+  (`find_last_pushed_state`).
+- **Pass** iff `HEAD_state` is absent (first publish) OR is an ancestor of the
+  view's current `Atomic-State` (a normal fast-forward advance).
+- **Fail** when `HEAD_state` exists but is not in the view's lineage — genuine
+  drift, including the git-checkout case (HEAD carries a foreign view's state, or
+  none this view can reach).
+
+**No blanket bypass — this is the key correction.** There is deliberately *no*
+`--force`/`--advance` flag that commits a state failing V3: that is exactly the
+escape hatch that reintroduced the incident (force-materialize over a clean tree
+→ loop → delete provenance to escape). To *intentionally* re-anchor a branch to a
+different view, the user reconciles **first**, producing a coherent state that V3
+then passes on its own merits. Because git shadows Atomic, the remedies are
+ordered by direction:
+- **Primary — re-shadow:** reset git to the view's last coherent published state
+  (`git reset --hard` to that shadow commit). git is the downstream shadow, so
+  discarding a poked-shadow state and regenerating from Atomic is the normal fix.
+- **Exception — onboard:** only when git HEAD carries genuinely-new *authored*
+  content that belongs in Atomic, import it (`atomic git import`) so the view's
+  lineage includes `HEAD_state`. This is the sole deliberate git → Atomic bridge.
+The `--allow-conflict-markers` override stays narrow (V1 only; V2 and V3 always
+apply). Reconcile-to-advance, never bypass-to-commit.
+
+### 6.4 Rule V4 — Excluded-path & provenance integrity  *(highest priority)*
+- The candidate MUST contain **no** paths under `.atomic/`, `.vault/`, or the
+  `.atomicignore` file. If staging would include any, fail V4.
+- The pipeline MUST NOT delete or modify `.vault/` or `.atomic/` as a side effect
+  of any tree reconciliation. (Directly serves Principle 3 and the §10 loss.)
+
+### 6.5 Failure semantics
+- **Interactive:** non-zero exit; message names the failing rule + first
+  offending path/line + remediation.
+- **Non-interactive (hook):** append `shadow-validate:<rule>` to
+  `.atomic/hook-errors.log`; create no commit; mutate neither git nor graph.
+- **Never partial.** The candidate is discarded atomically.
+
+## 7. Interaction with existing specs
+
+- **Conflict markers:** `SPEC-shadow-push-conflict-markers.md` = Rule V1 (done).
+- **ReviewGate trailer parser:** already fixed; once V2 owns tree↔view coherence
+  pre-commit, the parser stops being load-bearing but remains correct. No rework.
+- **Squash-insert (from `SPEC-review-gate-insert-originals.md`):** its post-hoc
+  `squash_insert_matches_tree` is the seed of V2; V2 generalizes it.
+
+## 8. Phased plan (each phase independently shippable, harness-first)
+
+- **Phase 0 — V1 markers.** ✅ *Done.* `push` guard + harness 33.
+- **Phase 1 — V4 provenance/excluded-path guard.** ✅ *Done.* `push` now (a)
+  ensures `.git/info/exclude` carries the shadow patterns before staging
+  (prevention) and (b) asserts no `.atomic/`/`.vault/`/`.atomicignore` path is
+  staged (V4 guard); on a hit it restores the index from HEAD, logs
+  `shadow-validate:V4`, and aborts with no commit. Harness
+  `34_shadow_provenance_guard.sh`. The failure log format was unified to
+  `shadow-validate:<rule>` (V1 now logs `shadow-validate:V1`).
+- **Phase 2 — single shadow-commit pipeline.** ✅ *Done.* New module
+  `atomic-cli/src/commands/git/shadow.rs` owns `stage_and_validate_tree`
+  (ensure-excludes → stage → V1 → V4 → `write_tree`), returning the candidate
+  tree. `push` (and therefore the turn-end hook, which shells `atomic git push`)
+  delegates to it; no independent `add_all`/`write_tree` remains in `push`'s run
+  path. V2/V3 slot into this one function ahead of `write_tree`.
+- **Phase 3 — serialization lock.** ✅ *Done.* `Repository::try_lock_shadow_commit`
+  is a non-blocking repo-scoped advisory lock (`.atomic/shadow-commit.lock`,
+  `fs2`), acquired **outermost** in `push` via `shadow::acquire_shadow_lock`;
+  contention is a logged no-op (`shadow-lock:contended`), never a block or an
+  interleave. Unit test `shadow_commit_lock_is_exclusive_and_non_blocking`;
+  harness `35_shadow_concurrent_push.sh`.
+- **Phase 4 — V2 pre-commit coherence.** ✅ *Done.* `stage_and_validate_tree`
+  now runs `first_incoherent_path` before returning the tree: it diffs the
+  candidate tree against git HEAD and, for each changed non-provenance path,
+  requires the staged bytes to equal `get_file_content_on_view` (the view's
+  recorded content). Divergence (un-recorded drift, or a tree that omits a
+  change the view records) aborts with `shadow-validate:V2`, restoring the
+  index. Always-on (not bypassed by `--allow-conflict-markers`, which is
+  content-marker-specific): to commit marker content you `record
+  --allow-conflict-markers` first, making disk match the view. Harness
+  `36_shadow_coherence_v2.sh`. (Import's `squash_insert_matches_tree` remains
+  the analogous check on the import path; the two coexist by design.)
+- **Phase 5 — V3 drift rule.** ✅ *Done.* The push pipeline (`push.rs`, at the
+  `find_last_pushed_state` lineage check) refuses when the branch's last
+  published `Atomic-State` exists but is not in the current view's history —
+  genuine drift — logging `shadow-validate:V3`, **with no bypass flag**
+  (reconcile-then-push). Replaces the old silent `unwrap_or(0)` re-push. Harness
+  `38_shadow_drift_v3.sh`. The `view switch` pre-switch guard was **deferred**
+  (§5.2): it false-positives on legitimate inter-view switches, and Direction A
+  + the push-time V2/V3 backstops already prevent committing the collision.
+- **Direction A (view switch → git HEAD ref move).** ✅ *Done.* `atomic view
+  switch` repoints the git shadow's HEAD to the mirror branch (ref move, not a
+  checkout), gated to shadow-sync repos, idempotent, creating the branch if
+  absent. `git/shadow.rs::sync_git_head_to_view`; harness
+  `37_shadow_view_branch_follow.sh`; `19_git_shadow` §9 updated to the new model.
+- **Phase 6 — Policy + advisory (NOT coupling the other way).** ✅ *Done.* Per
+  §5.4, full HEAD *mirroring* (git → Atomic) is a non-goal. Shipped: (a) a
+  **shadow-sync documentation** update ("Prefer Atomic over raw Git" — the
+  golden rule, the validator backstop table, and reconcile-then-push) in
+  `atomic-docs/.../git-shadow-sync.md`; and (b) a **warn-only** `post-checkout`
+  hook (`atomic git hooks install`) that prints a view↔branch mismatch + resync
+  hint, mutating nothing. The *guarantee* remains the Validator (V1–V4), not the
+  hook.
+
+## 9. Acceptance criteria (mapped to phases)
+
+- [x] (P2) Exactly one code path stages/commits the shadow working copy; no
+      independent `add_all`/`write_tree` remains in `push.rs`.
+- [x] (P0) A working copy with conflict markers never produces a shadow commit
+      (V1); record and push report identical detections.
+- [x] (P1) `.vault/`/`.atomic/`/`.atomicignore` are never staged into a shadow
+      commit and never modified/deleted as a side effect (V4).
+- [x] (P4) A materialize whose tree omits/adds changes vs the view's recorded set
+      is rejected before commit (V2), not refused later by import.
+- [x] (P5) A drifted view (state not in the branch's published lineage) is
+      rejected (V3) with **no bypass** — reconcile-then-push; fast-forward
+      advances are unaffected. (Pre-switch guard deferred as false-positive-prone;
+      Direction A + push-time V2/V3 cover the collision.)
+- [x] (P3) Concurrent materialize requests serialize; no partial staging is ever
+      observable.
+- [x] (P6) Shadow-sync docs state the “prefer Atomic over raw Git” policy +
+      reconcile recipe; the `post-checkout` hook is warn-only (no mutation, no
+      loop). Raw-git desync is caught by V1/V2/V3 at push, not by mirroring git.
+- [x] (all) Every abort leaves git, working copy, and graph byte-identical to
+      their pre-operation state, and is logged.
+
+## 10. Test plan
+
+- **Single-writer (P2):** assert `git push` and the hook invoke the shared
+  pipeline; grep-assert no `add_all`/`write_tree` outside it.
+- **V1 (P0):** synthetic markers ⇒ no commit; parity with `record`. *(harness 33)*
+- **V4 (P1):** attempt to stage `.vault/`/`.atomic/` ⇒ V4 failure; abort leaves
+  provenance dirs byte-identical (hash before/after).
+- **V2 (P4):** construct a view/tree mismatch (e.g. an out-of-band disk edit) ⇒
+  pre-commit rejection naming the path.
+- **V3 (P5):** publish view A to a branch, drift the branch's last state so it is
+  not in A's lineage ⇒ rejection; confirm a normal fast-forward advance passes.
+- **Concurrency (P3):** two simultaneous pipeline requests ⇒ one runs, one
+  queues/no-ops; no interleaved partial state.
+- **Policy + advisory (P6):** raw `git checkout` to a divergent branch ⇒ the next
+  `atomic git push` refuses with V2/V3 and a reconcile hint (the guarantee). Any
+  advisory hook is warn-only: it prints the mismatch + resync command and creates
+  no commit, switches no view, imports nothing.
+- **Idempotency:** repeated hook fires on an unchanged coherent state produce at
+  most one commit and never drift.
+
+## 11. Risks / non-goals
+
+- **Non-goal:** changing whether cross-view materialization *emits* markers for
+  human resolution. The Validator refuses to *commit* that state, nothing more.
+- **Non-goal:** automatic conflict resolution. Conflicts are made visible and
+  blocking, never silently committed.
+- **Risk (V3 false positives):** mitigated by the lineage-membership definition
+  (§6.3), which cannot fire on fast-forwards. There is intentionally **no bypass
+  flag** — the tension with "stricter gating can block a user" is resolved by
+  reconcile-then-push (reset git, or `atomic git import`), never by committing an
+  incoherent state. A bypass here is what let the original incident happen.
+- **Risk (external `git checkout`):** git is a working-copy materializer Atomic
+  does not control. Mitigated in depth — `view switch` refuses to render a
+  conflicting view over a checkout-moved HEAD (§5.2), and V1/V2/V3 refuse to
+  commit the mixed result at push time (§6.3).
+- **Risk (deadlock):** mitigated by fixed lock ordering (pipeline lock outermost).
+- **Migration:** repos already polluted (committed markers, drifted views) are
+  out of scope; recovery is reset git to the last clean published state and
+  re-derive the shadow — while protecting `.vault`/`.atomic` from deletion.
+
+## 12. Postmortem note (why this matters)
+
+The incident's final, irreversible loss was authored provenance — intents,
+memories, attestations in `.vault` — deleted to escape a corruption loop the
+tooling created and could not cleanly exit. A single-pipeline + validator design
+would have prevented incoherent state from ever being committed, so the escape
+hatch of deleting the provenance store would never have been reached. **Phase 1
+(V4) is sequenced first for exactly this reason:** protecting the provenance
+layer is the highest-order requirement, and it is independent of the rest.

--- a/tests/harness/19_git_shadow.sh
+++ b/tests/harness/19_git_shadow.sh
@@ -541,25 +541,33 @@ else
     _fail "git status stays clean after checked-out feature import" "$GIT_STATUS_AFTER_FEATURE"
 fi
 
-# Switching views must not move Git's administrative state even though `.git`
-# is ignored by the Atomic repository after Git import. Git remains able to
-# own and restore its checked-out worktree after the switch.
+# git shadows Atomic (SPEC-single-materializer-validator.md §5.4): an
+# `atomic view switch` now repoints the git shadow's HEAD to the mirror branch.
+# This supersedes the old "git owns the checkout; view switch must not move git"
+# model. It is a ref move — git metadata is preserved and files are never
+# re-rendered; Atomic stays the content authority.
 assert_success "Atomic view switch materializes primary view" atomic view switch "$PRIMARY_BRANCH"
 assert_dir_exists "Atomic view switch preserves Git metadata" ".git"
-GIT_STATUS_AFTER_ATOMIC_SWITCH=$(git status --short)
-if [[ -z "$GIT_STATUS_AFTER_ATOMIC_SWITCH" ]]; then
-    _pass "Atomic view switch preserves a clean Git checkout"
-else
-    _fail "Atomic view switch preserves a clean Git checkout" "$GIT_STATUS_AFTER_ATOMIC_SWITCH"
-fi
-git checkout "$PRIMARY_BRANCH" 2>/dev/null
-assert_success "incremental import restores Git-owned primary checkout" atomic git import --incremental --branch "$PRIMARY_BRANCH" --no-vault
+assert_file_content "primary view content is materialized" "shared.txt" "main baseline"
 
-GIT_STATUS_AFTER_RESTORE=$(git status --short)
-if [[ -z "$GIT_STATUS_AFTER_RESTORE" ]]; then
-    _pass "Git checkout restores a clean shared worktree"
+SWITCHED_GIT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
+if [ "$SWITCHED_GIT_BRANCH" = "$PRIMARY_BRANCH" ]; then
+    _pass "git shadow HEAD follows the view to '$PRIMARY_BRANCH'"
 else
-    _fail "Git checkout restores a clean shared worktree" "$GIT_STATUS_AFTER_RESTORE"
+    _fail "git shadow HEAD follows the view to '$PRIMARY_BRANCH'" "on '$SWITCHED_GIT_BRANCH'"
+fi
+
+# The feature-* files are residue from the earlier raw `git checkout
+# zz-materialization` (mixing raw git with Atomic — the anti-pattern SPEC §5.4
+# discourages). Now that git HEAD follows the view to the primary branch they
+# show as untracked; a shadow push would refuse them (V2). Clearing the residue
+# restores a clean tree.
+rm -f feature-only.txt feature-tool.sh feature-link
+GIT_STATUS_AFTER_CLEAN=$(git status --short)
+if [[ -z "$GIT_STATUS_AFTER_CLEAN" ]]; then
+    _pass "clean worktree once raw-git residue is cleared"
+else
+    _fail "clean worktree once raw-git residue is cleared" "$GIT_STATUS_AFTER_CLEAN"
 fi
 
 # ════════════════════════════════════════════════════════════════════════

--- a/tests/harness/32_review_gate_insert.sh
+++ b/tests/harness/32_review_gate_insert.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# 32_review_gate_insert.sh — Executable spec for squash-import → insert originals
+#
+# Walks the workflow from SPEC-review-gate-insert-originals.md:
+#
+#   1. git repo + `atomic git import`  → shared view (named after git default)
+#   2. Agent work in an Atomic draft    → per-turn CHANGE RECORDS (the originals)
+#   3. Simulated GitHub squash-merge    → a single git commit on the shared
+#      branch whose body carries the originals' `Atomic-Changes` trailers
+#      (multiple blocks, mimicking GitHub concatenating each squashed body)
+#   4. `atomic git import --incremental --branch <shared>`
+#
+# TARGET (SPEC §2, §4): the squash must NOT become a new change record. Instead
+# the importer inserts the named originals into the shared view (they already
+# live in the graph) and represents the squash as an aggregate ReviewGate TAG
+# (from…to, count, inserted:true). Deleting the draft must then be safe.
+#
+# STATUS: the insert path is not implemented yet. Target-behavior checks are
+# gated on $EXPECT_INSERT:
+#   - unset/0 → reported as pending (skipped), suite stays green
+#   - 1       → hard assertions, so this file drives implementation red→green
+#
+# What already holds today (hard-asserted here, no gate):
+#   - the import succeeds and the shared view materializes the squash content
+#   - a ReviewGate tag is created for the squash
+#   - its metadata lists EVERY original hash across ALL trailer blocks
+#     (the BUG-review-gate-original-hashes.md fix, validated end-to-end)
+
+HARNESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$HARNESS_DIR/helpers.sh"
+
+# ── Target-behavior gate ──────────────────────────────────────────────────
+#
+# assert_target <desc> <cmd...>
+#   pass    if the command succeeds (target behavior is present)
+#   fail    if it does not AND EXPECT_INSERT=1 (drives implementation)
+#   pending otherwise (feature not built yet — keeps the suite green)
+assert_target() {
+    local desc="$1"; shift
+    if "$@" >/dev/null 2>&1; then
+        _pass "$desc"
+    elif [[ "${EXPECT_INSERT:-0}" == "1" ]]; then
+        _fail "$desc" "target behavior (SPEC) not met"
+    else
+        _skip "$desc" "pending: insert-originals (SPEC §4) not implemented"
+    fi
+}
+
+# Predicate helpers (used as commands for assert_* so they run under the gate).
+#
+# main_has_record matches the change's `hash` FIELD exactly — not a raw substring
+# of the JSON. A squash change record embeds the originals' `Atomic-Changes`
+# trailers in its commit message, so a substring grep would spuriously match
+# even when the record was never inserted. Exact hash-field membership is the
+# real "is this original a change in the shared view?" test.
+# These predicates capture command output into a variable and then match with a
+# here-string, deliberately avoiding `cmd | grep -q`. Under `set -o pipefail`
+# (active via helpers.sh), `grep -q` exits on first match and closes the pipe;
+# the still-writing `atomic` process then dies with SIGPIPE, and pipefail
+# reports the pipeline as failed even though the text matched. Two more notes:
+#   * `grep -a` forces text mode — `tag show` / the router emit UTF-8 glyphs
+#     (…, ✓, —) that make macOS/BSD grep treat the stream as binary.
+#   * `main_has_record` matches the `hash` FIELD exactly (whole line), so a
+#     squash record's embedded trailer text can't produce a false positive.
+main_view_hashes() {
+    atomic log --view "$MAIN" -f json 2>/dev/null \
+        | grep -ao '"hash"[[:space:]]*:[[:space:]]*"[^"]*"' \
+        | sed -E 's/.*"([^"]+)"$/\1/'
+}
+main_has_record() {
+    local out; out="$(main_view_hashes)"
+    grep -qxaF "$1" <<<"$out"
+}
+tag_show_contains() {
+    local out; out="$(atomic tag show "$TAG_NAME" 2>/dev/null)"
+    grep -qaF "$1" <<<"$out"
+}
+# Dry-run router recommendation for the current target (SPEC §4.4).
+dry_run_recommends_insert() {
+    local out; out="$(atomic git import --incremental --branch "$MAIN" --dry-run 2>&1)"
+    grep -qaiE "squash|atomic header|insert" <<<"$out"
+}
+# The shared view materializes `src/two.rs` after switching to it.
+shared_view_materializes_two() {
+    atomic view switch "$MAIN" --force >/dev/null 2>&1 && test -f src/two.rs
+}
+
+# ── Suite banner ──────────────────────────────────────────────────────────
+
+echo ""
+echo "${BOLD}══════════════════════════════════════════════════════════════${RESET}"
+echo "${BOLD}  Suite: 32_review_gate_insert${RESET}"
+echo "${BOLD}══════════════════════════════════════════════════════════════${RESET}"
+
+# ════════════════════════════════════════════════════════════════════════
+# Section 1: Prerequisites
+# ════════════════════════════════════════════════════════════════════════
+
+begin_section "Prerequisites"
+require_git
+
+# ════════════════════════════════════════════════════════════════════════
+# Section 2: Seed the shared view from git
+# ════════════════════════════════════════════════════════════════════════
+
+begin_section "Seed shared view from git import"
+
+make_temp_repo "review-gate-insert"
+init_git_repo
+git_commit "Initial" "README.md" "# Project"
+
+assert_success "git import seeds the shared view" atomic git import --no-vault
+
+MAIN="$(git_default_branch)"
+_pass "shared view is '$MAIN'"
+
+# ════════════════════════════════════════════════════════════════════════
+# Section 3: Agent work in a draft view — the original change records
+# ════════════════════════════════════════════════════════════════════════
+
+begin_section "Record originals in a draft view"
+
+assert_success "create + switch to draft" \
+    atomic view create agent --draft --parent "$MAIN" --switch
+
+# Two per-turn changes. Their on-disk content must match what the squash tree
+# will contain, so inserting them reproduces the squash exactly (SPEC §5/D1).
+create_file "src/one.rs" "fn one() {}"
+add_files "src/one.rs"
+record_change "feat: one" >/dev/null
+
+create_file "src/two.rs" "fn two() {}"
+add_files "src/two.rs"
+record_change "feat: two" >/dev/null
+
+# Capture the two originals' hashes (newest-first). The draft's own changes are
+# the two most recent, regardless of whether inherited history is shown.
+ORIG=()
+while IFS= read -r h; do
+    [[ -n "$h" ]] && ORIG+=("$h")
+done < <(atomic log --view agent -f json 2>/dev/null \
+            | grep -o '"hash"[[:space:]]*:[[:space:]]*"[^"]*"' \
+            | sed -E 's/.*"([^"]+)"$/\1/')
+
+HASH_TWO="${ORIG[0]:-}"   # newest  (feat: two)
+HASH_ONE="${ORIG[1]:-}"   # older   (feat: one)
+
+if [[ -n "$HASH_ONE" && -n "$HASH_TWO" && "$HASH_ONE" != "$HASH_TWO" ]]; then
+    _pass "captured two original change hashes"
+else
+    _fail "captured two original change hashes" \
+        "one='$HASH_ONE' two='$HASH_TWO' (log parse failed?)"
+    print_summary
+    exit 1
+fi
+
+# ════════════════════════════════════════════════════════════════════════
+# Section 4: Simulate the GitHub squash merge onto the shared branch
+# ════════════════════════════════════════════════════════════════════════
+
+begin_section "Simulate squash-merge commit with multi-block trailers"
+
+# Return to the shared view so the working copy is the shared baseline; the
+# draft-only files disappear, then we recreate them as the squash tree.
+switch_view "$MAIN" >/dev/null
+
+# The squash tree == shared baseline + both originals' content.
+create_file "src/one.rs" "fn one() {}"
+create_file "src/two.rs" "fn two() {}"
+git add src/one.rs src/two.rs
+
+# GitHub concatenates each squashed commit's body, so the merge commit carries
+# ONE Atomic-Changes block per original. A bullet line heads each block so the
+# final paragraph is never mistaken for an `atomic git push` self-push trailer.
+git commit -q -m "Add feature one and two (#1)
+
+* feat: one
+Atomic-View: agent
+Atomic-Changes: $HASH_ONE
+
+* feat: two
+Atomic-View: agent
+Atomic-Changes: $HASH_TWO"
+
+assert_output_contains "squash commit carries both trailers (block 1)" \
+    "$HASH_ONE" git log -1 --format=%B
+assert_output_contains "squash commit carries both trailers (block 2)" \
+    "$HASH_TWO" git log -1 --format=%B
+
+# ════════════════════════════════════════════════════════════════════════
+# Section 5: Dry-run router (SPEC §4.4) — advisory classification
+# ════════════════════════════════════════════════════════════════════════
+
+begin_section "Dry-run classifies the incoming squash"
+
+# Always true today: the forecast reports the one new commit.
+assert_output_contains "dry-run forecasts one new commit" \
+    "1 commit" atomic git import --incremental --branch "$MAIN" --dry-run
+
+# TARGET (SPEC §4.4): the forecast should recognise atomic headers and route
+# the user to the insert path rather than a plain count.
+assert_target "dry-run flags an insertable atomic squash" dry_run_recommends_insert
+
+# ════════════════════════════════════════════════════════════════════════
+# Section 6: Incremental import of the squash
+# ════════════════════════════════════════════════════════════════════════
+
+begin_section "Incremental import: squash → shared view"
+
+MAIN_BEFORE="$(atomic log --view "$MAIN" 2>/dev/null | grep -c '^#' || true)"
+
+assert_success "incremental import of squash" \
+    atomic git import --incremental --branch "$MAIN" --no-vault
+
+switch_view "$MAIN" >/dev/null
+
+# Always-true guarantees (both current and target behavior satisfy these):
+assert_file_content "shared view materializes one.rs" "src/one.rs" "fn one() {}"
+assert_file_content "shared view materializes two.rs" "src/two.rs" "fn two() {}"
+
+TAG_NAME="pr-1"
+assert_output_contains "ReviewGate tag created for the squash" \
+    "$TAG_NAME" atomic tag list
+
+# Prerequisite fix (BUG-review-gate-original-hashes.md), validated end-to-end:
+# the ReviewGate metadata must list EVERY original hash, not just the first.
+assert_success "ReviewGate records first original hash" tag_show_contains "$HASH_ONE"
+assert_success "ReviewGate records second original hash" tag_show_contains "$HASH_TWO"
+
+# ════════════════════════════════════════════════════════════════════════
+# Section 7: TARGET behavior — originals inserted, squash is a tag
+# ════════════════════════════════════════════════════════════════════════
+
+begin_section "Target: originals live in the shared view (SPEC §2, §4)"
+
+# The shared view must reference the ORIGINAL records, not a new squash record.
+assert_target "shared view contains original one.rs record" main_has_record "$HASH_ONE"
+assert_target "shared view contains original two.rs record" main_has_record "$HASH_TWO"
+
+# The squash must NOT add a brand-new change record: with insert, the shared
+# view grows by exactly the two originals (not by a single squash record).
+MAIN_AFTER="$(atomic log --view "$MAIN" 2>/dev/null | grep -c '^#' || true)"
+assert_target "shared view grew by exactly the two originals" \
+    test "$MAIN_AFTER" -eq "$((MAIN_BEFORE + 2))"
+
+# The ReviewGate is an aggregate over the inserted records. `tag show` renders
+# the metadata (not raw JSON), so assert against the rendered provenance block.
+assert_target "ReviewGate marks the aggregate as inserted" tag_show_contains "inserted"
+assert_target "ReviewGate shows the aggregate range" tag_show_contains "Aggregate"
+assert_target "ReviewGate records the git squash provenance" tag_show_contains "squash"
+
+# ════════════════════════════════════════════════════════════════════════
+# Section 8: TARGET behavior — deleting the draft is safe
+# ════════════════════════════════════════════════════════════════════════
+
+begin_section "Target: draft is disposable, provenance survives (SPEC §1)"
+
+# Drafts must be deletable without losing the granular history: the shared view
+# now references the originals, so they stay alive and materializable.
+atomic view delete agent --force >/dev/null 2>&1 || \
+    atomic view delete agent >/dev/null 2>&1 || true
+
+assert_target "originals still in shared view after draft deletion" \
+    main_has_record "$HASH_ONE"
+assert_target "shared view still materializes after draft deletion" \
+    shared_view_materializes_two
+
+# ── Summary ────────────────────────────────────────────────────────────────
+
+print_summary

--- a/tests/harness/33_shadow_push_conflict_markers.sh
+++ b/tests/harness/33_shadow_push_conflict_markers.sh
@@ -101,10 +101,10 @@ fi
 
 begin_section "Hook audit log + record consistency"
 
-if [ -f .atomic/hook-errors.log ] && grep -qa "shadow-conflict" .atomic/hook-errors.log; then
-    _pass "hook-errors.log records a shadow-conflict entry"
+if [ -f .atomic/hook-errors.log ] && grep -qa "shadow-validate:V1" .atomic/hook-errors.log; then
+    _pass "hook-errors.log records a shadow-validate:V1 entry"
 else
-    _fail "hook-errors.log records a shadow-conflict entry" \
+    _fail "hook-errors.log records a shadow-validate:V1 entry" \
         "log: $(cat .atomic/hook-errors.log 2>/dev/null | head -3)"
 fi
 
@@ -118,6 +118,12 @@ assert_failure "record refuses the same conflict markers" \
 
 begin_section "Explicit --allow-conflict-markers override"
 
+# Realistic path: the markers are accepted as legitimate content by recording
+# them with record's own override, so the working copy now matches the view
+# (V2 tree↔view coherence holds). The shadow-push override then bypasses the V1
+# marker gate and commits.
+assert_success "record accepts markers with its override" \
+    atomic record --allow-conflict-markers -m "accept markers as content"
 assert_success "override commits a marker-laden tree" \
     atomic git push --no-push --allow-conflict-markers -m "override"
 

--- a/tests/harness/33_shadow_push_conflict_markers.sh
+++ b/tests/harness/33_shadow_push_conflict_markers.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# 33_shadow_push_conflict_markers.sh — Shadow push must never commit markers.
+#
+# Regression for SPEC-shadow-push-conflict-markers.md: `atomic git push`
+# (shadow materialization, incl. --no-push) committed working copies that still
+# carried unresolved conflict markers, silently corrupting git branches. This
+# suite pins the guard that shares `atomic record`'s detector:
+#
+#   1. A clean working copy shadow-pushes exactly as before (no regression).
+#   2. A working copy with Atomic's numbered/hash-tagged markers:
+#        - aborts the push (non-zero), names the file + line, creates NO commit,
+#        - leaves a `shadow-conflict` entry in .atomic/hook-errors.log
+#          (non-interactive/hook context),
+#        - and `atomic record` refuses the same file (detector consistency).
+#   3. `--allow-conflict-markers` is the explicit escape hatch and still commits.
+
+HARNESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$HARNESS_DIR/helpers.sh"
+
+echo ""
+echo "${BOLD}══════════════════════════════════════════════════════════════${RESET}"
+echo "${BOLD}  Suite: 33_shadow_push_conflict_markers${RESET}"
+echo "${BOLD}══════════════════════════════════════════════════════════════${RESET}"
+
+begin_section "Prerequisites"
+require_git
+
+# ════════════════════════════════════════════════════════════════════════
+# Setup: repo + a clean baseline shadow push
+# ════════════════════════════════════════════════════════════════════════
+
+begin_section "Clean shadow push (baseline, no regression)"
+
+make_temp_repo "shadow-conflict"
+init_git_repo
+git_commit "Initial" "README.md" "# Project"
+assert_success "git import seeds the view" atomic git import --no-vault
+
+create_file "src/app.ts" "const x = 1;"
+add_files "src/app.ts"
+record_change "feat: app" >/dev/null
+
+assert_success "clean working copy shadow-pushes" \
+    atomic git push --no-push -m "sync clean"
+
+CLEAN_COUNT="$(git_commit_count)"
+_pass "baseline git commit count = $CLEAN_COUNT"
+
+# ════════════════════════════════════════════════════════════════════════
+# A materialized conflict must abort the shadow push
+# ════════════════════════════════════════════════════════════════════════
+
+begin_section "Shadow push aborts on unresolved conflict markers"
+
+# Atomic's markers are numbered and change-hash-tagged (SPEC §4):
+#   >>>>>>> N   /   ======= N [HASH]   /   <<<<<<< N
+cat > src/app.ts <<'MARKERS'
+const shared = 1;
+>>>>>>> 1
+const a = 2;
+======= 1 [C2YTBAHQ]
+const b = 3;
+<<<<<<< 1
+MARKERS
+
+# Capture the aborted push once (output + rc + commit count around it).
+set +e
+PUSH_OUT="$(atomic git push --no-push -m "sync conflicted" 2>&1)"
+PUSH_RC=$?
+set -e
+AFTER_COUNT="$(git_commit_count)"
+
+if [ "$PUSH_RC" -ne 0 ]; then
+    _pass "shadow push exits non-zero on markers"
+else
+    _fail "shadow push exits non-zero on markers" "expected non-zero, got 0"
+fi
+
+if echo "$PUSH_OUT" | grep -qa "src/app.ts"; then
+    _pass "abort names the conflicted file"
+else
+    _fail "abort names the conflicted file" "output: $(echo "$PUSH_OUT" | head -5)"
+fi
+
+if echo "$PUSH_OUT" | grep -qa "line 2"; then
+    _pass "abort names the marker line"
+else
+    _fail "abort names the marker line" "output: $(echo "$PUSH_OUT" | head -5)"
+fi
+
+if [ "$AFTER_COUNT" -eq "$CLEAN_COUNT" ]; then
+    _pass "no git commit created on markers ($AFTER_COUNT)"
+else
+    _fail "no git commit created on markers" \
+        "expected $CLEAN_COUNT, got $AFTER_COUNT"
+fi
+
+# ════════════════════════════════════════════════════════════════════════
+# Hook audit trail + detector consistency with `record`
+# ════════════════════════════════════════════════════════════════════════
+
+begin_section "Hook audit log + record consistency"
+
+if [ -f .atomic/hook-errors.log ] && grep -qa "shadow-conflict" .atomic/hook-errors.log; then
+    _pass "hook-errors.log records a shadow-conflict entry"
+else
+    _fail "hook-errors.log records a shadow-conflict entry" \
+        "log: $(cat .atomic/hook-errors.log 2>/dev/null | head -3)"
+fi
+
+# `atomic record` must refuse the SAME working copy (shared detector, SPEC §5.4).
+assert_failure "record refuses the same conflict markers" \
+    atomic record -m "should be rejected"
+
+# ════════════════════════════════════════════════════════════════════════
+# Explicit override still commits
+# ════════════════════════════════════════════════════════════════════════
+
+begin_section "Explicit --allow-conflict-markers override"
+
+assert_success "override commits a marker-laden tree" \
+    atomic git push --no-push --allow-conflict-markers -m "override"
+
+OVERRIDE_COUNT="$(git_commit_count)"
+if [ "$OVERRIDE_COUNT" -gt "$CLEAN_COUNT" ]; then
+    _pass "override created a commit ($OVERRIDE_COUNT)"
+else
+    _fail "override created a commit" "expected > $CLEAN_COUNT, got $OVERRIDE_COUNT"
+fi
+
+print_summary

--- a/tests/harness/34_shadow_provenance_guard.sh
+++ b/tests/harness/34_shadow_provenance_guard.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# 34_shadow_provenance_guard.sh — Validator Rule V4 (provenance / excluded paths).
+#
+# SPEC-single-materializer-validator.md, Phase 1 / Rule V4: a shadow commit MUST
+# never stage a git-excluded Atomic provenance path (`.atomic/`, `.vault/`,
+# `.atomicignore`). `.vault` (intents/memories/attestations) and `.atomic` (the
+# change graph) are git-excluded and unbacked; committing or reconciling them is
+# how the motivating incident began (and ended in their deletion).
+#
+# This suite pins:
+#   1. A normal shadow commit contains ZERO provenance paths (prevention works).
+#   2. If a provenance path is already git-tracked (excludes can't save it), the
+#      push aborts (V4): no commit, names the path, logs shadow-validate:V4, and
+#      leaves git + the provenance dir byte-identical.
+
+HARNESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$HARNESS_DIR/helpers.sh"
+
+echo ""
+echo "${BOLD}══════════════════════════════════════════════════════════════${RESET}"
+echo "${BOLD}  Suite: 34_shadow_provenance_guard${RESET}"
+echo "${BOLD}══════════════════════════════════════════════════════════════${RESET}"
+
+begin_section "Prerequisites"
+require_git
+
+# Grep the committed tree for any Atomic provenance path.
+tree_has_provenance() {
+    git ls-tree -r --name-only HEAD 2>/dev/null \
+        | grep -qE '^\.atomic/|^\.vault/|^\.atomicignore$'
+}
+
+# ════════════════════════════════════════════════════════════════════════
+# A normal shadow commit never contains provenance paths
+# ════════════════════════════════════════════════════════════════════════
+
+begin_section "Normal shadow commit excludes provenance paths"
+
+make_temp_repo "v4-clean"
+init_git_repo
+git_commit "Initial" "README.md" "# Project"
+assert_success "git import seeds the view" atomic git import --no-vault
+
+assert_dir_exists ".atomic exists on disk" ".atomic"
+
+create_file "src/app.ts" "const x = 1;"
+add_files "src/app.ts"
+record_change "feat: app" >/dev/null
+assert_success "clean shadow push commits" atomic git push --no-push -m "sync"
+
+if tree_has_provenance; then
+    _fail "committed tree has no provenance paths" \
+        "found: $(git ls-tree -r --name-only HEAD | grep -E '^\.atomic/|^\.vault/|^\.atomicignore$' | head -3)"
+else
+    _pass "committed tree has no provenance paths"
+fi
+assert_dir_exists ".atomic untouched after push" ".atomic"
+
+# ════════════════════════════════════════════════════════════════════════
+# V4 fires when a provenance path is already git-tracked
+# ════════════════════════════════════════════════════════════════════════
+
+begin_section "V4 aborts on an already-tracked provenance path"
+
+make_temp_repo "v4-tracked"
+init_git_repo
+git_commit "Initial" "README.md" "# Project"
+assert_success "git import" atomic git import --no-vault
+
+# Simulate the dangerous pre-condition: a `.vault/` path that got committed to
+# git before excludes were in place, so it is TRACKED (exclude rules no longer
+# protect it and `git add -A`/update_all will keep staging it).
+mkdir -p .vault
+printf 'intent: precious' > .vault/note.md
+git add -f .vault/note.md
+git commit -q -m "Accidentally tracked a provenance path"
+
+VAULT_HASH_BEFORE="$(git hash-object .vault/note.md)"
+COUNT_BEFORE="$(git_commit_count)"
+
+# Record an ordinary change and attempt a shadow push.
+create_file "src/app.ts" "const y = 2;"
+add_files "src/app.ts"
+record_change "feat: app2" >/dev/null
+
+set +e
+PUSH_OUT="$(atomic git push --no-push -m "sync tracked provenance" 2>&1)"
+PUSH_RC=$?
+set -e
+COUNT_AFTER="$(git_commit_count)"
+
+if [ "$PUSH_RC" -ne 0 ]; then
+    _pass "shadow push aborts (V4) on a tracked provenance path"
+else
+    _fail "shadow push aborts (V4) on a tracked provenance path" "expected non-zero"
+fi
+
+if echo "$PUSH_OUT" | grep -qa ".vault/note.md"; then
+    _pass "abort names the provenance path"
+else
+    _fail "abort names the provenance path" "output: $(echo "$PUSH_OUT" | head -5)"
+fi
+
+if [ "$COUNT_AFTER" -eq "$COUNT_BEFORE" ]; then
+    _pass "no commit created ($COUNT_AFTER)"
+else
+    _fail "no commit created" "expected $COUNT_BEFORE, got $COUNT_AFTER"
+fi
+
+if [ -f .atomic/hook-errors.log ] && grep -qa "shadow-validate:V4" .atomic/hook-errors.log; then
+    _pass "hook-errors.log records a shadow-validate:V4 entry"
+else
+    _fail "hook-errors.log records a shadow-validate:V4 entry" \
+        "log: $(cat .atomic/hook-errors.log 2>/dev/null | head -3)"
+fi
+
+# Provenance byte-identical after the aborted push.
+VAULT_HASH_AFTER="$(git hash-object .vault/note.md)"
+if [ "$VAULT_HASH_AFTER" = "$VAULT_HASH_BEFORE" ]; then
+    _pass "provenance file left byte-identical on abort"
+else
+    _fail "provenance file left byte-identical on abort" \
+        "before=$VAULT_HASH_BEFORE after=$VAULT_HASH_AFTER"
+fi
+
+print_summary

--- a/tests/harness/35_shadow_concurrent_push.sh
+++ b/tests/harness/35_shadow_concurrent_push.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# 35_shadow_concurrent_push.sh — Shadow-commit serialization (Rule / Phase 3).
+#
+# SPEC-single-materializer-validator.md §4.3 / Principle 5: only one shadow
+# materialize/commit may be in flight per repo. Concurrent pushes must serialize
+# via the repo-scoped lock — one commits, the other no-ops — and must never
+# interleave into a corrupt tree or a double commit.
+#
+# The lock's exclusivity is proven deterministically by the Rust unit test
+# `shadow_commit_lock_is_exclusive_and_non_blocking`. This suite is the
+# end-to-end smoke test: two overlapping `atomic git push` invocations leave a
+# valid repo, add at most one commit, and converge.
+
+HARNESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$HARNESS_DIR/helpers.sh"
+
+echo ""
+echo "${BOLD}══════════════════════════════════════════════════════════════${RESET}"
+echo "${BOLD}  Suite: 35_shadow_concurrent_push${RESET}"
+echo "${BOLD}══════════════════════════════════════════════════════════════${RESET}"
+
+begin_section "Prerequisites"
+require_git
+
+begin_section "Concurrent shadow pushes serialize (no corruption, no double commit)"
+
+make_temp_repo "shadow-concurrent"
+init_git_repo
+git_commit "Initial" "README.md" "# Project"
+assert_success "git import" atomic git import --no-vault
+
+# Baseline shadow commit.
+create_file "src/a.ts" "const a = 1;"
+add_files "src/a.ts"
+record_change "feat: a" >/dev/null
+assert_success "baseline push" atomic git push --no-push -m "baseline"
+BASE_COUNT="$(git_commit_count)"
+
+# A new recorded change, then two overlapping pushes of the same state.
+create_file "src/b.ts" "const b = 2;"
+add_files "src/b.ts"
+record_change "feat: b" >/dev/null
+
+atomic git push --no-push -m "concurrent-1" >/dev/null 2>&1 &
+P1=$!
+atomic git push --no-push -m "concurrent-2" >/dev/null 2>&1 &
+P2=$!
+wait "$P1" || true
+wait "$P2" || true
+
+# The repo must remain valid (no interleaved/corrupt tree).
+assert_success "git repo still valid after concurrent pushes" git fsck --no-progress
+assert_success "atomic status still works" atomic status
+
+# The burst must add at most one commit — never a double commit.
+BURST_COUNT="$(git_commit_count)"
+if [ "$BURST_COUNT" -le "$((BASE_COUNT + 1))" ]; then
+    _pass "concurrent burst added at most one commit ($BURST_COUNT)"
+else
+    _fail "concurrent burst added at most one commit" \
+        "base=$BASE_COUNT after=$BURST_COUNT (double commit?)"
+fi
+
+# Convergence: a final push leaves the new change committed and the tree clean.
+atomic git push --no-push -m "converge" >/dev/null 2>&1 || true
+if git ls-tree -r --name-only HEAD 2>/dev/null | grep -qx "src/b.ts"; then
+    _pass "new change is committed after convergence"
+else
+    _fail "new change is committed after convergence" "src/b.ts not in HEAD tree"
+fi
+
+FINAL_COUNT="$(git_commit_count)"
+if [ "$FINAL_COUNT" -eq "$((BASE_COUNT + 1))" ]; then
+    _pass "exactly one commit for the new change ($FINAL_COUNT)"
+else
+    _fail "exactly one commit for the new change" \
+        "expected $((BASE_COUNT + 1)), got $FINAL_COUNT"
+fi
+
+print_summary

--- a/tests/harness/36_shadow_coherence_v2.sh
+++ b/tests/harness/36_shadow_coherence_v2.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# 36_shadow_coherence_v2.sh — Validator Rule V2 (tree ↔ view coherence).
+#
+# SPEC-single-materializer-validator.md §6.2 / Phase 4: the staged tree must
+# correspond to what the current view materializes. A working copy that has
+# drifted from the recorded view (e.g. an out-of-band edit that was never
+# recorded) must be rejected before commit — not silently baked into a shadow
+# commit whose Atomic-State trailer would then lie.
+#
+# This suite pins:
+#   1. A normal record → push is coherent and commits (no false positive).
+#   2. An out-of-band disk edit (not recorded) is rejected by V2: no commit,
+#      names the path, logs shadow-validate:V2, git left untouched.
+#   3. Recording that edit restores coherence, and the push then commits.
+
+HARNESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$HARNESS_DIR/helpers.sh"
+
+echo ""
+echo "${BOLD}══════════════════════════════════════════════════════════════${RESET}"
+echo "${BOLD}  Suite: 36_shadow_coherence_v2${RESET}"
+echo "${BOLD}══════════════════════════════════════════════════════════════${RESET}"
+
+begin_section "Prerequisites"
+require_git
+
+begin_section "Coherent record → push commits (no false positive)"
+
+make_temp_repo "v2-coherence"
+init_git_repo
+git_commit "Initial" "README.md" "# Project"
+assert_success "git import" atomic git import --no-vault
+
+create_file "src/a.ts" "const a = 1;"
+add_files "src/a.ts"
+record_change "feat: a" >/dev/null
+assert_success "coherent shadow push commits" atomic git push --no-push -m "baseline"
+BASE_COUNT="$(git_commit_count)"
+
+begin_section "Out-of-band drift is rejected by V2"
+
+# Edit a tracked file on disk WITHOUT recording it: the working copy now
+# diverges from the view's recorded content.
+overwrite_file "src/a.ts" "const a = 999; // edited on disk, never recorded"
+
+set +e
+PUSH_OUT="$(atomic git push --no-push -m "drift" 2>&1)"
+PUSH_RC=$?
+set -e
+AFTER_COUNT="$(git_commit_count)"
+
+if [ "$PUSH_RC" -ne 0 ]; then
+    _pass "shadow push aborts (V2) on out-of-band drift"
+else
+    _fail "shadow push aborts (V2) on out-of-band drift" "expected non-zero"
+fi
+
+if echo "$PUSH_OUT" | grep -qa "src/a.ts"; then
+    _pass "abort names the drifted file"
+else
+    _fail "abort names the drifted file" "output: $(echo "$PUSH_OUT" | head -5)"
+fi
+
+if [ "$AFTER_COUNT" -eq "$BASE_COUNT" ]; then
+    _pass "no commit created on drift ($AFTER_COUNT)"
+else
+    _fail "no commit created on drift" "expected $BASE_COUNT, got $AFTER_COUNT"
+fi
+
+if [ -f .atomic/hook-errors.log ] && grep -qa "shadow-validate:V2" .atomic/hook-errors.log; then
+    _pass "hook-errors.log records a shadow-validate:V2 entry"
+else
+    _fail "hook-errors.log records a shadow-validate:V2 entry" \
+        "log: $(cat .atomic/hook-errors.log 2>/dev/null | head -3)"
+fi
+
+begin_section "Recording the edit restores coherence"
+
+add_files "src/a.ts"
+record_change "feat: a (edited)" >/dev/null
+assert_success "push commits once coherent" atomic git push --no-push -m "recorded edit"
+
+FINAL_COUNT="$(git_commit_count)"
+if [ "$FINAL_COUNT" -eq "$((BASE_COUNT + 1))" ]; then
+    _pass "exactly one commit after recording ($FINAL_COUNT)"
+else
+    _fail "exactly one commit after recording" "expected $((BASE_COUNT + 1)), got $FINAL_COUNT"
+fi
+
+print_summary

--- a/tests/harness/37_shadow_view_branch_follow.sh
+++ b/tests/harness/37_shadow_view_branch_follow.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# 37_shadow_view_branch_follow.sh — git shadow HEAD follows `atomic view switch`.
+#
+# SPEC-single-materializer-validator.md §5.4, Direction A ("git shadows Atomic"):
+# Atomic is upstream, so switching the Atomic view points the downstream git
+# shadow's HEAD at the mirror branch. It is a ref move (never a `git checkout`):
+# the working copy Atomic just materialized is left untouched. Best-effort and
+# gated to shadow-sync repos.
+#
+# Pins:
+#   1. Switching to a view with no git branch yet CREATES the branch and moves
+#      HEAD to it, without disturbing the materialized working copy.
+#   2. Switching back moves HEAD back; already-on is an idempotent no-op.
+#   3. In a NON-shadow repo (no import/excludes), view switch does NOT touch git.
+
+HARNESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$HARNESS_DIR/helpers.sh"
+
+echo ""
+echo "${BOLD}══════════════════════════════════════════════════════════════${RESET}"
+echo "${BOLD}  Suite: 37_shadow_view_branch_follow${RESET}"
+echo "${BOLD}══════════════════════════════════════════════════════════════${RESET}"
+
+begin_section "Prerequisites"
+require_git
+
+git_head_branch() { git symbolic-ref --short HEAD 2>/dev/null; }
+
+# ════════════════════════════════════════════════════════════════════════
+# git shadow HEAD follows the Atomic view
+# ════════════════════════════════════════════════════════════════════════
+
+begin_section "Shadow HEAD follows view switch"
+
+make_temp_repo "view-branch-follow"
+init_git_repo
+git_commit "Initial" "README.md" "# Project"
+assert_success "git import establishes shadow sync" atomic git import --no-vault
+
+MAIN="$(git_head_branch)"
+_pass "shadow default branch is '$MAIN'"
+
+# Record a change and create a draft view (no --switch yet).
+create_file "src/a.ts" "const a = 1;"
+add_files "src/a.ts"
+record_change "feat: a" >/dev/null
+assert_success "create draft view" atomic view create agent --draft --parent "$MAIN"
+
+# Switching to the draft moves the git shadow onto a mirror branch (created).
+assert_success "switch to draft view" atomic view switch agent --force
+if [ "$(git_head_branch)" = "agent" ]; then
+    _pass "git HEAD followed to branch 'agent'"
+else
+    _fail "git HEAD followed to branch 'agent'" "on '$(git_head_branch)'"
+fi
+assert_success "mirror branch 'agent' exists" git rev-parse --verify --quiet refs/heads/agent
+
+# The materialized working copy is intact (ref move, not a checkout).
+assert_file_exists "working copy intact after follow" "src/a.ts"
+
+# Switching back moves HEAD back to the shared branch.
+assert_success "switch back to shared view" atomic view switch "$MAIN" --force
+if [ "$(git_head_branch)" = "$MAIN" ]; then
+    _pass "git HEAD followed back to '$MAIN'"
+else
+    _fail "git HEAD followed back to '$MAIN'" "on '$(git_head_branch)'"
+fi
+
+# Idempotent: switching to the view we're already on is a no-op.
+assert_success "switch to current view is a no-op" atomic view switch "$MAIN"
+if [ "$(git_head_branch)" = "$MAIN" ]; then
+    _pass "idempotent switch leaves HEAD on '$MAIN'"
+else
+    _fail "idempotent switch leaves HEAD on '$MAIN'" "on '$(git_head_branch)'"
+fi
+
+# ════════════════════════════════════════════════════════════════════════
+# Non-shadow repo: view switch must NOT touch git
+# ════════════════════════════════════════════════════════════════════════
+
+begin_section "Non-shadow repo: view switch leaves git alone"
+
+make_temp_repo "no-shadow"
+init_git_repo
+git_commit "Initial" "README.md" "# Plain"
+BEFORE_BRANCH="$(git_head_branch)"
+
+# Atomic repo WITHOUT git import (no shadow excludes → shadow sync not active).
+init_repo
+create_file "src/x.ts" "const x = 1;"
+add_files "src/x.ts"
+record_change "feat: x" >/dev/null
+new_view "other" >/dev/null 2>&1 || atomic view create other >/dev/null 2>&1
+assert_success "switch view in non-shadow repo" atomic view switch other --force
+
+if [ "$(git_head_branch)" = "$BEFORE_BRANCH" ]; then
+    _pass "git HEAD untouched in non-shadow repo ('$BEFORE_BRANCH')"
+else
+    _fail "git HEAD untouched in non-shadow repo" \
+        "expected '$BEFORE_BRANCH', got '$(git_head_branch)'"
+fi
+assert_failure "no mirror branch created in non-shadow repo" \
+    git rev-parse --verify --quiet refs/heads/other
+
+print_summary

--- a/tests/harness/38_shadow_drift_v3.sh
+++ b/tests/harness/38_shadow_drift_v3.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# 38_shadow_drift_v3.sh — Validator Rule V3 (git ↔ Atomic state lineage).
+#
+# SPEC-single-materializer-validator.md §6.3 / Phase 5: a shadow push must refuse
+# when the git branch's last published Atomic-State is NOT in the current view's
+# recorded lineage (genuine drift — the branch was reset, or published from a
+# state this view cannot reach). There is NO bypass flag: the remedy is
+# reconcile-then-push (git reset to the last coherent shadow commit, or import).
+#
+# Pins:
+#   1. A normal fast-forward push (last state IS in lineage) commits (no false
+#      positive).
+#   2. When the branch tip advertises a state absent from the view's history,
+#      the push aborts (V3): no commit, reconcile hint, shadow-validate:V3.
+#   3. Reconciling (git reset to drop the drift commit) lets the push succeed.
+
+HARNESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$HARNESS_DIR/helpers.sh"
+
+echo ""
+echo "${BOLD}══════════════════════════════════════════════════════════════${RESET}"
+echo "${BOLD}  Suite: 38_shadow_drift_v3${RESET}"
+echo "${BOLD}══════════════════════════════════════════════════════════════${RESET}"
+
+begin_section "Prerequisites"
+require_git
+
+# Extract the current view's tip Atomic-State (base32) from the log.
+view_tip_state() {
+    atomic log --view "$MAIN" -f json 2>/dev/null \
+        | grep -o '"state"[[:space:]]*:[[:space:]]*"[^"]*"' \
+        | head -1 \
+        | sed -E 's/.*"([^"]+)"$/\1/'
+}
+
+begin_section "Fast-forward push commits (no false positive)"
+
+make_temp_repo "drift-v3"
+init_git_repo
+git_commit "Initial" "README.md" "# Project"
+assert_success "git import" atomic git import --no-vault
+MAIN="$(git symbolic-ref --short HEAD)"
+
+create_file "src/a.ts" "const a = 1;"
+add_files "src/a.ts"
+record_change "feat: a" >/dev/null
+assert_success "baseline push (fast-forward)" atomic git push --no-push -m "A"
+BASE_COUNT="$(git_commit_count)"
+
+begin_section "Drift (state not in lineage) is rejected by V3"
+
+# Record another change (not yet pushed).
+create_file "src/b.ts" "const b = 2;"
+add_files "src/b.ts"
+record_change "feat: b" >/dev/null
+
+# Fabricate drift: a git commit on the branch advertising an Atomic-State that
+# is NOT in the view's history (mutate the tip state's last char). find_last_
+# pushed_state will pick this up as the branch's last published state.
+TIP_STATE="$(view_tip_state)"
+# Mutate a MIDDLE character (full data bits) rather than the last (which carries
+# base32 padding bits) so the result is still a valid merkle, just a different
+# one that is not in the view's history.
+IDX=10
+ORIG_CHAR="${TIP_STATE:$IDX:1}"
+REPL="Q"; [ "$ORIG_CHAR" = "Q" ] && REPL="Z"
+FAKE_STATE="${TIP_STATE:0:$IDX}$REPL${TIP_STATE:$((IDX + 1))}"
+git commit --allow-empty -q -m "Simulated drift
+
+Atomic-View: $MAIN
+Atomic-State: $FAKE_STATE"
+
+DRIFT_TIP_COUNT="$(git_commit_count)"
+
+set +e
+PUSH_OUT="$(atomic git push --no-push -m "onto drift" 2>&1)"
+PUSH_RC=$?
+set -e
+AFTER_COUNT="$(git_commit_count)"
+
+if [ "$PUSH_RC" -ne 0 ]; then
+    _pass "shadow push aborts (V3) on drift"
+else
+    _fail "shadow push aborts (V3) on drift" "expected non-zero"
+fi
+
+if echo "$PUSH_OUT" | grep -qaiE "drift|lineage|reconcile"; then
+    _pass "abort explains the drift + reconcile"
+else
+    _fail "abort explains the drift + reconcile" "output: $(echo "$PUSH_OUT" | head -5)"
+fi
+
+if [ "$AFTER_COUNT" -eq "$DRIFT_TIP_COUNT" ]; then
+    _pass "no commit created on drift ($AFTER_COUNT)"
+else
+    _fail "no commit created on drift" "expected $DRIFT_TIP_COUNT, got $AFTER_COUNT"
+fi
+
+if [ -f .atomic/hook-errors.log ] && grep -qa "shadow-validate:V3" .atomic/hook-errors.log; then
+    _pass "hook-errors.log records a shadow-validate:V3 entry"
+else
+    _fail "hook-errors.log records a shadow-validate:V3 entry" \
+        "log: $(cat .atomic/hook-errors.log 2>/dev/null | head -3)"
+fi
+
+begin_section "Reconcile-then-push succeeds"
+
+# Reconcile by dropping the drift commit so the branch tip is a coherent shadow
+# state again.
+git reset --hard HEAD~1 >/dev/null 2>&1
+assert_success "push succeeds after reconcile" atomic git push --no-push -m "recorded b"
+FINAL_COUNT="$(git_commit_count)"
+if [ "$FINAL_COUNT" -gt "$BASE_COUNT" ]; then
+    _pass "reconciled push created a commit ($FINAL_COUNT)"
+else
+    _fail "reconciled push created a commit" "expected > $BASE_COUNT, got $FINAL_COUNT"
+fi
+
+print_summary


### PR DESCRIPTION
This pull request introduces two main improvements: (1) it adds support for exporting the causal decision graph(s) (change ledger/provenance) in the JSON output of the `atomic change show` command, and (2) it updates repository initialization so that when importing from Git, the default view matches the Git default branch rather than always being `dev`. These changes improve interoperability with external tools and ensure a smoother Git integration experience.

**JSON Change Output and Provenance Ledger:**

* The JSON output for changes (`JsonChange`) now includes a `ledger` field, carrying the machine-readable causal decision graph(s) explaining the change. The ledger is omitted if no provenance is available. [[1]](diffhunk://#diff-9ddd0f1243ff223ea634aa83699c6fd0645168614ac42e38c1ef24e5d0b7e8b6R245-R251) [[2]](diffhunk://#diff-9ddd0f1243ff223ea634aa83699c6fd0645168614ac42e38c1ef24e5d0b7e8b6R305-R464) [[3]](diffhunk://#diff-60229ac3285fb60ab0b771f64768102c9b5a9a698af9690210a2b6d005bda3c5L71-R89)
* The `ChangeCmd` command loads provenance graphs from the repository and attaches them to the JSON output. Test coverage ensures the ledger is present when provenance exists and omitted otherwise. [[1]](diffhunk://#diff-4427cf1f2c05273a9eca129b91e58c572c845de6a9c2315c86b04299df6b7e87R661-R689) [[2]](diffhunk://#diff-86ffa8c4a1cb51470394a14b69e419535aa00e6bc89bd0dbe5fa02cdf3fcbd00R844-R931) [[3]](diffhunk://#diff-86ffa8c4a1cb51470394a14b69e419535aa00e6bc89bd0dbe5fa02cdf3fcbd00L857-R945) [[4]](diffhunk://#diff-86ffa8c4a1cb51470394a14b69e419535aa00e6bc89bd0dbe5fa02cdf3fcbd00L512-R512) [[5]](diffhunk://#diff-86ffa8c4a1cb51470394a14b69e419535aa00e6bc89bd0dbe5fa02cdf3fcbd00L524-R524)
* New types (`JsonChangeLedger`, `JsonLedgerNode`, `JsonLedgerEdge`) provide a stable, self-describing, and tool-friendly encoding of provenance graphs.

**Repository Initialization and Default View:**

* When importing a Git repository, the Atomic repository is now initialized with the Git default branch as its default view (instead of always using `dev`). This is handled by a new `init_with_view` method in `Repository`. [[1]](diffhunk://#diff-94ef74913277bb663c884963c6345c55b80353a8ed2e284f3c883d9310de31f5R461-R479) [[2]](diffhunk://#diff-94ef74913277bb663c884963c6345c55b80353a8ed2e284f3c883d9310de31f5L486-L488) [[3]](diffhunk://#diff-e6fb908e7852ab01ffc10ccdb8b3030ec546e76a3fcc56d8316e0114b20faf67R243-R268) [[4]](diffhunk://#diff-e6fb908e7852ab01ffc10ccdb8b3030ec546e76a3fcc56d8316e0114b20faf67L266-R292) [[5]](diffhunk://#diff-e6fb908e7852ab01ffc10ccdb8b3030ec546e76a3fcc56d8316e0114b20faf67L285-R336)
* Test coverage ensures that `init_with_view` correctly sets the default view and persists it across repository reopenings.

These changes enhance the CLI's JSON output for downstream automation and improve the user experience when integrating Atomic with existing Git workflows.