### PR TITLE
Feat/set based view convergence

### DIFF
--- a/atomic-cli/src/commands/push/command.rs
+++ b/atomic-cli/src/commands/push/command.rs
@@ -514,11 +514,10 @@ impl Push {
                 known_on_remote.extend(rm.changes.iter().copied());
             }
 
-            let plan = plan_view_sync(&manifest, remote_manifest.as_ref(), self.force).map_err(
-                |conflict| {
+            let plan = plan_view_sync(&manifest, remote_manifest.as_ref(), self.force, is_leaf)
+                .map_err(|conflict| {
                     self.divergence_error(name, &manifest, remote_manifest.as_ref(), &conflict)
-                },
-            )?;
+                })?;
 
             if plan.forced {
                 print_warning(&format!(
@@ -568,11 +567,23 @@ impl Push {
 
         for sync in &syncs {
             if sync.plan.is_noop() {
-                println!(
-                    "  {} {} already up to date",
-                    success("✓"),
-                    style_view(&sync.remote_name)
-                );
+                if sync.plan.shrink {
+                    // Ancestor view shrank locally but its remote copy is larger.
+                    // We leave the remote intact (it already satisfies the view
+                    // we're pushing) rather than implicitly rewriting shared
+                    // history; the user can rewrite it deliberately.
+                    print_warning(&format!(
+                        "View '{}' is larger on the remote than locally; leaving it unchanged. \
+                         Push '{}' directly with --force to rewrite it to your smaller set.",
+                        sync.remote_name, sync.remote_name
+                    ));
+                } else {
+                    println!(
+                        "  {} {} already up to date",
+                        success("✓"),
+                        style_view(&sync.remote_name)
+                    );
+                }
                 continue;
             }
 

--- a/atomic-cli/src/commands/push/helpers.rs
+++ b/atomic-cli/src/commands/push/helpers.rs
@@ -153,6 +153,14 @@ pub struct ViewSyncPlan {
     /// True when divergence was overridden with `--force`. The server is
     /// still authoritative and may reject the declare.
     pub forced: bool,
+
+    /// True when the local view is a strict *subset* of the remote (it shrank,
+    /// e.g. after `atomic view split` moved changes out). By default such a
+    /// declare is skipped (`declare == false`) so the remote keeps its fuller
+    /// set and a descendant push is not blocked; with `--force` it is declared
+    /// (`declare == true`, `forced == true`), rewriting the remote view to the
+    /// smaller set. Purely informational — lets the caller explain the skip.
+    pub shrink: bool,
 }
 
 impl ViewSyncPlan {
@@ -177,10 +185,21 @@ impl ViewSyncPlan {
 /// the declare is attempted anyway, leaving the server as the authority.
 /// Identity mismatches (scope/parent) are never forced — they are
 /// structural, and the server would reject them regardless.
+///
+/// `is_leaf` marks the view the user actually asked to push (the tip of the
+/// chain) versus an *ancestor* pulled in only because a descendant needs it.
+/// For an ancestor whose remote already contains every local change, there is
+/// nothing to do — the remote already satisfies the descendant — so it is
+/// skipped even if the local ancestor shrank (e.g. via `atomic view split`);
+/// this keeps an ancestor's local shrink from aborting a leaf push, and never
+/// rewrites shared history implicitly. For the leaf, `local ⊂ remote` is
+/// genuinely ambiguous (local is behind vs. local shrank), so it is left to the
+/// prefix/divergence rules, which err toward "pull first, or `--force`".
 pub fn plan_view_sync(
     local: &ViewManifest,
     remote: Option<&ViewManifest>,
     force: bool,
+    is_leaf: bool,
 ) -> Result<ViewSyncPlan, ViewSyncConflict> {
     let remote = match remote {
         None => {
@@ -189,6 +208,7 @@ pub fn plan_view_sync(
                 suffix: local.changes.clone(),
                 declare: true,
                 forced: false,
+                shrink: false,
             });
         }
         Some(r) => r,
@@ -210,6 +230,27 @@ pub fn plan_view_sync(
             local: show(&local.parent),
             remote: show(&remote.parent),
         });
+    }
+
+    // Ancestor already satisfied. When this view is NOT the one being pushed (an
+    // ancestor pulled in for a descendant) and the remote already holds every
+    // local change, there is nothing to do: the remote's set already satisfies
+    // the descendant, and pushing a child never implies rewriting a parent. Skip
+    // without error — so a child push is never blocked by an ancestor whose
+    // remote is merely larger (a local shrink) — and flag `shrink` when the
+    // remote is strictly larger so the caller can explain the skip. The leaf
+    // falls through to the prefix/divergence rules below, where `local ⊂ remote`
+    // is ambiguous and errs toward "pull or --force".
+    if !is_leaf {
+        let remote_set: HashSet<&Hash> = remote.changes.iter().collect();
+        if local.changes.iter().all(|h| remote_set.contains(h)) {
+            return Ok(ViewSyncPlan {
+                suffix: Vec::new(),
+                declare: false,
+                forced: false,
+                shrink: local.changes.len() != remote.changes.len(),
+            });
+        }
     }
 
     // Prefix rule.
@@ -249,6 +290,7 @@ pub fn plan_view_sync(
             suffix,
             declare: true,
             forced: true,
+            shrink: false,
         });
     }
 
@@ -259,6 +301,7 @@ pub fn plan_view_sync(
         suffix,
         declare,
         forced: false,
+        shrink: false,
     })
 }
 
@@ -593,7 +636,7 @@ mod tests {
     #[test]
     fn test_plan_absent_remote_uploads_full_log() {
         let local = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2), h(3)]);
-        let plan = plan_view_sync(&local, None, false).unwrap();
+        let plan = plan_view_sync(&local, None, false, true).unwrap();
 
         assert_eq!(plan.suffix, vec![h(1), h(2), h(3)]);
         assert!(plan.declare);
@@ -604,7 +647,7 @@ mod tests {
     fn test_plan_remote_prefix_uploads_suffix_only() {
         let local = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2), h(3), h(4)]);
         let remote = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2)]);
-        let plan = plan_view_sync(&local, Some(&remote), false).unwrap();
+        let plan = plan_view_sync(&local, Some(&remote), false, true).unwrap();
 
         assert_eq!(plan.suffix, vec![h(3), h(4)]);
         assert!(plan.declare);
@@ -615,7 +658,7 @@ mod tests {
     fn test_plan_identical_logs_is_noop() {
         let local = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2)]);
         let remote = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2)]);
-        let plan = plan_view_sync(&local, Some(&remote), false).unwrap();
+        let plan = plan_view_sync(&local, Some(&remote), false, true).unwrap();
 
         assert!(plan.suffix.is_empty());
         assert!(!plan.declare);
