### PR TITLE
fix(ci): add statically linked musl builds for Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,15 +58,28 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Linux x86_64
+          # Linux x86_64 (glibc — requires glibc 2.17+)
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact: atomic-x86_64-unknown-linux-gnu.tar.gz
 
-          # Linux aarch64 (cross-compiled)
+          # Linux x86_64 (musl — statically linked, works on any Linux)
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            artifact: atomic-x86_64-unknown-linux-musl.tar.gz
+            musl: true
+
+          # Linux aarch64 (glibc, cross-compiled)
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             artifact: atomic-aarch64-unknown-linux-gnu.tar.gz
+            cross: true
+
+          # Linux aarch64 (musl — statically linked, works on any Linux)
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            artifact: atomic-aarch64-unknown-linux-musl.tar.gz
+            musl: true
             cross: true
 
           # macOS x86_64 (Intel)
@@ -94,8 +107,21 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation OpenSSL (aarch64)
-        if: matrix.cross
+      - name: Install zig (for musl builds)
+        if: matrix.musl
+        uses: mlugg/setup-zig@v1
+        with:
+          version: '0.13.0'
+
+      - name: Install musl tools and cargo-zigbuild
+        if: matrix.musl
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y musl-tools
+          cargo install cargo-zigbuild --quiet
+
+      - name: Install cross-compilation toolchain (aarch64-gnu)
+        if: matrix.cross && !matrix.musl
         run: |
           # Install only the cross-compiler toolchain. OpenSSL is built from
           # source via OPENSSL_VENDORED so no arm64 system libraries are needed.
@@ -114,11 +140,19 @@ jobs:
             ${{ runner.os }}-${{ matrix.target }}-cargo-release-
 
       - name: Build release binary
-        if: ${{ !matrix.cross }}
+        if: ${{ !matrix.cross && !matrix.musl }}
         run: cargo build --release --target ${{ matrix.target }} -p atomic-cli
 
-      - name: Build release binary (cross)
-        if: matrix.cross
+      - name: Build release binary (musl x86_64)
+        if: matrix.musl && !matrix.cross
+        run: cargo zigbuild --release --target ${{ matrix.target }} -p atomic-cli
+
+      - name: Build release binary (musl aarch64)
+        if: matrix.musl && matrix.cross
+        run: cargo zigbuild --release --target ${{ matrix.target }} -p atomic-cli
+
+      - name: Build release binary (cross aarch64-gnu)
+        if: matrix.cross && !matrix.musl
         env:
           # OpenSSL is compiled from source via git2's vendored-openssl feature.
           # Only the linker needs to be set explicitly for the target triple.
@@ -232,13 +266,25 @@ jobs:
           sudo mv atomic /usr/local/bin/
           ```
 
-          ### Linux (x86_64)
+          ### Linux (x86_64, statically linked — works on any Linux including Ubuntu 20.04+)
+          ```bash
+          curl -L https://github.com/${{ github.repository }}/releases/download/${{ needs.version.outputs.tag }}/atomic-x86_64-unknown-linux-musl.tar.gz | tar xz
+          sudo mv atomic /usr/local/bin/
+          ```
+
+          ### Linux (x86_64, glibc — requires glibc 2.17+)
           ```bash
           curl -L https://github.com/${{ github.repository }}/releases/download/${{ needs.version.outputs.tag }}/atomic-x86_64-unknown-linux-gnu.tar.gz | tar xz
           sudo mv atomic /usr/local/bin/
           ```
 
-          ### Linux (aarch64)
+          ### Linux (aarch64, statically linked — works on any Linux)
+          ```bash
+          curl -L https://github.com/${{ github.repository }}/releases/download/${{ needs.version.outputs.tag }}/atomic-aarch64-unknown-linux-musl.tar.gz | tar xz
+          sudo mv atomic /usr/local/bin/
+          ```
+
+          ### Linux (aarch64, glibc)
           ```bash
           curl -L https://github.com/${{ github.repository }}/releases/download/${{ needs.version.outputs.tag }}/atomic-aarch64-unknown-linux-gnu.tar.gz | tar xz
           sudo mv atomic /usr/local/bin/


### PR DESCRIPTION
Fixes #181.

## Problem

The prebuilt Linux binaries were compiled on `ubuntu-latest` (Ubuntu 24.04, glibc 2.39), which bakes in a glibc 2.38/2.39 symbol version requirement. This breaks the binary on Ubuntu 22.04 LTS, Debian 12, RHEL 9, Linux Mint 21, Pop!_OS 22.04, and any other distro shipping glibc < 2.38 — all still in active support.

## Solution

Add `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` matrix entries to the release workflow. musl binaries are **fully statically linked** with no glibc dependency, so they run on any Linux kernel ≥ 3.x regardless of distro.

**Why musl builds are safe for this project:**
- `git2` already uses `vendored-openssl` — OpenSSL is compiled from source
- `rusqlite` already uses `bundled` — SQLite is compiled from source
- No other dynamic native libs remain; the musl binary has zero shared library deps

**Toolchain:** `cargo-zigbuild` + zig 0.13.0 via `mlugg/setup-zig`. Zig acts as a musl-compatible linker shim for both arches without needing a separate musl cross-compiler package. The `musl-tools` apt package provides the musl libc headers for x86_64.

## Test

Built locally on macOS (cross-compiling to `x86_64-unknown-linux-musl`):

```
Finished `release` profile [optimized] target(s) in 3m 15s
```

```
$ file target/x86_64-unknown-linux-musl/release/atomic
atomic: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
```

Zero link errors. The gnu targets are unchanged.

## Changes

- `release.yml`: 2 new matrix entries (musl x86_64 + aarch64), conditional build steps using `cargo-zigbuild`, release notes updated to lead with musl artifacts as the recommended Linux install