### PR TITLE
fix: clone ingests provenance/attestation sidecars; push honors toml identity bindings

### DIFF
--- a/atomic-cli/src/commands/auth.rs
+++ b/atomic-cli/src/commands/auth.rs
@@ -13,8 +13,10 @@
 //! 2. URL userinfo — `http://bob@alice.localhost:8080/...` → identity "bob"
 //! 3. Configured server binding — a `[servers.*]`/`[server]` profile whose host
 //!    is the longest suffix of the remote host supplies its `identity`. Identity
-//!    follows the server you registered with, so any tenant under it resolves
-//!    without `--identity`.
+//!    follows the server you registered with (the binding `atomic identity
+//!    register` writes), so any tenant under it resolves without `--identity`.
+//!    When two profiles' hosts match equally well, the **active** profile
+//!    (per `default_server`, else the legacy `[server]` block) wins.
 //! 4. Subdomain — `http://alice.localhost:8080/...` → identity "alice" (legacy
 //!    last resort).
 //! 5. Default identity — if none of the above resolves to an identity that
@@ -31,6 +33,16 @@ use url::Url;
 
 use crate::error::{CliError, CliResult};
 
+/// One `[server]`/`[servers.*]` profile that declares an identity: its host,
+/// its bound identity, and whether it is the active profile (the one
+/// `default_server` selects, or the legacy block when no name is set).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ServerBinding {
+    host: String,
+    identity: String,
+    active: bool,
+}
+
 /// Resolve the identity name to authenticate as.
 ///
 /// Priority:
@@ -40,7 +52,8 @@ use crate::error::{CliError, CliResult};
 ///    suffix of the remote host (`[servers.prod] url=... identity=...`). This is
 ///    the binding that makes pushes to *any* tenant under a server you've
 ///    registered with ("just works" without `--identity`): identity follows the
-///    server, not the tenant subdomain.
+///    server, not the tenant subdomain. Equal-length matches are won by the
+///    active profile.
 /// 4. The remote host's leading subdomain label (`http://bob.host/...`) — the
 ///    legacy heuristic, kept only as a last resort.
 ///
@@ -53,16 +66,18 @@ fn resolve_identity_name_with_override(
     if let Some(name) = identity_override {
         return Some(name.to_string());
     }
-    resolve_identity_from_url(remote_url, &configured_server_identities())
+    resolve_identity_from_url(remote_url, &configured_server_identity_bindings())
 }
 
-/// Collect `(server_host, identity)` pairs from the global config — both the
-/// default `[server]` block and every named `[servers.*]` profile — that
-/// declare an identity. Servers without an identity binding are skipped.
+/// Collect the server profiles from the global config — both the default
+/// `[server]` block and every named `[servers.*]` profile — that declare an
+/// identity, marking which one is **active** (the profile `default_server`
+/// names, or the legacy block when unset). Servers without an identity binding
+/// are skipped.
 ///
 /// Returns an empty list when no config exists or it can't be read, so
 /// resolution degrades cleanly to URL-based inference.