@@ -627,7 +670,7 @@ mod tests {
         // View exists on the remote but its log is empty (freshly declared).
         let local = manifest("dev", ViewScope::Shared, None, vec![h(1)]);
         let remote = manifest("dev", ViewScope::Shared, None, vec![]);
-        let plan = plan_view_sync(&local, Some(&remote), false).unwrap();
+        let plan = plan_view_sync(&local, Some(&remote), false, true).unwrap();
 
         assert_eq!(plan.suffix, vec![h(1)]);
         assert!(plan.declare);
@@ -637,7 +680,7 @@ mod tests {
     fn test_plan_diverged_hash_mismatch() {
         let local = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2), h(3)]);
         let remote = manifest("dev", ViewScope::Shared, None, vec![h(1), h(9)]);
-        let err = plan_view_sync(&local, Some(&remote), false).unwrap_err();
+        let err = plan_view_sync(&local, Some(&remote), false, true).unwrap_err();
 
         assert_eq!(
             err,
@@ -651,10 +694,11 @@ mod tests {
 
     #[test]
     fn test_plan_diverged_remote_longer() {
-        // Remote is ahead of local: not a prefix, so pull first.
+        // Leaf pushed and remote is ahead (local ⊂ remote): ambiguous — behind
+        // vs. shrunk — so the leaf still errs toward "pull first, or --force".
         let local = manifest("dev", ViewScope::Shared, None, vec![h(1)]);
         let remote = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2)]);
-        let err = plan_view_sync(&local, Some(&remote), false).unwrap_err();
+        let err = plan_view_sync(&local, Some(&remote), false, true).unwrap_err();
 
         assert_eq!(
             err,
@@ -670,7 +714,7 @@ mod tests {
     fn test_plan_forced_diverged_stores_set_difference() {
         let local = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2), h(3)]);
         let remote = manifest("dev", ViewScope::Shared, None, vec![h(1), h(9)]);
-        let plan = plan_view_sync(&local, Some(&remote), true).unwrap();
+        let plan = plan_view_sync(&local, Some(&remote), true, true).unwrap();
 
         // h(1) is already on the remote view; h(2), h(3) are not.
         assert_eq!(plan.suffix, vec![h(2), h(3)]);
