### PR TITLE
full bare server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,7 @@ dependencies = [
  "atomic-config",
  "atomic-core",
  "atomic-identity",
+ "atomic-objects",
  "atomic-remote",
  "atomic-repository",
  "atomic-semantic",
@@ -272,6 +273,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-objects"
+version = "0.16.2"
+dependencies = [
+ "blake3",
+ "data-encoding",
+ "postcard",
+ "serde",
+ "serde_json",
+ "zstd",
+]
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +299,7 @@ version = "0.16.2"
 dependencies = [
  "anyhow",
  "atomic-core",
+ "atomic-objects",
  "bytes",
  "chrono",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "atomic-core",
     "atomic-config",
     "atomic-identity",
+    "atomic-objects",
     "atomic-remote",
     "atomic-repository",
     "atomic-semantic",
@@ -29,6 +30,7 @@ atomic-canonical = { path = "atomic-canonical" }
 atomic-core = { path = "atomic-core" }
 atomic-config = { path = "atomic-config" }
 atomic-identity = { path = "atomic-identity" }
+atomic-objects = { path = "atomic-objects" }
 atomic-remote = { path = "atomic-remote" }
 atomic-repository = { path = "atomic-repository" }
 atomic-semantic = { path = "atomic-semantic" }

--- a/atomic-cli/Cargo.toml
+++ b/atomic-cli/Cargo.toml
@@ -27,6 +27,7 @@ atomic-canonical = { workspace = true }
 atomic-core = { workspace = true }
 atomic-config = { workspace = true }
 atomic-identity = { workspace = true }
+atomic-objects = { workspace = true }
 atomic-remote = { workspace = true }
 atomic-repository = { workspace = true }
 atomic-semantic = { workspace = true }

--- a/atomic-cli/src/commands/clone/command.rs
+++ b/atomic-cli/src/commands/clone/command.rs
@@ -34,15 +34,17 @@
 //! resolution. If the clone fails partway through, the `CleanupGuard`
 //! ensures the partially created directory is removed.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::time::Duration;
 
+use bytes::Bytes;
 use clap::Parser;
 use git2::Repository as GitRepository;
 
 use atomic_core::pristine::ViewScope;
-use atomic_core::types::{Base32, Hash};
+use atomic_core::types::{Base32, Hash, SetId};
+use atomic_objects::{ObjectFamily, SyncPack, SyncWants, ViewSnapshot};
 use atomic_remote::{HttpRemote, HttpRemoteConfig, RemoteError};
 use atomic_repository::{ManifestApplyOutcome, Repository, ViewManifest};
 
@@ -343,16 +345,107 @@ impl Clone {
     /// Fetch and validate one view's manifest from the remote.
     ///
     /// Returns `Ok(None)` if the remote does not have the view.
-    async fn fetch_view_manifest(
+    /// Reconstruct one view's manifest from a pulled [`SyncPack`]: find its ref
+    /// target, then its view-snapshot object, and render the manifest text.
+    /// Returns `Ok(None)` when the pack carries no ref/snapshot for `view`.
+    ///
+    /// This replaces the per-object `get_view_ref` + `get_object("views", …)`
+    /// round-trips: clone reads every view's state from the single `/code` pull.
+    fn view_manifest_from_pack(
         &self,
-        remote: &HttpRemote,
+        pack: &SyncPack,
         view: &str,
     ) -> CliResult<Option<ViewManifest>> {
-        match remote.get_view_manifest(view).await {
-            Ok(Some(text)) => parse_remote_manifest(view, &text, &self.url).map(Some),
-            Ok(None) => Ok(None),
-            Err(e) => Err(self.manifest_fetch_error(e)),
+        let target = match pack.refs.iter().find(|r| r.name == view) {
+            Some(r) => r.new_target.clone(),
+            None => return Ok(None),
+        };
+        let snapshot = pack
+            .objects
+            .iter()
+            .find(|o| o.family == ObjectFamily::View && o.key == target)
+            .and_then(|o| ViewSnapshot::from_bytes(&o.bytes));
+        let snapshot = match snapshot {
+            Some(s) => s,
+            None => return Ok(None),
+        };
+        let manifest = parse_remote_manifest(view, &snapshot.to_manifest_text(view), &self.url)?;
+        // O(1) producer-integrity cross-check: the snapshot's declared
+        // `own_set_id` must equal the order-invariant fold of its own change
+        // list (content addressing guarantees the bytes, not a self-consistent
+        // producer).
+        let mut fold = SetId::ZERO;
+        for h in &manifest.changes {
+            fold = fold.add(h);
         }
+        if fold.to_base32() != snapshot.own_set_id {
+            print_warning(&format!(
+                "Remote view '{view}' snapshot set-id disagrees with its change list; \
+                 the remote object may be inconsistent."
+            ));
+        }
+        Ok(Some(manifest))
+    }
+
+    /// Verify convergence with the order-invariant `SetId`: each applied view's
+    /// local **effective** set-id must equal the remote's, taken from the server
+    /// view inventory (`GET /refs/views`), which the server folds over each
+    /// view's effective (own ∪ ancestors) change set. Comparing against the
+    /// server-computed value — an independent source — catches a dropped or
+    /// corrupt change that counts/merkle-order alone would miss, and is correct
+    /// for drafts (whose effective set differs from their own set).
+    async fn verify_convergence(
+        &self,
+        repo: &Repository,
+        remote: &HttpRemote,
+        views: &HashSet<String>,
+    ) {
+        let inventory = match remote.list_view_refs().await {
+            Ok(inv) => inv,
+            // Inventory unavailable — skip verification rather than fail the clone.
+            Err(_) => return,
+        };
+        let remote_set: HashMap<String, String> = inventory
+            .into_iter()
+            .filter_map(|v| v.set_id.map(|s| (v.name, s)))
+            .collect();
+
+        let mut verified = 0usize;
+        let mut mismatched = 0usize;
+        for view in views {
+            let Some(expected) = remote_set.get(view) else {
+                continue; // remote reported no set-id for this view
+            };
+            match repo.view_set_id(view) {
+                Ok(local) if &local.to_base32() == expected => verified += 1,
+                Ok(local) => {
+                    mismatched += 1;
+                    print_warning(&format!(
+                        "Set-id mismatch for view '{}': local {} != remote {}. \
+                         The clone may be incomplete or divergent.",
+                        view,
+                        local.to_base32(),
+                        expected
+                    ));
+                }
+                Err(e) => print_warning(&format!(
+                    "Could not compute local set-id for view '{}': {}",
+                    view, e
+                )),
+            }
+        }
+        if mismatched == 0 && verified > 0 {
+            print_success("Verified: cloned view set-ids match the remote (convergent)");
+        }
+    }
+
+    /// Index a pack's change objects into `base32 hash → bytes` for local save.
+    fn change_objects_from_pack(pack: &SyncPack) -> HashMap<String, Vec<u8>> {
+        pack.objects
+            .iter()
+            .filter(|o| o.family == ObjectFamily::Change)
+            .map(|o| (o.key.clone(), o.bytes.clone()))
+            .collect()
     }
 
     /// Fetch the requested view's manifest and walk its parent chain up to
@@ -362,11 +455,8 @@ impl Clone {
     /// remote. A declared parent that is missing remotely, or a parent chain
     /// that loops, means the remote's view metadata is corrupted and is a
     /// hard error.
-    async fn fetch_manifest_chain(
-        &self,
-        remote: &HttpRemote,
-    ) -> CliResult<Option<Vec<ViewManifest>>> {
-        let Some(leaf) = self.fetch_view_manifest(remote, &self.view).await? else {
+    fn fetch_manifest_chain(&self, pack: &SyncPack) -> CliResult<Option<Vec<ViewManifest>>> {
+        let Some(leaf) = self.view_manifest_from_pack(pack, &self.view)? else {
             return Ok(None);
         };
 
@@ -390,8 +480,7 @@ impl Clone {
                 .map(|m| m.name.clone())
                 .unwrap_or_else(|| self.view.clone());
             let manifest = self
-                .fetch_view_manifest(remote, &parent)
-                .await?
+                .view_manifest_from_pack(pack, &parent)?
                 .ok_or_else(|| CliError::RemoteError {
                     message: format!(
                         "View '{}' declares parent '{}', but the remote has no such view",
@@ -412,10 +501,10 @@ impl Clone {
     ///
     /// Stops on the first download failure to maintain consistency (the
     /// manifest apply would fail on the missing change anyway).
-    async fn download_missing_changes(
+    fn download_missing_changes(
         &self,
         repo: &Repository,
-        remote: &HttpRemote,
+        change_objects: &HashMap<String, Vec<u8>>,
         missing: &[Hash],
         stats: &mut CloneStats,
         progress: &mut CloneProgress,
@@ -434,12 +523,12 @@ impl Clone {
             let hash_str = hash.to_base32();
             let hash_display = &hash_str[..12.min(hash_str.len())];
 
-            match remote.download_change(&hash_str).await {
-                Ok(data) => {
+            match change_objects.get(&hash_str) {
+                Some(data) => {
                     let data_len = data.len() as u64;
 
                     // Save to local change store
-                    match save_downloaded_change(repo, hash, data) {
+                    match save_downloaded_change(repo, hash, Bytes::from(data.clone())) {
                         Ok(()) => {
                             stats.record_change_downloaded(data_len);
                             progress.record_downloaded();
@@ -464,19 +553,18 @@ impl Clone {
                         }
                     }
                 }
-                Err(e) => {
+                None => {
                     stats.record_failed();
                     println!(
-                        "  {} {}... ({}/{}) download failed: {}",
+                        "  {} {}... ({}/{}) not found on remote",
                         error("✗"),
                         hash_display,
                         i + 1,
                         missing.len(),
-                        e
                     );
-
-                    // Stop on first failure to maintain consistency
-                    return Err(convert_remote_error(e, &self.url));
+                    return Err(CliError::ChangeNotFound {
+                        hash: hash_str.clone(),
+                    });
                 }
             }
 
@@ -599,27 +687,18 @@ impl Clone {
     /// Manifests are ordered parents-before-children; changes are
     /// content-addressed and deduplicated against everything already
     /// downloaded. Returns the number of additional views cloned.
-    async fn clone_additional_views(
+    fn clone_additional_views(
         &self,
         repo: &mut Repository,
-        remote: &HttpRemote,
+        pack: &SyncPack,
+        change_objects: &HashMap<String, Vec<u8>>,
         stats: &mut CloneStats,
         applied: &mut HashSet<String>,
     ) -> CliResult<usize> {
-        // The user explicitly asked for every view, so a missing inventory
-        // is a hard error, not a silent single-view clone.
-        let remote_views = remote
-            .list_views()
-            .await
-            .map_err(|e| CliError::RemoteError {
-                message: format!(
-                    "--all-views requires the view inventory (?views), but the request failed: {}",
-                    e
-                ),
-                url: Some(self.url.clone()),
-            })?;
-
-        let names: Vec<String> = remote_views.into_iter().map(|v| v.name).collect();
+        // With `--all-views` the primary pull requested every view, so the pack
+        // already carries all view refs + snapshots. Derive the inventory from
+        // it — no separate `GET /refs/views` round-trip.
+        let names: Vec<String> = pack.refs.iter().map(|r| r.name.clone()).collect();
         let others = match classify_inventory(&names, applied) {
             InventoryOutcome::Views(others) => others,
             InventoryOutcome::NothingNew => return Ok(0),
@@ -644,7 +723,7 @@ impl Clone {
         // Fetch manifests for every remaining view.
         let mut manifests: Vec<ViewManifest> = Vec::with_capacity(others.len());
         for name in &others {
-            match self.fetch_view_manifest(remote, name).await {
+            match self.view_manifest_from_pack(pack, name) {
                 Ok(Some(m)) => manifests.push(m),
                 Ok(None) => {
                     print_warning(&format!(
@@ -682,8 +761,7 @@ impl Clone {
             .collect();
         let mut progress = CloneProgress::new(missing.len());
         progress.phase = ClonePhase::Downloading;
-        self.download_missing_changes(repo, remote, &missing, stats, &mut progress)
-            .await?;
+        self.download_missing_changes(repo, change_objects, &missing, stats, &mut progress)?;
 
         let mut cloned = 0usize;
         for manifest in &ordered {
@@ -714,12 +792,15 @@ impl Clone {
     /// not hinted. Best-effort: silent if the server has no inventory
     /// endpoint or nothing else to clone.
     async fn hint_other_views(&self, remote: &HttpRemote, applied: &HashSet<String>) {
-        let Ok(remote_views) = remote.list_views().await else {
+        // A cheap ref advertisement (refs only, no change bodies) lists every
+        // view on the remote.
+        let Ok(adv) = remote.sync_pull(&SyncWants::advertise(vec![])).await else {
             return;
         };
-        let others: Vec<String> = remote_views
+        let others: Vec<String> = adv
+            .refs
             .into_iter()
-            .map(|v| v.name)
+            .map(|r| r.name)
             .filter(|name| name != &self.view && !applied.contains(name))
             .collect();
         if others.is_empty() {
@@ -789,15 +870,37 @@ impl Clone {
         })?;
         finish_success(&spinner, "Connected");
 
-        // Fetch the requested view's manifest chain (view → ... → root).
-        // The manifests carry each view's identity, so clone reconstructs
-        // scope and parent exactly. An old server without manifest support
-        // is a hard error — there is no identity-losing fallback.
-        let spinner = create_spinner("Fetching view manifests...");
-        let manifests = match self.fetch_manifest_chain(&remote).await {
+        // One `/code` pull for the whole clone: request the view (every view
+        // with `--all-views`) and take the response — view snapshots + change
+        // bodies. A fresh clone holds nothing, so it declares no `haves`.
+        let spinner = create_spinner("Fetching from remote...");
+        let wants = if self.all_views {
+            SyncWants::all(Vec::new())
+        } else {
+            SyncWants {
+                refs: vec![self.view.clone()],
+                haves: Vec::new(),
+                refs_only: false,
+            }
+        };
+        let pack = match remote.sync_pull(&wants).await {
+            Ok(p) => p,
+            Err(e) => {
+                finish_error(&spinner, "Failed to fetch from remote");
+                return Err(convert_remote_error(e, &self.url));
+            }
+        };
+        let change_objects = Self::change_objects_from_pack(&pack);
+        finish_success(&spinner, "Fetched from remote");
+
+        // Reconstruct the requested view's manifest chain (view → ... → root)
+        // from the pulled snapshots. The manifests carry each view's identity,
+        // so clone reconstructs scope and parent exactly.
+        let spinner = create_spinner("Reading view manifests...");
+        let manifests = match self.fetch_manifest_chain(&pack) {
             Ok(m) => m,
             Err(e) => {
-                finish_error(&spinner, "Failed to fetch view manifests");
+                finish_error(&spinner, "Failed to read view manifests");
                 return Err(e);
             }
         };
@@ -873,9 +976,8 @@ impl Clone {
         let mut progress = CloneProgress::new(missing.len());
         progress.phase = ClonePhase::Downloading;
 
-        // Download the missing changes
-        self.download_missing_changes(&repo, &remote, &missing, &mut stats, &mut progress)
-            .await?;
+        // Save the missing changes from the pulled pack.
+        self.download_missing_changes(&repo, &change_objects, &missing, &mut stats, &mut progress)?;
 
         // Apply changes (unless download-only)
         if self.download_only {
@@ -1008,10 +1110,13 @@ impl Clone {
         // recoverable and preserved — cloned views keep their identity.
         if !self.download_only && apply_errors.is_empty() {
             if self.all_views {
-                match self
-                    .clone_additional_views(&mut repo, &remote, &mut stats, &mut applied_views)
-                    .await
-                {
+                match self.clone_additional_views(
+                    &mut repo,
+                    &pack,
+                    &change_objects,
+                    &mut stats,
+                    &mut applied_views,
+                ) {
                     Ok(0) => {}
                     Ok(n) => print_success(&format!(
                         "Cloned {} additional {}",
@@ -1025,6 +1130,14 @@ impl Clone {
             } else {
                 self.hint_other_views(&remote, &applied_views).await;
             }
+        }
+
+        // Validate convergence with the order-invariant SetId across every
+        // applied view (chain + any `--all-views` extras), against the
+        // server-computed effective set-ids.
+        if !self.download_only && apply_errors.is_empty() {
+            self.verify_convergence(&repo, &remote, &applied_views)
+                .await;
         }
 
         // Drop the temporary parking view, if scaffold reconciliation

--- a/atomic-cli/src/commands/pull/command.rs
+++ b/atomic-cli/src/commands/pull/command.rs
@@ -26,14 +26,17 @@
 //! - Missing remote channels
 //! - Diverged history warnings
 
+use std::collections::HashMap;
 use std::time::Duration;
 
+use bytes::Bytes;
 use clap::Parser;
 
-use atomic_core::types::{Base32, Hash};
-use atomic_remote::{HttpRemote, HttpRemoteConfig};
+use atomic_core::types::{Base32, Hash, Merkle, SetId};
+use atomic_objects::{ObjectFamily, SyncPack, SyncWants, ViewSnapshot};
+use atomic_remote::{ChangelistEntry, HttpRemote, HttpRemoteConfig, StateResponse};
 use atomic_repository::history::HistoryOptions;
-use atomic_repository::{InsertOptions, Repository};
+use atomic_repository::{InsertOptions, Repository, ViewManifest};
 
 use crate::commands::{find_repository_root, format_hash, Command};
 use crate::error::{CliError, CliResult};
@@ -48,6 +51,97 @@ use super::helpers::{
     format_bytes, format_count, has_local_only_changes, save_downloaded_change,
 };
 use super::types::{PullChange, PullStats};
+
+/// Reconstruct a view's manifest from a pulled [`SyncPack`]: find the view's ref
+/// target, then its view-snapshot object, and render the manifest text.
+/// Returns `None` when the pack carries no ref/snapshot for `name` (the remote
+/// view does not exist).
+///
+/// This replaces the per-object `get_view_ref` + `get_object("views", …)`
+/// round-trips: a pull now reads the remote's view state from the single `/code`
+/// sync response.
+fn manifest_from_pack(pack: &SyncPack, name: &str, url: &str) -> CliResult<Option<ViewManifest>> {
+    let target = match pack.refs.iter().find(|r| r.name == name) {
+        Some(r) => r.new_target.clone(),
+        None => return Ok(None),
+    };
+    let snapshot = pack
+        .objects
+        .iter()
+        .find(|o| o.family == ObjectFamily::View && o.key == target)
+        .and_then(|o| ViewSnapshot::from_bytes(&o.bytes));
+    let snapshot = match snapshot {
+        Some(s) => s,
+        None => return Ok(None),
+    };
+    let manifest = ViewManifest::parse(&snapshot.to_manifest_text(name)).map_err(|e| {
+        CliError::RemoteError {
+            message: format!("Corrupt manifest for view '{name}': {e}"),
+            url: Some(url.to_string()),
+        }
+    })?;
+    // O(1) producer-integrity cross-check: the snapshot's declared `own_set_id`
+    // must equal the order-invariant fold of its own change list. Content
+    // addressing guarantees the object's bytes, but not that a (buggy) producer
+    // minted a self-consistent set-id; this catches that cheaply.
+    let mut fold = SetId::ZERO;
+    for h in &manifest.changes {
+        fold = fold.add(h);
+    }
+    if fold.to_base32() != snapshot.own_set_id {
+        print_warning(&format!(
+            "Remote view '{name}' snapshot set-id disagrees with its change list; \
+             the remote object may be inconsistent."
+        ));
+    }
+    Ok(Some(manifest))
+}
+
+/// Index a pack's objects of one family into `content key → bytes`.
+fn pack_objects_by_key(pack: &SyncPack, family: ObjectFamily) -> HashMap<String, Vec<u8>> {
+    pack.objects
+        .iter()
+        .filter(|o| o.family == family)
+        .map(|o| (o.key.clone(), o.bytes.clone()))
+        .collect()
+}
+
+/// Reconstruct the requested view's metadata chain from a sync pack in
+/// root-to-leaf order. The server includes the requested ref and every ancestor
+/// snapshot. Views are metadata closures over the common graph, so pull applies
+/// this whole chain after saving the missing graph objects.
+fn manifest_chain_from_pack(
+    pack: &SyncPack,
+    leaf: &str,
+    url: &str,
+) -> CliResult<Vec<ViewManifest>> {
+    let mut by_name = HashMap::new();
+    for r in &pack.refs {
+        if let Some(m) = manifest_from_pack(pack, &r.name, url)? {
+            by_name.insert(r.name.clone(), m);
+        }
+    }
+
+    let mut chain = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    let mut cursor = Some(leaf.to_string());
+    while let Some(name) = cursor {
+        if !seen.insert(name.clone()) {
+            return Err(CliError::RemoteError {
+                message: format!("Remote view parent chain contains a cycle at '{name}'"),
+                url: Some(url.to_string()),
+            });
+        }
+        let manifest = by_name.remove(&name).ok_or_else(|| CliError::RemoteError {
+            message: format!("Remote view metadata is missing '{name}'"),
+            url: Some(url.to_string()),
+        })?;
+        cursor = manifest.parent.clone();
+        chain.push(manifest);
+    }
+    chain.reverse();
+    Ok(chain)
+}
 
 // Constants
 
@@ -396,20 +490,13 @@ impl Pull {
         let remote_view = self.get_remote_view(repo.current_view());
         let local_view = self.get_local_view(&remote_view);
 
-        // Ensure the local target view exists. When pulling a view that is
-        // not present locally (a teammate's view, or a `--to-view` naming a
-        // fresh view), create it so downloaded changes have somewhere to go
-        // instead of failing to apply with "View not found". A dry run must
-        // not mutate the repository, so it only records the view's absence.
-        let mut local_view_exists = repo
+        // Whether the local target view already exists. Creation is deferred
+        // until the remote manifest is known (below), so a pulled draft can be
+        // created with the remote's identity (scope + parent) — inheriting its
+        // parent's history — instead of a flat shared view.
+        let local_view_exists = repo
             .view_exists(&local_view)
             .map_err(CliError::Repository)?;
-        if !local_view_exists && !self.dry_run {
-            repo.create_shared_view(&local_view)
-                .map_err(CliError::Repository)?;
-            local_view_exists = true;
-            print_info(&format!("Created local view '{}'", local_view));
-        }
 
         // Print header
         println!(
@@ -429,32 +516,11 @@ impl Pull {
         })?;
         finish_success(&spinner, "Connected");
 
-        // Query remote state
-        let spinner = create_spinner("Querying remote state...");
-        let remote_state = remote.get_state(&remote_view).await.map_err(|e| {
-            finish_error(&spinner, "Failed to query state");
-            convert_remote_error(e, &remote_url)
-        })?;
-        finish_success(&spinner, "Got remote state");
-
-        // Get remote changelist
-        let spinner = create_spinner("Fetching remote changelist...");
-        let remote_from = 0; // Always get full changelist for comparison
-        let remote_entries = remote
-            .get_changelist(&remote_view, remote_from)
-            .await
-            .map_err(|e| {
-                finish_error(&spinner, "Failed to fetch changelist");
-                convert_remote_error(e, &remote_url)
-            })?;
-        finish_success(
-            &spinner,
-            &format!("Got {} remote changes", remote_entries.len()),
-        );
-
-        // Get local history for the target view. A freshly created view (or,
-        // under --dry-run, one that does not exist yet) has no local changes,
-        // so every remote change is treated as missing.
+        // Load the target view's history for display only. Object negotiation is
+        // graph-wide: `haves` is every change node already registered in the
+        // common pristine, regardless of which view metadata currently exposes
+        // it. This prevents the server from resending shared-view nodes when a
+        // draft's own local log is empty.
         let spinner = create_spinner("Loading local history...");
         let local_entries = if local_view_exists {
             repo.log(HistoryOptions::new().view(&local_view))
@@ -462,9 +528,85 @@ impl Pull {
         } else {
             Vec::new()
         };
+        let haves: Vec<String> = repo
+            .registered_change_hashes()
+            .map_err(CliError::Repository)?
+            .into_iter()
+            .map(|hash| hash.to_base32())
+            .collect();
         finish_success(
             &spinner,
-            &format!("Loaded {} local changes", local_entries.len()),
+            &format!(
+                "Loaded {} local view changes ({} graph objects present)",
+                local_entries.len(),
+                haves.len()
+            ),
+        );
+
+        // One `/code` pull: request the remote view metadata chain and any graph
+        // objects absent from the graph-wide `haves`. The response carries the
+        // requested view + ancestor snapshots and the missing `.change` objects.
+        let spinner = create_spinner("Fetching remote view...");
+        let pull_pack = remote
+            .sync_pull(&SyncWants {
+                refs: vec![remote_view.clone()],
+                haves,
+                // A dry run only needs the manifest to compute the delta; skip
+                // downloading change bodies it will not apply.
+                refs_only: self.dry_run,
+            })
+            .await
+            .map_err(|e| {
+                finish_error(&spinner, "Failed to fetch remote view");
+                convert_remote_error(e, &remote_url)
+            })?;
+        let mut remote_chain = match manifest_chain_from_pack(&pull_pack, &remote_view, &remote_url)
+        {
+            Ok(chain) if !chain.is_empty() => chain,
+            _ => {
+                finish_error(&spinner, "Remote view not found");
+                return Err(CliError::RemoteError {
+                    message: format!("Remote view '{}' does not exist", remote_view),
+                    url: Some(remote_url.clone()),
+                });
+            }
+        };
+        // `--to-view` renames only the requested leaf locally. Ancestor closure
+        // metadata retains its canonical names; the leaf's parent remains that
+        // reconciled local ancestor.
+        if let Some(leaf) = remote_chain.last_mut() {
+            leaf.name = local_view.clone();
+        }
+        let remote_manifest = remote_chain.last().expect("non-empty remote chain").clone();
+        // Adapt the manifest's change log to the existing delta/display types.
+        // Reconstruct each change's merkle state by folding from `Merkle::ZERO`
+        // (the same fold `ViewManifest` uses), so `calculate_pull_delta` — which
+        // parses `entry.merkle` and skips any that fail — sees valid states and
+        // the final one matches `remote_manifest.state`.
+        let remote_entries: Vec<ChangelistEntry> = {
+            let mut acc = Merkle::ZERO;
+            remote_manifest
+                .changes
+                .iter()
+                .enumerate()
+                .map(|(i, h)| {
+                    acc = acc.next(h);
+                    ChangelistEntry::new(i as u64, h.to_base32(), acc.to_base32(), false)
+                })
+                .collect()
+        };
+        let remote_state = if remote_manifest.changes.is_empty() {
+            StateResponse::empty()
+        } else {
+            StateResponse::state(
+                (remote_manifest.changes.len() as u64).saturating_sub(1),
+                remote_manifest.state.to_base32(),
+                String::new(),
+            )
+        };
+        finish_success(
+            &spinner,
+            &format!("Got {} remote changes", remote_entries.len()),
         );
 
         // Display state comparison
@@ -484,23 +626,32 @@ impl Pull {
             self.display_local_only_warning(&local_only);
         }
 
-        // Calculate what to pull
-        let to_download = calculate_pull_delta(&remote_entries, &local_entries, self.all);
+        // The server already subtracted the graph-wide `haves`; every change
+        // object in the pack is a genuinely missing node in the common graph.
+        // Do not derive this from one view's log.
+        let change_objects = pack_objects_by_key(&pull_pack, ObjectFamily::Change);
+        let to_download: Vec<PullChange> = change_objects
+            .keys()
+            .enumerate()
+            .filter_map(|(i, key)| {
+                Hash::from_base32(key.as_bytes())
+                    .map(|hash| PullChange::new(hash, i as u64, Merkle::ZERO))
+            })
+            .collect();
 
         // Handle dry run
         if self.dry_run {
             return self.display_dry_run(&remote_name, &remote_url, &remote_view, &to_download);
         }
 
-        // Check for nothing to pull
-        if to_download.is_empty() {
-            print_success("Already up to date");
-            return Ok(());
+        // Save missing graph nodes first. Even when none are missing, continue:
+        // remote view metadata may still add closures around nodes already in
+        // the local graph (for example, advancing local `dev` before applying a
+        // draft's metadata).
+        if !to_download.is_empty() {
+            println!("Downloading {}:", format_count(to_download.len(), "change"));
+            print_blank();
         }
-
-        // Download changes
-        println!("Downloading {}:", format_count(to_download.len(), "change"));
-        print_blank();
 
         let progress = create_progress_bar(to_download.len() as u64, "Pulling changes");
         let mut stats = PullStats::new();
@@ -509,15 +660,12 @@ impl Pull {
             let hash_str = change.hash.to_base32();
             let msg = change.message_or_default();
 
-            // Download the change
-            let result = remote.download_change(&hash_str).await;
-
-            match result {
-                Ok(data) => {
+            match change_objects.get(&hash_str) {
+                Some(data) => {
                     let data_len = data.len() as u64;
 
                     // Save to local change store
-                    match save_downloaded_change(&repo, &change.hash, data) {
+                    match save_downloaded_change(&repo, &change.hash, Bytes::from(data.clone())) {
                         Ok(()) => {
                             stats.record_change_downloaded(data_len);
                             println!(
@@ -543,20 +691,19 @@ impl Pull {
                         }
                     }
                 }
-                Err(e) => {
+                None => {
                     stats.record_failed();
                     println!(
-                        "  {} {} ({}/{}) {} - {}",
+                        "  {} {} ({}/{}) {} - not found on remote",
                         error("✗"),
                         style_hash(&format_hash(&change.hash, false)),
                         i + 1,
                         to_download.len(),
                         msg,
-                        e
                     );
-
-                    // Stop on first failure to maintain consistency
-                    return Err(convert_remote_error(e, &remote_url));
+                    return Err(CliError::ChangeNotFound {
+                        hash: hash_str.clone(),
+                    });
                 }
             }
 
@@ -580,56 +727,36 @@ impl Pull {
         // Atomic session index without any relationship queries against
         // the server.
         let mut provenance_count = 0usize;
-        match remote.get_provenance_list().await {
-            Ok(remote_provenance) => {
-                for prov_hash_str in remote_provenance {
-                    let Some(prov_hash) = Hash::from_base32(prov_hash_str.as_bytes()) else {
-                        continue;
-                    };
-                    if repo.has_provenance_graph(&prov_hash) {
+        for (prov_hash_str, data) in pack_objects_by_key(&pull_pack, ObjectFamily::Provenance) {
+            let Some(prov_hash) = Hash::from_base32(prov_hash_str.as_bytes()) else {
+                continue;
+            };
+            if repo.has_provenance_graph(&prov_hash) {
+                continue;
+            }
+            match atomic_core::change::ProvenanceGraph::deserialize(&data) {
+                Ok((graph, computed)) => {
+                    if computed != prov_hash {
+                        print_warning(&format!(
+                            "Provenance {} failed hash verification — skipped",
+                            &prov_hash_str[..12.min(prov_hash_str.len())]
+                        ));
                         continue;
                     }
-                    match remote.download_provenance(&prov_hash_str).await {
-                        Ok(data) => {
-                            match atomic_core::change::ProvenanceGraph::deserialize(&data) {
-                                Ok((graph, computed)) => {
-                                    if computed != prov_hash {
-                                        print_warning(&format!(
-                                            "Provenance {} failed hash verification — skipped",
-                                            &prov_hash_str[..12.min(prov_hash_str.len())]
-                                        ));
-                                        continue;
-                                    }
-                                    match repo.save_provenance_graph(&graph) {
-                                        Ok(_) => provenance_count += 1,
-                                        Err(e) => print_warning(&format!(
-                                            "Failed to register provenance {}: {}",
-                                            &prov_hash_str[..12.min(prov_hash_str.len())],
-                                            e
-                                        )),
-                                    }
-                                }
-                                Err(e) => print_warning(&format!(
-                                    "Corrupt provenance {}: {}",
-                                    &prov_hash_str[..12.min(prov_hash_str.len())],
-                                    e
-                                )),
-                            }
-                        }
+                    match repo.save_provenance_graph(&graph) {
+                        Ok(_) => provenance_count += 1,
                         Err(e) => print_warning(&format!(
-                            "Failed to download provenance {}: {}",
+                            "Failed to register provenance {}: {}",
                             &prov_hash_str[..12.min(prov_hash_str.len())],
                             e
                         )),
                     }
                 }
-            }
-            Err(_) => {
-                // Server does not support the provenance inventory extension —
-                // provenance sync is skipped, not fatal.
-                print_hint(
-                    "Remote does not support provenance sync; session provenance stays local",
-                );
+                Err(e) => print_warning(&format!(
+                    "Corrupt provenance {}: {}",
+                    &prov_hash_str[..12.min(prov_hash_str.len())],
+                    e
+                )),
             }
         }
         if provenance_count > 0 {
@@ -650,50 +777,71 @@ impl Pull {
             return Ok(());
         }
 
-        // Apply downloaded changes to the local view
+        // Reconcile view metadata root-to-leaf over the now-populated common
+        // graph. Shared ancestors union their local and remote own memberships;
+        // the requested draft (if any) then naturally inherits the synchronized
+        // shared closure. These are metadata closures around graph nodes — not
+        // per-view object transfers.
         print_blank();
-        let spinner = create_spinner("Applying changes to view...");
-
-        // Apply downloaded changes to the local view in sequence order.
-        // Changes that failed to save during download are skipped gracefully
-        // by insert_change_rec (it will return a "change not found" error).
+        let spinner = create_spinner("Reconciling view metadata...");
         let mut apply_errors: Vec<String> = Vec::new();
-
-        for change in &to_download {
-            let options = InsertOptions::default().apply_deps(true).view(&local_view);
-
-            match repo.insert_change_rec(&change.hash, options) {
-                Ok(_outcome) => {
-                    stats.record_applied();
+        for manifest in &remote_chain {
+            match repo.reconcile_view_manifest(manifest) {
+                Ok(outcome) => {
+                    for _ in 0..outcome.replayed {
+                        stats.record_applied();
+                    }
                 }
-                Err(e) => {
-                    // Log but don't abort — other changes may still apply
-                    apply_errors.push(format!(
-                        "Failed to apply {}: {}",
-                        format_hash(&change.hash, false),
-                        e
-                    ));
-                }
+                Err(e) => apply_errors.push(format!(
+                    "Failed to reconcile view '{}': {}",
+                    manifest.name, e
+                )),
             }
         }
 
-        if stats.has_applied() {
+        if apply_errors.is_empty() {
             finish_success(
                 &spinner,
-                &format!(
-                    "Applied {} to {}",
-                    format_count(stats.changes_applied, "change"),
-                    local_view
-                ),
+                &format!("Reconciled {} view closures", remote_chain.len()),
             );
         } else {
-            finish_error(&spinner, "No changes were applied");
-        }
-
-        // Report any per-change apply errors
-        if !apply_errors.is_empty() {
+            finish_error(&spinner, "View metadata reconciliation failed");
             for err in &apply_errors {
                 print_warning(err);
+            }
+        }
+
+        // Validate the pull with the SetId — the order-invariant convergence
+        // identity. The remote's expected set-id is the server-computed
+        // **effective** (own ∪ ancestors) set-id from the view inventory
+        // (`GET /refs/views`), compared to the local view's set after applying.
+        // Using the server's effective value is correct for drafts (whose
+        // effective set differs from their own set) and is an independent source
+        // — it proves the pull reproduced exactly the remote set, regardless of
+        // change counts or merkle order.
+        if stats.has_applied() {
+            let remote_set = remote.list_view_refs().await.ok().and_then(|inv| {
+                inv.into_iter()
+                    .find(|v| v.name == remote_view)
+                    .and_then(|v| v.set_id)
+            });
+            match (repo.view_set_id(&local_view), remote_set) {
+                (Ok(local), Some(expected)) => {
+                    if local.to_base32() == expected {
+                        print_success(
+                            "Verified: local view set-id matches the remote (convergent)",
+                        );
+                    } else {
+                        print_warning(&format!(
+                            "Set-id mismatch after pull: local {} != remote {}. \
+                             The view may be divergent or incomplete.",
+                            local.to_base32(),
+                            expected
+                        ));
+                    }
+                }
+                (Ok(_), None) => { /* remote reported no set-id; skip verification */ }
+                (Err(e), _) => print_warning(&format!("Could not compute local set-id: {}", e)),
             }
         }
 
@@ -735,45 +883,29 @@ impl Pull {
 
         // Download tags from the remote view.
         let mut tags_downloaded: usize = 0;
-        {
-            let remote_tags = remote
-                .list_remote_tags(&remote_view)
-                .await
-                .unwrap_or_default();
-
-            for (tag_hash, tag_name) in &remote_tags {
-                // Skip tags we already have locally
-                if let Ok(Some(_)) = repo.get_tag_from_view(tag_name, &local_view) {
-                    continue;
-                }
-
-                match remote.download_tag(tag_hash).await {
-                    Ok(tag_bytes) => match atomic_repository::deserialize_tag(&tag_bytes) {
-                        Ok(tag) => {
-                            let tag_len = tag_bytes.len() as u64;
-                            if let Err(e) = repo.save_synced_tag(&tag) {
-                                print_warning(&format!("Failed to save tag '{}': {}", tag_name, e));
-                            } else {
-                                tags_downloaded += 1;
-                                stats.record_tag_downloaded(tag_len);
-                                println!(
-                                    "  {} tag '{}' ({})",
-                                    success("\u{2713}"),
-                                    tag_name,
-                                    tag.kind,
-                                );
-                            }
-                        }
-                        Err(e) => {
-                            print_warning(&format!(
-                                "Failed to deserialize tag '{}': {}",
-                                tag_name, e
-                            ));
-                        }
-                    },
-                    Err(e) => {
-                        log::debug!("Tag download failed for '{}': {}", tag_name, e);
+        for (_tag_hash, tag_bytes) in pack_objects_by_key(&pull_pack, ObjectFamily::Tag) {
+            match atomic_repository::deserialize_tag(&tag_bytes) {
+                Ok(tag) => {
+                    // Skip tags we already have locally.
+                    if let Ok(Some(_)) = repo.get_tag_from_view(&tag.name, &local_view) {
+                        continue;
                     }
+                    let tag_len = tag_bytes.len() as u64;
+                    if let Err(e) = repo.save_synced_tag(&tag) {
+                        print_warning(&format!("Failed to save tag '{}': {}", tag.name, e));
+                    } else {
+                        tags_downloaded += 1;
+                        stats.record_tag_downloaded(tag_len);
+                        println!(
+                            "  {} tag '{}' ({})",
+                            success("\u{2713}"),
+                            tag.name,
+                            tag.kind,
+                        );
+                    }
+                }
+                Err(e) => {
+                    print_warning(&format!("Failed to deserialize tag: {}", e));
                 }
             }
         }

--- a/atomic-cli/src/commands/pull/command.rs
+++ b/atomic-cli/src/commands/pull/command.rs
@@ -917,13 +917,23 @@ impl Pull {
             ));
         }
 
-        // Bootstrap vault if .vault/ files were pulled but redb tables don't exist.
-        // This happens when another user initialized the vault and pushed changes
-        // that were then pulled by a collaborator who hasn't run `vault init`.
-        if stats.has_applied() {
-            let vault_on_disk = repo.vault_dir().exists();
-            let vault_in_db = repo.has_vault().unwrap_or(false);
-            if vault_on_disk && !vault_in_db {
+        // The graph-materialized working copy is authoritative after pull.
+        // Deflate `.vault/` disk content into redb; never inflate redb back over
+        // these tracked files, which would regenerate system frontmatter and make
+        // a clean pull immediately appear modified.
+        if stats.has_applied() && repo.vault_dir().exists() {
+            if repo.has_vault().unwrap_or(false) {
+                match repo.vault_record_working_copy() {
+                    Ok(paths) => log::info!(
+                        "Synchronized {} pulled vault entries into redb",
+                        paths.len()
+                    ),
+                    Err(e) => print_warning(&format!(
+                        "Failed to synchronize pulled vault content: {}",
+                        e
+                    )),
+                }
+            } else {
                 print_info(
                     "Vault files detected \u{2014} initializing vault from pulled content...",
                 );
@@ -944,13 +954,6 @@ impl Pull {
             match repo.kg_enrich_from_vcs() {
                 Ok(kg_stats) => log::info!("KG enriched after pull: {}", kg_stats),
                 Err(e) => log::warn!("KG enrichment after pull failed: {}", e),
-            }
-
-            // Materialize any new vault entries pulled (only if vault exists)
-            if repo.has_vault().unwrap_or(false) {
-                if let Err(e) = repo.vault_materialize_all() {
-                    log::warn!("Vault materialization after pull failed: {}", e);
-                }
             }
         }
 

--- a/atomic-cli/src/commands/pull/mod.rs
+++ b/atomic-cli/src/commands/pull/mod.rs
@@ -151,7 +151,7 @@
 // Submodules
 
 mod command;
-mod helpers;
+pub(crate) mod helpers;
 pub mod types;
 
 // Re-exports

--- a/atomic-cli/src/commands/push/command.rs
+++ b/atomic-cli/src/commands/push/command.rs
@@ -8,13 +8,15 @@
 //! a shared remote view. Each view's scope, parent, and exact change log
 //! survive the transfer.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
-use bytes::Bytes;
 use clap::Parser;
 
-use atomic_core::types::{Base32, Hash};
+use atomic_core::types::{Base32, Hash, SetId};
+use atomic_objects::{
+    ObjectFamily, ObjectRecord, RefRecord, SyncPack, SyncWants, ViewScopeLabel, ViewSnapshot,
+};
 use atomic_remote::{HttpRemote, HttpRemoteConfig};
 use atomic_repository::{Repository, ViewManifest};
 
@@ -27,9 +29,87 @@ use crate::output::{
 
 use super::helpers::{
     build_view_chain, convert_remote_error, display_manifest_divergence, format_count,
-    load_change_data, load_change_message, parse_remote_manifest, plan_view_sync,
-    require_manifest_support, ChainError, ViewSyncConflict, ViewSyncPlan,
+    load_change_data, load_change_message, parse_remote_manifest, plan_view_sync, ChainError,
+    ViewSyncConflict, ViewSyncPlan,
 };
+
+/// The remote ref advertisement, fetched once per push via a single `/code`
+/// sync call: each remote view's current snapshot object key (the CAS `prev`)
+/// and its manifest reconstructed from that snapshot.
+struct RemoteAdvertisement {
+    /// remote view name → current view-snapshot object key.
+    ref_targets: HashMap<String, String>,
+    /// remote view name → manifest reconstructed from that snapshot.
+    manifests: HashMap<String, ViewManifest>,
+}
+
+/// Parse a ref-advertisement [`SyncPack`] (from `sync_pull` with `refs_only`)
+/// into per-view snapshot keys and manifests.
+///
+/// This replaces the legacy per-view `get_view_ref` + `get_object("views", …)`
+/// round-trips: push negotiation now reads the remote's view state from a single
+/// `/code` advertisement, uniform across local (`FsStore`) and geo (`S3Store`).
+fn parse_advertisement(adv: &SyncPack, url: &str) -> CliResult<RemoteAdvertisement> {
+    let mut snapshots: HashMap<String, ViewSnapshot> = HashMap::new();
+    for obj in &adv.objects {
+        if obj.family == ObjectFamily::View {
+            if let Some(s) = ViewSnapshot::from_bytes(&obj.bytes) {
+                snapshots.insert(obj.key.clone(), s);
+            }
+        }
+    }
+    let mut ref_targets = HashMap::new();
+    let mut manifests = HashMap::new();
+    for r in &adv.refs {
+        ref_targets.insert(r.name.clone(), r.new_target.clone());
+        match snapshots.get(&r.new_target) {
+            Some(s) => {
+                let manifest = parse_remote_manifest(&r.name, &s.to_manifest_text(&r.name), url)?;
+                manifests.insert(r.name.clone(), manifest);
+            }
+            None => {
+                // Ref points at a snapshot the advertisement did not carry;
+                // treat the view as absent (a re-push heals it).
+            }
+        }
+    }
+    Ok(RemoteAdvertisement {
+        ref_targets,
+        manifests,
+    })
+}
+
+/// Mint the content-addressed `ViewSnapshot` for a view from its local manifest
+/// and the remote's current snapshot key (`prev`, for the CAS-on-`prev` chain).
+///
+/// The `own_set_id` fold matches the server's `from_manifest` bridge exactly, so
+/// client and server mint byte-identical objects with identical content keys.
+fn mint_view_snapshot(manifest: &ViewManifest, prev: Option<String>) -> ViewSnapshot {
+    let own_changes: Vec<String> = manifest.changes.iter().map(|h| h.to_base32()).collect();
+    let mut acc = SetId::ZERO;
+    for h in &manifest.changes {
+        acc = acc.add(h);
+    }
+    let own_set_id = acc.to_base32();
+    let merkle_state = if manifest.changes.is_empty() {
+        None
+    } else {
+        Some(manifest.state.to_base32())
+    };
+    let scope = if manifest.scope.is_draft() {
+        ViewScopeLabel::Draft
+    } else {
+        ViewScopeLabel::Shared
+    };
+    ViewSnapshot::new(
+        scope,
+        manifest.parent.clone(),
+        prev.into_iter().collect(),
+        own_changes,
+        own_set_id,
+        merkle_state,
+    )
+}
 
 // Constants
 
@@ -455,6 +535,31 @@ impl Push {
         })?;
         finish_success(&spinner, "Connected");
 
+        // Fetch remote view metadata only. Push does not import remote graph
+        // nodes or mutate local view metadata: doing so would change the current
+        // view's effective closure without materializing its working copy. The
+        // server performs the local∪remote set union when publishing refs.
+        let remote_names: Vec<String> = chain
+            .iter()
+            .map(|name| {
+                if name == &local_view {
+                    remote_view.clone()
+                } else {
+                    name.clone()
+                }
+            })
+            .collect();
+        let spinner = create_spinner("Fetching remote view metadata...");
+        let adv_pack = remote
+            .sync_pull(&SyncWants::advertise(remote_names.clone()))
+            .await
+            .map_err(|e| {
+                finish_error(&spinner, "Failed to fetch remote metadata");
+                convert_remote_error(e, &remote_url)
+            })?;
+        let adv = parse_advertisement(&adv_pack, &remote_url)?;
+        finish_success(&spinner, "Fetched remote view metadata");
+
         // Plan phase: for each view in the chain, export the local manifest,
         // fetch the remote's, and compute the fast-forward suffix. Hashes
         // known to be on the remote (remote prefixes, or stored for an
@@ -478,35 +583,17 @@ impl Push {
                 manifest.name = remote_view_name.clone();
             }
 
-            // Fetch the remote's manifest. A server without manifest support
-            // is a hard error: there is no flatten fallback.
-            let spinner = create_spinner(&format!(
-                "Fetching remote manifest for {}...",
-                style_view(&remote_view_name)
-            ));
-            let remote_text = require_manifest_support(
-                remote.get_view_manifest(&remote_view_name).await,
-                &remote_url,
-            )
-            .inspect_err(|_| finish_error(&spinner, "Failed to fetch manifest"))?;
-            let remote_manifest = match remote_text {
-                Some(text) => Some(parse_remote_manifest(
-                    &remote_view_name,
-                    &text,
-                    &remote_url,
-                )?),
-                None => None,
-            };
-            finish_success(
-                &spinner,
-                &format!(
-                    "Remote {} {}",
-                    style_view(&remote_view_name),
-                    match &remote_manifest {
-                        Some(m) => format!("has {}", format_count(m.changes.len(), "change")),
-                        None => "does not exist yet".to_string(),
-                    }
-                ),
+            // The remote's manifest for this view comes from the single ref
+            // advertisement fetched up front (no per-view round-trip).
+            let remote_manifest = adv.manifests.get(&remote_view_name).cloned();
+            println!(
+                "  {} Remote {} {}",
+                success("✓"),
+                style_view(&remote_view_name),
+                match &remote_manifest {
+                    Some(m) => format!("has {}", format_count(m.changes.len(), "change")),
+                    None => "does not exist yet".to_string(),
+                }
             );
 
             // Everything the remote view already logs is known-present.
@@ -564,6 +651,9 @@ impl Push {
         let mut total_stored = 0usize;
         let mut views_declared = 0usize;
         let mut stored_hashes: Vec<Hash> = Vec::new();
+        // One SyncPack for the whole push: objects (changes, view snapshots,
+        // attestations, provenance, tags) + ref CAS moves, sent via `/code`.
+        let mut pack = SyncPack::empty();
 
         for sync in &syncs {
             if sync.plan.is_noop() {
@@ -604,30 +694,19 @@ impl Push {
                     let msg = load_change_message(&repo, hash)
                         .unwrap_or_else(|| "(no message)".to_string());
 
-                    match remote.store_change(&hash.to_base32(), data).await {
-                        Ok(()) => {
-                            println!(
-                                "  {} {} ({}/{}) {}",
-                                success("✓"),
-                                style_hash(&format_hash(hash, false)),
-                                i + 1,
-                                sync.to_store.len(),
-                                msg,
-                            );
-                        }
-                        Err(e) => {
-                            finish_error(&progress, "Store failed");
-                            println!(
-                                "  {} {} ({}/{}) {}",
-                                crate::output::error("✗"),
-                                style_hash(&format_hash(hash, false)),
-                                i + 1,
-                                sync.to_store.len(),
-                                msg,
-                            );
-                            return Err(convert_remote_error(e, &remote_url));
-                        }
-                    }
+                    pack.objects.push(ObjectRecord::new(
+                        ObjectFamily::Change,
+                        hash.to_base32(),
+                        data.to_vec(),
+                    ));
+                    println!(
+                        "  {} {} ({}/{}) {}",
+                        success("✓"),
+                        style_hash(&format_hash(hash, false)),
+                        i + 1,
+                        sync.to_store.len(),
+                        msg,
+                    );
                     progress.inc(1);
                 }
 
@@ -640,42 +719,40 @@ impl Push {
                 stored_hashes.extend(sync.to_store.iter().copied());
             }
 
-            // Declare the view's identity and log. The server creates the
-            // view (with the declared scope/parent) if absent, fast-forwards
-            // its log, and verifies the merkle state.
-            let spinner = create_spinner(&format!(
-                "Declaring view {}...",
-                style_view(&sync.remote_name)
+            // Mint the content-addressed snapshot and queue its object plus a
+            // ref CAS move (`prev` = the remote's current tip from the
+            // advertisement). The store and ancestry-gated CAS happen
+            // server-side in the single `/code` push below.
+            let prev = adv.ref_targets.get(&sync.remote_name).cloned();
+            let snapshot = mint_view_snapshot(&sync.manifest, prev.clone());
+            let snap_key = snapshot.content_key();
+            pack.objects.push(ObjectRecord::new(
+                ObjectFamily::View,
+                snap_key.clone(),
+                snapshot.to_canonical_bytes(),
             ));
-            match remote
-                .put_view_manifest(&sync.remote_name, sync.manifest.to_text())
-                .await
-            {
-                Ok(()) => {
-                    views_declared += 1;
-                    finish_success(
-                        &spinner,
-                        &format!(
-                            "Declared {} [{}] ({} in log)",
-                            style_view(&sync.remote_name),
-                            sync.manifest.scope,
-                            format_count(sync.manifest.changes.len(), "change"),
-                        ),
-                    );
-                }
-                Err(e) => {
-                    finish_error(&spinner, "Declare failed");
-                    return Err(convert_remote_error(e, &remote_url));
-                }
-            }
+            pack.refs.push(RefRecord {
+                name: sync.remote_name.clone(),
+                expect_old: prev,
+                new_target: snap_key,
+            });
+            views_declared += 1;
+            println!(
+                "  {} Declared {} [{}] ({} in log)",
+                success("✓"),
+                style_view(&sync.remote_name),
+                sync.manifest.scope,
+                format_count(sync.manifest.changes.len(), "change"),
+            );
         }
 
-        // All changes in the leaf view's log are on the remote after a
-        // successful sync (chain views are subsets by the prefix rule).
+        // Sidecars may travel only when every covered change is in the closure
+        // being published (the union of this view chain's own memberships), not
+        // merely somewhere in the local common graph.
         let all_synced: HashSet<Hash> = syncs
-            .last()
-            .map(|s| s.manifest.changes.iter().copied().collect())
-            .unwrap_or_default();
+            .iter()
+            .flat_map(|sync| sync.manifest.changes.iter().copied())
+            .collect();
 
         // Upload attestations that cover the pushed changes.
         // Attestations are graph-level audit nodes — they travel with
@@ -713,52 +790,33 @@ impl Push {
             }
 
             for (attest_hash, attestation) in &unique_attestations {
-                // Load and upload the raw attestation bytes
+                // Load the raw attestation bytes and queue them.
                 let attest_data = match attestation.serialize() {
-                    Ok(data) => Bytes::from(data),
+                    Ok(data) => data,
                     Err(_) => continue,
                 };
 
-                match remote
-                    .upload_attestation(&attest_hash.to_base32(), attest_data)
-                    .await
-                {
-                    Ok(()) => {
-                        attest_count += 1;
-                        println!(
-                            "  {} {} attestation ({}, {} covered)",
-                            success("✓"),
-                            style_hash(&format_hash(attest_hash, false)),
-                            attestation.cost_display(),
-                            attestation.change_count(),
-                        );
-                    }
-                    Err(e) => {
-                        print_warning(&format!(
-                            "Failed to upload attestation {}: {}",
-                            &attest_hash.to_base32()[..12],
-                            e
-                        ));
-                    }
-                }
+                pack.objects.push(ObjectRecord::new(
+                    ObjectFamily::Attest,
+                    attest_hash.to_base32(),
+                    attest_data,
+                ));
+                attest_count += 1;
+                println!(
+                    "  {} {} attestation ({}, {} covered)",
+                    success("✓"),
+                    style_hash(&format_hash(attest_hash, false)),
+                    attestation.cost_display(),
+                    attestation.change_count(),
+                );
             }
         }
 
-        // Upload provenance graphs that explain the pushed changes.
-        // Provenance graphs are causal decision DAGs — they travel with
-        // their dependencies but aren't part of any view's changelog.
-        //
-        // Same model as .change files: query the server's flat inventory,
-        // upload only what it does not already hold.
+        // Upload provenance graphs that explain the pushed changes, via the
+        // RESTful provenance object family: `HEAD /provenance/{key}` to skip
+        // what the server already holds, `PUT /provenance/{key}` to store.
         let mut provenance_count = 0;
         {
-            let remote_provenance: HashSet<String> = remote
-                .get_provenance_list()
-                .await
-                .unwrap_or_default()
-                .into_iter()
-                .collect();
-
             // Collect unique provenance graphs — same dedup logic as attestations.
             let mut seen_prov: HashSet<Hash> = HashSet::new();
             let mut unique_graphs: Vec<(Hash, atomic_core::change::ProvenanceGraph)> = Vec::new();
@@ -786,39 +844,28 @@ impl Push {
                     continue;
                 }
 
-                // Skip provenance the server already holds (presence delta).
-                if remote_provenance.contains(&prov_hash.to_base32()) {
-                    continue;
-                }
+                let prov_key = prov_hash.to_base32();
 
-                // Load and upload the raw provenance bytes
+                // Load the raw provenance bytes and queue them. The server
+                // dedupes idempotently, so there is no per-object presence probe.
                 let prov_data = match graph.serialize() {
-                    Ok(data) => Bytes::from(data),
+                    Ok(data) => data,
                     Err(_) => continue,
                 };
 
-                match remote
-                    .upload_provenance(&prov_hash.to_base32(), prov_data)
-                    .await
-                {
-                    Ok(()) => {
-                        provenance_count += 1;
-                        println!(
-                            "  {} {} provenance ({} nodes, {} changes)",
-                            success("✓"),
-                            style_hash(&format_hash(prov_hash, false)),
-                            graph.node_count(),
-                            graph.change_count(),
-                        );
-                    }
-                    Err(e) => {
-                        print_warning(&format!(
-                            "Failed to upload provenance graph {}: {}",
-                            &prov_hash.to_base32()[..12],
-                            e
-                        ));
-                    }
-                }
+                pack.objects.push(ObjectRecord::new(
+                    ObjectFamily::Provenance,
+                    prov_key,
+                    prov_data,
+                ));
+                provenance_count += 1;
+                println!(
+                    "  {} {} provenance ({} nodes, {} changes)",
+                    success("✓"),
+                    style_hash(&format_hash(prov_hash, false)),
+                    graph.node_count(),
+                    graph.change_count(),
+                );
             }
         }
 
@@ -834,32 +881,81 @@ impl Push {
                 let tag_hash_str = tag_hash.to_base32();
 
                 let tag_bytes = match atomic_repository::serialize_tag(tag) {
-                    Ok(bytes) => Bytes::from(bytes),
+                    Ok(bytes) => bytes,
                     Err(e) => {
                         print_warning(&format!("Failed to serialize tag '{}': {}", tag.name, e));
                         continue;
                     }
                 };
 
-                match remote
-                    .upload_tag(&tag_hash_str, &remote_view, tag_bytes)
-                    .await
+                pack.objects.push(ObjectRecord::new(
+                    ObjectFamily::Tag,
+                    tag_hash_str.clone(),
+                    tag_bytes,
+                ));
+                tag_count += 1;
+                println!(
+                    "  {} {} tag '{}' ({})",
+                    success("\u{2713}"),
+                    style_hash(&tag_hash_str[..12]),
+                    tag.name,
+                    tag.kind,
+                );
+            }
+        }
+
+        // Send everything in one `/code` push: objects stored + refs CAS-moved.
+        if !pack.is_empty() {
+            let spinner = create_spinner("Pushing to remote...");
+            remote.sync_push(&pack).await.map_err(|e| {
+                finish_error(&spinner, "Push failed");
+                convert_remote_error(e, &remote_url)
+            })?;
+
+            // Re-read final metadata only. A concurrent writer may have caused
+            // the server to publish a larger union, which is valid. Push verifies
+            // that every locally proposed patch is present remotely; it does not
+            // import remote-only nodes or mutate the local closures.
+            let final_pack = remote
+                .sync_pull(&SyncWants::advertise(remote_names.clone()))
+                .await
+                .map_err(|e| {
+                    finish_error(&spinner, "Push landed, but remote verification failed");
+                    convert_remote_error(e, &remote_url)
+                })?;
+            let final_adv = parse_advertisement(&final_pack, &remote_url)?;
+            for sync in &syncs {
+                let final_manifest =
+                    final_adv.manifests.get(&sync.remote_name).ok_or_else(|| {
+                        CliError::RemoteError {
+                            message: format!(
+                                "Remote did not advertise pushed view '{}'",
+                                sync.remote_name
+                            ),
+                            url: Some(remote_url.clone()),
+                        }
+                    })?;
+                let final_set: HashSet<Hash> = final_manifest.changes.iter().copied().collect();
+                if let Some(missing) = sync
+                    .manifest
+                    .changes
+                    .iter()
+                    .find(|hash| !final_set.contains(hash))
                 {
-                    Ok(()) => {
-                        tag_count += 1;
-                        println!(
-                            "  {} {} tag '{}' ({})",
-                            success("\u{2713}"),
-                            style_hash(&tag_hash_str[..12]),
-                            tag.name,
-                            tag.kind,
-                        );
-                    }
-                    Err(e) => {
-                        print_warning(&format!("Failed to upload tag '{}': {}", tag.name, e));
-                    }
+                    finish_error(&spinner, "Push landed, but remote union is incomplete");
+                    return Err(CliError::Conflict {
+                        description: format!(
+                            "Remote view '{}' does not contain proposed patch {}",
+                            sync.remote_name,
+                            missing.to_base32()
+                        ),
+                    });
                 }
             }
+            finish_success(
+                &spinner,
+                "Push complete; remote union contains proposed patches",
+            );
         }
 
         // Summary

--- a/atomic-cli/src/commands/push/helpers.rs
+++ b/atomic-cli/src/commands/push/helpers.rs
@@ -198,12 +198,11 @@ impl ViewSyncPlan {
 pub fn plan_view_sync(
     local: &ViewManifest,
     remote: Option<&ViewManifest>,
-    force: bool,
-    is_leaf: bool,
+    _force: bool,
+    _is_leaf: bool,
 ) -> Result<ViewSyncPlan, ViewSyncConflict> {
     let remote = match remote {
         None => {
-            // View absent on remote: the whole log is the suffix.
             return Ok(ViewSyncPlan {
                 suffix: local.changes.clone(),
                 declare: true,
@@ -214,8 +213,9 @@ pub fn plan_view_sync(
         Some(r) => r,
     };
 
-    // Identity must match: the manifest declares scope and parent, and the
-    // server refuses to mutate an existing view's identity.
+    // View identity is immutable metadata. Membership is not compared as an
+    // ordered prefix: patches are nodes in a causal graph and independently
+    // added compatible nodes reconcile by set union.
     if remote.scope != local.scope {
         return Err(ViewSyncConflict::IdentityMismatch {
             field: "scope",
@@ -232,74 +232,20 @@ pub fn plan_view_sync(
         });
     }
 
-    // Ancestor already satisfied. When this view is NOT the one being pushed (an
-    // ancestor pulled in for a descendant) and the remote already holds every
-    // local change, there is nothing to do: the remote's set already satisfies
-    // the descendant, and pushing a child never implies rewriting a parent. Skip
-    // without error — so a child push is never blocked by an ancestor whose
-    // remote is merely larger (a local shrink) — and flag `shrink` when the
-    // remote is strictly larger so the caller can explain the skip. The leaf
-    // falls through to the prefix/divergence rules below, where `local ⊂ remote`
-    // is ambiguous and errs toward "pull or --force".
-    if !is_leaf {
-        let remote_set: HashSet<&Hash> = remote.changes.iter().collect();
-        if local.changes.iter().all(|h| remote_set.contains(h)) {
-            return Ok(ViewSyncPlan {
-                suffix: Vec::new(),
-                declare: false,
-                forced: false,
-                shrink: local.changes.len() != remote.changes.len(),
-            });
-        }
-    }
-
-    // Prefix rule.
-    let diverged = if remote.changes.len() > local.changes.len() {
-        Some(ViewSyncConflict::Diverged {
-            first_mismatch: None,
-            local_len: local.changes.len(),
-            remote_len: remote.changes.len(),
-        })
-    } else {
-        remote
-            .changes
-            .iter()
-            .zip(local.changes.iter())
-            .position(|(r, l)| r != l)
-            .map(|i| ViewSyncConflict::Diverged {
-                first_mismatch: Some(i),
-                local_len: local.changes.len(),
-                remote_len: remote.changes.len(),
-            })
-    };
-
-    if let Some(conflict) = diverged {
-        if !force {
-            return Err(conflict);
-        }
-        // Forced: store whatever the remote view lacks and attempt the
-        // declare anyway. The server remains authoritative.
-        let remote_set: HashSet<&Hash> = remote.changes.iter().collect();
-        let suffix: Vec<Hash> = local
-            .changes
-            .iter()
-            .filter(|h| !remote_set.contains(h))
-            .copied()
-            .collect();
-        return Ok(ViewSyncPlan {
-            suffix,
-            declare: true,
-            forced: true,
-            shrink: false,
-        });
-    }
-
-    // Remote is a (possibly complete) prefix of local.
-    let suffix: Vec<Hash> = local.changes[remote.changes.len()..].to_vec();
-    let declare = !suffix.is_empty();
+    let remote_set: HashSet<Hash> = remote.changes.iter().copied().collect();
+    let local_set: HashSet<Hash> = local.changes.iter().copied().collect();
+    let suffix = local
+        .changes
+        .iter()
+        .filter(|hash| !remote_set.contains(hash))
+        .copied()
+        .collect();
     Ok(ViewSyncPlan {
         suffix,
-        declare,
+        // Normal sync is monotonic. If the remote already contains every local
+        // member, there is nothing to publish even when the remote union is
+        // larger. Otherwise the server unions the proposal with its current set.
+        declare: !local_set.is_subset(&remote_set),
         forced: false,
         shrink: false,
     })
@@ -677,49 +623,36 @@ mod tests {
     }
 
     #[test]
-    fn test_plan_diverged_hash_mismatch() {
-        let local = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2), h(3)]);
+    fn test_plan_independent_membership_uses_set_difference() {
+        let local = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2), h(3), h(9)]);
         let remote = manifest("dev", ViewScope::Shared, None, vec![h(1), h(9)]);
-        let err = plan_view_sync(&local, Some(&remote), false, true).unwrap_err();
+        let plan = plan_view_sync(&local, Some(&remote), false, true).unwrap();
 
-        assert_eq!(
-            err,
-            ViewSyncConflict::Diverged {
-                first_mismatch: Some(1),
-                local_len: 3,
-                remote_len: 2,
-            }
-        );
+        assert_eq!(plan.suffix, vec![h(2), h(3)]);
+        assert!(plan.declare);
+        assert!(!plan.forced);
     }
 
     #[test]
-    fn test_plan_diverged_remote_longer() {
-        // Leaf pushed and remote is ahead (local ⊂ remote): ambiguous — behind
-        // vs. shrunk — so the leaf still errs toward "pull first, or --force".
+    fn test_plan_remote_superset_is_noop_after_local_reconciliation() {
         let local = manifest("dev", ViewScope::Shared, None, vec![h(1)]);
         let remote = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2)]);
-        let err = plan_view_sync(&local, Some(&remote), false, true).unwrap_err();
+        let plan = plan_view_sync(&local, Some(&remote), false, true).unwrap();
 
-        assert_eq!(
-            err,
-            ViewSyncConflict::Diverged {
-                first_mismatch: None,
-                local_len: 1,
-                remote_len: 2,
-            }
-        );
+        assert!(plan.suffix.is_empty());
+        assert!(!plan.declare, "remote already contains every local patch");
+        assert!(!plan.forced);
     }
 
     #[test]
-    fn test_plan_forced_diverged_stores_set_difference() {
-        let local = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2), h(3)]);
+    fn test_force_does_not_change_set_union_semantics() {
+        let local = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2), h(3), h(9)]);
         let remote = manifest("dev", ViewScope::Shared, None, vec![h(1), h(9)]);
         let plan = plan_view_sync(&local, Some(&remote), true, true).unwrap();
 
-        // h(1) is already on the remote view; h(2), h(3) are not.
         assert_eq!(plan.suffix, vec![h(2), h(3)]);
         assert!(plan.declare);
-        assert!(plan.forced);
+        assert!(!plan.forced);
     }
 
     #[test]
@@ -742,54 +675,24 @@ mod tests {
     }
 
     #[test]
-    fn test_plan_ancestor_shrunk_is_skipped_not_blocking() {
-        // An ANCESTOR in the chain (is_leaf = false) shrank locally, but the
-        // remote already holds every local change. It is skipped (no store, no
-        // declare) so a descendant push is not blocked, and `shrink` is flagged
-        // so the caller can explain the skip. Force does not change this —
-        // rewriting an ancestor must be done by pushing it directly.
+    fn test_plan_remote_only_members_are_not_removed() {
         let local = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2)]);
         let remote = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2), h(3), h(4)]);
 
         let plan = plan_view_sync(&local, Some(&remote), false, false).unwrap();
-        assert!(plan.suffix.is_empty(), "nothing to store for an ancestor");
-        assert!(!plan.declare, "an ancestor shrink is not declared");
-        assert!(!plan.forced);
-        assert!(plan.shrink, "flagged so the push can explain the skip");
-        assert!(plan.is_noop());
-
-        let forced = plan_view_sync(&local, Some(&remote), true, false).unwrap();
-        assert!(
-            !forced.declare,
-            "force does not rewrite an ancestor via a child push"
-        );
-    }
-
-    #[test]
-    fn test_plan_leaf_shrunk_forced_declares_smaller_set() {
-        // The LEAF being pushed shrank; with --force the remote view is rewritten
-        // to the smaller set (nothing new to store, since local ⊂ remote).
-        let local = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2)]);
-        let remote = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2), h(3), h(4)]);
-        let plan = plan_view_sync(&local, Some(&remote), true, true).unwrap();
-
         assert!(plan.suffix.is_empty());
-        assert!(
-            plan.declare,
-            "a forced leaf shrink rewrites the remote view"
-        );
-        assert!(plan.forced);
+        assert!(!plan.declare);
+        assert!(!plan.forced);
+        assert!(!plan.shrink);
     }
 
     #[test]
-    fn test_plan_genuine_divergence_still_errors_not_masked_by_shrink() {
-        // Remote is longer AND holds a change local lacks that local did not
-        // simply drop (h(2) local vs h(5)/h(6) remote) — a real divergence, not a
-        // subset shrink. Must still error without --force, even as an ancestor.
+    fn test_plan_independent_sets_do_not_conflict() {
         let local = manifest("dev", ViewScope::Shared, None, vec![h(1), h(2)]);
         let remote = manifest("dev", ViewScope::Shared, None, vec![h(1), h(5), h(6)]);
-        let err = plan_view_sync(&local, Some(&remote), false, false).unwrap_err();
-        assert!(matches!(err, ViewSyncConflict::Diverged { .. }));
+        let plan = plan_view_sync(&local, Some(&remote), false, false).unwrap();
+        assert_eq!(plan.suffix, vec![h(2)]);
+        assert!(plan.declare);
     }
 
     #[test]

--- a/atomic-cli/src/commands/view/list.rs
+++ b/atomic-cli/src/commands/view/list.rs
@@ -155,8 +155,11 @@ impl List {
             let config = attach_identity(config, &remote_url, self.identity.as_deref()).await;
             let remote = HttpRemote::with_config(&remote_url, config)
                 .map_err(|e| CliError::remote_error(e.to_string(), Some(remote_url.clone())))?;
+            // Bare object+ref model: the inventory is composed server-side from
+            // the `.view` objects (GET /refs/views), independent of any
+            // reconciled read-model.
             remote
-                .list_views()
+                .list_view_refs()
                 .await
                 .map_err(|e| CliError::remote_error(e.to_string(), Some(remote_url.clone())))
         })?;

--- a/atomic-objects/Cargo.toml
+++ b/atomic-objects/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "atomic-objects"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Canonical, content-addressed object encodings shared by the Atomic client and server (bare object+ref sync)."
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+blake3 = { workspace = true }
+data-encoding = { workspace = true }
+postcard = { workspace = true }
+zstd = { workspace = true }

--- a/atomic-objects/src/lib.rs
+++ b/atomic-objects/src/lib.rs
@@ -1,0 +1,57 @@
+//! Canonical, content-addressed object encodings shared by the Atomic client
+//! and server.
+//!
+//! This crate is the thin, engine-free foundation of the **bare object + ref**
+//! sync model (see `docs/view-snapshot-sync-design.md`). It defines the on-wire
+//! *objects* — content-addressed, immutable, byte-identical on both sides — with
+//! **no dependency on the redb graph engine** (`atomic-core`) or the repository
+//! layer (`atomic-repository`). That decoupling is deliberate:
+//!
+//! - The **client** derives these objects from its redb truth on push.
+//! - The **server** stores the object bytes verbatim and can compose
+//!   *structure* reads (view inventory, membership) straight from them — no
+//!   graph apply.
+//! - The **bare transport** (`ObjectStore`/`RefStore`) moves these as opaque
+//!   bytes keyed by their content address.
+//!
+//! Because both sides link this exact crate, `blake3(canonical_bytes)` is
+//! guaranteed identical everywhere, which is what makes content addressing and
+//! CAS-on-`prev` sound.
+//!
+//! The first object family is [`ViewSnapshot`]; vault objects
+//! (`VaultEntry`/`VaultManifest`) will land here later as additional families
+//! riding the identical transport.
+//!
+//! The [`sync`] module defines the **single `/code` transport** wire format —
+//! the header-negotiated, postcard+zstd [`sync::SyncPack`]/[`sync::SyncWants`]
+//! exchange that carries every object family and ref move for push/pull/clone.
+
+mod sync;
+mod view_snapshot;
+
+pub use sync::{
+    decode, decode_with_limit, encode, ObjectFamily, ObjectRecord, RefRecord, SyncError, SyncPack,
+    SyncWants, DEFAULT_MAX_DECOMPRESSED, DEFAULT_ZSTD_LEVEL, PROTOCOL_HEADER, PROTOCOL_SYNC_V1,
+    SYNC_MEDIA_TYPE,
+};
+pub use view_snapshot::{ViewScopeLabel, ViewSnapshot};
+
+/// The content address of an object: the lowercase-hex Blake3 of its canonical
+/// serialization. Kept as a plain `String` (rather than a newtype) so it drops
+/// straight into object-store keys, ref values, and REST paths without
+/// conversion; helpers here centralize the hashing so every producer agrees.
+pub type ObjectKey = String;
+
+/// Compute the canonical content address (lowercase hex Blake3) of arbitrary
+/// object bytes. Every object family keys itself with this, so the transport
+/// never needs to know an object's type to verify it: `content_key(bytes) ==
+/// key` is a universal, type-agnostic integrity check.
+pub fn content_key(bytes: &[u8]) -> ObjectKey {
+    blake3::hash(bytes).to_hex().to_string()
+}
+
+/// Whether `bytes` hash to `key` — the content-addressed integrity check the
+/// bare server runs on every `PUT /{family}/{key}` before storing.
+pub fn verify_key(key: &str, bytes: &[u8]) -> bool {
+    content_key(bytes) == key
+}

--- a/atomic-objects/src/lib.rs
+++ b/atomic-objects/src/lib.rs
@@ -22,9 +22,9 @@
 //! (`VaultEntry`/`VaultManifest`) will land here later as additional families
 //! riding the identical transport.
 //!
-//! The [`sync`] module defines the **single `/code` transport** wire format —
-//! the header-negotiated, postcard+zstd [`sync::SyncPack`]/[`sync::SyncWants`]
-//! exchange that carries every object family and ref move for push/pull/clone.
+//! The synchronization types define the **single `/code` transport** wire format —
+//! the header-negotiated, postcard+zstd [`SyncPack`]/[`SyncWants`] exchange that
+//! carries every object family and ref move for push/pull/clone.
 
 mod sync;
 mod view_snapshot;

--- a/atomic-objects/src/sync.rs
+++ b/atomic-objects/src/sync.rs
@@ -1,0 +1,458 @@
+//! The `/code` git-shaped sync wire format — the single transport for
+//! `atomic push`, `atomic pull`, and `atomic clone`.
+//!
+//! # One endpoint, header-negotiated
+//!
+//! All bare objects and refs move through **one** endpoint per project — the
+//! remote URL `…/projects/{slug}/code`. There are no per-object or per-ref
+//! transport URLs (those exist only as read-only *WebUI* resources). The client
+//! selects this binary protocol with a request header
+//! ([`PROTOCOL_HEADER`]`: `[`PROTOCOL_SYNC_V1`]); when the header is absent the
+//! server answers with plain JSON (a project-info ping / browse response), so
+//! the same URL serves both machine sync and human/WebUI reads.
+//!
+//! # The two directions
+//!
+//! - **push** = `POST …/code` with the sync header, body = an encoded
+//!   [`SyncPack`]: the object bytes the client is contributing plus the
+//!   [`RefRecord`] compare-and-swaps that move each view ref. The server stores
+//!   every object (content-addressed, integrity-verified) and CAS-moves each
+//!   ref (ancestry-gated, fast-forward only).
+//! - **pull / clone** = `GET …/code` with the sync header, body = an encoded
+//!   [`SyncWants`]: which view refs the client wants and which object keys it
+//!   already `haves`. The server replies with a [`SyncPack`] containing only the
+//!   objects the client is missing, plus the current ref targets.
+//!
+//! Negotiation (`haves`/`wants`) keeps a push/pull from re-sending objects the
+//! other side already holds — the git-style "have/want" exchange, collapsed into
+//! a single request/response because the object graph is content-addressed and
+//! the membership set travels in the view snapshots.
+//!
+//! # Encoding
+//!
+//! The body is [`postcard`]-serialized (compact, `no_std`-friendly, deterministic
+//! field order) and then **zstd**-compressed. Both sides link this exact crate,
+//! so the framing is byte-for-byte agreed. Use [`encode`]/[`decode`] (or the
+//! typed [`SyncPack::encode`]/[`SyncPack::decode`] wrappers) — never hand-roll
+//! the two steps, so the compression envelope stays consistent.
+
+use std::io::Read;
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+/// Request header that selects the binary sync protocol on `…/code`. Its
+/// presence (value [`PROTOCOL_SYNC_V1`]) switches the endpoint from the default
+/// JSON project-info/WebUI response to the object+ref sync exchange.
+pub const PROTOCOL_HEADER: &str = "Atomic-Protocol";
+
+/// The version-1 value of [`PROTOCOL_HEADER`]. Bump the suffix on any
+/// wire-breaking change so an old server rejects (and an old client is told to
+/// upgrade via `X-Atomic-Min-Version`).
+pub const PROTOCOL_SYNC_V1: &str = "sync/1";
+
+/// The media type of an encoded [`SyncPack`]/[`SyncWants`] body — set as the
+/// `Content-Type` so proxies and logs can identify the payload.
+pub const SYNC_MEDIA_TYPE: &str = "application/vnd.atomic.sync.v1";
+
+/// zstd level used for outbound bodies. Level 3 is zstd's default: a good
+/// size/speed tradeoff for the mixed text+binary change payloads.
+pub const DEFAULT_ZSTD_LEVEL: i32 = 3;
+
+/// Default ceiling on a *decompressed* body (2 GiB). Bounds the zip-bomb blast
+/// radius: [`decode`] refuses to inflate past this. Callers handling untrusted
+/// input (the server) can tighten it with [`decode_with_limit`].
+pub const DEFAULT_MAX_DECOMPRESSED: usize = 2 * 1024 * 1024 * 1024;
+
+/// The object families that ride the transport. Each maps 1:1 to the storage
+/// key segment under a project's object prefix (e.g. `…/changes/{key}`), so the
+/// server can route a decoded [`ObjectRecord`] to storage without inspecting its
+/// bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ObjectFamily {
+    /// A `.change` object — the unit of history.
+    Change,
+    /// A `.tag` object — a named, signed state.
+    Tag,
+    /// A `.provenance` object — the AI/decision graph sidecar for a change.
+    Provenance,
+    /// An `.attest` object — an attestation sidecar for a change.
+    Attest,
+    /// A view-snapshot object (`ViewSnapshot`) — a view's membership + lineage.
+    View,
+}
+
+impl ObjectFamily {
+    /// The storage key segment for this family (the `{family}` in
+    /// `{prefix}/{family}/{key}`). Stable on the wire — do not rename without a
+    /// protocol bump.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ObjectFamily::Change => "changes",
+            ObjectFamily::Tag => "tags",
+            ObjectFamily::Provenance => "provenance",
+            ObjectFamily::Attest => "attest",
+            ObjectFamily::View => "views",
+        }
+    }
+
+    /// Parse a family from its storage key segment; `None` for an unknown one.
+    pub fn from_segment(s: &str) -> Option<Self> {
+        match s {
+            "changes" => Some(ObjectFamily::Change),
+            "tags" => Some(ObjectFamily::Tag),
+            "provenance" => Some(ObjectFamily::Provenance),
+            "attest" => Some(ObjectFamily::Attest),
+            "views" => Some(ObjectFamily::View),
+            _ => None,
+        }
+    }
+
+    /// Every family, for iteration (inventory scans, closure walks).
+    pub fn all() -> [ObjectFamily; 5] {
+        [
+            ObjectFamily::Change,
+            ObjectFamily::Tag,
+            ObjectFamily::Provenance,
+            ObjectFamily::Attest,
+            ObjectFamily::View,
+        ]
+    }
+}
+
+/// A single content-addressed object in transit: its family (→ storage
+/// segment), its Blake3 content key, and its raw bytes. The receiver verifies
+/// `blake3(bytes) == key` before storing, so `family` never needs to be trusted
+/// for integrity — only for routing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ObjectRecord {
+    /// Which object family (→ storage key segment) this belongs to.
+    pub family: ObjectFamily,
+    /// The object's content address (lowercase-hex Blake3 of `bytes`).
+    pub key: String,
+    /// The object's canonical bytes.
+    pub bytes: Vec<u8>,
+}
+
+impl ObjectRecord {
+    /// Construct a record. The caller supplies the already-computed content key
+    /// (producers hash once on the way out of redb).
+    pub fn new(family: ObjectFamily, key: impl Into<String>, bytes: Vec<u8>) -> Self {
+        ObjectRecord {
+            family,
+            key: key.into(),
+            bytes,
+        }
+    }
+}
+
+/// A view-ref compare-and-swap in a push. Moves `name` from the client's
+/// last-known target (`expect_old`) to `new_target`; the server accepts it only
+/// if `expect_old` is the current target *and* it is an ancestor of
+/// `new_target` in the snapshot `prev` chain (fast-forward). `expect_old` is
+/// `None` for a ref the client believes does not exist yet (genesis).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RefRecord {
+    /// The view name (the `{name}` in `refs/views/{name}`).
+    pub name: String,
+    /// The target the client expects the ref to currently hold, or `None` for a
+    /// genesis create.
+    #[serde(default)]
+    pub expect_old: Option<String>,
+    /// The view-snapshot object key the ref should point at after the CAS.
+    pub new_target: String,
+}
+
+/// The push payload / pull response: a batch of objects plus the ref moves that
+/// make them reachable. On **push** the client fills both; on **pull/clone** the
+/// server fills `objects` with what the client lacks and `refs` with each
+/// requested view's current target (`expect_old` unused in that direction).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SyncPack {
+    /// Content-addressed objects being transferred.
+    pub objects: Vec<ObjectRecord>,
+    /// View-ref updates (push) or current targets (pull/clone).
+    pub refs: Vec<RefRecord>,
+}
+
+impl SyncPack {
+    /// An empty pack (no objects, no refs) — a no-op push or an up-to-date pull.
+    pub fn empty() -> Self {
+        SyncPack::default()
+    }
+
+    /// Whether this pack carries nothing.
+    pub fn is_empty(&self) -> bool {
+        self.objects.is_empty() && self.refs.is_empty()
+    }
+
+    /// Encode to a compressed wire body. See [`encode`].
+    pub fn encode(&self) -> Result<Vec<u8>, SyncError> {
+        encode(self)
+    }
+
+    /// Decode from a compressed wire body, bounded by [`DEFAULT_MAX_DECOMPRESSED`].
+    pub fn decode(bytes: &[u8]) -> Result<Self, SyncError> {
+        decode(bytes)
+    }
+}
+
+/// The pull/clone request: which view refs the client wants and which object
+/// keys it already holds. An empty `refs` means "every view" (a full clone);
+/// `haves` lets the server omit objects the client already has, so an
+/// incremental pull transfers only the delta.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SyncWants {
+    /// View names to fetch; empty = all views on the remote.
+    pub refs: Vec<String>,
+    /// Object keys (any family) the client already has, so the server can skip
+    /// them. Order-insensitive; the server treats it as a set.
+    pub haves: Vec<String>,
+    /// Ref-advertisement mode: when `true`, the server returns only the view
+    /// refs and their view-snapshot objects (for the requested views and their
+    /// ancestor chains) — **no** change bodies or sidecars. This is the cheap
+    /// "fetch refs" plane a push uses to negotiate what the remote already has
+    /// before sending a pack (the git `info/refs` advertisement, collapsed onto
+    /// `/code`). Defaults to `false` (a full pull/clone).
+    #[serde(default)]
+    pub refs_only: bool,
+}
+
+impl SyncWants {
+    /// Want every view (a full clone), declaring the given `haves`.
+    pub fn all(haves: Vec<String>) -> Self {
+        SyncWants {
+            refs: Vec::new(),
+            haves,
+            refs_only: false,
+        }
+    }
+
+    /// A ref advertisement for the given views (and their ancestors): refs +
+    /// view-snapshot objects only, no change bodies. Used by push negotiation.
+    pub fn advertise(refs: Vec<String>) -> Self {
+        SyncWants {
+            refs,
+            haves: Vec::new(),
+            refs_only: true,
+        }
+    }
+
+    /// Whether this asks for all views (empty `refs`).
+    pub fn wants_all(&self) -> bool {
+        self.refs.is_empty()
+    }
+
+    /// Encode to a compressed wire body. See [`encode`].
+    pub fn encode(&self) -> Result<Vec<u8>, SyncError> {
+        encode(self)
+    }
+
+    /// Decode from a compressed wire body, bounded by [`DEFAULT_MAX_DECOMPRESSED`].
+    pub fn decode(bytes: &[u8]) -> Result<Self, SyncError> {
+        decode(bytes)
+    }
+}
+
+/// Errors from the sync codec: serialization or (de)compression failures.
+#[derive(Debug)]
+pub enum SyncError {
+    /// postcard failed to (de)serialize the value.
+    Codec(postcard::Error),
+    /// zstd failed to compress or decompress the body.
+    Compression(std::io::Error),
+    /// The decompressed body exceeded the configured limit — a likely zip bomb.
+    TooLarge {
+        /// The limit that was exceeded (bytes).
+        limit: usize,
+    },
+}
+
+impl std::fmt::Display for SyncError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SyncError::Codec(e) => write!(f, "sync codec error: {e}"),
+            SyncError::Compression(e) => write!(f, "sync compression error: {e}"),
+            SyncError::TooLarge { limit } => {
+                write!(f, "decompressed sync body exceeds {limit} bytes")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SyncError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            SyncError::Codec(e) => Some(e),
+            SyncError::Compression(e) => Some(e),
+            SyncError::TooLarge { .. } => None,
+        }
+    }
+}
+
+/// Serialize `value` with postcard and zstd-compress it into a wire body.
+///
+/// Deterministic for a given value (postcard field order is fixed and zstd is
+/// deterministic at a fixed level), which keeps request bodies reproducible for
+/// tests and caches.
+pub fn encode<T: Serialize>(value: &T) -> Result<Vec<u8>, SyncError> {
+    let raw = postcard::to_allocvec(value).map_err(SyncError::Codec)?;
+    zstd::encode_all(raw.as_slice(), DEFAULT_ZSTD_LEVEL).map_err(SyncError::Compression)
+}
+
+/// Decompress and deserialize a wire body, bounded by
+/// [`DEFAULT_MAX_DECOMPRESSED`]. Use [`decode_with_limit`] to set a tighter cap
+/// for untrusted input.
+pub fn decode<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, SyncError> {
+    decode_with_limit(bytes, DEFAULT_MAX_DECOMPRESSED)
+}
+
+/// Decompress and deserialize a wire body, refusing to inflate past `max_len`
+/// bytes. The bound is enforced during decompression (streaming), so a zip bomb
+/// is stopped before it is fully materialized.
+pub fn decode_with_limit<T: DeserializeOwned>(
+    bytes: &[u8],
+    max_len: usize,
+) -> Result<T, SyncError> {
+    let raw = decompress(bytes, max_len)?;
+    postcard::from_bytes(&raw).map_err(SyncError::Codec)
+}
+
+/// Streaming zstd decompress with a hard output ceiling. Reads at most
+/// `max_len + 1` bytes so an overrun is detected without buffering the whole
+/// bomb.
+fn decompress(bytes: &[u8], max_len: usize) -> Result<Vec<u8>, SyncError> {
+    let decoder = zstd::stream::read::Decoder::new(bytes).map_err(SyncError::Compression)?;
+    let mut out = Vec::new();
+    let read = decoder
+        .take(max_len as u64 + 1)
+        .read_to_end(&mut out)
+        .map_err(SyncError::Compression)?;
+    if read > max_len {
+        return Err(SyncError::TooLarge { limit: max_len });
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_pack() -> SyncPack {
+        SyncPack {
+            objects: vec![
+                ObjectRecord::new(ObjectFamily::Change, "aa", b"change-body".to_vec()),
+                ObjectRecord::new(ObjectFamily::View, "bb", b"{\"scope\":\"shared\"}".to_vec()),
+                ObjectRecord::new(ObjectFamily::Provenance, "cc", b"prov".to_vec()),
+            ],
+            refs: vec![
+                RefRecord {
+                    name: "dev".to_string(),
+                    expect_old: None,
+                    new_target: "bb".to_string(),
+                },
+                RefRecord {
+                    name: "feature".to_string(),
+                    expect_old: Some("bb".to_string()),
+                    new_target: "cc".to_string(),
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn pack_roundtrips_through_the_wire() {
+        let pack = sample_pack();
+        let bytes = pack.encode().expect("encode");
+        let decoded = SyncPack::decode(&bytes).expect("decode");
+        assert_eq!(decoded, pack);
+    }
+
+    #[test]
+    fn wants_roundtrip_and_all_helper() {
+        let wants = SyncWants::all(vec!["aa".to_string(), "bb".to_string()]);
+        assert!(wants.wants_all());
+        let bytes = wants.encode().expect("encode");
+        assert_eq!(SyncWants::decode(&bytes).expect("decode"), wants);
+
+        let scoped = SyncWants {
+            refs: vec!["dev".to_string()],
+            haves: vec![],
+            refs_only: false,
+        };
+        assert!(!scoped.wants_all());
+
+        let adv = SyncWants::advertise(vec!["dev".to_string()]);
+        assert!(adv.refs_only);
+        assert!(!adv.wants_all());
+        assert_eq!(SyncWants::decode(&adv.encode().unwrap()).unwrap(), adv);
+    }
+
+    #[test]
+    fn empty_pack_is_empty() {
+        let pack = SyncPack::empty();
+        assert!(pack.is_empty());
+        let decoded = SyncPack::decode(&pack.encode().unwrap()).unwrap();
+        assert!(decoded.is_empty());
+    }
+
+    #[test]
+    fn family_segment_mapping_is_stable_and_reversible() {
+        for f in ObjectFamily::all() {
+            assert_eq!(ObjectFamily::from_segment(f.as_str()), Some(f));
+        }
+        assert_eq!(
+            ObjectFamily::from_segment("changes"),
+            Some(ObjectFamily::Change)
+        );
+        assert_eq!(
+            ObjectFamily::from_segment("attest"),
+            Some(ObjectFamily::Attest)
+        );
+        assert_eq!(ObjectFamily::from_segment("nope"), None);
+    }
+
+    #[test]
+    fn body_is_compressed_smaller_than_raw_postcard_for_repetitive_input() {
+        // A highly compressible object: zstd should shrink it well below the
+        // raw postcard size, confirming compression is actually applied.
+        let pack = SyncPack {
+            objects: vec![ObjectRecord::new(
+                ObjectFamily::Change,
+                "k",
+                vec![b'a'; 10_000],
+            )],
+            refs: vec![],
+        };
+        let raw = postcard::to_allocvec(&pack).unwrap();
+        let wire = pack.encode().unwrap();
+        assert!(
+            wire.len() < raw.len(),
+            "compressed {} should be < raw {}",
+            wire.len(),
+            raw.len()
+        );
+    }
+
+    #[test]
+    fn decode_rejects_a_body_over_the_limit() {
+        // Compress 5000 bytes, then demand it decode within 1000 — the streaming
+        // guard must reject it as TooLarge rather than allocating the full output.
+        let pack = SyncPack {
+            objects: vec![ObjectRecord::new(
+                ObjectFamily::Change,
+                "k",
+                vec![7u8; 5000],
+            )],
+            refs: vec![],
+        };
+        let wire = pack.encode().unwrap();
+        let err = decode_with_limit::<SyncPack>(&wire, 1000).unwrap_err();
+        assert!(matches!(err, SyncError::TooLarge { limit: 1000 }));
+    }
+
+    #[test]
+    fn decode_rejects_garbage() {
+        assert!(SyncPack::decode(b"not a zstd frame").is_err());
+    }
+}

--- a/atomic-objects/src/view_snapshot.rs
+++ b/atomic-objects/src/view_snapshot.rs
@@ -1,0 +1,268 @@
+//! The view-snapshot object — the content-addressed representation of a view's
+//! identity, lineage, and membership at one point in time.
+//!
+//! A [`ViewSnapshot`] is immutable and content-addressed by the Blake3 of its
+//! canonical JSON. A `views/{name}` ref points at the current snapshot key and
+//! is CAS-updated (fast-forward gated on `prev`) on each view-state change.
+//!
+//! # Membership is own-set + parent pointer
+//!
+//! A snapshot inlines only the view's **own** change set; the effective union is
+//! composed on read by walking `parent_view` up the chain (see
+//! [`ViewSnapshot::effective_changes`]). So a draft off a 100k-change `dev`
+//! stays tiny — the big set lives only in the shared root it points at. This
+//! mirrors Atomic's `VIEW_CHANGES[this] + parent` model exactly.
+
+use serde::{Deserialize, Serialize};
+
+/// The two view scopes, as they appear in the object's `scope` string. Kept as
+/// a light label here (the authoritative `ViewScope` enum lives in
+/// `atomic-core`) so this crate stays engine-free.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ViewScopeLabel {
+    /// A collaborative root/shared view. Serialized as `"shared"`.
+    Shared,
+    /// A personal draft view parented on another view. Serialized as `"draft"`.
+    Draft,
+}
+
+impl ViewScopeLabel {
+    /// The canonical string form stored in the object.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ViewScopeLabel::Shared => "shared",
+            ViewScopeLabel::Draft => "draft",
+        }
+    }
+
+    /// Parse from the object's `scope` string. Unknown values are treated as
+    /// `Shared` — the safe default (a root that inherits nothing).
+    pub fn parse(s: &str) -> Self {
+        if s == "draft" {
+            ViewScopeLabel::Draft
+        } else {
+            ViewScopeLabel::Shared
+        }
+    }
+}
+
+/// An immutable, content-addressed snapshot of a view's state.
+///
+/// Serialized as canonical JSON; content address = Blake3 of the canonical
+/// bytes (see [`ViewSnapshot::content_key`]). Field order is fixed by the
+/// struct definition and every field is deterministic, so two repositories
+/// holding the same view state mint byte-identical objects with identical keys.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ViewSnapshot {
+    /// View scope: `"shared"` or `"draft"`.
+    pub scope: String,
+    /// Parent view **name**, or `None` for a root view. Inherited membership is
+    /// resolved against the parent's *current* head at read time (live by-name,
+    /// decision D6), preserving Atomic's inheritance semantics.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub parent_view: Option<String>,
+    /// Predecessor snapshot key(s) (hex Blake3). Usually 1; empty for genesis;
+    /// >1 only for a view merge. Makes the view's history a content-addressed
+    /// DAG — fast-forward vs divergence is decided by walking `prev`, not by
+    /// log-shape heuristics.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub prev: Vec<String>,
+    /// The view's **own** change hashes (base32), in log order. For a draft
+    /// this is just the draft's own changes; for a shared root it is the full
+    /// change log. The effective union is composed on read via `parent_view`.
+    pub own_changes: Vec<String>,
+    /// Order-invariant `SetId` of `own_changes` (base32), computed by the
+    /// producer (which has the engine). Carried opaquely here so a reader can
+    /// do an O(1) "same own-set?" check by string equality without the engine.
+    pub own_set_id: String,
+    /// The view's merkle state (base32) — the fold of the change log. `None`
+    /// for an empty view.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub merkle_state: Option<String>,
+}
+
+impl ViewSnapshot {
+    /// Construct a snapshot from its parts. The producer computes `own_set_id`
+    /// (order-invariant over `own_changes`) and `merkle_state` from its engine;
+    /// this crate carries them opaquely.
+    pub fn new(
+        scope: ViewScopeLabel,
+        parent_view: Option<String>,
+        prev: Vec<String>,
+        own_changes: Vec<String>,
+        own_set_id: String,
+        merkle_state: Option<String>,
+    ) -> Self {
+        ViewSnapshot {
+            scope: scope.as_str().to_string(),
+            parent_view,
+            prev,
+            own_changes,
+            own_set_id,
+            merkle_state,
+        }
+    }
+
+    /// Serialize to canonical JSON bytes. Deterministic: struct field order is
+    /// fixed and every field is deterministic, so the byte output — and thus the
+    /// content key — is stable across client and server.
+    pub fn to_canonical_bytes(&self) -> Vec<u8> {
+        serde_json::to_vec(self).expect("ViewSnapshot serializes")
+    }
+
+    /// The content address (hex Blake3) of the canonical bytes — this object's
+    /// key in the object store and the value a `views/{name}` ref points at.
+    pub fn content_key(&self) -> crate::ObjectKey {
+        crate::content_key(&self.to_canonical_bytes())
+    }
+
+    /// Deserialize from canonical bytes. Returns `None` on malformed input.
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        serde_json::from_slice(bytes).ok()
+    }
+
+    /// The parsed scope label.
+    pub fn scope_label(&self) -> ViewScopeLabel {
+        ViewScopeLabel::parse(&self.scope)
+    }
+
+    /// Whether this snapshot represents a draft view.
+    pub fn is_draft(&self) -> bool {
+        self.scope_label() == ViewScopeLabel::Draft
+    }
+
+    /// The number of changes this view owns (does not include inherited).
+    pub fn own_change_count(&self) -> usize {
+        self.own_changes.len()
+    }
+
+    /// Compose the **effective** change set (own ∪ ancestors) from an ordered
+    /// chain of snapshots: `chain[0]` is this view, each subsequent element its
+    /// parent, up to the root. Order-preserving and deduplicated (root-first,
+    /// then descendants), so callers get a stable membership list without
+    /// touching the graph.
+    ///
+    /// The caller resolves the chain by walking `parent_view` (each name → its
+    /// ref → its snapshot); this function is the pure composition step.
+    pub fn effective_changes(chain: &[&ViewSnapshot]) -> Vec<String> {
+        use std::collections::HashSet;
+        let mut seen: HashSet<&str> = HashSet::new();
+        let mut out: Vec<String> = Vec::new();
+        // Root-first so inherited history precedes a draft's own additions,
+        // matching the order redb's filter chain yields.
+        for snap in chain.iter().rev() {
+            for h in &snap.own_changes {
+                if seen.insert(h.as_str()) {
+                    out.push(h.clone());
+                }
+            }
+        }
+        out
+    }
+
+    /// The size of the effective change set for a resolved ancestor chain
+    /// (`chain[0]` = this view). Deduplicates across the chain.
+    pub fn effective_change_count(chain: &[&ViewSnapshot]) -> usize {
+        use std::collections::HashSet;
+        let mut seen: HashSet<&str> = HashSet::new();
+        for snap in chain {
+            for h in &snap.own_changes {
+                seen.insert(h.as_str());
+            }
+        }
+        seen.len()
+    }
+
+    /// Render the legacy tab-separated manifest text this snapshot represents,
+    /// for the transitional `?view-manifest` compatibility path. New code
+    /// should read the object directly.
+    pub fn to_manifest_text(&self, name: &str) -> String {
+        let parent = self.parent_view.as_deref().unwrap_or("-");
+        let state = self.merkle_state.as_deref().unwrap_or("-");
+        let mut out = format!("{}\t{}\t{}\t{}\n", name, self.scope, parent, state);
+        for hash in &self.own_changes {
+            out.push_str(hash);
+            out.push('\n');
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snap(scope: ViewScopeLabel, parent: Option<&str>, own: &[&str]) -> ViewSnapshot {
+        ViewSnapshot::new(
+            scope,
+            parent.map(|s| s.to_string()),
+            vec![],
+            own.iter().map(|s| s.to_string()).collect(),
+            "SETID".to_string(),
+            own.last().map(|_| "MERKLE".to_string()),
+        )
+    }
+
+    #[test]
+    fn content_key_is_deterministic_and_bytes_roundtrip() {
+        let a = snap(ViewScopeLabel::Draft, Some("dev"), &["C1", "C2"]);
+        let b = a.clone();
+        assert_eq!(a.content_key(), b.content_key());
+
+        let bytes = a.to_canonical_bytes();
+        assert!(crate::verify_key(&a.content_key(), &bytes));
+        let decoded = ViewSnapshot::from_bytes(&bytes).expect("roundtrip");
+        assert_eq!(decoded, a);
+    }
+
+    #[test]
+    fn different_membership_changes_the_key() {
+        let a = snap(ViewScopeLabel::Shared, None, &["C1"]);
+        let b = snap(ViewScopeLabel::Shared, None, &["C2"]);
+        assert_ne!(a.content_key(), b.content_key());
+    }
+
+    #[test]
+    fn scope_and_parent_survive_roundtrip() {
+        let s = snap(ViewScopeLabel::Draft, Some("dev"), &["C3"]);
+        let decoded = ViewSnapshot::from_bytes(&s.to_canonical_bytes()).unwrap();
+        assert!(decoded.is_draft());
+        assert_eq!(decoded.parent_view.as_deref(), Some("dev"));
+    }
+
+    #[test]
+    fn effective_set_composes_root_first_and_dedups() {
+        // dev (root) owns C1,C2 ; draft owns C2 (dup) + C3.
+        let dev = snap(ViewScopeLabel::Shared, None, &["C1", "C2"]);
+        let draft = snap(ViewScopeLabel::Draft, Some("dev"), &["C2", "C3"]);
+
+        // chain[0] = this view (draft), chain[1] = parent (dev).
+        let chain = [&draft, &dev];
+        assert_eq!(
+            ViewSnapshot::effective_changes(&chain),
+            vec!["C1".to_string(), "C2".to_string(), "C3".to_string()],
+            "root-first, deduped"
+        );
+        assert_eq!(ViewSnapshot::effective_change_count(&chain), 3);
+        assert_eq!(draft.own_change_count(), 2);
+    }
+
+    #[test]
+    fn genesis_has_empty_prev_and_omits_optionals_in_json() {
+        let s = snap(ViewScopeLabel::Shared, None, &[]);
+        let text = String::from_utf8(s.to_canonical_bytes()).unwrap();
+        // Empty prev and None parent/merkle are skipped in the canonical form.
+        assert!(!text.contains("prev"));
+        assert!(!text.contains("parent_view"));
+        assert!(!text.contains("merkle_state"));
+    }
+
+    #[test]
+    fn manifest_text_has_tab_header() {
+        let s = snap(ViewScopeLabel::Draft, Some("dev"), &["C1", "C2"]);
+        let text = s.to_manifest_text("feature");
+        assert!(text.starts_with("feature\tdraft\tdev\tMERKLE\n"));
+        assert!(text.contains("C1\n"));
+        assert!(text.contains("C2\n"));
+    }
+}

--- a/atomic-objects/src/view_snapshot.rs
+++ b/atomic-objects/src/view_snapshot.rs
@@ -61,8 +61,8 @@ pub struct ViewSnapshot {
     /// decision D6), preserving Atomic's inheritance semantics.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub parent_view: Option<String>,
-    /// Predecessor snapshot key(s) (hex Blake3). Usually 1; empty for genesis;
-    /// >1 only for a view merge. Makes the view's history a content-addressed
+    /// Predecessor snapshot key(s) (hex Blake3). Usually one; empty for genesis;
+    /// multiple only for a view merge. Makes the view's history a content-addressed
     /// DAG — fast-forward vs divergence is decided by walking `prev`, not by
     /// log-shape heuristics.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]

--- a/atomic-remote/Cargo.toml
+++ b/atomic-remote/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["development-tools"]
 [dependencies]
 # Internal crates
 atomic-core = { workspace = true }
+atomic-objects = { workspace = true }
 
 # HTTP client
 reqwest = { workspace = true, features = ["json", "gzip", "deflate", "stream"] }

--- a/atomic-remote/src/http/bare.rs
+++ b/atomic-remote/src/http/bare.rs
@@ -1,0 +1,82 @@
+//! Client for the remaining read-only WebUI resource(s).
+//!
+//! Push/pull/clone transport moved to the single `/code` sync protocol (see
+//! [`super::code_sync`]); the per-object `PUT`/`GET`/`HEAD` and view-ref CAS
+//! calls that used to live here were retired with that cutover. What remains is
+//! the one read a CLI command still needs outside `/code`:
+//! [`HttpRemote::list_view_refs`], backing `atomic view list --remote`.
+
+use log::debug;
+use reqwest::StatusCode;
+
+use super::HttpRemote;
+use crate::error::{RemoteError, RemoteResult};
+use crate::types::RemoteViewInfo;
+
+impl HttpRemote {
+    /// Build a sibling REST resource URL from the `/code` base URL.
+    ///
+    /// `https://h/workspaces/w/projects/p/code` + `refs/views` →
+    /// `https://h/workspaces/w/projects/p/refs/views`.
+    pub(crate) fn resource_url(&self, path: &str) -> String {
+        let base = self.base_url.as_str();
+        let base = base.strip_suffix('/').unwrap_or(base);
+        let project_base = base.strip_suffix("/code").unwrap_or(base);
+        format!("{project_base}/{path}")
+    }
+
+    /// The view inventory (`GET /refs/views`), composed on the server from the
+    /// `.view` objects. Read-only WebUI/browse surface used by
+    /// `atomic view list --remote`.
+    pub async fn list_view_refs(&self) -> RemoteResult<Vec<RemoteViewInfo>> {
+        let url = self.resource_url("refs/views");
+        debug!("GET view refs: {url}");
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| RemoteError::connection_failed(&url, e))?;
+        match response.status() {
+            StatusCode::OK => {
+                let text = response
+                    .text()
+                    .await
+                    .map_err(|e| RemoteError::connection_failed(&url, e))?;
+                Ok(text.lines().filter_map(RemoteViewInfo::parse).collect())
+            }
+            StatusCode::NOT_FOUND => Ok(Vec::new()),
+            s => Err(RemoteError::http(
+                s.as_u16(),
+                response.text().await.unwrap_or_default(),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resource_url_replaces_code_suffix() {
+        let r = HttpRemote::new("https://h/workspaces/w/projects/p/code").unwrap();
+        assert_eq!(
+            r.resource_url("refs/views"),
+            "https://h/workspaces/w/projects/p/refs/views"
+        );
+        assert_eq!(
+            r.resource_url("refs/views/dev"),
+            "https://h/workspaces/w/projects/p/refs/views/dev"
+        );
+    }
+
+    #[test]
+    fn resource_url_without_code_suffix_appends() {
+        let r = HttpRemote::new("https://h/workspaces/w/projects/p").unwrap();
+        assert_eq!(
+            r.resource_url("refs/views"),
+            "https://h/workspaces/w/projects/p/refs/views"
+        );
+    }
+}

--- a/atomic-remote/src/http/code_sync.rs
+++ b/atomic-remote/src/http/code_sync.rs
@@ -1,0 +1,111 @@
+//! Client transport for the single `/code` git-shaped sync protocol.
+//!
+//! This is the client counterpart to the server's `/code` handler: all of
+//! `atomic push`/`pull`/`clone` move objects and refs through **one** endpoint —
+//! the remote's `base_url` (`…/projects/{slug}/code`) — using the header-
+//! negotiated binary [`SyncPack`]/[`SyncWants`] format from [`atomic_objects`].
+//! It replaces the per-object [`super::bare`] REST calls (`put_object`,
+//! `get_object`, `put_view_ref`, …) for transport; those RESTful URLs remain
+//! only as read-only WebUI surfaces.
+//!
+//! - [`HttpRemote::sync_push`] `POST`s a [`SyncPack`] (objects + ref CAS moves).
+//! - [`HttpRemote::sync_pull`] `GET`s with a [`SyncWants`] body and decodes the
+//!   returned [`SyncPack`] (the objects the client is missing + ref targets).
+
+use atomic_objects::{SyncPack, SyncWants, PROTOCOL_HEADER, PROTOCOL_SYNC_V1, SYNC_MEDIA_TYPE};
+use reqwest::header::CONTENT_TYPE;
+use reqwest::StatusCode;
+use serde::Deserialize;
+
+use super::HttpRemote;
+use crate::error::{RemoteError, RemoteResult};
+
+/// The server's push summary (`{ "stored", "refs_moved" }`).
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct PushSummary {
+    /// Number of objects stored (or already present).
+    #[serde(default)]
+    pub stored: usize,
+    /// Number of view refs moved by the CAS batch.
+    #[serde(default)]
+    pub refs_moved: usize,
+}
+
+impl HttpRemote {
+    /// Push a [`SyncPack`] to the remote's `/code` endpoint.
+    ///
+    /// A `409 Conflict` (a divergent, non-fast-forward ref move) surfaces as a
+    /// [`RemoteError::Protocol`] carrying the server's message, so the caller can
+    /// tell the user to pull first.
+    pub async fn sync_push(&self, pack: &SyncPack) -> RemoteResult<PushSummary> {
+        let url = self.base_url.as_str().to_string();
+        let body = pack
+            .encode()
+            .map_err(|e| RemoteError::protocol(format!("failed to encode sync pack: {e}")))?;
+        let response = self
+            .client
+            .post(&url)
+            .header(PROTOCOL_HEADER, PROTOCOL_SYNC_V1)
+            .header(CONTENT_TYPE, SYNC_MEDIA_TYPE)
+            .body(body)
+            .send()
+            .await
+            .map_err(|e| RemoteError::connection_failed(&url, e))?;
+        crate::check_min_version_header(response.headers());
+        match response.status() {
+            StatusCode::OK | StatusCode::CREATED => {
+                Ok(response.json::<PushSummary>().await.unwrap_or_default())
+            }
+            StatusCode::CONFLICT => Err(RemoteError::protocol(
+                response.text().await.unwrap_or_default(),
+            )),
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => Err(RemoteError::auth_failed(
+                &url,
+                response.text().await.unwrap_or_default(),
+            )),
+            s => Err(RemoteError::http(
+                s.as_u16(),
+                response.text().await.unwrap_or_default(),
+            )),
+        }
+    }
+
+    /// Pull from the remote's `/code` endpoint: send `wants` (which views, and
+    /// the object keys already held) and decode the returned [`SyncPack`] of
+    /// missing objects + current ref targets. An empty [`SyncWants::refs`] asks
+    /// for every view (a full clone).
+    pub async fn sync_pull(&self, wants: &SyncWants) -> RemoteResult<SyncPack> {
+        let url = self.base_url.as_str().to_string();
+        let body = wants
+            .encode()
+            .map_err(|e| RemoteError::protocol(format!("failed to encode sync wants: {e}")))?;
+        let response = self
+            .client
+            .get(&url)
+            .header(PROTOCOL_HEADER, PROTOCOL_SYNC_V1)
+            .header(CONTENT_TYPE, SYNC_MEDIA_TYPE)
+            .body(body)
+            .send()
+            .await
+            .map_err(|e| RemoteError::connection_failed(&url, e))?;
+        crate::check_min_version_header(response.headers());
+        match response.status() {
+            StatusCode::OK => {
+                let bytes = response
+                    .bytes()
+                    .await
+                    .map_err(|e| RemoteError::connection_failed(&url, e))?;
+                SyncPack::decode(&bytes)
+                    .map_err(|e| RemoteError::protocol(format!("failed to decode sync pack: {e}")))
+            }
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => Err(RemoteError::auth_failed(
+                &url,
+                response.text().await.unwrap_or_default(),
+            )),
+            s => Err(RemoteError::http(
+                s.as_u16(),
+                response.text().await.unwrap_or_default(),
+            )),
+        }
+    }
+}

--- a/atomic-remote/src/http/code_sync.rs
+++ b/atomic-remote/src/http/code_sync.rs
@@ -4,9 +4,9 @@
 //! `atomic push`/`pull`/`clone` move objects and refs through **one** endpoint —
 //! the remote's `base_url` (`…/projects/{slug}/code`) — using the header-
 //! negotiated binary [`SyncPack`]/[`SyncWants`] format from [`atomic_objects`].
-//! It replaces the per-object [`super::bare`] REST calls (`put_object`,
-//! `get_object`, `put_view_ref`, …) for transport; those RESTful URLs remain
-//! only as read-only WebUI surfaces.
+//! It replaces the per-object REST calls (`put_object`, `get_object`,
+//! `put_view_ref`, …) for transport; those RESTful URLs remain only as
+//! read-only WebUI surfaces.
 //!
 //! - [`HttpRemote::sync_push`] `POST`s a [`SyncPack`] (objects + ref CAS moves).
 //! - [`HttpRemote::sync_pull`] `GET`s with a [`SyncWants`] body and decodes the
@@ -35,8 +35,8 @@ impl HttpRemote {
     /// Push a [`SyncPack`] to the remote's `/code` endpoint.
     ///
     /// A `409 Conflict` (a divergent, non-fast-forward ref move) surfaces as a
-    /// [`RemoteError::Protocol`] carrying the server's message, so the caller can
-    /// tell the user to pull first.
+    /// [`RemoteError::ProtocolError`] carrying the server's message, so the caller
+    /// can tell the user to pull first.
     pub async fn sync_push(&self, pack: &SyncPack) -> RemoteResult<PushSummary> {
         let url = self.base_url.as_str().to_string();
         let body = pack

--- a/atomic-remote/src/http/mod.rs
+++ b/atomic-remote/src/http/mod.rs
@@ -30,6 +30,8 @@
 //! }
 //! ```
 
+mod bare;
+pub mod code_sync;
 mod download;
 mod queries;
 mod upload;

--- a/atomic-remote/src/lib.rs
+++ b/atomic-remote/src/lib.rs
@@ -139,6 +139,7 @@ pub use version::{check_min_version_header, needs_upgrade};
 pub use error::{RemoteError, RemoteResult};
 
 // HTTP client
+pub use http::code_sync::PushSummary;
 pub use http::{HttpRemote, HttpRemoteConfig};
 
 // Storage management client
@@ -151,7 +152,7 @@ pub use storage_types::{
 // Protocol types
 pub use types::{
     ChangelistEntry, Node, NodeType, ParseChangelistError, ParseNodeTypeError, ParseStateError,
-    PullDelta, PushDelta, RemoteViewInfo, StateResponse,
+    PullDelta, PushDelta, RefUpdate, RemoteViewInfo, StateResponse,
 };
 
 // Sync engine

--- a/atomic-remote/src/types.rs
+++ b/atomic-remote/src/types.rs
@@ -609,13 +609,31 @@ pub struct RemoteViewInfo {
 
     /// The view's current base32 Merkle state, or `None` if the view is empty.
     pub state: Option<String>,
+
+    /// Order-invariant `SetId` (base32) of the view's effective change set, when
+    /// the server advertises it (6th wire field). This is the convergence
+    /// identity used to validate that a pull/clone reproduced the exact set;
+    /// `None` against servers that predate it.
+    pub set_id: Option<String>,
+}
+
+/// Outcome of a bare view-ref compare-and-swap (`PUT /refs/views/{name}`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RefUpdate {
+    /// The ref moved to the new snapshot key (fast-forward or genesis).
+    Committed,
+    /// The move was rejected — divergent history or a lost concurrent CAS.
+    /// Carries the server's explanation.
+    Conflict(String),
 }
 
 impl RemoteViewInfo {
     /// Parse one protocol line into a [`RemoteViewInfo`].
     ///
-    /// Wire format (tab-separated): `name\tscope\tparent\tchange_count\tstate`,
-    /// where `parent` and `state` use `-` to mean "none".
+    /// Wire format (tab-separated):
+    /// `name\tscope\tparent\tchange_count\tstate\tset_id`, where `parent`,
+    /// `state`, and `set_id` use `-`/absence to mean "none". The trailing
+    /// `set_id` is optional so older 5-field servers still parse.
     ///
     /// Returns `None` for blank lines or lines that don't have at least the
     /// `name` and `scope` fields, so unrelated output (e.g. an older server's
@@ -639,6 +657,7 @@ impl RemoteViewInfo {
             .and_then(|c| c.trim().parse::<u64>().ok())
             .unwrap_or(0);
         let state = fields.next().map(str::trim).filter(|s| !s.is_empty());
+        let set_id = fields.next().map(str::trim).filter(|s| !s.is_empty());
 
         let none_or = |v: Option<&str>| match v {
             Some("-") | None => None,
@@ -651,6 +670,7 @@ impl RemoteViewInfo {
             parent: none_or(parent),
             change_count,
             state: none_or(state),
+            set_id: none_or(set_id),
         })
     }
 

--- a/atomic-repository/src/repository/changes.rs
+++ b/atomic-repository/src/repository/changes.rs
@@ -170,6 +170,22 @@ impl Repository {
         self.change_store.has_change(hash)
     }
 
+    /// Return every normal change registered in the repository's common graph.
+    ///
+    /// This is the authoritative object inventory for sync negotiation: changes
+    /// are repository-global graph nodes, not owned by a particular view. A
+    /// client advertises these hashes as `haves` so the server never resends a
+    /// `.change` merely because it is absent from one view's own metadata.
+    pub fn registered_change_hashes(&self) -> Result<Vec<Hash>, RepositoryError> {
+        let txn = self
+            .pristine
+            .read_txn()
+            .map_err(|e| RepositoryError::Database(e.to_string()))?;
+        txn.list_registered_changes()
+            .map(|items| items.into_iter().map(|(_, hash)| hash).collect())
+            .map_err(|e| RepositoryError::Database(e.to_string()))
+    }
+
     /// Backfill the pristine normal-change dependency index from stored changes.
     ///
     /// This is intended for legacy repositories that predate the `CHANGE_DEPS`

--- a/atomic-repository/src/repository/vault.rs
+++ b/atomic-repository/src/repository/vault.rs
@@ -2454,14 +2454,27 @@ mod tests {
         )
         .unwrap();
 
-        // Precondition: vault tables don't exist yet
+        // Precondition: vault tables don't exist yet. Capture exact graph-
+        // materialized bytes: bootstrap is disk→redb and must not rewrite them.
         assert!(!repo2.has_vault().unwrap());
+        let arch_before = std::fs::read(vault2.join("memory/architecture.md")).unwrap();
+        let rust_before = std::fs::read(vault2.join("skills/rust.md")).unwrap();
 
         // ── Bootstrap ──────────────────────────────────────────────
         repo2.bootstrap_vault_from_working_copy().unwrap();
 
         // ── Assertions ─────────────────────────────────────────────
         assert!(repo2.has_vault().unwrap());
+        assert_eq!(
+            std::fs::read(vault2.join("memory/architecture.md")).unwrap(),
+            arch_before,
+            "bootstrap must not rewrite tracked vault files"
+        );
+        assert_eq!(
+            std::fs::read(vault2.join("skills/rust.md")).unwrap(),
+            rust_before,
+            "bootstrap must not rewrite tracked vault files"
+        );
 
         // Both entries should now be in repo2's redb
         let arch = repo2

--- a/atomic-repository/src/repository/views.rs
+++ b/atomic-repository/src/repository/views.rs
@@ -774,6 +774,94 @@ impl Repository {
         Ok(manifest)
     }
 
+    /// Reconcile a view manifest by **set union** over the common causal graph.
+    ///
+    /// Normal synchronization is monotonic: independently-added patches in a
+    /// shared view commute, so neither ordered log replaces the other. This
+    /// method preserves the local own membership and adds every incoming own
+    /// change not already present. For drafts, inherited membership remains
+    /// derived from the already-reconciled parent metadata; only the draft's
+    /// own changes are unioned here.
+    ///
+    /// The caller applies ancestor manifests root-to-leaf. Every referenced
+    /// `.change` must already be stored; `insert_change` registers/applies a
+    /// graph node only when absent and otherwise performs the metadata write.
+    /// Identity (scope + parent) is immutable and must match.
+    pub fn reconcile_view_manifest(
+        &mut self,
+        manifest: &ViewManifest,
+    ) -> Result<ManifestApplyOutcome, RepositoryError> {
+        manifest.verify()?;
+
+        for hash in &manifest.changes {
+            if !self.has_change(hash) {
+                return Err(RepositoryError::ManifestMissingChanges {
+                    view: manifest.name.clone(),
+                    count: 1,
+                    first: hash.to_base32(),
+                });
+            }
+        }
+
+        if self.view_exists(&manifest.name)? {
+            let info = self.get_view_info(&manifest.name)?;
+            if info.scope != manifest.scope {
+                return Err(RepositoryError::ManifestIdentityMismatch {
+                    view: manifest.name.clone(),
+                    reason: format!(
+                        "local scope is {:?}, manifest declares {:?}",
+                        info.scope, manifest.scope
+                    ),
+                });
+            }
+            if info.parent_name != manifest.parent {
+                return Err(RepositoryError::ManifestIdentityMismatch {
+                    view: manifest.name.clone(),
+                    reason: format!(
+                        "local parent is {:?}, manifest declares {:?}",
+                        info.parent_name, manifest.parent
+                    ),
+                });
+            }
+        } else {
+            self.create_view_with_identity(
+                &manifest.name,
+                manifest.scope,
+                manifest.parent.as_deref(),
+            )
+            .map_err(|e| match e {
+                RepositoryError::ViewNotFound { name } => RepositoryError::ManifestParentMissing {
+                    view: manifest.name.clone(),
+                    parent: name,
+                },
+                other => other,
+            })?;
+        }
+
+        let local = self.view_manifest(&manifest.name)?;
+        let mut present: HashSet<Hash> = local.changes.iter().copied().collect();
+        let already_present = manifest
+            .changes
+            .iter()
+            .filter(|hash| present.contains(hash))
+            .count();
+        let mut replayed = 0usize;
+        for hash in &manifest.changes {
+            if present.insert(*hash) {
+                self.insert_change(hash, InsertOptions::default().view(&manifest.name))?;
+                replayed += 1;
+            }
+        }
+
+        let info = self.get_view_info(&manifest.name)?;
+        Ok(ManifestApplyOutcome {
+            view: manifest.name.clone(),
+            already_present,
+            replayed,
+            state: info.state,
+        })
+    }
+
     /// Declaratively apply a [`ViewManifest`]: create the view with its
     /// declared identity if absent, then fast-forward its change log to
     /// match the manifest.


### PR DESCRIPTION
This pull request significantly refactors the clone logic in the `atomic-cli` to optimize remote data fetching and improve consistency checks. Instead of making multiple round-trips to the remote server for each view and change, the clone process now performs a single `/code` pull to retrieve all necessary view snapshots and change objects in one go. Manifests and change data are reconstructed locally from this pack, reducing network overhead and making the process more robust. Additionally, a new convergence verification step checks that the locally reconstructed views match the remote's effective state.

Key changes include:

**Clone process optimization:**
- Refactored the clone logic to fetch all view snapshots and change objects in a single `sync_pull` call, eliminating multiple per-view and per-change remote requests. Manifests are now reconstructed locally from the pulled pack. (`atomic-cli/src/commands/clone/command.rs`) [[1]](diffhunk://#diff-8ace27124ebe2af933665aa1062ab2b4e8c5ff0edfdff2aff739aa4622e7b120L346-R459) [[2]](diffhunk://#diff-8ace27124ebe2af933665aa1062ab2b4e8c5ff0edfdff2aff739aa4622e7b120L792-R903)
- Added helper methods to extract manifests and change objects from the `SyncPack`, and adjusted the main clone flow to use these local reconstructions. (`atomic-cli/src/commands/clone/command.rs`) [[1]](diffhunk://#diff-8ace27124ebe2af933665aa1062ab2b4e8c5ff0edfdff2aff739aa4622e7b120L346-R459) [[2]](diffhunk://#diff-8ace27124ebe2af933665aa1062ab2b4e8c5ff0edfdff2aff739aa4622e7b120L415-R507) [[3]](diffhunk://#diff-8ace27124ebe2af933665aa1062ab2b4e8c5ff0edfdff2aff739aa4622e7b120L437-R531)

**Convergence verification:**
- Introduced a new step after cloning to verify that each applied view's effective set-id matches the remote's, ensuring consistency and catching divergence or corruption. (`atomic-cli/src/commands/clone/command.rs`) [[1]](diffhunk://#diff-8ace27124ebe2af933665aa1062ab2b4e8c5ff0edfdff2aff739aa4622e7b120L346-R459) [[2]](diffhunk://#diff-8ace27124ebe2af933665aa1062ab2b4e8c5ff0edfdff2aff739aa4622e7b120R1135-R1142)

**Interface and dependency updates:**
- Updated method signatures throughout the clone command to operate on local data extracted from the `SyncPack` rather than making remote calls. (`atomic-cli/src/commands/clone/command.rs`) [[1]](diffhunk://#diff-8ace27124ebe2af933665aa1062ab2b4e8c5ff0edfdff2aff739aa4622e7b120L346-R459) [[2]](diffhunk://#diff-8ace27124ebe2af933665aa1062ab2b4e8c5ff0edfdff2aff739aa4622e7b120L602-R701)
- Added the `atomic-objects` crate as a workspace member and dependency in `Cargo.toml` and `atomic-cli/Cargo.toml`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R10) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R33) [[3]](diffhunk://#diff-114013fe183ffb9c325447ac26230adfa7fa4df8ff6295470180c48174712052R30)

**Other improvements:**
- Made the `helpers` module in `atomic-cli/src/commands/pull` public to allow reuse.
- Updated imports in the push command for consistency with the new object model. (`atomic-cli/src/commands/push/command.rs`)