### PR TITLE
Fix view hierarchy issues

### DIFF
--- a/atomic-repository/src/repository/views.rs
+++ b/atomic-repository/src/repository/views.rs
@@ -203,6 +203,61 @@ impl Repository {
         Ok(())
     }
 
+    /// Repair an existing view's full identity (scope **and** parent) to match
+    /// a declared manifest/snapshot.
+    ///
+    /// Unlike [`Repository::set_view_scope`], which only touches the scope
+    /// (and clears the parent when promoting to Shared), this sets both fields
+    /// atomically, resolving `parent_name` to its id. It is used on the sync
+    /// path when a view was auto-created with the wrong identity (e.g. a draft
+    /// that `ensure_view_exists` created as Shared before its snapshot was
+    /// reconciled) so a subsequent `apply_view_manifest` no longer fails the
+    /// identity check.
+    ///
+    /// Returns `ViewNotFound` if the view — or a named parent — does not exist.
+    pub fn set_view_identity(
+        &self,
+        name: &str,
+        scope: ViewScope,
+        parent_name: Option<&str>,
+    ) -> Result<(), RepositoryError> {
+        let mut txn = self
+            .pristine
+            .write_txn()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        let mut view = txn
+            .get_view(name)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?
+            .ok_or_else(|| RepositoryError::ViewNotFound {
+                name: name.to_string(),
+            })?;
+
+        let parent_id = match parent_name {
+            Some(p) => Some(
+                txn.get_view(p)
+                    .map_err(|e| RepositoryError::Database(e.to_string()))?
+                    .ok_or_else(|| RepositoryError::ViewNotFound {
+                        name: p.to_string(),
+                    })?
+                    .id,
+            ),
+            None => None,
+        };
+
+        view.kind = scope;
+        // A Shared view is a root; it never carries a parent.
+        view.parent = if scope.is_shared() { None } else { parent_id };
+
+        txn.update_view(&view)
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        txn.commit()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+
+        Ok(())
+    }
+
     /// Walk the parent chain from `view_name` and return the name of the
     /// first Shared view encountered.  If `view_name` is itself Shared,
     /// it is returned immediately.  This is used to determine the correct

--- a/atomic-repository/tests/view_manifest_test.rs
+++ b/atomic-repository/tests/view_manifest_test.rs
@@ -262,3 +262,50 @@ fn empty_view_manifest_declares_identity_only() {
     assert_eq!(info.parent_name.as_deref(), Some("dev"));
     assert!(info.is_empty());
 }
+
+/// Regression: a draft pushed alongside its changes can be auto-created as a
+/// Shared view (the server's `ensure_view_exists` does this before the view
+/// snapshot is reconciled). `apply_view_manifest` then refuses it forever with
+/// an identity mismatch. `set_view_identity` repairs the scope + parent so the
+/// manifest applies and the view resolves as a draft off its parent.
+#[test]
+fn repair_identity_unsticks_autocreated_shared_draft() {
+    let (origin, _t1, _r1, _hashes) = build_origin();
+
+    let dev_m = origin.view_manifest("dev").expect("dev manifest");
+    let orange_m = origin.view_manifest("orange").expect("orange manifest");
+
+    // Mirror gets dev (the parent) plus every change orange references.
+    let (mut mirror, _t2, _r2) = init_repo();
+    transfer_changes(&origin, &mirror, &dev_m);
+    mirror.apply_view_manifest(&dev_m).expect("apply dev");
+    transfer_changes(&origin, &mirror, &orange_m);
+
+    // Simulate the server auto-creating the draft as Shared before its
+    // snapshot was reconciled.
+    mirror
+        .create_shared_view("orange")
+        .expect("auto-create as shared");
+
+    // Left uncorrected, the identity check rejects the draft manifest.
+    let err = mirror
+        .apply_view_manifest(&orange_m)
+        .expect_err("scope mismatch must be rejected");
+    assert!(
+        matches!(err, RepositoryError::ManifestIdentityMismatch { .. }),
+        "got: {err}"
+    );
+
+    // Repair the identity, then the same manifest applies cleanly.
+    mirror
+        .set_view_identity("orange", ViewScope::Draft, Some("dev"))
+        .expect("repair identity");
+    mirror
+        .apply_view_manifest(&orange_m)
+        .expect("apply after repair");
+
+    let info = mirror.get_view_info("orange").unwrap();
+    assert_eq!(info.scope, ViewScope::Draft);
+    assert_eq!(info.parent_name.as_deref(), Some("dev"));
+    assert_eq!(info.state, orange_m.state);
+}


### PR DESCRIPTION
This pull request introduces a new method to repair the identity of a view in the repository and adds a regression test to ensure correct handling of auto-created views with mismatched identities. The main focus is to allow fixing views that were created with the wrong scope or parent, particularly addressing issues encountered during synchronization.

**Repository API enhancements:**

* Added the `set_view_identity` method to `Repository`, which atomically updates both the scope and parent of a view to match a declared manifest or snapshot. This is especially useful for repairing views that were auto-created with incorrect identities, ensuring that subsequent manifest applications succeed.

**Testing and regression coverage:**

* Added a regression test `repair_identity_unsticks_autocreated_shared_draft` to verify that `set_view_identity` can repair a view's identity, allowing a previously rejected manifest to be applied successfully. This test simulates the scenario where a draft view is auto-created as shared and then repaired.