@@ -683,14 +727,14 @@ mod tests {
         let local = manifest("x", ViewScope::Draft, Some("dev"), vec![h(1)]);
         let remote = manifest("x", ViewScope::Shared, Some("dev"), vec![h(1)]);
 
-        let err = plan_view_sync(&local, Some(&remote), false).unwrap_err();
+        let err = plan_view_sync(&local, Some(&remote), false, true).unwrap_err();
         assert!(matches!(
             err,
             ViewSyncConflict::IdentityMismatch { field: "scope", .. }
         ));
 
         // Identity mismatches are structural — force does not bypass them.
-        let err = plan_view_sync(&local, Some(&remote), true).unwrap_err();
+        let err = plan_view_sync(&local, Some(&remote), true, true).unwrap_err();
         assert!(matches!(
             err,
             ViewSyncConflict::IdentityMismatch { field: "scope", .. }
@@ -698,10 +742,61 @@ mod tests {
     }
 
     #[test]
+    fn test_plan_ancestor_shrunk_is_skipped_not_blocking() {
+        // An ANCESTOR in the chain (is_leaf = false) shrank locally, but the
+        // remote already holds every local change. It is skipped (no store, no
+        // declare) so a descendant push is not blocked, and `shrink` is flagged
+        // so the caller can explain the skip. Force does not change this —
+        // rewriting an ancestor must be done by pushing it directly.
+        let local = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2)]);
+        let remote = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2), h(3), h(4)]);
+
+        let plan = plan_view_sync(&local, Some(&remote), false, false).unwrap();
+        assert!(plan.suffix.is_empty(), "nothing to store for an ancestor");
+        assert!(!plan.declare, "an ancestor shrink is not declared");
+        assert!(!plan.forced);
+        assert!(plan.shrink, "flagged so the push can explain the skip");
+        assert!(plan.is_noop());
+
+        let forced = plan_view_sync(&local, Some(&remote), true, false).unwrap();
+        assert!(
+            !forced.declare,
+            "force does not rewrite an ancestor via a child push"
+        );
+    }
+
+    #[test]
+    fn test_plan_leaf_shrunk_forced_declares_smaller_set() {
+        // The LEAF being pushed shrank; with --force the remote view is rewritten
+        // to the smaller set (nothing new to store, since local ⊂ remote).
+        let local = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2)]);
+        let remote = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2), h(3), h(4)]);
+        let plan = plan_view_sync(&local, Some(&remote), true, true).unwrap();
+
+        assert!(plan.suffix.is_empty());
+        assert!(
+            plan.declare,
+            "a forced leaf shrink rewrites the remote view"
+        );
+        assert!(plan.forced);
+    }
+
+    #[test]
+    fn test_plan_genuine_divergence_still_errors_not_masked_by_shrink() {
+        // Remote is longer AND holds a change local lacks that local did not
+        // simply drop (h(2) local vs h(5)/h(6) remote) — a real divergence, not a
+        // subset shrink. Must still error without --force, even as an ancestor.
+        let local = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2)]);
+        let remote = manifest("dev", ViewScope::Shared, None, vec![h(1), h(5), h(6)]);
+        let err = plan_view_sync(&local, Some(&remote), false, false).unwrap_err();
+        assert!(matches!(err, ViewSyncConflict::Diverged { .. }));
+    }
+
+    #[test]
     fn test_plan_parent_mismatch_is_conflict() {
         let local = manifest("x", ViewScope::Draft, Some("dev"), vec![h(1)]);
         let remote = manifest("x", ViewScope::Draft, Some("release"), vec![h(1)]);
-        let err = plan_view_sync(&local, Some(&remote), false).unwrap_err();
+        let err = plan_view_sync(&local, Some(&remote), false, true).unwrap_err();
 
         match err {
             ViewSyncConflict::IdentityMismatch {

--- a/atomic-repository/src/repository/history.rs
+++ b/atomic-repository/src/repository/history.rs
@@ -484,6 +484,120 @@ impl Repository {
         Ok((view.state, view.change_count))
     }
 
+    /// Converge a view's own change log to a target effective set by
+    /// **removing** every own change absent from `target`.
+    ///
+    /// This is the removal half of set-based view convergence (the add half is
+    /// [`insert_change`](crate::Repository::insert_change)). A durable view
+    /// record declares the view's effective change set (its own changes plus
+    /// everything inherited through its parent chain); any of the view's OWN
+    /// changes not in that set were removed upstream — e.g. by `view split`,
+    /// which moves changes out of a view — and are unrecorded here so the local
+    /// view matches the declared set.
+    ///
+    /// Only the view's **own** log is considered: inherited changes live in an
+    /// ancestor view's log (converge the ancestor to drop those) and are never
+    /// touched here, so passing a `target` that omits an inherited change does
+    /// not remove it. Because `target` is the *effective* set, any own change
+    /// that should remain — inherited or not — is present in it and kept.
+    ///
+    /// Removal is at the `VIEW_CHANGES` level only, exactly like
+    /// [`unrecord`](crate::Repository::unrecord): the change bytes and graph
+    /// edges remain, so the removal is reversible via
+    /// [`reinsert_change`](crate::Repository::reinsert_change) or
+    /// [`insert_change`](crate::Repository::insert_change). The working copy is
+    /// **not** re-materialized (a caller that needs the tree on disk updated
+    /// must do so separately); stale `FILE_INDEX` entries for affected paths are
+    /// cleared so the next `status` recomputes against the graph.
+    ///
+    /// Idempotent: a view already matching its target removes nothing and
+    /// returns an empty vector. On success returns the hashes removed.
+    pub fn retain_view_changes(
+        &self,
+        view_name: &str,
+        target: &HashSet<Hash>,
+    ) -> Result<Vec<Hash>, RepositoryError> {
+        let mut txn = self
+            .pristine
+            .write_txn()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        let mut view = txn
+            .get_view(view_name)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+            .ok_or_else(|| RepositoryError::ViewNotFound {
+                name: view_name.to_string(),
+            })?;
+
+        // Snapshot the view's own change ids first (the iterator borrows the
+        // txn immutably; collecting frees it for the mutable `del_change`).
+        let own_ids: Vec<NodeId> = txn
+            .iter_changes(&view, 0)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+            .map(|entry| entry.map(|(_seq, change_id, _merkle)| change_id))
+            .collect::<Result<_, _>>()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        // Any own change whose external hash is not in the target set is stale.
+        let mut to_remove: Vec<(NodeId, Hash)> = Vec::new();
+        for change_id in own_ids {
+            let hash = txn
+                .get_external(change_id)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?
+                .ok_or_else(|| {
+                    RepositoryError::Database(format!(
+                        "change {} has no external hash",
+                        change_id.0
+                    ))
+                })?;
+            if !target.contains(&hash) {
+                to_remove.push((change_id, hash));
+            }
+        }
+
+        if to_remove.is_empty() {
+            // Leave the write txn unwritten — nothing to converge.
+            return Ok(Vec::new());
+        }
+
+        // `del_change` re-derives the sequence from `change_id` on each call, so
+        // it is robust to the resequencing it performs internally; removal order
+        // does not affect the final set.
+        let mut removed = Vec::with_capacity(to_remove.len());
+        for (change_id, hash) in &to_remove {
+            let seq = txn
+                .del_change(&mut view, *change_id, hash)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+            if seq.is_some() {
+                removed.push(*hash);
+            }
+        }
+
+        txn.update_view(&view)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        txn.commit()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        // Post-removal: drop stale FILE_INDEX entries for affected paths so the
+        // next `status` does a full content comparison against the graph rather
+        // than trusting an index keyed to now-removed content (mirrors
+        // `unrecord`). We do NOT re-materialize — that would clobber on-disk work.
+        for hash in &removed {
+            if let Ok(change) = self.load_change(hash) {
+                if let Ok(mut idx_txn) = self.pristine.write_txn() {
+                    for op in change.hunks() {
+                        if let Some(p) = op.path() {
+                            let _ = idx_txn.del_file_index(p);
+                        }
+                    }
+                    let _ = idx_txn.commit();
+                }
+            }
+        }
+
+        Ok(removed)
+    }
+
     /// Check if a change can be unrecorded.
     ///
     /// This checks whether the change is in the view and whether it has

--- a/atomic-repository/tests/view_setid_test.rs
+++ b/atomic-repository/tests/view_setid_test.rs
@@ -89,3 +89,56 @@ fn view_set_id_round_trips_home_after_split_and_reinsert() {
         "Merkle is order-sensitive and must differ after reordering the log"
     );
 }
+
+/// `retain_view_changes` is the removal half of set-based view convergence: it
+/// drops exactly the view's own changes absent from a target set, is
+/// idempotent, and converges the view's `SetId` to the target.
+#[test]
+fn retain_view_changes_drops_changes_absent_from_target() {
+    use std::collections::HashSet;
+
+    let (repo, _temp, root) = init_repo();
+    let dev = repo.current_view().to_string();
+
+    // Three independent changes → the middle one can be dropped freely.
+    write_and_add(&repo, &root, "a.txt", "alpha\n");
+    let c1 = record(&repo, "add a");
+    write_and_add(&repo, &root, "b.txt", "bravo\n");
+    let c2 = record(&repo, "add b");
+    write_and_add(&repo, &root, "c.txt", "charlie\n");
+    let c3 = record(&repo, "add c");
+
+    // Target keeps {a, c} and drops b — the shape a `view split` leaves behind.
+    let target: HashSet<Hash> = [c1, c3].into_iter().collect();
+    let removed = repo.retain_view_changes(&dev, &target).expect("retain");
+    assert_eq!(
+        removed,
+        vec![c2],
+        "only the change absent from the target is removed"
+    );
+
+    // The converged view now holds exactly the target set.
+    let expected = SetId::ZERO.add(&c1).add(&c3);
+    assert_eq!(
+        repo.view_set_id(&dev).expect("set id"),
+        expected,
+        "view SetId converges to the target set"
+    );
+
+    // Idempotent: converging again to the same target removes nothing.
+    assert!(
+        repo.retain_view_changes(&dev, &target)
+            .expect("retain again")
+            .is_empty(),
+        "an already-converged view removes nothing"
+    );
+
+    // A superset target (the view is a subset of it) has nothing to drop.
+    let superset: HashSet<Hash> = [c1, c2, c3].into_iter().collect();
+    assert!(
+        repo.retain_view_changes(&dev, &superset)
+            .expect("retain superset")
+            .is_empty(),
+        "a target that is a superset of the view removes nothing"
+    );
+}

--- a/docs/vault-sync-design.md
+++ b/docs/vault-sync-design.md
@@ -1,0 +1,211 @@
+# Vault as Objects: Server Sync & WebUI Design
+
+> Status: **draft / proposal.** Companion to
+> [`view-snapshot-sync-design.md`](./view-snapshot-sync-design.md); it reuses the
+> same bare object+ref transport and demand-scoped read model. This doc covers
+> getting **vault** data (sessions, intents, memories, goals, skills) onto the
+> server and rendering it to a WebUI.
+
+## Overview
+
+The vault holds the durable knowledge Atomic produces alongside code: session
+turns, intents, memories, goals, skills. Today it is **100% local** — a content
+search for `vault` across `atomic-remote` and the push command returns no
+matches. `atomic vault sync` ingests `.vault/` files into redb; `atomic vault
+materialize` writes them back to disk; nothing ever reaches a server. So none of
+this shows up on the remote, and there is no surface to render it to a WebUI.
+
+The good news from digging through the subsystem: **the vault is already in the
+exact shape the bare object+ref model wants** — content-addressed entries indexed
+by a merkled manifest. It doesn't need re-architecting; it needs the *same
+transport* views are getting, plus a read API. It becomes a second object family
+and one ref riding the identical wire protocol as changes, tags, provenance, and
+view-snapshots.
+
+## What the vault already is
+
+- **Content objects** — `VaultEntry` (`atomic-core/src/pristine/vault.rs:75`):
+  `{ entry_type, content_hash: [u8;32] (Blake3 of body), content_bytes,
+  frontmatter_json, created_at, updated_at, introduced_by }`, stored in
+  `VAULT_ENTRIES` keyed by vault path (`sessions/…`, `intents/…`, `memory/…`,
+  `skills/…`). A content-addressed object, structurally like a `.change`.
+- **A manifest = index + merkle** — `VaultManifest`
+  (`atomic-core/src/pristine/vault.rs:250`): a singleton with summary maps for
+  `goals`, `memory`, `intents`, `skills`, plus `index` stats, totals, intent-id
+  counters, and an incremental **`merkle`** (`Hash(prev_merkle || change_hash)`).
+  `Repository::vault_manifest_merkle` (`atomic-repository/src/repository/vault.rs:448`):
+  *two repos with the same manifest merkle have identical vault state* — i.e. a
+  snapshot with lineage already.
+- **Derived read-models** — `sync` also builds a knowledge graph (`KgMutTxnT`),
+  embeddings (`EmbeddingsMutTxnT`), and triples (`vault_triples.rs`). The vault's
+  "graph," derived from the entries.
+- **sync vs materialize:**
+  - `atomic vault sync` → `Repository::vault_record_working_copy`
+    (`atomic-repository/src/repository/vault.rs:654`): scan `.vault/` → `vault_store`
+    each into redb (entries + manifest + KG). Ingest disk → store.
+  - `atomic vault materialize` → `Repository::vault_materialize_all`
+    (`atomic-repository/src/repository/vault.rs:495`): redb → `.vault/` markdown +
+    `_manifest.json`. Store → disk.
+
+## Core principle
+
+**The vault is a second content-addressed object family plus one `vault` ref,
+riding the same bare object+ref transport. The server stores entry objects and
+the manifest object and CASes the ref — no apply, no server-side KG build. The
+WebUI renders on demand: the manifest for the index, entry objects for detail,
+the derived KG/embeddings for search.**
+
+## It maps 1:1 onto the object+ref model
+
+| view / change world | vault world |
+|---|---|
+| `.change` / `.tag` object (content-addressed) | **`VaultEntry` object** (already Blake3-addressed) |
+| view-snapshot (membership + merkle) | **`VaultManifest` object** (summaries + merkle) |
+| `views/{name}` ref → snapshot | **`vault` ref → manifest** (one per project) |
+| redb graph (derived, demand-built) | **KG + embeddings** (derived, demand-built) |
+| materialize graph → files | `vault_materialize` redb → `.vault/` files |
+
+A `.vault` push is therefore: **store the new entry objects + the manifest
+object, then CAS the `vault` ref** — the same bare store+CAS as a view. Bare
+server, trivially convergent, serverless-friendly for exactly the reasons in the
+companion doc.
+
+## WebUI: the two-plane read model
+
+- **Index / structure** (list intents with status, memories, sessions, goals,
+  counts) → read the `vault` ref → **manifest** → its summary maps. One object
+  read, no bodies, no KG. *The manifest is the WebUI index.*
+- **Detail** (full intent body, session transcript, memory text) → fetch that one
+  **entry object** by key. On demand.
+- **Search / relationships** (intents touching X, semantic memory search) → the
+  derived **KG / embeddings** read-model, built lazily and query-scoped — the
+  same demand-scoped graph-slice pattern as code content reads.
+
+If no WebUI/search endpoint is exercised, the KG/embeddings are never built —
+storage holds only the entry objects, the manifest, and the ref.
+
+## Preserving the vault graph
+
+An intent is not a flat blob: it decomposes into **acceptance-criterion and task
+nodes** with edges, memories link into it (`wasDerivedFrom`), ACs cite the
+changes that satisfy them, and tasks name the files they modify. That graph must
+stay intact on the server. It does — because it is **derived, not applied**.
+
+**Derived, not applied.** `Repository::vault_extract_kg`
+(`atomic-repository/src/repository/vault_triples.rs:35`) parses a single
+`VaultEntry` into `(Vec<KgNode>, Vec<KgEdge>)` via `atomic_canonical::lift`. The
+server never "introduces" AC/task nodes on push; it re-derives the whole KG on
+demand by running that **same deterministic lift** over the pushed entry objects.
+Same objects + same extractor (both live in `atomic-canonical`/`atomic-repository`,
+linked by the server) ⇒ identical nodes and edges. The graph stays intact because
+it is *reconstructed*, not transported.
+
+**Two edge kinds, handled differently:**
+- **Intra-object (ACs, tasks inside an intent):** parsed from the intent body
+  (`:::acceptance-criterion{#…}`, `:::task{#… criteria=…}`), so they **travel
+  inside the intent object** — they cannot go missing and there are no separate
+  AC/task objects to dangle.
+- **Inter-object (memory → `wasDerivedFrom` → AC/task/intent; AC → evidence
+  change; task → file):** encoded as references in the *referencing* object, so
+  they require the target present → the push must transfer the **reference
+  closure**, and the rebuilder **defers a dangling reference** until its target
+  lands (self-healing, like change reconcile).
+
+**The load-bearing rule — encode edges by portable identity, never a local
+`NodeId`.** A pristine `NodeId` (u64) is a **repo-local index** allocated at
+`register_change`; the same change gets a *different* NodeId in another repo or on
+the server, so a transmitted NodeId identifies nothing there. The **edge is
+preserved; its target is referenced portably** and re-resolved on each side:
+
+| target | portable form | resolved locally via |
+|---|---|---|
+| a change | Hash / `urn:atomic:change:…` | `INTERNAL` (Hash → NodeId) |
+| a file | path | `TREE` (path → inode) |
+| an AC / task / memory | `urn:atomic:…` | the canonical lift |
+
+The vault format **already does this** where it counts: an AC cites its change as
+`:::acceptance-criterion{#ac-1 … evidence=urn:atomic:change:01J8}` and a task
+names its file as `::file-ref{path=…}` — both portable. When the server rebuilds
+the KG it resolves those URNs/paths to *its own* NodeIds/inodes, exactly as change
+apply resolves dependency hashes to local NodeIds. `NodeId` never travels; the
+Hash/URN/path travels and is re-bound locally.
+
+**Closure spans both object families.** These edges cross out of the vault into
+the code graph (intent → AC → evidence change; task → file). So an intent's push
+must pull in the **changes/files its ACs and tasks reference** — uniform with
+change dependency closure, just crossing vault↔code on one bare store.
+
+**The one leak to fix:** `VaultEntry.introduced_by: u64`
+(`atomic-core/src/pristine/vault.rs:96`) is a raw local NodeId. It is bookkeeping,
+not a KG edge (the KG expresses that link as `urn:atomic:change:…`), so the
+transport/rebuild must **not** depend on it — re-derive the linkage from the URN.
+Auditing every portable field for stray NodeIds is the concrete correctness task.
+
+## Decisions / nuances
+
+- **Scope is per-project, not per-view.** The manifest is a singleton, so it's
+  **one `vault` ref per project** (like a special branch), not one per view.
+  Per-view intents/memories could come later; today the vault is global to the
+  repo.
+- **Object addressing.** The entry's `content_hash` covers only the body — for the
+  *transported object*, hash the canonical serialization of the whole `VaultEntry`
+  (type + body + frontmatter) so frontmatter edits are captured. Derive from redb
+  on push (the client-truth-now model, D1(a) in the companion doc).
+- **Manifest representation — do NOT push one ever-growing object.** The redb
+  `VaultManifest` is a singleton that is rewritten wholesale on every change;
+  serialized as *one* pushed object, that reintroduces the quadratic
+  (index-size × transitions) problem view D3 solved — a new memory would
+  re-serialize summaries of *all* intents/memories/sessions/skills. Fix it the
+  same two-axis way:
+  - **Shard by kind (hierarchical):** the `vault` ref points at a tiny **root**
+    object referencing per-kind sub-manifest objects (`goals`, `memory`,
+    `intents`, `skills`). A new intent rewrites only the *intents* sub-manifest +
+    the small root; other shards are shared by hash. Bonus: the WebUI lists
+    per-kind, so shards are also the natural read unit.
+  - **Delta + periodic full (temporal), per shard:** if one kind gets large,
+    encode its sub-manifest as `{added/updated/removed}` vs prev with a periodic
+    full; reconstruct by a short walk. Mirrors view D3 exactly.
+  Entry *objects* never have this problem — they are immutable, deduped leaves;
+  only the index needed sharding.
+- **Ancestry / CAS.** The manifest's incremental `merkle` already gives O(1)
+  "same state?" and a prev-chain fold — the CAS-on-`prev` lineage for the `vault`
+  ref is essentially already present; make the predecessor explicit so
+  fast-forward vs. divergence is decidable exactly as for view refs.
+- **Derived layers never push.** KG, embeddings, and triples are rebuildable
+  read-models, built on demand server-side (embeddings the heavier, lazier one).
+  Never on the push path.
+- **Client truth stays redb.** `VAULT_ENTRIES` + manifest remain the client's
+  source of truth; objects are serialized on push. `materialize` stays the local
+  disk step, off the push path — same split as views.
+- **Divergence is a set-union.** Two divergent vault states reconcile by unioning
+  their entry sets and folding a new manifest (the intent-id counters merge via
+  the existing per-author `intent_seq`, which is already collision-safe offline) —
+  patch-style, not a 3-way merge, matching the companion doc's transport/merge
+  split.
+
+## Relationship to the view-snapshot design
+
+This rides entirely on the companion doc's machinery:
+- Same **bare object store + refs** and **wire protocol** (advertise ref →
+  negotiate missing objects → transfer → CAS ref).
+- Same **demand-scoped read-model** discipline (manifest = structure plane,
+  entry objects = content plane, KG/embeddings = derived slice).
+- Same **deployment story** (S3/R2 objects, a conditional-write/DO ref, serverless
+  compute, managed replication — no NATS).
+
+The only vault-specific pieces are: the `VaultEntry`/`VaultManifest` object
+encodings, the single per-project `vault` ref, and the WebUI read API.
+
+## Phased plan
+
+1. **Object encodings.** Canonical serialization + Blake3 key for `VaultEntry`
+   and `VaultManifest`; derive from redb (no client re-architecture).
+2. **`vault` ref + client push/pull.** Advertise `vault` ref → transfer missing
+   entry objects + manifest → CAS ref. Reuse the view transport; add a `vault`
+   ref alongside `views/{name}`.
+3. **Server read API (WebUI).** `vault` ref + manifest → index; entry object
+   fetch → detail. Both pure object reads, no graph.
+4. **Search endpoints.** Demand-built KG/embeddings slice for semantic memory
+   search and relationship queries.
+5. **Pull/materialize parity.** `atomic pull` brings vault objects down; existing
+   `vault_materialize_all` writes `.vault/` — unchanged, off the sync path.

--- a/docs/view-snapshot-sync-design.md
+++ b/docs/view-snapshot-sync-design.md
@@ -1,0 +1,412 @@
+# Views as Objects: Bare Server & View-Snapshot Sync Design
+
+> Status: **draft / proposal.** Captures the design agreed in discussion. Supersedes
+> the bespoke `?view-manifest` + `ViewRecord` + reconcile set-convergence approach
+> prototyped on `atomic-storage` `feat/geodist-view-sync` and `atomic`
+> `feat/set-based-view-convergence` (whose *primitives* it reuses — see
+> [Relationship to prior work](#relationship-to-prior-work)).
+
+## Benefits
+
+**Thesis: a patch-theoretic causal graph on the client; git-shaped object+ref
+transport on the server — with divergence resolved by patch union, not 3-way
+merge.**
+
+The model deliberately splits the two things git couples together. Ancestry is
+used only for *transport and head management*; the objects flowing through it are
+still commutative patches, so *merging* stays patch-theoretic.
+
+**Client (non-bare) — keeps full patch theory + causal graph, unchanged:**
+- Commutative changes, the dependency/causal graph, the CRDT token layer.
+- Conflict-free merges when changes are independent; patch-level conflict
+  handling when they genuinely overlap — never a textual 3-way merge.
+- `record` / `insert` / `diff` / `blame` / `materialize` exactly as today. This is
+  where work happens, so it keeps the rich model.
+
+**Server (bare) — gains git's wire + ancestry model:**
+- Content-addressed object store + refs; push/pull = transfer the missing object
+  closure and CAS a ref. No apply, no materialize on the write path.
+- Fast-forward vs. divergence decided by `prev`-chain ancestry — deletes the
+  `is_leaf` / prefix / shrink heuristics.
+- Trivially convergent across pods (store immutable object + move a pointer), so
+  geodist multi-pod durability falls out for free — no bespoke convergence.
+- Graph-lazy, not graph-blind: the causal graph is built on demand, scoped to a
+  read endpoint, and never for data nobody queries.
+
+**The synthesis bonus neither system has on its own:**
+- Git's dumb-fast-convergent *transport* with patch theory's principled *merge*.
+  Two divergent view heads reconcile by **set-union of changes** (a new snapshot
+  whose membership is the union and whose `prev` lists both heads — why `prev` is
+  a `Vec`), not a 3-way snapshot merge. Git's merge pain never reaches the server.
+
+**Honest costs (scoped below, neither on the convergent hot path):**
+- The client must emit a canonical snapshot + move a ref on each mutation (D1a).
+- The server must build the causal graph on demand for its read endpoints.
+
+## Competition
+
+The current wave of git-acceleration products (Pierre, Origin/Cursor, and
+similar) make git faster largely by improving the **storage substrate**: a
+high-IOPS-disk-backed, S3-like filesystem (e.g. a modified SeaweedFS on
+provisioned AWS IOPS) under an otherwise-unmodified git server. That accelerates
+the substrate beneath an inherently server-heavy model. This design removes the
+server-heavy work from the **model** itself — same goal, a different (lower)
+layer.
+
+**Why git needs the fast-disk trick.** Git assumes a POSIX filesystem and stores
+objects in **mutable packfiles**. Serving a fetch walks commit reachability to
+compute what to send, delta-compresses, and periodically repacks/gcs — all
+**random-IO + CPU heavy**, worsening with history depth and repo size. Fast
+disks under an S3-like FS make that random IO tolerable *without changing git* —
+i.e. paying (provisioned IOPS is expensive) to make an object store *pretend* to
+be a fast POSIX disk, because git can't address an object store natively.
+
+**Why the bare server doesn't.** Its access pattern is **object-store-native**,
+not retrofitted:
+- **Push** = content-addressed PUT (append, never rewrite) + one tiny **ref
+  CAS**. No repack, no gc, no reachability walk, no server-side merge.
+- **Clone/pull** = read the ref → read the `.view` snapshot → its membership *is*
+  the list of keys to send → stream those immutable blobs. No negotiation walk
+  over a commit graph to compute "what to send" — the snapshot is the manifest.
+- **No mutable aggregates.** Immutable content-addressed blobs + one CAS pointer
+  map cleanly onto an eventually-consistent object store; the only
+  strong-consistency point is the tiny ref CAS.
+
+**The distinction that matters.** Git's bottleneck is **random IOPS + CPU**
+(packing, walking, repacking); ours is **sequential throughput** of immutable
+blobs. Object stores are cheap and fast at the second and poor at the first —
+exactly why git needs the fast-disk translation layer and we don't. We are fast
+on *commodity* S3-class storage.
+
+**It inverts the cost curve.** They add hardware cost (provisioned high-IOPS) to
+reach parity with git's own model. We get the speed by *deleting the work* — and
+get patch theory's conflict-free merge on top, which no amount of fast disk buys
+them. That is a **cost moat and a capability moat**, not a speed/price tradeoff.
+We could run on their fast-disk SeaweedFS — we'd just leave it massively
+over-provisioned, because the bare server barely asks anything of the disk.
+
+**Honest caveats.** Huge clones are still bandwidth-bound — but that's sequential
+throughput (CDN-/cache-friendly), not the random IOPS git struggles with. Cold
+graph-slice builds for content endpoints (materializing a hot file's deep
+history) do touch storage — but they are demand-scoped, cacheable, and off the
+write path, not a per-request tax.
+
+## Overview
+
+Today a view is a bespoke, server-special entity. Receiving a push means the
+server **stores** change bytes, **applies** them into its redb graph, updates
+`VIEW_CHANGES`, and validates a `?view-manifest`. That server-side apply is
+stateful, order-sensitive, and racy across geodist pods — the source of the
+split-brain / convergence complexity.
+
+This design reframes views to ride the **same object machinery as changes, tags,
+and provenance**, so the client and server hold byte-identical objects and the
+wire protocol only ever does two things: **move objects** and **move refs** —
+exactly git.
+
+It rests on four observations:
+
+1. **A view is a mutable entity over immutable state.** `record`, `insert`, and
+   `view *` move a view's head. Everything a view *points at* is immutable; only
+   the head is mutable — so a view needs exactly one **ref**, like a git branch.
+2. **A view-snapshot is commit-shaped.** `{ scope, parent_view, prev_state,
+   membership }` — a parent (lineage) pointer plus a snapshot of contents — is a
+   commit. A view's history is its own little DAG.
+3. **The snapshot's membership *is* the change-set structure of the view.** A
+   snapshot stores the view's **own** contribution plus a **pointer to its
+   parent view's snapshot** — the object-form of what redb already holds
+   (`VIEW_CHANGES[this]` + `parent`). The effective union (own ∪ ancestors ∪
+   dep-closure) is **composed on read** by a shallow walk up the parent chain,
+   so membership/structure queries touch a handful of small objects, never the
+   graph. Because only its own set is inlined, a **draft off a 100k-change
+   `dev` stays tiny** — the big set lives only in the shared root it points at.
+4. **The server can be bare.** If storing an immutable object and moving a ref
+   are the only things a push does, both halves are trivially convergent. The
+   redb graph becomes a *derived read-model*, built **on demand, scoped to the
+   query** — never on the push path, never for data nobody reads.
+
+## Core principle
+
+**The object store + refs are the source of truth. The redb graph is a
+disposable, demand-built read-model. Sync moves objects and CASes refs; it never
+applies.**
+
+```
+  SOURCE OF TRUTH (write model)              DERIVED (read model)
+  ═══════════════════════════════            ══════════════════════
+                                             built on demand, scoped
+  objects/  (content-addressed)              to the query, cached
+    AB/CDEF…  .change   ── bytes             opportunistically:
+    12/34..   .tag      ── bytes
+    9F/A0..   .view     ── keys only  ─────▶   redb graph slice
+    E1/..     .provenance                      (only for CONTENT reads:
+                                                file bytes, diff, blame)
+  refs/
+    views/dev            → 9FA0…  (CAS)      membership/structure reads
+    views/orange-night   → 4B2C…  (CAS)      need NO graph — just .view
+```
+
+## The three tiers
+
+```
+  refs            views/{name} → snapshot-key            (mutable, one per view)
+    │
+    ▼
+  view-snapshots  { scope, parent, prev, membership }    (immutable, commit-shaped)
+    │  membership = KEYS only
+    ▼
+  content         .change / .tag bytes                   (immutable, deduped leaves)
+```
+
+- A **ref** is the only mutable object. `views/dev → <snapshot-key>`.
+- A **view-snapshot** is immutable and content-addressed by the Blake3 of its
+  canonical bytes. It carries identity, lineage (`prev`), and membership.
+- **Membership holds keys, not content.** A change in `dev`, `release`, and three
+  drafts is stored **once** in `objects/`, referenced five times. (Git: a commit's
+  tree references blobs by hash; it never inlines file bytes.)
+
+## The view-snapshot object
+
+```rust
+/// Immutable, content-addressed snapshot of a view's state at one point in time.
+/// Content address = Blake3 of the canonical serialization.
+struct ViewSnapshot {
+    /// Identity.
+    scope: ViewScope,               // Shared | Draft
+    parent_view: Option<String>,    // parent view NAME (the parent's ref, resolved
+                                    // to its own snapshot chain at read time)
+
+    /// Lineage — the predecessor state(s) this transition was built on. Makes the
+    /// view's history a content-addressed DAG, exactly like change history. This
+    /// is what makes fast-forward vs. divergence decidable (see below).
+    prev: Vec<SnapshotKey>,         // usually 1; 0 for the genesis; >1 only if we
+                                    // ever model a view merge.
+
+    /// Membership = this view's OWN change/tag keys only (NOT the flattened
+    /// union). The inherited part is reached via `parent_view` (resolved live to
+    /// the parent's snapshot). Own history is encoded delta-vs-`prev` with
+    /// periodic fulls (decision D3), so a shared root's growth stays cheap and a
+    /// draft stores only its handful of own keys.
+    own: Membership,
+
+    /// Order-invariant identity of this view's OWN set. The EFFECTIVE set_id is
+    /// composed on read: `own_set_id.combine(parent.effective_set_id)` — an
+    /// O(1)-per-level hash compose, so set-equality / convergence needs no graph.
+    own_set_id: SetId,
+
+    /// Optional slot for provenance/attestation of the transition (who/why).
+    /// Left empty in v1; wired later (decision D4).
+    provenance: Option<ProvenanceKey>,
+}
+
+enum Membership {
+    /// Full OWN key list — a checkpoint snapshot.
+    Full { changes: Vec<ChangeKey>, tags: Vec<TagKey> },
+    /// Delta vs `prev` — the common case (append one key on `record`/`insert`,
+    /// remove keys on `view split`). Reconstruct this view's own set by walking
+    /// back to the last Full.
+    Delta { added: Vec<Key>, removed: Vec<Key> },
+}
+```
+
+`own` is just this view's contribution; the **effective union is composed on
+read** — own ∪ (parent snapshot's effective union), recursively up the parent
+chain (depth 2–4 in practice), exactly the filter redb computes today. Two
+independent sharing axes keep this small:
+
+- **Hierarchical (parent pointer):** a draft never inlines its parent's set, so
+  the large membership lives only in shared roots — the views that actually
+  accumulate. This is the dominant win (see decision D3).
+- **Temporal (delta + periodic full):** a shared root's own history is a chain of
+  small deltas with occasional full checkpoints, so even `dev`'s growth is cheap
+  to write and its current own-set is a short walk to reconstruct.
+
+The `prev` chain gives a view's *own* set at any past state; joining it with the
+parent's `prev` chain reconstructs a historical *effective* set when needed.
+
+## Bare server
+
+A bare server is git's `--bare`: object DB + refs, **no working tree and no
+graph-apply on the write path.** On push it does only:
+
+1. **Store** the objects it lacks (`.change`, `.tag`, `.view`, `.provenance`) —
+   content-addressed, append-only. Convergent by construction.
+2. **CAS the ref** `views/{name}` from the client's known-old to the new snapshot
+   key, gated on the `prev` chain (fast-forward unless `--force`).
+
+No `insert`, no CRDT apply, no `VIEW_CHANGES` mutation, no materialize.
+
+Terminology (Atomic's, precisely):
+
+| layer | what | on the bare push path? |
+|---|---|---|
+| **object** | `.change`/`.tag`/`.view`/`.provenance` files | **yes** — store |
+| **ref** | `views/{name}` → snapshot key | **yes** — CAS |
+| **apply** | write objects into the redb graph (GRAPH, `VIEW_CHANGES`, deps) | **no** — demand-built |
+| **materialize** | graph → files on disk (working tree) | **no** — client-only |
+
+The redb graph is a **read-model**, not truth. It is:
+
+- **demand-built and query-scoped** — see next section,
+- **rebuildable** — losing it loses nothing; rebuild from objects,
+- **optionally checkpointed** — snapshots to S3 bound cold rebuild to
+  "latest checkpoint + tail," never genesis (the existing geodist
+  `write_snapshot`/`maybe_restore_snapshot` mechanism, demoted to an
+  optimization).
+
+## Demand-scoped reads: two query planes
+
+The server builds **only the graph fragment a specific endpoint needs, when it's
+called.** No derived endpoints exercised ⇒ no graph ever built. Crucially, most
+queries split into a plane that needs no graph at all:
+
+**Structure / membership — served purely from `.view` objects, no graph:**
+
+- "what changes are in `dev`?" → read `views/dev` → snapshot → membership.
+- "is change `C` in `dev`?" → membership lookup.
+- "set-diff `dev` vs `release`" → two snapshots, compare (or compare `set_id`).
+- "what was `dev` 6 months ago?" → walk `prev` to that snapshot.
+- "are these two views the same set?" → O(1) `set_id` compare.
+
+**Content — needs a graph slice, scoped to the request:**
+
+- "file `X`'s bytes at `dev@head`" → snapshot's membership ∩ changes touching
+  `X`'s inode, folded. O(history of `X`), not O(repo). Change headers name the
+  paths they touch, so the relevant subset is locatable from cheap metadata.
+- "diff of change `C`" → read that one `.change` object + touch its file's
+  vertices via `INODE_GRAPH`. Sublinear.
+
+Any index that accelerates "which changes touch path `X`" stays **derived**
+(rebuildable), never authoritative — that is the invariant that keeps the server
+honest-dumb. Caching (per-file materialization, per-view checkpoints) is an
+**optimization, never a correctness requirement.**
+
+## Wire protocol (git-shaped)
+
+Push/pull negotiate refs and transfer the missing object closure. No server
+apply.
+
+```
+  push dev:
+    1. advertise    client GETs remote ref:  views/dev → R (or ∅)
+    2. negotiate    client walks local prev-chain from its tip L back until it
+                    reaches R (have/want); the frontier is the set of snapshot
+                    keys the remote lacks — same dependency-closure walk `?insert`
+                    already does, now over the snapshot DAG + the changes those
+                    snapshots reference.
+    3. transfer     PUT (?store) every missing object: .view snapshots, and the
+                    .change/.tag bytes their membership references that the remote
+                    lacks. Content-addressed ⇒ idempotent.
+    4. move ref     CAS views/dev : R → L. Fast-forward iff R is an ancestor of L
+                    in the prev-chain. Non-ancestor ⇒ reject unless --force.
+```
+
+- **clone/pull** are the same in reverse: pure object + ref transfer. The client
+  is the **non-bare** side and builds its own graph locally, because that is where
+  someone works.
+- **Fast-forward / divergence is decided by ancestry**, not by guessing from log
+  shapes. This deletes the `is_leaf` / prefix-rule / shrink-ambiguity heuristic:
+  - remote tip is an ancestor of local → fast-forward.
+  - local tip is an ancestor of remote → you're behind, pull.
+  - neither → genuine divergence → `--force`.
+  A `view split` (shrink) is just a normal new snapshot whose `prev` is the old
+  tip — a fast-forward, not a special case.
+
+## Membership representation (decision D3 — resolved)
+
+Keys-only fixes **content dedup** (a change stored once across all views). It does
+**not** by itself fix **membership-list size**: a flat union list is O(view size),
+and rewriting it on every transition is quadratic (~100k × 32-byte keys ≈ 3–5 MB
+*per* snapshot × every transition). Two axes of sharing fix it, and the important
+one is hierarchical:
+
+**Axis 1 — hierarchical (the big win).** A snapshot stores only the view's **own**
+set + a **parent pointer**; the effective union is composed on read. So the large
+membership exists **only in shared root views** (`dev`/`release`/`main`). A draft
+off a 100k `dev` stores ~its own handful of keys, not 100k. This mirrors Atomic's
+existing `VIEW_CHANGES[this] + parent` model exactly — no new semantics.
+
+**Axis 2 — temporal (for the roots that *are* big).** A shared root's own history
+is encoded **delta-vs-`prev` + a `Full` checkpoint every N transitions**.
+Append-friendly (view logs are overwhelmingly append), tiny writes, reconstruct
+the current own-set by walking back to the last `Full`. Reuses the checkpoint
+idea already in geodist.
+
+**Resolution:** own-set + parent-pointer (Axis 1) × delta+periodic-full (Axis 2).
+Drafts are cheap by construction; only shared roots carry a big set, and even
+theirs is a delta chain. If a single shared root's *own* set ever grows large
+enough that even the periodic `Full` is a problem, the `Full` variant of
+`Membership` can later be replaced by a **structurally-shared Merkle set object**
+(git-tree-shaped, O(shared) storage, O(log) reads) without touching refs, the wire
+protocol, or callers — the `own`/`own_set_id` shape is deliberately encoding-
+agnostic to allow that drop-in.
+
+## Relationship to prior work
+
+The **primitives survive**; the **orchestration/representation is replaced.**
+
+Reused as-is (become the local materializer / read-model builder):
+- `Repository::create_draft_view`, `create_shared_view`, `delete_view`
+- `Repository::retain_view_changes` (declarative "make the view's log equal the
+  snapshot's membership" = remove-not-in ∪ insert-missing)
+- `Repository::view_set_id`, `atomic_core::types::SetId`
+- geodist `write_snapshot`/`maybe_restore_snapshot` checkpoints (demoted to an
+  optional read-model accelerator)
+
+Replaced / retired:
+- `?view-manifest` declare endpoint and synchronous `apply_manifest`
+- `ViewRecord` (`views/{name}.json`) as a name-keyed LWW blob → becomes a
+  content-addressed `.view` object + a CAS ref
+- reconcile-time imperative set-convergence (`converge_view_sets`,
+  `ensure_views_from_records` as sync-path steps) → declarative materialize, off
+  the write path
+- client `plan_view_sync`'s `is_leaf` / prefix / shrink heuristics → ancestry-based
+  fast-forward/divergence
+
+## Open decisions
+
+- **D1 — client source of truth. RESOLVED: (a) now, shaped for (b).** redb stays
+  the client's truth; the `.view` snapshot is serialized from redb on demand (at
+  push). The object format is kept complete + canonical so it can later be
+  promoted to authoritative (b: snapshot chain is truth, redb a rebuildable
+  cache — the fully git-shaped endgame) without changing the object or the wire
+  protocol. The client keeps a small remote-tracking ref (last pushed snapshot
+  key per remote) so CAS/ancestry works even under (a).
+- **D2 — ref update semantics. RESOLVED: CAS-on-`prev`.** A ref move is a
+  compare-and-swap from the client's known-old snapshot key to the new one,
+  accepted only if old is an ancestor of new in the `prev` chain (fast-forward),
+  else rejected unless `--force`. This is the payoff of the whole model and
+  deletes the `is_leaf`/prefix/shrink heuristics.
+- **D3 — membership representation. RESOLVED:** own-set + parent-pointer
+  (hierarchical) × delta+periodic-full (temporal); drafts store only their own
+  keys, big sets live only in shared roots, `Full` can later become a
+  structurally-shared Merkle set object. See
+  [Membership representation](#membership-representation-decision-d3--resolved).
+- **D6 — parent reference. RESOLVED: live / by-name.** The snapshot names its
+  parent view; inherited membership resolves against the parent's *current* head
+  at read time — preserving Atomic's inheritance semantics (`record` onto `dev`
+  ⇒ drafts off `dev` see it). The object stays immutable on what it owns; a
+  historical effective set is reconstructable by joining both `prev` chains.
+- **D4 — provenance on transitions. DEFAULT (revisit later):** leave a
+  `provenance` slot in the object, don't wire it in v1. `record`/`insert`/`view
+  split` emitting attestable view-state events is a later layer.
+- **D5 — v1 derived endpoints. DEFAULT (revisit later):** smallest set that
+  avoids reintroducing a full applier — raw `.change`/`.view`/`.tag` object fetch
+  (no graph), single-file content at a ref, single-change diff. Web tree, blame,
+  etc. layer on afterward.
+
+## Phased plan
+
+1. **Object + ref model (single node).** Define `ViewSnapshot`, its canonical
+   serialization + Blake3 key, and the `views/{name}` ref. Client writes a snapshot
+   + moves the ref on `record`/`insert`/`view *` (D1(a): derive from redb).
+2. **Bare push/pull for one view.** Advertise ref → prev-chain negotiate →
+   transfer missing objects → CAS ref. No server apply. Replaces `?view-manifest`.
+3. **Local materializer.** "check out ref R" = ensure membership's change-closure
+   present, then rebuild the redb view to equal the snapshot (via
+   `retain_view_changes` + `insert`). Off the sync path.
+4. **Demand-scoped read endpoints (D5).** Object fetch; single-file content;
+   single-change diff — each building only its slice.
+5. **Geodist = free.** Bare store over S3 + refs; NATS announces objects/ref moves;
+   checkpoints accelerate the read-model. No bespoke view convergence.
+```


### PR DESCRIPTION
## Set-based view convergence primitives + design docs

This branch ships the **client-side primitives** and **design docs** for durable geodist view-sync. It pairs with [atomic-storage PR #91](https://github.com/atomicdotdev/atomic-storage/pull/91), which implements the server-side view-snapshot sync (writer stores+announces, reader discovers and applies).

### What's in here

**1. `Repository::retain_view_changes(view, target)` — the removal half of set-based convergence.**

Today the reader can *add* changes to a view (`insert_change`) but can't *remove* them. When a `view split` moves changes out of `dev` into a draft, the reader needs to drop those changes from `dev`'s log to match the declared set. `retain_view_changes` does that:

- Takes a view name + a target `HashSet<Hash>` (the effective set = own + inherited).
- Drops every own change of the view NOT in the target set.
- Operates at `VIEW_CHANGES` level only (like `unrecord`) — reversible, no re-materialize, clears stale `FILE_INDEX`.
- Idempotent — already-matching returns empty.
- Returns the removed hashes.

**2. `plan_view_sync` gains `is_leaf` + `shrink` — handles shrinks in the push planner.**

For an ancestor whose remote already holds every local change, the plan is now a no-op skip (not a divergence error), so a `view split` on `dev` no longer blocks a draft's push. The leaf keeps the strict prefix rule: `local ⊂ remote` is ambiguous (behind vs shrunk) and errs toward "pull first, or --force."

**3. Design docs:**

- `docs/view-snapshot-sync-design.md` — the bare object+ref server model: views are content-addressed snapshots + CAS refs, no apply on the write path, redb is a demand-built read-model.
- `docs/vault-sync-design.md` — extends the same model to vault data (sessions, intents, memories, goals, skills): vault entries are content-addressed objects, the manifest is a ref, KG/embeddings stay derived.

### How it pairs with atomic-storage PR #91

| | atomic-storage (#91) | atomic (this PR) |
|---|---|---|
| Writer | Stores manifest as content-addressed snapshot + CAS ref + NATS | `plan_view_sync` handles shrinks (ancestor skip, leaf --force) |
| Reader: add | `apply_view_manifest` replays the suffix | — |
| Reader: shrink | Calls `retain_view_changes` (from this PR) | `retain_view_changes` primitive |

**Integration:** once this PR merges and releases, atomic-storage bumps its atomic dependency and adds one call in `reconcile_view_snapshots` — `retain_view_changes` after creating the view, before `apply_view_manifest` — so the reader converges on both additions and removals.

### Test plan
- [x] `retain_view_changes` convergence/idempotence tests
- [x] `plan_view_sync` ancestor-skip, leaf-force shrink, genuine-divergence-not-masked cases
- [ ] Integration test with atomic-storage PR #91 (multi-pod geodist stack)