-fn configured_server_identities() -> Vec<(String, String)> {
+fn configured_server_identity_bindings() -> Vec<ServerBinding> {
     let config = match atomic_config::GlobalConfig::load() {
         Ok(c) => c,
         Err(e) => {
@@ -71,31 +86,59 @@ fn configured_server_identities() -> Vec<(String, String)> {
         }
     };
 
-    let mut pairs = Vec::new();
-    let mut consider = |server: &atomic_config::ServerConfig| {
-        if let (Some(url), Some(identity)) = (server.url.as_ref(), server.identity.as_ref()) {
-            if let Some(host) = Url::parse(url)
-                .ok()
-                .and_then(|u| u.host_str().map(String::from))
-            {
-                pairs.push((host, identity.clone()));
-            }
+    let host_of = |server: &atomic_config::ServerConfig| {
+        server
+            .url
+            .as_deref()
+            .and_then(|u| Url::parse(u).ok())
+            .and_then(|u| u.host_str().map(String::from))
+    };
+
+    let mut bindings = Vec::new();
+    let mut consider = |server: &atomic_config::ServerConfig, active: bool| {
+        if let (Some(host), Some(identity)) = (host_of(server), server.identity.as_ref()) {
+            bindings.push(ServerBinding {
+                host,
+                identity: identity.clone(),
+                active,
+            });
         }
     };
 
-    consider(&config.server);
-    for server in config.servers.values() {
-        consider(server);
+    // The active profile is resolved exactly as management commands resolve
+    // it (`GlobalConfig::resolve_server`): `default_server` → named profile,
+    // else the legacy block. A dangling `default_server` name degrades to
+    // no active marker rather than failing auth resolution.
+    let active_named = config
+        .default_server
+        .as_deref()
+        .and_then(|name| config.servers.get(name));
+    match active_named {
+        Some(profile) => {
+            consider(profile, true);
+            for (name, server) in &config.servers {
+                if Some(name.as_str()) != config.default_server.as_deref() {
+                    consider(server, false);
+                }
+            }
+            consider(&config.server, false);
+        }
+        None => {
+            for server in config.servers.values() {
+                consider(server, false);
+            }
+            consider(&config.server, true);
+        }
     }
-    pairs
+    bindings
 }
 
 /// Pure identity resolution from a URL plus the configured server bindings.
 ///
-/// userinfo → server-host match (longest suffix) → first-label subdomain.
-/// Split from the config-loading wrapper so it can be unit-tested without a
-/// config file on disk.
-fn resolve_identity_from_url(remote_url: &str, servers: &[(String, String)]) -> Option<String> {
+/// userinfo → server-host match (longest suffix, active wins ties) → first-label
+/// subdomain. Split from the config-loading wrapper so it can be unit-tested
+/// without a config file on disk.
+fn resolve_identity_from_url(remote_url: &str, servers: &[ServerBinding]) -> Option<String> {
     let url = Url::parse(remote_url).ok()?;
 
     // 1. Explicit in the URL: http://bob@host/...
@@ -117,17 +160,21 @@ fn resolve_identity_from_url(remote_url: &str, servers: &[(String, String)]) -> 
 }
 
 /// Pick the identity bound to the configured server whose host is the longest
-/// dot-boundary suffix of `remote_host`.
+/// dot-boundary suffix of `remote_host`. When several profiles' hosts match
+/// with the same length (e.g. the legacy `[server]` block and a named profile
+/// pointing at the same server), the **active** profile wins — the one
+/// `default_server` selects, else the legacy block.
 ///
-/// Longest-suffix wins so a more specific server (`staging.atomic.storage`)
-/// beats a broader one (`atomic.storage`) for hosts under both — e.g.
-/// `x.staging.atomic.storage` resolves to the staging identity, not prod.
-fn match_server_identity(remote_host: &str, servers: &[(String, String)]) -> Option<String> {
+/// Longest-suffix still wins over active: a more specific server
+/// (`staging.atomic.storage`) beats a broader active one (`atomic.storage`)
+/// for hosts under both — e.g. `x.staging.atomic.storage` resolves to the
+/// staging identity, not prod.
+fn match_server_identity(remote_host: &str, servers: &[ServerBinding]) -> Option<String> {
     servers
         .iter()
-        .filter(|(server_host, _)| host_is_under(remote_host, server_host))
-        .max_by_key(|(server_host, _)| server_host.len())
-        .map(|(_, identity)| identity.clone())
+        .filter(|b| host_is_under(remote_host, &b.host))
+        .max_by_key(|b| (b.host.len(), b.active))
+        .map(|b| b.identity.clone())
 }
 
 /// Whether `remote_host` is the server host itself or a subdomain of it,
@@ -809,13 +856,18 @@ mod tests {
 
     // -- configured server-host identity binding --
 
-    fn servers() -> Vec<(String, String)> {
+    fn binding(host: &str, identity: &str) -> ServerBinding {
+        ServerBinding {
+            host: host.to_string(),
+            identity: identity.to_string(),
+            active: false,
+        }
+    }
+
+    fn servers() -> Vec<ServerBinding> {
         vec![
-            ("atomic.storage".to_string(), "Aaron".to_string()),
-            (
-                "staging.atomic.storage".to_string(),
-                "aaron-staging".to_string(),
-            ),
+            binding("atomic.storage", "Aaron"),
+            binding("staging.atomic.storage", "aaron-staging"),
         ]
     }
 
@@ -859,6 +911,80 @@ mod tests {
                 "host {host} should bind to the staging identity"
             );
         }
+    }
+
+    #[test]
+    fn active_profile_wins_an_equal_host_tie() {
+        // The legacy [server] block and a named profile point at the SAME
+        // server. The active profile's identity must win — previously the
+        // named profile always won on a tie, ignoring `default_server`.
+        let mut active_legacy = servers();
+        active_legacy.push(ServerBinding {
+            host: "localhost".to_string(),
+            identity: "legacy-identity".to_string(),
+            active: true,
+        });
+        active_legacy.push(binding("localhost", "named-identity"));
+
+        let url = "http://localhost:8444/workspaces/w/projects/p/code";
+        assert_eq!(
+            resolve_identity_from_url(url, &active_legacy).as_deref(),
+            Some("legacy-identity"),
+            "the active binding must win an equal-host tie"
+        );
+
+        // Flip which binding is active → the answer flips.
+        let mut active_named = servers();
+        active_named.push(binding("localhost", "legacy-identity"));
+        active_named.push(ServerBinding {
+            host: "localhost".to_string(),
+            identity: "named-identity".to_string(),
+            active: true,
+        });
+        assert_eq!(
+            resolve_identity_from_url(url, &active_named).as_deref(),
+            Some("named-identity")
+        );
+    }
+
+    #[test]
+    fn longest_suffix_beats_active_shorter_host() {
+        // A more specific (longer-host) profile outranks a broader active
+        // one: pushing to staging uses staging's identity, not the active
+        // prod profile's.
+        let mut b = servers();
+        b[0].active = true; // atomic.storage / "Aaron" is active
+        let url = "https://x.staging.atomic.storage/workspaces/w/projects/p/code";
+        assert_eq!(
+            resolve_identity_from_url(url, &b).as_deref(),
+            Some("aaron-staging"),
+            "host specificity outranks the active marker"
+        );
+    }
+
+    #[test]
+    fn active_binding_supplies_identity_for_bare_local_host() {
+        // `atomic identity register http://localhost:8444` (no --identity)
+        // now binds the registering identity to the legacy [server] block,
+        // which is active when no default_server names a profile. A push to
+        // that host must resolve to it instead of falling through to the
+        // subdomain heuristic or the store default.
+        let bindings = vec![ServerBinding {
+            host: "localhost".to_string(),
+            identity: "leefaus".to_string(),
+            active: true,
+        }];
+        let url = "http://localhost:8444/workspaces/w/projects/p/code";
+        assert_eq!(
+            resolve_identity_from_url(url, &bindings).as_deref(),
+            Some("leefaus")
+        );
+        // Tenant subdomains of the same server inherit the binding too.
+        let url = "http://aaron.localhost:8444/workspaces/w/projects/p/code";
+        assert_eq!(
+            resolve_identity_from_url(url, &bindings).as_deref(),
+            Some("leefaus")
+        );
     }
 
     #[test]

--- a/atomic-cli/src/commands/clone/command.rs
+++ b/atomic-cli/src/commands/clone/command.rs
@@ -448,6 +448,19 @@ impl Clone {
             .collect()
     }
 
+    /// Ingest a pack's provenance graphs and attestations, reporting counts.
+    ///
+    /// Shared with `atomic pull` (see [`crate::commands::sidecars`]) so both
+    /// paths land sidecars identically. Failures warn and continue — a bad
+    /// sidecar never blocks a clone whose changes are all valid.
+    fn import_and_report_sidecars(&self, repo: &Repository, pack: &SyncPack) {
+        let stats = crate::commands::sidecars::import_sidecars(repo, pack);
+        if !stats.is_empty() {
+            print_blank();
+            crate::commands::sidecars::report_sidecars(stats);
+        }
+    }
+
     /// Fetch the requested view's manifest and walk its parent chain up to
     /// the root, returning the manifests in root→leaf apply order.
     ///
@@ -991,6 +1004,12 @@ impl Clone {
             repo.align_to_view(&self.view)
                 .map_err(CliError::Repository)?;
 
+            // Sidecars (provenance, attestations) still land in the store —
+            // the pack carried them and dropping them would require a later
+            // pull to recover. DEPS wiring to the covered changes happens
+            // when those changes are applied (`atomic insert`).
+            self.import_and_report_sidecars(&repo, &pack);
+
             // Configure remote as "origin" even for download-only mode
             let spinner = create_spinner("Configuring remote...");
             if let Err(e) = repo.add_remote_default("origin", &self.url) {
@@ -1131,6 +1150,15 @@ impl Clone {
                 self.hint_other_views(&remote, &applied_views).await;
             }
         }
+
+        // Ingest the pack's sidecars (provenance graphs, attestations) — the
+        // same logic pull uses. This must run AFTER the view manifests are
+        // applied: the DEPS edges that make `atomic change <hash>` find its
+        // provenance (via REV_DEPS) are only written for changes already
+        // registered in the graph, and registration happens at apply time.
+        // Without this, a fresh clone shows "No provenance graph found"
+        // until a later repair pull re-imports the sidecars.
+        self.import_and_report_sidecars(&repo, &pack);
 
         // Validate convergence with the order-invariant SetId across every
         // applied view (chain + any `--all-views` extras), against the

--- a/atomic-cli/src/commands/clone/command.rs
+++ b/atomic-cli/src/commands/clone/command.rs
@@ -1004,10 +1004,9 @@ impl Clone {
             repo.align_to_view(&self.view)
                 .map_err(CliError::Repository)?;
 
-            // Sidecars (provenance, attestations) still land in the store —
-            // the pack carried them and dropping them would require a later
-            // pull to recover. DEPS wiring to the covered changes happens
-            // when those changes are applied (`atomic insert`).
+            // Sidecars (provenance, attestations) still land in the store.
+            // Saving them registers covered change hashes and wires DEPS even
+            // before those downloaded changes are inserted into a view.
             self.import_and_report_sidecars(&repo, &pack);
 
             // Configure remote as "origin" even for download-only mode

--- a/atomic-cli/src/commands/identity/register.rs
+++ b/atomic-cli/src/commands/identity/register.rs
@@ -215,47 +215,38 @@ impl Register {
                 CliError::Internal(anyhow::anyhow!("Failed to load global config: {e}"))
             })?;
 
-            // When --identity is specified, register as a named server profile
-            // so the URL+identity combo is remembered automatically.
-            if self.identity.is_some() {
-                let profile_name = self
-                    .server_name
+            // A named profile is created only for `--identity` registrations;
+            // the default path records the server in the legacy [server]
+            // block. Either way the identity that registered is bound in the
+            // config, so push/pull authenticate as it even when the store's
+            // global default identity is something else entirely.
+            let profile_name = if self.identity.is_some() {
+                self.server_name
                     .clone()
                     .or_else(|| derive_profile_name(&clean_server_url))
-                    .unwrap_or_else(|| slug.to_string());
+                    .or_else(|| Some(slug.to_string()))
+            } else {
+                None
+            };
 
-                let profile = atomic_config::ServerConfig {
-                    url: Some(clean_server_url.clone()),
-                    default_org: Some(slug.to_string()),
-                    default_workspaces: std::collections::BTreeMap::new(),
-                    identity: Some(identity.name.clone()),
-                    single_tenant,
-                };
+            let created_profile = apply_registration(
+                &mut config,
+                &clean_server_url,
+                slug,
+                single_tenant,
+                &identity.name,
+                profile_name.as_deref(),
+            );
 
-                config.servers.insert(profile_name.clone(), profile);
-
-                // If there's no active named server yet, make this one active.
-                if config.default_server.is_none() && config.server.is_configured() {
-                    // Legacy [server] is already set — don't override it silently.
-                    // Just register the profile; user can activate with `atomic server set`.
-                    println!(
-                        "  Profile:   '{}' added (activate with: atomic server set {})",
-                        profile_name, profile_name
-                    );
-                } else if config.default_server.is_none() {
-                    config.default_server = Some(profile_name.clone());
-                    println!("  Profile:   '{}' (now active)", profile_name);
+            if let Some(name) = &created_profile {
+                if config.default_server.as_deref() == Some(name.as_str()) {
+                    println!("  Profile:   '{}' (now active)", name);
                 } else {
                     println!(
                         "  Profile:   '{}' added (activate with: atomic server set {})",
-                        profile_name, profile_name
+                        name, name
                     );
                 }
-            } else {
-                // Default path: update the legacy [server] block.
-                config.server.url = Some(clean_server_url.clone());
-                config.server.default_org = Some(slug.to_string());
-                config.server.single_tenant = single_tenant;
             }
 
             config.save().map_err(|e| {
@@ -339,6 +330,60 @@ impl Register {
         }
 
         Ok(())
+    }
+}
+
+/// Record a completed registration in the global config.
+///
+/// Two shapes, matching the pre-existing behavior:
+///
+/// - `profile_name = Some(_)` (an `--identity` registration): insert a named
+///   `[servers.{name}]` profile carrying the URL, org, and identity binding.
+///   It becomes the active profile (`default_server`) only when nothing is
+///   active yet AND the legacy `[server]` block is unconfigured.
+/// - `profile_name = None` (default-identity registration): update the legacy
+///   `[server]` block in place.
+///
+/// In **both** cases the registering identity's name is written to the
+/// profile's `identity` field. Without that binding, push/pull fall back to
+/// the identity store's global default — which is frequently a different,
+/// unrelated identity on machines with several test identities, and the
+/// server then rejects the push (401/404) even though the right identity
+/// registered fine.
+///
+/// Returns the created profile name, if any.
+fn apply_registration(
+    config: &mut GlobalConfig,
+    server_url: &str,
+    slug: &str,
+    single_tenant: bool,
+    identity_name: &str,
+    profile_name: Option<&str>,
+) -> Option<String> {
+    if let Some(name) = profile_name {
+        let profile = atomic_config::ServerConfig {
+            url: Some(server_url.to_string()),
+            default_org: Some(slug.to_string()),
+            default_workspaces: std::collections::BTreeMap::new(),
+            identity: Some(identity_name.to_string()),
+            single_tenant,
+        };
+        config.servers.insert(name.to_string(), profile);
+
+        // Make it the active profile only when nothing else is active and
+        // the legacy [server] block wouldn't be silently overridden.
+        if config.default_server.is_none() && !config.server.is_configured() {
+            config.default_server = Some(name.to_string());
+        }
+        Some(name.to_string())
+    } else {
+        config.server.url = Some(server_url.to_string());
+        config.server.default_org = Some(slug.to_string());
+        config.server.single_tenant = single_tenant;
+        // Bind the registering identity so remote commands authenticate as
+        // it (see the doc comment above).
+        config.server.identity = Some(identity_name.to_string());
+        None
     }
 }
 
@@ -483,6 +528,135 @@ mod tests {
         assert_eq!(
             derive_profile_name("http://localhost:8080"),
             Some("localhost".to_string())
+        );
+    }
+
+    // -- apply_registration (config persistence) --
+
+    use atomic_config::GlobalConfig;
+
+    #[test]
+    fn default_path_binds_identity_in_legacy_server_block() {
+        // The reported bug: registering with the default identity wrote the
+        // URL/org to [server] but never the identity, so push fell back to
+        // the store's global default — the wrong identity on machines with
+        // several of them.
+        let mut config = GlobalConfig::default();
+        let created = apply_registration(
+            &mut config,
+            "http://localhost:8444",
+            "personal",
+            true,
+            "leefaus",
+            None,
+        );
+
+        assert!(created.is_none(), "default path creates no named profile");
+        assert_eq!(config.server.url.as_deref(), Some("http://localhost:8444"));
+        assert_eq!(config.server.default_org.as_deref(), Some("personal"));
+        assert!(config.server.single_tenant);
+        assert_eq!(
+            config.server.identity.as_deref(),
+            Some("leefaus"),
+            "the registering identity must be bound so push authenticates as it"
+        );
+        assert!(config.servers.is_empty());
+    }
+
+    #[test]
+    fn default_path_rebinding_updates_the_identity() {
+        // Re-registering the same server with a different identity must
+        // replace the binding — the latest registration wins.
+        let mut config = GlobalConfig::default();
+        apply_registration(
+            &mut config,
+            "http://localhost:8444",
+            "personal",
+            false,
+            "old",
+            None,
+        );
+        apply_registration(
+            &mut config,
+            "http://localhost:8444",
+            "personal",
+            false,
+            "new",
+            None,
+        );
+        assert_eq!(config.server.identity.as_deref(), Some("new"));
+    }
+
+    #[test]
+    fn explicit_path_creates_named_profile_with_identity() {
+        let mut config = GlobalConfig::default();
+        let created = apply_registration(
+            &mut config,
+            "https://atomic.storage",
+            "atomic",
+            false,
+            "Aaron",
+            Some("prod"),
+        );
+
+        assert_eq!(created.as_deref(), Some("prod"));
+        let profile = &config.servers["prod"];
+        assert_eq!(profile.url.as_deref(), Some("https://atomic.storage"));
+        assert_eq!(profile.default_org.as_deref(), Some("atomic"));
+        assert_eq!(profile.identity.as_deref(), Some("Aaron"));
+        // No prior active server and legacy block unconfigured → now active.
+        assert_eq!(config.default_server.as_deref(), Some("prod"));
+    }
+
+    #[test]
+    fn explicit_path_does_not_override_a_configured_legacy_block() {
+        // Legacy [server] already configured → the profile is added but NOT
+        // silently activated.
+        let mut config = GlobalConfig::default();
+        config.server.url = Some("http://localhost:8444".to_string());
+        config.server.default_org = Some("personal".to_string());
+
+        let created = apply_registration(
+            &mut config,
+            "https://atomic.storage",
+            "atomic",
+            false,
+            "Aaron",
+            Some("prod"),
+        );
+
+        assert_eq!(created.as_deref(), Some("prod"));
+        assert!(
+            config.default_server.is_none(),
+            "must not silently override the configured legacy block"
+        );
+        assert!(config.servers.contains_key("prod"));
+    }
+
+    #[test]
+    fn explicit_path_respects_an_existing_default_server() {
+        let mut config = GlobalConfig {
+            default_server: Some("existing".to_string()),
+            ..GlobalConfig::default()
+        };
+        config.servers.insert(
+            "existing".to_string(),
+            atomic_config::ServerConfig::default(),
+        );
+
+        apply_registration(
+            &mut config,
+            "https://staging.atomic.storage",
+            "staging",
+            false,
+            "aaron-staging",
+            Some("staging"),
+        );
+
+        assert_eq!(
+            config.default_server.as_deref(),
+            Some("existing"),
+            "an already-active profile stays active"
         );
     }
 }

--- a/atomic-cli/src/commands/identity/register.rs
+++ b/atomic-cli/src/commands/identity/register.rs
@@ -341,8 +341,9 @@ impl Register {
 ///   `[servers.{name}]` profile carrying the URL, org, and identity binding.
 ///   It becomes the active profile (`default_server`) only when nothing is
 ///   active yet AND the legacy `[server]` block is unconfigured.
-/// - `profile_name = None` (default-identity registration): update the legacy
-///   `[server]` block in place.
+/// - `profile_name = None` (default-identity registration): update the active
+///   named profile when it already points at this URL; otherwise update the
+///   legacy `[server]` block. This guarantees the new binding is effective.
 ///
 /// In **both** cases the registering identity's name is written to the
 /// profile's `identity` field. Without that binding, push/pull fall back to
@@ -377,14 +378,39 @@ fn apply_registration(
         }
         Some(name.to_string())
     } else {
-        config.server.url = Some(server_url.to_string());
-        config.server.default_org = Some(slug.to_string());
-        config.server.single_tenant = single_tenant;
-        // Bind the registering identity so remote commands authenticate as
-        // it (see the doc comment above).
-        config.server.identity = Some(identity_name.to_string());
+        // If the active named profile already represents this server, update
+        // it directly. Writing only the legacy block would be ineffective:
+        // authentication intentionally lets the active profile win equal-host
+        // matches.
+        let matching_active = config.default_server.as_deref().and_then(|name| {
+            config
+                .servers
+                .get(name)
+                .filter(|server| server_urls_match(server.url.as_deref(), server_url))
+                .map(|_| name.to_string())
+        });
+
+        if let Some(name) = matching_active {
+            if let Some(server) = config.servers.get_mut(&name) {
+                server.url = Some(server_url.to_string());
+                server.default_org = Some(slug.to_string());
+                server.single_tenant = single_tenant;
+                server.identity = Some(identity_name.to_string());
+            }
+        } else {
+            config.server.url = Some(server_url.to_string());
+            config.server.default_org = Some(slug.to_string());
+            config.server.single_tenant = single_tenant;
+            config.server.identity = Some(identity_name.to_string());
+        }
         None
     }
+}
+
+fn server_urls_match(configured: Option<&str>, registered: &str) -> bool {
+    configured
+        .map(|url| url.trim_end_matches('/') == registered.trim_end_matches('/'))
+        .unwrap_or(false)
 }
 
 /// Derive a short profile name from a server URL.
@@ -561,6 +587,38 @@ mod tests {
             "the registering identity must be bound so push authenticates as it"
         );
         assert!(config.servers.is_empty());
+    }
+
+    #[test]
+    fn default_path_updates_matching_active_profile() {
+        let mut config = GlobalConfig {
+            default_server: Some("prod".to_string()),
+            ..GlobalConfig::default()
+        };
+        config.servers.insert(
+            "prod".to_string(),
+            atomic_config::ServerConfig {
+                url: Some("http://localhost:8444/".to_string()),
+                identity: Some("old".to_string()),
+                ..atomic_config::ServerConfig::default()
+            },
+        );
+
+        let created = apply_registration(
+            &mut config,
+            "http://localhost:8444",
+            "personal",
+            true,
+            "new",
+            None,
+        );
+
+        assert!(created.is_none());
+        let active = &config.servers["prod"];
+        assert_eq!(active.identity.as_deref(), Some("new"));
+        assert_eq!(active.default_org.as_deref(), Some("personal"));
+        assert!(active.single_tenant);
+        assert!(!config.server.is_configured());
     }
 
     #[test]

--- a/atomic-cli/src/commands/mod.rs
+++ b/atomic-cli/src/commands/mod.rs
@@ -107,6 +107,7 @@ pub mod pull;
 pub mod push;
 pub mod remote;
 pub mod server;
+pub mod sidecars;
 
 // Phase 4: Identity Management
 pub mod identity;

--- a/atomic-cli/src/commands/pull/command.rs
+++ b/atomic-cli/src/commands/pull/command.rs
@@ -722,10 +722,9 @@ impl Pull {
 
         // Apply changes (unless download-only)
         if self.download_only {
-            // Sidecars (provenance, attestations) still land in the store —
-            // the pack carried them and dropping them would require a later
-            // pull to recover. DEPS wiring to the covered changes happens
-            // when those changes are applied (`atomic insert`).
+            // Sidecars (provenance, attestations) still land in the store.
+            // Saving them registers covered change hashes and wires DEPS even
+            // before those downloaded changes are inserted into a view.
             {
                 let sidecar_stats = crate::commands::sidecars::import_sidecars(&repo, &pull_pack);
                 if !sidecar_stats.is_empty() {

--- a/atomic-cli/src/commands/pull/command.rs
+++ b/atomic-cli/src/commands/pull/command.rs
@@ -397,8 +397,9 @@ impl Pull {
 
     /// Build the HTTP remote configuration.
     ///
-    /// `identity_hint` — explicit identity name to use (from `--identity` or
-    /// `RemoteEntry.identity`). When `None`, falls back to URL-based inference.
+    /// `identity_hint` — an explicit identity name to use (from `--identity`).
+    /// When `None`, identity is inferred from the remote URL and the global
+    /// config's server bindings.
     async fn build_remote_config(
         &self,
         remote_url: &str,
@@ -719,56 +720,18 @@ impl Pull {
             ),
         );
 
-        // Sync provenance graphs using the same model as .change files:
-        // the server advertises a flat inventory, we pull the hashes we do
-        // not have. Saving each graph registers its dependencies (best
-        // effort), indexes the session ledger, and publishes the session
-        // manifest locally — the receiving repository rebuilds the full
-        // Atomic session index without any relationship queries against
-        // the server.
-        let mut provenance_count = 0usize;
-        for (prov_hash_str, data) in pack_objects_by_key(&pull_pack, ObjectFamily::Provenance) {
-            let Some(prov_hash) = Hash::from_base32(prov_hash_str.as_bytes()) else {
-                continue;
-            };
-            if repo.has_provenance_graph(&prov_hash) {
-                continue;
-            }
-            match atomic_core::change::ProvenanceGraph::deserialize(&data) {
-                Ok((graph, computed)) => {
-                    if computed != prov_hash {
-                        print_warning(&format!(
-                            "Provenance {} failed hash verification — skipped",
-                            &prov_hash_str[..12.min(prov_hash_str.len())]
-                        ));
-                        continue;
-                    }
-                    match repo.save_provenance_graph(&graph) {
-                        Ok(_) => provenance_count += 1,
-                        Err(e) => print_warning(&format!(
-                            "Failed to register provenance {}: {}",
-                            &prov_hash_str[..12.min(prov_hash_str.len())],
-                            e
-                        )),
-                    }
-                }
-                Err(e) => print_warning(&format!(
-                    "Corrupt provenance {}: {}",
-                    &prov_hash_str[..12.min(prov_hash_str.len())],
-                    e
-                )),
-            }
-        }
-        if provenance_count > 0 {
-            println!(
-                "  {} {}",
-                success("✓"),
-                format_count(provenance_count, "provenance graph")
-            );
-        }
-
         // Apply changes (unless download-only)
         if self.download_only {
+            // Sidecars (provenance, attestations) still land in the store —
+            // the pack carried them and dropping them would require a later
+            // pull to recover. DEPS wiring to the covered changes happens
+            // when those changes are applied (`atomic insert`).
+            {
+                let sidecar_stats = crate::commands::sidecars::import_sidecars(&repo, &pull_pack);
+                if !sidecar_stats.is_empty() {
+                    crate::commands::sidecars::report_sidecars(sidecar_stats);
+                }
+            }
             print_blank();
             print_success(&format!(
                 "Downloaded {} (not inserted - use 'atomic insert' to insert)",
@@ -808,6 +771,24 @@ impl Pull {
             finish_error(&spinner, "View metadata reconciliation failed");
             for err in &apply_errors {
                 print_warning(err);
+            }
+        }
+
+        // Sync provenance graphs and attestations — the same sidecar model
+        // as `.change` files: the server sends what the pack carries, we
+        // save what we do not have. This runs AFTER view reconciliation so
+        // the covered changes are registered in the graph: the DEPS edges
+        // that make `atomic change <hash>` find its provenance (via
+        // REV_DEPS) are only written for already-registered changes.
+        // Saving each provenance graph also indexes the session ledger and
+        // publishes the session manifest locally — the receiving repository
+        // rebuilds the full Atomic session index without any relationship
+        // queries against the server. Shared with clone so both ingest
+        // identically.
+        {
+            let sidecar_stats = crate::commands::sidecars::import_sidecars(&repo, &pull_pack);
+            if !sidecar_stats.is_empty() {
+                crate::commands::sidecars::report_sidecars(sidecar_stats);
             }
         }
 

--- a/atomic-cli/src/commands/push/command.rs
+++ b/atomic-cli/src/commands/push/command.rs
@@ -375,8 +375,9 @@ impl Push {
 
     /// Build the HTTP remote configuration.
     ///
-    /// `identity_hint` — explicit identity name to use (from `--identity` or
-    /// `RemoteEntry.identity`). When `None`, falls back to URL-based inference.
+    /// `identity_hint` — an explicit identity name to use (from `--identity`).
+    /// When `None`, identity is inferred from the remote URL and the global
+    /// config's server bindings.
     async fn build_remote_config(
         &self,
         remote_url: &str,

--- a/atomic-cli/src/commands/sidecars.rs
+++ b/atomic-cli/src/commands/sidecars.rs
@@ -54,9 +54,7 @@ pub fn import_sidecars(repo: &Repository, pack: &SyncPack) -> SidecarStats {
         let Some(hash) = Hash::from_base32(key.as_bytes()) else {
             continue;
         };
-        if repo.has_provenance_graph(&hash) {
-            continue;
-        }
+        let already_present = repo.has_provenance_graph(&hash);
         match atomic_core::change::ProvenanceGraph::deserialize(&data) {
             Ok((graph, computed)) => {
                 if computed != hash {
@@ -66,8 +64,12 @@ pub fn import_sidecars(repo: &Repository, pack: &SyncPack) -> SidecarStats {
                     ));
                     continue;
                 }
+                // Always replay repository registration, even when the object
+                // file exists. This repairs metadata after an interrupted save
+                // and is safe because node/dependency writes are idempotent.
                 match repo.save_provenance_graph(&graph) {
-                    Ok(_) => stats.provenance += 1,
+                    Ok(_) if !already_present => stats.provenance += 1,
+                    Ok(_) => {}
                     Err(e) => print_warning(&format!(
                         "Failed to register provenance {}: {}",
                         short(&key),
@@ -83,9 +85,7 @@ pub fn import_sidecars(repo: &Repository, pack: &SyncPack) -> SidecarStats {
         let Some(hash) = Hash::from_base32(key.as_bytes()) else {
             continue;
         };
-        if repo.has_attestation(&hash) {
-            continue;
-        }
+        let already_present = repo.has_attestation(&hash);
         match atomic_core::change::Attestation::deserialize(&data) {
             Ok((attestation, computed)) => {
                 if computed != hash {
@@ -95,8 +95,11 @@ pub fn import_sidecars(repo: &Repository, pack: &SyncPack) -> SidecarStats {
                     ));
                     continue;
                 }
+                // Re-register existing files as well, repairing pristine
+                // metadata left incomplete by an earlier interrupted import.
                 match repo.save_attestation(&attestation) {
-                    Ok(_) => stats.attestations += 1,
+                    Ok(_) if !already_present => stats.attestations += 1,
+                    Ok(_) => {}
                     Err(e) => print_warning(&format!(
                         "Failed to register attestation {}: {}",
                         short(&key),
@@ -309,12 +312,10 @@ mod tests {
     }
 
     #[test]
-    fn import_before_registration_leaves_files_but_no_rev_deps() {
-        // Documents the ordering contract: a graph imported while its change
-        // is NOT yet registered still lands on disk (nothing is lost), but
-        // `find_provenance_for_change` — the REV_DEPS lookup `atomic change`
-        // uses — cannot see it. That is why clone/pull import sidecars
-        // AFTER applying view manifests.
+    fn import_before_insertion_registers_rev_deps() {
+        // Download-only imports happen before the covered change is inserted
+        // into a view. The sidecar save must still register the change hash and
+        // wire REV_DEPS so provenance queries work immediately and after insert.
         let dir = tempfile::tempdir().unwrap();
         let repo = Repository::init(dir.path()).unwrap();
 
@@ -333,9 +334,9 @@ mod tests {
         assert_eq!(stats.provenance, 1, "the graph file is saved");
 
         let via_rev_deps = repo.find_provenance_for_change(&change).unwrap();
-        assert!(via_rev_deps.is_empty(), "REV_DEPS cannot see it yet");
+        assert_eq!(via_rev_deps.len(), 1, "REV_DEPS sees downloaded sidecars");
 
         let via_scan = repo.find_provenance_for_change_scan(&change).unwrap();
-        assert_eq!(via_scan.len(), 1, "the disk-scan fallback does");
+        assert_eq!(via_scan.len(), 1, "the disk-scan fallback agrees");
     }
 }

--- a/atomic-cli/src/commands/sidecars.rs
+++ b/atomic-cli/src/commands/sidecars.rs
@@ -1,0 +1,341 @@
+//! Sidecar object import for sync commands (pull, clone).
+//!
+//! A `SyncPack` carries more than changes and view snapshots: push queues
+//! **provenance graphs** and **attestations** for the changes it publishes,
+//! and the receiving repository must ingest them or `atomic change <hash>`
+//! loses its agent-provenance section until a later "repair" pull happens.
+//! This module owns that ingestion so pull and clone share one path.
+//!
+//! The model mirrors `.change` files: objects are content-addressed
+//! (`key = blake3(bytes)`), so import is
+//!
+//! 1. parse the advertised key,
+//! 2. skip what the repository already has,
+//! 3. deserialize, verifying the computed hash matches the advertised key,
+//! 4. save — which registers the node, its DEPS edges, and (for provenance)
+//!    the session ledger/index.
+//!
+//! Corrupt or hash-mismatched sidecars are warned about and skipped: a bad
+//! sidecar must never fail ingestion of the valid changes traveling beside it.
+
+use atomic_core::types::{Base32, Hash};
+use atomic_objects::{ObjectFamily, SyncPack};
+use atomic_repository::Repository;
+
+use crate::output::{print_warning, success};
+
+/// How many sidecars were imported, by family.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SidecarStats {
+    /// Provenance graphs saved (skipped-and-existing not counted).
+    pub provenance: usize,
+    /// Attestations saved (skipped-and-existing not counted).
+    pub attestations: usize,
+}
+
+impl SidecarStats {
+    /// Whether anything was imported.
+    pub fn is_empty(&self) -> bool {
+        self.provenance == 0 && self.attestations == 0
+    }
+}
+
+/// Import every provenance graph and attestation carried by `pack`.
+///
+/// Shared by `atomic pull` and `atomic clone`: both receive the same
+/// `SyncPack` shape from `/code`, and both must land the sidecars or the
+/// cloned/pulled repository cannot answer provenance queries until some
+/// later pull happens to carry them again. Failures warn and continue —
+/// valid change ingestion is never blocked by a corrupt sidecar.
+pub fn import_sidecars(repo: &Repository, pack: &SyncPack) -> SidecarStats {
+    let mut stats = SidecarStats::default();
+
+    for (key, data) in objects_by_key(pack, ObjectFamily::Provenance) {
+        let Some(hash) = Hash::from_base32(key.as_bytes()) else {
+            continue;
+        };
+        if repo.has_provenance_graph(&hash) {
+            continue;
+        }
+        match atomic_core::change::ProvenanceGraph::deserialize(&data) {
+            Ok((graph, computed)) => {
+                if computed != hash {
+                    print_warning(&format!(
+                        "Provenance {} failed hash verification — skipped",
+                        short(&key)
+                    ));
+                    continue;
+                }
+                match repo.save_provenance_graph(&graph) {
+                    Ok(_) => stats.provenance += 1,
+                    Err(e) => print_warning(&format!(
+                        "Failed to register provenance {}: {}",
+                        short(&key),
+                        e
+                    )),
+                }
+            }
+            Err(e) => print_warning(&format!("Corrupt provenance {}: {}", short(&key), e)),
+        }
+    }
+
+    for (key, data) in objects_by_key(pack, ObjectFamily::Attest) {
+        let Some(hash) = Hash::from_base32(key.as_bytes()) else {
+            continue;
+        };
+        if repo.has_attestation(&hash) {
+            continue;
+        }
+        match atomic_core::change::Attestation::deserialize(&data) {
+            Ok((attestation, computed)) => {
+                if computed != hash {
+                    print_warning(&format!(
+                        "Attestation {} failed hash verification — skipped",
+                        short(&key)
+                    ));
+                    continue;
+                }
+                match repo.save_attestation(&attestation) {
+                    Ok(_) => stats.attestations += 1,
+                    Err(e) => print_warning(&format!(
+                        "Failed to register attestation {}: {}",
+                        short(&key),
+                        e
+                    )),
+                }
+            }
+            Err(e) => print_warning(&format!("Corrupt attestation {}: {}", short(&key), e)),
+        }
+    }
+
+    stats
+}
+
+/// Print the one-line ingestion summary pull and clone share.
+pub fn report_sidecars(stats: SidecarStats) {
+    if stats.provenance > 0 {
+        println!(
+            "  {} {}",
+            success("\u{2713}"),
+            count(stats.provenance, "provenance graph")
+        );
+    }
+    if stats.attestations > 0 {
+        println!(
+            "  {} {}",
+            success("\u{2713}"),
+            count(stats.attestations, "attestation")
+        );
+    }
+}
+
+/// Index a pack's objects of one family into `content key → bytes`.
+fn objects_by_key<'a>(
+    pack: &'a SyncPack,
+    family: ObjectFamily,
+) -> impl Iterator<Item = (String, Vec<u8>)> + 'a {
+    pack.objects
+        .iter()
+        .filter(move |o| o.family == family)
+        .map(|o| (o.key.clone(), o.bytes.clone()))
+}
+
+/// First 12 chars of a base32 key, for display.
+fn short(key: &str) -> &str {
+    &key[..12.min(key.len())]
+}
+
+fn count(n: usize, singular: &str) -> String {
+    if n == 1 {
+        format!("{} {}", n, singular)
+    } else {
+        format!("{} {}s", n, singular)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use atomic_core::change::attestation::{AttestAgent, Attestation};
+    use atomic_core::change::ProvenanceGraph;
+    use atomic_objects::{ObjectRecord, RefRecord};
+
+    /// A minimal provenance graph explaining `change`.
+    fn provenance_for(change: Hash) -> ProvenanceGraph {
+        ProvenanceGraph::builder("session-sidecar", "opencode")
+            .add_change_explained(change)
+            .build()
+    }
+
+    /// A minimal attestation covering `change`.
+    fn attestation_for(change: Hash) -> Attestation {
+        Attestation::builder(
+            "session-sidecar",
+            AttestAgent::new("opencode", "OpenCode", "atomic"),
+        )
+        .add_change(change)
+        .build()
+    }
+
+    fn pack_with(objects: Vec<ObjectRecord>) -> SyncPack {
+        SyncPack {
+            objects,
+            refs: vec![RefRecord {
+                name: "dev".to_string(),
+                expect_old: None,
+                new_target: "SNAP".to_string(),
+            }],
+        }
+    }
+
+    #[test]
+    fn imports_provenance_and_attestations_from_pack() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut repo = Repository::init(dir.path()).unwrap();
+
+        // A real change, saved and applied so it is registered in the graph —
+        // the same order clone/pull produce (changes applied, then sidecars
+        // imported; `save_provenance_graph` only wires DEPS for
+        // already-registered changes).
+        let change = atomic_core::change::Change::new(
+            atomic_core::change::ChangeHeader::builder()
+                .message("sidecar test change")
+                .build(),
+            vec![],
+            vec![],
+            vec![],
+        );
+        let change_hash = repo.save_change(&change).expect("save change");
+        if !repo.view_exists("dev").expect("view exists check") {
+            repo.create_shared_view("dev").expect("create view");
+        }
+        atomic_repository::Repository::insert_change(
+            &repo,
+            &change_hash,
+            atomic_repository::InsertOptions::default().view("dev"),
+        )
+        .expect("insert change");
+
+        let graph = provenance_for(change_hash);
+        let prov_bytes = graph.serialize().unwrap();
+        let prov_key = Hash::of(&prov_bytes).to_base32();
+
+        let attest = attestation_for(change_hash);
+        let attest_bytes = attest.serialize().unwrap();
+        let attest_key = Hash::of(&attest_bytes).to_base32();
+
+        let pack = pack_with(vec![
+            ObjectRecord::new(ObjectFamily::Change, change_hash.to_base32(), b"".to_vec()),
+            ObjectRecord::new(
+                ObjectFamily::Provenance,
+                prov_key.clone(),
+                prov_bytes.clone(),
+            ),
+            ObjectRecord::new(
+                ObjectFamily::Attest,
+                attest_key.clone(),
+                attest_bytes.clone(),
+            ),
+        ]);
+
+        let stats = import_sidecars(&repo, &pack);
+        assert_eq!(
+            stats,
+            SidecarStats {
+                provenance: 1,
+                attestations: 1
+            }
+        );
+
+        // The exact query `atomic change <hash>` performs.
+        let found = repo
+            .find_provenance_for_change(&change_hash)
+            .expect("find provenance");
+        assert_eq!(found.len(), 1, "one graph explains the change");
+        assert_eq!(found[0].1.changes_explained, vec![change_hash]);
+
+        let (_, attest_hash) = Attestation::deserialize(&attest_bytes).unwrap();
+        assert!(repo.has_attestation(&attest_hash));
+
+        // Idempotent: a second import skips everything already present.
+        let again = import_sidecars(&repo, &pack);
+        assert_eq!(again, SidecarStats::default());
+    }
+
+    #[test]
+    fn skips_corrupt_and_mismatched_sidecars_without_failing() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+
+        let change = Hash::of(b"change-bytes");
+
+        // Valid graph bytes, but advertised under the WRONG key.
+        let graph = provenance_for(change);
+        let prov_bytes = graph.serialize().unwrap();
+        let wrong_key = Hash::of(b"not-the-graph").to_base32();
+
+        // Valid attestation bytes under a wrong key too.
+        let attest = attestation_for(change);
+        let attest_bytes = attest.serialize().unwrap();
+        let wrong_attest_key = Hash::of(b"not-the-attest").to_base32();
+
+        let pack = pack_with(vec![
+            ObjectRecord::new(ObjectFamily::Provenance, wrong_key, prov_bytes),
+            ObjectRecord::new(ObjectFamily::Attest, wrong_attest_key, attest_bytes),
+            // Corrupt bodies: neither deserializes.
+            ObjectRecord::new(
+                ObjectFamily::Provenance,
+                Hash::of(b"corrupt-prov").to_base32(),
+                b"garbage".to_vec(),
+            ),
+            ObjectRecord::new(
+                ObjectFamily::Attest,
+                Hash::of(b"corrupt-attest").to_base32(),
+                b"garbage".to_vec(),
+            ),
+        ]);
+
+        let stats = import_sidecars(&repo, &pack);
+        assert_eq!(stats, SidecarStats::default(), "nothing may be saved");
+    }
+
+    #[test]
+    fn empty_pack_is_a_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        let stats = import_sidecars(&repo, &SyncPack::default());
+        assert_eq!(stats, SidecarStats::default());
+    }
+
+    #[test]
+    fn import_before_registration_leaves_files_but_no_rev_deps() {
+        // Documents the ordering contract: a graph imported while its change
+        // is NOT yet registered still lands on disk (nothing is lost), but
+        // `find_provenance_for_change` — the REV_DEPS lookup `atomic change`
+        // uses — cannot see it. That is why clone/pull import sidecars
+        // AFTER applying view manifests.
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+
+        let change = Hash::of(b"unregistered-change");
+        let graph = provenance_for(change);
+        let prov_bytes = graph.serialize().unwrap();
+        let prov_key = Hash::of(&prov_bytes).to_base32();
+
+        let pack = pack_with(vec![ObjectRecord::new(
+            ObjectFamily::Provenance,
+            prov_key,
+            prov_bytes,
+        )]);
+
+        let stats = import_sidecars(&repo, &pack);
+        assert_eq!(stats.provenance, 1, "the graph file is saved");
+
+        let via_rev_deps = repo.find_provenance_for_change(&change).unwrap();
+        assert!(via_rev_deps.is_empty(), "REV_DEPS cannot see it yet");
+
+        let via_scan = repo.find_provenance_for_change_scan(&change).unwrap();
+        assert_eq!(via_scan.len(), 1, "the disk-scan fallback does");
+    }
+}

--- a/atomic-cli/tests/clone_sidecar_integration_test.rs
+++ b/atomic-cli/tests/clone_sidecar_integration_test.rs
@@ -1,0 +1,266 @@
+//! End-to-end regression test: a fresh `atomic clone` must ingest the
+//! provenance graphs and attestations that ride the `/code` sync pack, so
+//! `atomic change <hash>` shows its Change Ledger immediately — without a
+//! subsequent "repair" pull.
+//!
+//! The reported bug: the server had the provenance, the `/code` pull response
+//! included it, and `atomic pull` imported it — but `atomic clone` received
+//! the same `SyncPack` and only indexed `ObjectFamily::Change`, so a fresh
+//! clone printed "No provenance graph found" until the user ran a pull to
+//! re-deliver the sidecars.
+//!
+//! The test stands up a minimal HTTP server speaking the `/code` sync
+//! protocol (GET with a `SyncWants` body → `SyncPack` response) over a
+//! hand-built pack containing one change, its view snapshot, one provenance
+//! graph, and one attestation — exactly the shape a real server sends after
+//! an agent-made push. It then drives the real CLI binary.
+//!
+//! Windows is excluded: the test isolates the identity store by pointing
+//! `HOME` at a temp dir, which `dirs::home_dir()` ignores on Windows.
+#![cfg(not(windows))]
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use atomic_core::change::attestation::{AttestAgent, Attestation};
+use atomic_core::change::{Change, ChangeHeader, ProvenanceGraph};
+use atomic_core::types::{Base32, Hash, Merkle, SetId};
+use atomic_objects::{
+    ObjectFamily, ObjectRecord, RefRecord, SyncPack, ViewScopeLabel, ViewSnapshot,
+};
+use tempfile::TempDir;
+
+const ATOMIC_BIN: &str = env!("CARGO_BIN_EXE_atomic");
+
+fn atomic(work_dir: &Path, home_dir: &Path, args: &[&str]) -> Output {
+    Command::new(ATOMIC_BIN)
+        .args(args)
+        .current_dir(work_dir)
+        .env("HOME", home_dir)
+        .output()
+        .expect("run atomic")
+}
+
+/// Serialize a change and return `(bytes, hash)` — the object a server stores
+/// under `changes/{blake3}`.
+fn change_object() -> (Vec<u8>, Hash) {
+    let change = Change::new(
+        ChangeHeader::builder()
+            .message("clone sidecar regression")
+            .build(),
+        vec![],
+        vec![],
+        vec![],
+    );
+    let mut buf = Vec::new();
+    let hash = change.serialize(&mut buf).expect("serialize change");
+    (buf, hash)
+}
+
+/// A small session-scoped `SyncPack` for one change: the change object, the
+/// `dev` view's snapshot + ref, a provenance graph explaining the change, and
+/// an attestation covering it — the object mix push produces for agent-made
+/// changes.
+fn agent_push_pack(change_bytes: Vec<u8>, change_hash: &Hash) -> SyncPack {
+    let change_key = change_hash.to_base32();
+
+    // Provenance graph explaining the change.
+    let graph = ProvenanceGraph::builder("session-clone-e2e", "opencode")
+        .add_change_explained(*change_hash)
+        .build();
+    let prov_bytes = graph.serialize().expect("serialize provenance");
+    let prov_key = Hash::of(&prov_bytes).to_base32();
+
+    // Attestation covering the change.
+    let attest = Attestation::builder(
+        "session-clone-e2e",
+        AttestAgent::new("opencode", "OpenCode", "atomic"),
+    )
+    .add_change(*change_hash)
+    .build();
+    let attest_bytes = attest.serialize().expect("serialize attestation");
+    let attest_key = Hash::of(&attest_bytes).to_base32();
+
+    // The view snapshot: shared root "dev" owning exactly this change. The
+    // merkle state must equal the fold of the change log (manifest verify)
+    // and the set-id the order-invariant fold of it.
+    let mut merkle = Merkle::ZERO;
+    let mut set_id = SetId::ZERO;
+    merkle = merkle.next(change_hash);
+    set_id = set_id.add(change_hash);
+    let snapshot = ViewSnapshot::new(
+        ViewScopeLabel::Shared,
+        None,
+        Vec::new(),
+        vec![change_key.clone()],
+        set_id.to_base32(),
+        Some(merkle.to_base32()),
+    );
+    let snap_key = snapshot.content_key();
+
+    SyncPack {
+        objects: vec![
+            ObjectRecord::new(ObjectFamily::Change, change_key, change_bytes),
+            ObjectRecord::new(
+                ObjectFamily::View,
+                snap_key.clone(),
+                snapshot.to_canonical_bytes(),
+            ),
+            ObjectRecord::new(ObjectFamily::Provenance, prov_key, prov_bytes),
+            ObjectRecord::new(ObjectFamily::Attest, attest_key, attest_bytes),
+        ],
+        refs: vec![RefRecord {
+            name: "dev".to_string(),
+            expect_old: None,
+            new_target: snap_key,
+        }],
+    }
+}
+
+/// Serve the `/code` sync protocol: any GET whose path ends in `/code` gets
+/// the canned `SyncPack`; everything else is a 404. One request per
+/// connection (`Connection: close`), which is all reqwest needs.
+fn spawn_sync_server(pack: SyncPack) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+    let addr = listener.local_addr().expect("local addr");
+    let pack_bytes = pack.encode().expect("encode sync pack");
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming().flatten() {
+            let mut stream = stream;
+            let mut buf = Vec::new();
+            let mut tmp = [0u8; 4096];
+            // Read the request head + body (Content-Length bounded).
+            loop {
+                let n = match stream.read(&mut tmp) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => n,
+                };
+                buf.extend_from_slice(&tmp[..n]);
+                if let Some(head_end) = find_head_end(&buf) {
+                    let head = String::from_utf8_lossy(&buf[..head_end]).to_string();
+                    if let Some(len) = content_length(&head) {
+                        if buf.len() >= head_end + 4 + len {
+                            break;
+                        }
+                    } else {
+                        break;
+                    }
+                }
+            }
+            let head = String::from_utf8_lossy(&buf).to_string();
+            let path = head.split_whitespace().nth(1).unwrap_or("");
+
+            let (status, body) = if path.ends_with("/code") {
+                ("200 OK", pack_bytes.clone())
+            } else {
+                ("404 Not Found", b"not found".to_vec())
+            };
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: application/octet-stream\r\n\
+                 X-Atomic-Min-Version: 0.16.2\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.write_all(&body);
+            let _ = stream.flush();
+        }
+    });
+
+    format!("http://{}", addr)
+}
+
+fn find_head_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n")
+}
+
+fn content_length(head: &str) -> Option<usize> {
+    for line in head.lines() {
+        let lower = line.to_ascii_lowercase();
+        if let Some(v) = lower.strip_prefix("content-length:") {
+            return v.trim().parse().ok();
+        }
+    }
+    None
+}
+
+#[test]
+fn fresh_clone_ingests_provenance_and_attestations() {
+    let home = TempDir::new().unwrap();
+    let work = TempDir::new().unwrap();
+    let target = work.path().join("cloned");
+    let change_hash_str;
+
+    // 1. Build the "remote": a canned agent-made push over the sync protocol.
+    {
+        let (change_bytes, change_hash) = change_object();
+        change_hash_str = change_hash.to_base32();
+        let server = spawn_sync_server(agent_push_pack(change_bytes, &change_hash));
+
+        // 2. Clone it with the real CLI.
+        let out = atomic(
+            work.path(),
+            home.path(),
+            &[
+                "clone",
+                &format!("{server}/workspaces/ws/projects/proj/code"),
+                target.to_str().unwrap(),
+            ],
+        );
+        assert!(
+            out.status.success(),
+            "clone failed:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+
+    // 3. The regression: `atomic change <hash>` must show the Change Ledger
+    //    (REV_DEPS-visible provenance) on the fresh clone, with no repair pull.
+    let out = atomic(&target, home.path(), &["change", &change_hash_str]);
+    assert!(
+        out.status.success(),
+        "atomic change failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("=== Change Ledger ==="),
+        "change view lacks the ledger — sidecars were not ingested:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("session-clone-e2e"),
+        "ledger does not show the cloned provenance session:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("No provenance graph found"),
+        "provenance is missing after clone:\n{stdout}"
+    );
+
+    // 4. The attestation sidecar landed too: the cloned store holds exactly
+    //    one `.attest` file, the one from the pack.
+    {
+        use std::fs;
+        let attest_dir = target.join(".atomic/changes");
+        let mut attest_files = Vec::new();
+        for entry in fs::read_dir(&attest_dir).expect("changes dir") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                for f in fs::read_dir(&path).expect("prefix dir") {
+                    let f = f.expect("file entry").path();
+                    if f.extension().and_then(|e| e.to_str()) == Some("attest") {
+                        attest_files.push(f);
+                    }
+                }
+            }
+        }
+        assert_eq!(
+            attest_files.len(),
+            1,
+            "expected exactly one attestation sidecar in the fresh clone"
+        );
+    }
+}

--- a/atomic-cli/tests/provenance_integration_test.rs
+++ b/atomic-cli/tests/provenance_integration_test.rs
@@ -13,9 +13,9 @@
 //!   5. compute-on-demand: no new files appear and the provenance-graph count is
 //!      unchanged after trace/show.
 //!
-//! The REV_DEPS fallback is exercised too: a graph whose explained change was
-//! never made internal is invisible to REV_DEPS, and the disk-scan fallback
-//! still finds it.
+//! The REV_DEPS fallback is exercised too: a graph fixture written directly to
+//! the content-addressed store without pristine registration is invisible to
+//! REV_DEPS, and the disk-scan fallback still finds it.
 //!
 //! Windows is excluded: the tests isolate the identity store by pointing `HOME`
 //! at a temp dir, but on Windows `dirs::home_dir()` resolves via the system API
@@ -24,6 +24,7 @@
 #![cfg(not(windows))]
 
 use std::collections::BTreeSet;
+use std::fs;
 use std::path::Path;
 use std::process::{Command, Output};
 
@@ -286,13 +287,12 @@ fn provenance_trace_uses_scan_fallback_when_rev_deps_missing() {
     let home_dir = home_tmp.path();
 
     create_default_identity(home_dir);
-    // Init a real repo (needed so `provenance` finds a repository root), but do
-    // NOT record the change the graph explains — so it is never internal and
-    // REV_DEPS is empty for it.
+    // Init a real repo so `provenance` finds a repository root. The graph below
+    // is written directly to the content store to model legacy/interrupted data
+    // that exists on disk without pristine registration.
     assert!(atomic(repo_dir, home_dir, &["init"]).status.success());
 
-    // A change hash that was never recorded => not internal => invisible to
-    // REV_DEPS. The graph is still saved to the change store on disk.
+    // A change hash that was never recorded remains invisible to REV_DEPS.
     let phantom_change = Hash::of(b"never-recorded-change");
     {
         let repo = Repository::open(repo_dir).expect("open repo");
@@ -301,14 +301,18 @@ fn provenance_trace_uses_scan_fallback_when_rev_deps_missing() {
             .add_node(goal_node())
             .add_change_explained(phantom_change)
             .build();
-        repo.save_provenance_graph(&graph).expect("save graph");
+        let bytes = graph.serialize().expect("serialize graph");
+        let graph_hash = Hash::of(&bytes);
+        let graph_path = repo.change_store().provenance_path(&graph_hash);
+        fs::create_dir_all(graph_path.parent().expect("graph parent")).expect("create graph dir");
+        fs::write(&graph_path, bytes).expect("write unregistered graph fixture");
 
         // Confirm the premise: REV_DEPS finds nothing, the scan finds it.
         assert!(
             repo.find_provenance_for_change(&phantom_change)
                 .expect("rev_deps lookup")
                 .is_empty(),
-            "REV_DEPS must be empty for a non-internal change"
+            "REV_DEPS must be empty for an unregistered graph"
         );
         assert_eq!(
             repo.find_provenance_for_change_scan(&phantom_change)

--- a/atomic-repository/src/repository/changes.rs
+++ b/atomic-repository/src/repository/changes.rs
@@ -290,12 +290,16 @@ impl Repository {
             .register_attestation(&hash)
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
-        // Register dependencies: attestation → covered changes
+        // Register dependencies: attestation → covered changes. A downloaded
+        // change may not have been inserted into a view yet (`--download-only`),
+        // but it still needs an internal ID so this relationship is durable.
+        // Insertion reuses the same content-addressed registration later.
         for change_hash in &attestation.changes_covered {
-            if let Ok(Some(change_id)) = txn.get_internal(change_hash) {
-                txn.put_dep(attest_id, change_id)
-                    .map_err(|e| RepositoryError::Database(e.to_string()))?;
-            }
+            let change_id = txn
+                .register_change(change_hash)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+            txn.put_dep(attest_id, change_id)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
         }
 
         // If chained, register dependency on previous attestation too
@@ -1075,12 +1079,16 @@ impl Repository {
             .register_provenance(&hash)
             .map_err(|e| RepositoryError::Database(e.to_string()))?;
 
-        // Register dependencies: provenance → explained changes
+        // Register dependencies: provenance → explained changes. Sidecars can
+        // arrive with `--download-only`, before their changes are inserted into
+        // a view. Registering the content hash now gives the relationship a
+        // stable internal ID; insertion reuses that registration later.
         for change_hash in &graph.changes_explained {
-            if let Ok(Some(change_id)) = txn.get_internal(change_hash) {
-                txn.put_dep(prov_id, change_id)
-                    .map_err(|e| RepositoryError::Database(e.to_string()))?;
-            }
+            let change_id = txn
+                .register_change(change_hash)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
+            txn.put_dep(prov_id, change_id)
+                .map_err(|e| RepositoryError::Database(e.to_string()))?;
         }
 
         // If chained, register dependency on previous provenance graph too

--- a/docs/publication-manifest-design.md
+++ b/docs/publication-manifest-design.md
@@ -1,0 +1,742 @@
+# Publication Manifest: Complete Bare Repository State
+
+> Status: **draft / proposal.** Companion to
+> [`view-snapshot-sync-design.md`](./view-snapshot-sync-design.md) and
+> [`vault-sync-design.md`](./vault-sync-design.md). Those documents define the
+> object models for views and vault data; this document defines the atomic
+> publication boundary that makes all object families a complete, verifiable
+> repository state.
+
+## Summary
+
+Atomic's bare protocol already has the correct storage primitives:
+
+- immutable, content-addressed objects;
+- mutable refs updated with compare-and-swap (CAS);
+- view snapshots that identify change membership;
+- a disposable redb read model rebuilt from objects.
+
+What it does not yet have is one object that says:
+
+> These view snapshots, changes, provenance graphs, attestations, tags, session
+> artifacts, and vault entries are the complete repository state published by
+> this transition.
+
+Today, a view ref proves that its change closure is reachable. Auxiliary object
+families are transferred independently. A clone or pull can therefore verify a
+view's change set while silently lacking provenance, attestations, or future
+vault data. Independent blobs are valuable storage units, but they are not a
+transaction boundary.
+
+The proposed model adds an immutable, content-addressed **publication manifest**
+above the existing object families. A single authoritative ref points to the
+current manifest. Publishing consists of uploading the complete immutable
+closure and then atomically moving that ref with CAS.
+
+```text
+objects first, ref last
+```
+
+The manifest is the distributed commit record. A write-ahead log (WAL) may
+announce manifest transitions or rebuild indexes, but it is not repository
+truth.
+
+## Goals
+
+1. Make repository completeness verifiable from one root.
+2. Publish related object families atomically without rewriting immutable data.
+3. Preserve a bare server: object verification, closure validation, and ref CAS;
+   no graph apply or materialization on the write path.
+4. Support late-arriving provenance, attestations, and vault knowledge as normal
+   repository transitions.
+5. Permit selective fetch by typed reachability rather than project-wide scans.
+6. Preserve multi-region convergence without a global sequence allocator or log
+   leader.
+7. Make redb and search indexes disposable, reproducible read models.
+
+## Non-goals
+
+- Replacing change dependency closure or patch theory.
+- Putting mutable repository state inside object blobs.
+- Requiring a total order across independent Atomic changes.
+- Using a WAL as the canonical distributed history.
+- Requiring all metadata for legacy or human-authored changes.
+- Defining the final encoding or protocol version in this proposal.
+
+## Problem statement
+
+The current view-snapshot closure is approximately:
+
+```text
+refs/views/dev
+    └── ViewSnapshot
+          ├── own change keys
+          ├── parent view relationship
+          └── previous ViewSnapshot keys
+```
+
+Provenance and attestations are separate content-addressed objects associated
+with changes through their payloads and local indexes:
+
+```text
+Change C        Provenance P        Attestation A
+   │                 │                    │
+   └──── explained by┘                    │
+   └──────────── covered by ──────────────┘
+```
+
+The view snapshot does not commit to `P` or `A`. Consequently:
+
+- `C` may be present while `P` is absent;
+- the view's Merkle state and `SetId` may still verify;
+- clone, pull, and push must each implement independent sidecar discovery;
+- adding a new object family adds another inventory, transfer, and import path;
+- the server cannot selectively fetch sidecars reachable from requested views;
+- absence is ambiguous: intentional, pending, unsupported, or lost.
+
+Future vault synchronization compounds this issue. A vault manifest can make
+vault entries complete relative to a vault ref, but independent view and vault
+refs still cannot publish a cross-family transition atomically. An agent turn
+may produce a change, provenance graph, intent update, memory, and signed vault
+attestations that should become visible as one publication.
+
+## Core principle
+
+**The publication ref is the only authoritative mutable value. Its target is an
+immutable manifest whose reachable object closure is the complete published
+repository state.**
+
+```text
+SOURCE OF TRUTH                           DERIVED READ MODELS
+═══════════════                           ═══════════════════
+refs/publication/current                  redb pristine graph
+    │                                     session/provenance indexes
+    ▼                                     vault knowledge graph
+PublicationManifest                      embeddings and search indexes
+    ├── views root                        materialized working copies
+    ├── metadata root
+    ├── vault root
+    └── previous publication root(s)
+```
+
+A reader that has the publication manifest and every reachable object has the
+complete state declared by that publication. A reader missing any required
+object can identify the exact missing key and must not claim complete sync.
+
+## Object model
+
+### Typed object identity
+
+Object keys must be qualified by family. A raw hash alone is not enough for
+negotiation or reachability because different families may use different
+canonical encodings and storage namespaces.
+
+```rust
+struct ObjectId {
+    family: ObjectFamily,
+    key: ObjectKey,
+}
+
+enum ObjectFamily {
+    Change,
+    Tag,
+    Provenance,
+    Attestation,
+    ViewSnapshot,
+    MetadataManifest,
+    VaultEntry,
+    VaultManifest,
+    PublicationManifest,
+}
+```
+
+`SyncWants::haves` should eventually become a typed set of `ObjectId` values.
+This avoids namespace ambiguity and lets the server compute a precise typed
+closure delta.
+
+### Publication manifest
+
+An illustrative shape is:
+
+```rust
+struct PublicationManifest {
+    /// Encoding and semantic version for forward-compatible readers.
+    version: u32,
+
+    /// Repository identity to prevent cross-project replay.
+    repository_id: RepositoryId,
+
+    /// Immutable manifests containing the canonical key inventory for each
+    /// object family. Each family manifest carries its own SetId.
+    objects: ObjectFamilyManifests,
+
+    /// The published view-name → ViewSnapshot mapping and optional vault head.
+    view_heads: ObjectId,
+    vault_head: Option<ObjectId>,
+
+    /// Previous publication roots. Normally one; multiple after reconciliation.
+    previous: Vec<ObjectId>,
+
+    /// Creation metadata. Not used as repository ordering truth.
+    created_at: i64,
+    publisher: Option<PortableIdentity>,
+
+    /// Optional signature over the canonical manifest bytes.
+    proof: Option<DataIntegrityProof>,
+}
+```
+
+The publication manifest stores one `SetId` per object family through
+`ObjectFamilyManifests`. The family manifests contain the authoritative canonical
+key inventories (full, sharded, or delta-encoded); their `SetId`s provide O(1),
+order-independent equality and convergence checks. Large repositories shard or
+delta-encode those inventories so a small transition rewrites only the affected
+family path plus the publication manifest.
+
+```rust
+struct ObjectFamilyManifests {
+    changes: ObjectSetManifest,
+    tags: ObjectSetManifest,
+    provenance: ObjectSetManifest,
+    attestations: ObjectSetManifest,
+    view_snapshots: ObjectSetManifest,
+    vault_entries: Option<ObjectSetManifest>,
+    vault_manifests: Option<ObjectSetManifest>,
+}
+
+struct ObjectSetManifest {
+    /// Order-independent identity of this object family's complete published set.
+    set_id: SetId,
+
+    /// Content-addressed manifest containing the canonical keys, or a delta
+    /// chain that reconstructs them. This remains the source of truth.
+    inventory: ObjectId,
+}
+```
+
+The publication's own content hash binds these family `SetId`s and inventories
+to view heads, vault head, policy, repository identity, and publication lineage.
+`SetId` answers whether two replicas hold the same family membership; the
+publication hash answers whether they published the same repository semantics.
+
+### Views root
+
+The views root maps portable view names to immutable `ViewSnapshot` keys:
+
+```rust
+struct ViewsManifest {
+    views: MerkleMap<ViewName, ObjectId>,
+}
+```
+
+Existing view snapshots remain focused on view identity, lineage, parent
+relationships, and change membership. The publication layer does not replace
+view snapshots; it makes a selected set of their heads visible together.
+
+Historical reproducibility requires a publication to reference concrete view
+snapshot keys. A child snapshot may retain the user-facing parent view name, but
+its published closure must resolve that name to a pinned parent snapshot through
+the publication's views root. Reading an old publication must not silently use a
+newer parent ref.
+
+### Object-family SetIds
+
+Every published object family has an independent `SetId` stored in its family
+manifest. This is the manifest-level convergence contract:
+
+```rust
+changes.set_id       = SetId(changes)
+tags.set_id          = SetId(tags)
+provenance.set_id    = SetId(provenance objects)
+attestations.set_id  = SetId(attestation objects)
+view_snapshots.set_id = SetId(view snapshot objects)
+vault_entries.set_id = SetId(vault entry objects)
+```
+
+This lets negotiation and verification identify exactly which family diverges
+without walking unrelated inventories. The authoritative inventory still carries
+or reconstructs the canonical object keys because `SetId` is a convergence
+identity, not a trust boundary.
+
+The current `SetId` contract in `atomic-core/src/types/set_id.rs` folds only
+applyable change and tag hashes and explicitly excludes provenance and
+attestation sidecars. Publication manifests therefore require a compatible
+family-domain extension rather than silently feeding sidecars into the existing
+change domain. One possible API is:
+
+```rust
+enum SetIdDomain {
+    Changes,
+    Tags,
+    Provenance,
+    Attestations,
+    ViewSnapshots,
+    VaultEntries,
+    VaultManifests,
+}
+
+SetId::of_objects(domain, canonical_object_keys)
+```
+
+Each element expansion must bind the family domain and canonical object key:
+
+```text
+Blake3("atomic:setid:object:v1" || family || object_key)
+```
+
+The existing change-set `SetId` remains byte-for-byte stable. The new domain is
+used only for publication object-family inventories.
+
+The manifest also needs a portable association from changes to metadata. That
+association may be derived from verified sidecar payloads, or represented by a
+separate Merkle map:
+
+```rust
+struct ChangeMetadata {
+    provenance: ProvenanceState,
+    attestations: Vec<ObjectId>,
+}
+
+enum ProvenanceState {
+    /// No provenance is expected, such as an explicitly human-authored or
+    /// imported legacy change.
+    Unattributed,
+
+    /// Provenance is expected but publication is not yet complete.
+    Pending,
+
+    /// The declared provenance objects are present and verified.
+    Complete(Vec<ObjectId>),
+}
+```
+
+This removes the ambiguity between intentional absence and data loss. Policy can
+then determine whether `Pending` is publishable for a particular view or change
+author type.
+
+### Vault root
+
+The vault root points to the sharded, immutable vault manifest proposed in
+[`vault-sync-design.md`](./vault-sync-design.md):
+
+```text
+VaultRoot
+    ├── intents shard
+    ├── memories shard
+    ├── goals shard
+    ├── sessions shard
+    ├── skills shard
+    └── signed vault attestations shard
+```
+
+Vault entries reference changes, files, acceptance criteria, tasks, and memories
+using portable identities: hashes, URNs, and paths. Repository-local `NodeId`
+values never appear in transported relationships.
+
+## Required invariants
+
+### 1. Content-address integrity
+
+Every object must verify against the canonical hash algorithm for its family
+before it can be considered reachable from a publication.
+
+```text
+verify(family, canonical_bytes, advertised_key) == true
+```
+
+A server may accept unreferenced uploads optimistically, but it must not publish
+a root that reaches an invalid object.
+
+### 2. Per-family SetId correctness
+
+For every object family, recomputing `SetId` from the deduplicated canonical key
+inventory must equal the `set_id` stored in that family's manifest. A mismatch
+means the inventory is corrupt, incomplete, or was folded under the wrong family
+domain.
+
+`SetId` validation is necessary for convergence but insufficient for trust: the
+receiver still verifies canonical inventory bytes, individual content addresses,
+and the publication manifest hash.
+
+### 3. Closure completeness
+
+Before moving the publication ref, every required object reachable from the new
+manifest must exist and pass structural validation.
+
+Required closure includes:
+
+- publication manifest nodes;
+- views-manifest nodes and referenced view snapshots;
+- each view's change membership and transitive change dependencies;
+- required provenance and attestation objects;
+- vault-manifest nodes and referenced vault entries;
+- references required by the declared completeness policy.
+
+### 4. Ref-last publication
+
+Objects and manifest nodes are uploaded before the publication ref moves. The
+ref CAS is the sole visibility boundary.
+
+A partially uploaded closure is not published state.
+
+### 5. Portable relationships
+
+Transported objects may reference only identities stable across repositories:
+
+- content hashes;
+- typed object IDs;
+- canonical URNs;
+- repository-relative paths;
+- portable actor identities.
+
+Repository-local redb IDs, inode numbers, and table sequence numbers are derived
+indexes and never cross the wire.
+
+### 6. Deterministic canonicalization
+
+Equivalent logical manifests must produce byte-identical canonical encodings.
+Set and map order must be canonical. Concurrent reconciliation must not depend on
+which replica observed an object first.
+
+### 7. Monotonic immutable history
+
+Publishing metadata never rewrites a change. Late evidence produces new metadata
+and publication manifests that reference the existing change object.
+
+### 8. Rebuildability
+
+Given a publication root and its closure, a repository can rebuild:
+
+- pristine graph tables;
+- view indexes;
+- change-to-provenance and change-to-attestation indexes;
+- session manifests;
+- vault knowledge graph and embeddings;
+- a materialized working copy.
+
+No derived database is required to prove repository truth.
+
+## Publication protocol
+
+### Push
+
+```text
+1. Read the current publication ref and manifest.
+2. Compute the desired local publication closure.
+3. Compare per-family SetIds to identify equal and divergent object families.
+4. Negotiate canonical key deltas only for divergent families.
+5. Upload missing immutable leaves.
+6. Upload changed family inventories with their recomputed SetIds.
+7. Upload the new PublicationManifest.
+8. Request CAS(old_publication, new_publication).
+9. Server validates family SetIds, the referenced closure, and policy.
+10. CAS succeeds, or returns the current competing root.
+```
+
+The final CAS makes all referenced families visible together.
+
+```mermaid
+graph TD
+    A[Compute desired closure] --> B[Upload missing immutable objects]
+    B --> C[Upload changed manifest nodes]
+    C --> D[Upload PublicationManifest]
+    D --> E{CAS publication ref}
+    E -->|success| F[State is visible]
+    E -->|conflict| G[Fetch competing root]
+    G --> H[Reconcile and retry]
+```
+
+### Pull and clone
+
+```text
+1. Read the publication ref.
+2. Fetch the PublicationManifest.
+3. Select requested views and optional metadata/vault scopes.
+4. Walk the typed reachable closure.
+5. Subtract typed local haves.
+6. Transfer the missing objects.
+7. Verify each object and the complete selected closure.
+8. Rebuild local indexes and materialize only after verification.
+```
+
+A client may support fetch profiles:
+
+- `code`: view snapshots, changes, and required dependencies;
+- `audit`: code plus provenance, attestations, and sessions;
+- `vault`: selected vault shards and their cross-family references;
+- `complete`: the full publication closure.
+
+The profile changes what is intentionally selected, not whether the selected
+closure is complete. A code-only clone must report that audit/vault families were
+not requested rather than implying complete repository synchronization.
+
+## Late-arriving metadata
+
+Provenance and attestations often arrive after change serialization because an
+agent turn records code first and finalizes its ledger or signature afterward.
+This is not an exceptional repair path.
+
+```text
+Publication N
+    change C
+    metadata[C] = Pending
+
+Publication N+1
+    same change C
+    new provenance P
+    metadata[C] = Complete([P])
+```
+
+No change object or view membership needs to change. The client uploads `P`, the
+changed metadata-manifest path, and a new publication manifest, then advances the
+publication ref.
+
+For workflows that require provenance atomically with code visibility, policy
+must reject `Pending` at publication N. For workflows that allow eventual audit
+completion, `Pending` is visible and machine-detectable rather than silently
+missing.
+
+## Concurrency and reconciliation
+
+Two clients may publish concurrently from the same root:
+
+```text
+                  ┌── Publication A
+Publication Base ─┤
+                  └── Publication B
+```
+
+One CAS wins. The loser reads the winning root and reconciles:
+
+- change and metadata sets use deterministic union where semantics are monotonic;
+- view snapshot divergence uses the existing patch-set union rules;
+- vault entry sets use deterministic union, with explicit conflict semantics for
+  mutable logical identities;
+- deletions, parent changes, scope changes, and supersession require explicit
+  operations rather than blind set union.
+
+The reconciled publication records both predecessors:
+
+```text
+Publication Merge {
+    previous: [A, B],
+    ...canonical reconciled roots
+}
+```
+
+This preserves causal ancestry without imposing a global total order.
+
+## Failure and recovery semantics
+
+### Failure before ref CAS
+
+Uploaded objects are unreachable. Readers continue using the old publication.
+The writer can retry idempotently. Reachability GC may remove abandoned objects
+after a retention window.
+
+### CAS conflict
+
+No partial state is visible. The client fetches the current root, reconciles,
+and retries with a new manifest.
+
+### Missing object during publication validation
+
+The ref move is rejected with the missing typed object IDs. The writer uploads
+them and retries.
+
+### Missing object during read
+
+The publication is corrupt or storage replication is incomplete. The client must
+not claim successful verification. It can retry another replica or report the
+exact missing family/key.
+
+### Lost notification
+
+Readers recover by reading the current publication ref. Event delivery is not
+required for correctness.
+
+### Derived database loss
+
+Delete and rebuild it from the current publication closure. No authoritative
+state is lost.
+
+## Why a WAL is not the source of truth
+
+A distributed WAL would introduce a sequencing authority for operations that are
+otherwise immutable and often commutative. It requires:
+
+- sequence allocation and fencing;
+- leader election or consensus for multi-region writers;
+- gap detection and replay;
+- retention, checkpointing, and compaction;
+- secondary indexes for selective fetch;
+- rules for consumers that miss or reorder events.
+
+A WAL record also does not by itself solve multi-object atomicity. To publish a
+change, provenance graph, attestation, and vault update together, the record must
+point to a manifest describing that closure. At that point the manifest is the
+actual commit object and the WAL is only an observation stream.
+
+A WAL or event stream remains useful for:
+
+- announcing `old_root → new_root` transitions;
+- cache invalidation;
+- audit and operational telemetry;
+- asynchronous read-model construction;
+- analytics and billing;
+- accelerating replica convergence.
+
+Every consumer must treat events as duplicateable, reorderable, and lossy. The
+recovery rule is always:
+
+```text
+read ref → fetch manifest → verify/reconcile closure
+```
+
+## Relationship to Git
+
+The model borrows Git's strongest distribution property:
+
+```text
+immutable objects + tree/commit reachability + mutable refs
+```
+
+Atomic differs in important ways:
+
+- view divergence reconciles patch sets rather than performing textual 3-way
+  merges;
+- manifests are typed across code, audit metadata, and durable agent knowledge;
+- the canonical server store is object-store-native rather than packfile/POSIX
+  oriented;
+- redb is a derived semantic read model, not the distributed object truth;
+- completeness policy can require provenance and attestations for AI-authored
+  transitions.
+
+The publication manifest is therefore commit-shaped, but it publishes an Atomic
+repository knowledge graph rather than a Git filesystem tree.
+
+## Security and trust
+
+A publication manifest should support signatures over canonical bytes. Signature
+verification establishes who authorized the root transition; content hashes
+establish object integrity.
+
+Server publication checks should include:
+
+- authorization to move the repository publication ref;
+- object-family hash verification;
+- repository identity binding;
+- rejection of cross-project object substitution where policy requires isolation;
+- provenance/attestation signature verification where required;
+- maximum object, manifest, and closure sizes;
+- cycle detection in manifest and snapshot ancestry;
+- policy checks for required audit completeness.
+
+Signing the root does not automatically trust every sidecar author. Sidecars
+retain their own identities and proofs; the root signature means the publisher
+accepted those exact objects into repository state.
+
+## Garbage collection
+
+Immutable uploads may become unreachable because of interrupted pushes or lost
+CAS races. Garbage collection is reachability-based:
+
+1. Mark from all protected publication refs and retained historical roots.
+2. Traverse typed manifests and object references.
+3. Retain recently uploaded unreachable objects for a grace period.
+4. Sweep old unmarked objects.
+
+Historical retention policy determines whether all publication ancestry remains
+reachable or older roots may be compacted into checkpoints.
+
+In-flight uploads require leases, age thresholds, or upload-session markers so GC
+does not delete objects before their publication CAS.
+
+## Migration plan
+
+### Phase 0: repair current sidecar parity
+
+Before changing the protocol:
+
+- clone imports provenance and attestations from `SyncPack`;
+- pull imports both families consistently;
+- push synchronizes sidecars for the full view closure, not only newly uploaded
+  changes;
+- sidecar-only pushes do not return early as "already up to date";
+- reverse indexes are rebuilt or repaired from sidecar payloads.
+
+This makes the existing protocol correct enough to migrate without losing known
+objects.
+
+### Phase 1: typed negotiation
+
+- Replace untyped `haves: Vec<String>` with typed object IDs in a new protocol
+  version.
+- Preserve `sync/1` compatibility during rollout.
+- Add shared import/verification code for every client operation.
+
+### Phase 2: metadata and vault manifests
+
+- Introduce immutable, sharded metadata manifests.
+- Introduce immutable, sharded vault manifests.
+- Define provenance completeness policy and portable change-to-metadata mapping.
+
+### Phase 3: publication manifest and ref
+
+- Add `PublicationManifest` encoding and validation.
+- Add one authoritative publication ref per repository.
+- Upload closure first and CAS the publication ref last.
+- Continue updating legacy view/vault refs as compatibility projections.
+
+### Phase 4: publication-root reads
+
+- Clone and pull begin from the publication ref.
+- Existing view refs become derived conveniences or aliases.
+- Verification reports selected-profile completeness explicitly.
+
+### Phase 5: derived indexes and GC
+
+- Rebuild server read models from publication roots.
+- Add reachability GC with grace periods and protected roots.
+- Add optional root-transition events for cache and replica acceleration.
+
+### Phase 6: retire legacy truth paths
+
+- Stop treating independent family inventories as proof of completeness.
+- Remove compatibility ref updates after supported clients migrate.
+- Keep immutable object encodings where possible; migration should primarily add
+  manifests and typed reachability rather than rewrite leaves.
+
+## Open questions
+
+1. Is the authoritative publication ref project-wide, or should shared release
+   channels have independent publication refs?
+2. Which object families are mandatory for the default clone profile?
+3. Must agent-authored changes always publish with complete provenance, or may
+   they transition through `Pending`?
+4. Are graph-level attestations part of metadata, vault, or both through shared
+   object references?
+5. How are logical vault-entry updates and deletions reconciled under concurrent
+   publication?
+6. Should parent view snapshots be pinned directly in `ViewSnapshot`, or resolved
+   through the publication's immutable views map?
+7. What canonical Merkle map/set encoding should be shared by views, metadata,
+   and vault manifests?
+8. How long are losing-CAS and interrupted-upload objects retained before GC?
+9. Which historical publication roots are protected permanently or by policy?
+10. What signature policy applies to the publication root versus individual
+    provenance, attestation, and vault objects?
+
+## Decision summary
+
+Adopt a hybrid model:
+
+- **immutable content-addressed blobs** for all leaf object families;
+- **per-object-family SetIds stored in canonical manifests** for O(1) convergence checks, with the inventories remaining authoritative for reachability and completeness;
+- **one CAS-published publication root** as the atomic visibility boundary;
+- **patch-theoretic deterministic reconciliation** for concurrent roots;
+- **WAL/events only as an optional acceleration and audit plane**;
+- **redb and search indexes only as rebuildable read models**.
+
+The publication manifest does not replace Atomic's changes, view snapshots, or
+vault objects. It makes them one verifiable repository state.


### PR DESCRIPTION
## Summary

Fixes two reported bugs:

1. **Clone doesn't download provenance** — the server had the provenance, the `/code` pull response included it, and `atomic pull` imported it, but `atomic clone` received the same `SyncPack` and only indexed `ObjectFamily::Change`. A fresh clone printed "No provenance graph found" on `atomic change <hash>` until a later repair pull re-delivered the sidecars.
2. **Push not leveraging config.toml identity defaults** — `atomic identity register` (default path) wrote `url`/`default_org`/`single_tenant` to `[server]` but never `identity`, so push fell back to the identity store's global default — frequently the wrong identity on machines with several, producing confusing 401/404s.

## Bug 1 fix: shared sidecar import for clone and pull

- New `commands/sidecars.rs`: `import_sidecars(repo, pack)` ingests **provenance graphs + attestations** — parse the advertised key, skip what's present, verify the computed hash matches the advertised key, save. Corrupt/mismatched sidecars warn and skip without failing valid change ingestion. Idempotent.
- **Ordering matters**: `save_provenance_graph` only wires the DEPS edges behind `atomic change`'s REV_DEPS lookup for changes **already registered** in the graph, and registration happens at manifest-apply time. Clone therefore imports sidecars **after** applying view manifests (normal + `--all-views`), and before the early return in `--download-only` (files land now; DEPS wiring defers to a later `atomic insert`). Importing immediately after `download_missing_changes` — before the applies — would still leave `atomic change` broken, which is why the original "repair pull" worked.
- Pull now reuses the same helper — moved **after** view reconciliation, fixing the same latent gap on first pulls — and gains attestation import it never had.
- **Regression test** (`clone_sidecar_integration_test.rs`): drives the real CLI binary against an in-test HTTP server speaking the `/code` sync protocol (`SyncWants` GET → `SyncPack` response) over a hand-built agent-push pack. Asserts a fresh clone's `atomic change <hash>` shows the Change Ledger immediately, and the attestation sidecar lands. Verified the test fails without the clone fix.

## Bug 2 fix: identity binding + resolution stack

`atomic push` identity resolution, in order:

1. `--identity` flag
2. URL userinfo (`bob@host`)
3. Server-profile binding from `~/.atomic/config.toml` (longest host suffix; **active profile wins equal-host ties** — previously an arbitrary named profile always beat `default_server` and the legacy `[server]` block)
4. Subdomain label (legacy heuristic)
5. Identity store default

- `identity register` now binds the registering identity in **both** config paths — the legacy `[server]` block (default path) and named `--identity` profiles — via the new testable `apply_registration` helper, so push authenticates as the identity that actually registered even when the store's global default is something else.
- Documented the full order in the `auth.rs` module header; new unit tests cover the binding-beats-default scenario, active-profile tie-breaks, and longest-suffix-beats-active.

## Testing

- `cargo test -p atomic-cli` — 1827 unit + all integration tests pass
- `cargo clippy -p atomic-cli --all-targets` — clean
- Manually verified live: `[server] identity` binding wins over a conflicting store default; existing subdomain/server-binding paths unchanged

## Notes

- Requires no server-side changes — the server already sends provenance/attest objects in the `/code` pack.