### PR TITLE
fix(agent): atomic-skills registry view = dev

### DIFF
--- a/atomic-agent/src/integrations/registry.toml
+++ b/atomic-agent/src/integrations/registry.toml
@@ -12,7 +12,7 @@ schema = 1
 
 [agents.atomic-skills]
 url = "https://atomic.atomic.storage/workspaces/oss/projects/atomic-skills/code"
-view = "release"
+view = "dev"
 
 [agents.agy]
 url = "https://atomic.atomic.storage/workspaces/oss/projects/atomic-agy/code"


### PR DESCRIPTION
The `release` view on atomic-storage is empty due to a server-side view-snapshot sync bug (https://github.com/atomicdotdev/atomic-storage/pull/91). The `dev` view has the content (3 changes, 6 declared skills, AGENTS.md, README).

Use `dev` until the server bug is fixed and the release view materializes correctly.

Verified: `atomic clone ... --view dev` downloads all content with 6 `[[declared-skill]]` entries.