### PR TITLE
fix(ci): enforce glibc 2.28 floor for Linux releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,12 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   BINARY_NAME: atomic
+  # Linux release binaries must run on all supported LTS distributions,
+  # including RHEL 9. Keep this explicit so runner upgrades cannot silently
+  # raise the minimum required glibc version.
+  GLIBC_MIN: "2.28"
+  CARGO_ZIGBUILD_VERSION: "0.23.4"
+  ZIG_VERSION: "0.16.0"
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -31,6 +37,8 @@ jobs:
   version:
     name: Extract Version
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
@@ -54,6 +62,8 @@ jobs:
     name: Build (${{ matrix.target }})
     needs: [version]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -62,27 +72,36 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact: atomic-x86_64-unknown-linux-gnu.tar.gz
+            build_mode: zig
+            verify_glibc: true
 
           # Linux aarch64 (cross-compiled)
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             artifact: atomic-aarch64-unknown-linux-gnu.tar.gz
-            cross: true
+            build_mode: zig
+            verify_glibc: true
 
           # macOS x86_64 (Intel)
           - os: macos-latest
             target: x86_64-apple-darwin
             artifact: atomic-x86_64-apple-darwin.tar.gz
+            build_mode: native
+            verify_glibc: false
 
           # macOS aarch64 (Apple Silicon)
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact: atomic-aarch64-apple-darwin.tar.gz
+            build_mode: native
+            verify_glibc: false
 
           # Windows x86_64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: atomic-x86_64-pc-windows-msvc.zip
+            build_mode: native
+            verify_glibc: false
 
     steps:
       - uses: actions/checkout@v4
@@ -94,13 +113,11 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation OpenSSL (aarch64)
-        if: matrix.cross
-        run: |
-          # Install only the cross-compiler toolchain. OpenSSL is built from
-          # source via OPENSSL_VENDORED so no arm64 system libraries are needed.
-          sudo apt-get update -qq
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+      - name: Install Zig
+        if: matrix.build_mode == 'zig'
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: ${{ env.ZIG_VERSION }}
 
       - name: Cache cargo registry and build
         uses: actions/cache@v4
@@ -109,21 +126,46 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ matrix.target }}-${{ matrix.build_mode }}-zig-${{ env.ZIG_VERSION }}-glibc-${{ env.GLIBC_MIN }}-cargo-zigbuild-${{ env.CARGO_ZIGBUILD_VERSION }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.target }}-cargo-release-
+            ${{ runner.os }}-${{ matrix.target }}-${{ matrix.build_mode }}-zig-${{ env.ZIG_VERSION }}-glibc-${{ env.GLIBC_MIN }}-cargo-zigbuild-${{ env.CARGO_ZIGBUILD_VERSION }}-cargo-release-
+
+      - name: Install cargo-zigbuild
+        if: matrix.build_mode == 'zig'
+        run: cargo install --locked cargo-zigbuild --version "${CARGO_ZIGBUILD_VERSION}"
 
       - name: Build release binary
-        if: ${{ !matrix.cross }}
+        if: matrix.build_mode == 'native'
         run: cargo build --release --target ${{ matrix.target }} -p atomic-cli
 
-      - name: Build release binary (cross)
-        if: matrix.cross
-        env:
-          # OpenSSL is compiled from source via git2's vendored-openssl feature.
-          # Only the linker needs to be set explicitly for the target triple.
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-        run: cargo build --release --target ${{ matrix.target }} -p atomic-cli
+      - name: Build Linux release binary with glibc floor
+        if: matrix.build_mode == 'zig'
+        run: cargo zigbuild --release --target "${{ matrix.target }}.${GLIBC_MIN}" -p atomic-cli
+
+      - name: Verify Linux glibc floor
+        if: matrix.verify_glibc
+        shell: bash
+        run: |
+          BINARY="target/${{ matrix.target }}/release/${BINARY_NAME}"
+          MAX_GLIBC=$(
+            readelf -W --version-info "$BINARY" \
+              | sed -n 's/.*Name: GLIBC_\([0-9][0-9.]*\).*/\1/p' \
+              | sort -V \
+              | tail -1
+          )
+
+          if [[ -z "$MAX_GLIBC" ]]; then
+            echo "::error::Could not determine the minimum glibc version for $BINARY"
+            exit 1
+          fi
+
+          HIGHEST=$(printf '%s\n%s\n' "$GLIBC_MIN" "$MAX_GLIBC" | sort -V | tail -1)
+          if [[ "$HIGHEST" != "$GLIBC_MIN" ]]; then
+            echo "::error::$BINARY requires glibc $MAX_GLIBC, above the supported floor $GLIBC_MIN"
+            exit 1
+          fi
+
+          echo "$BINARY requires glibc $MAX_GLIBC (supported floor: $GLIBC_MIN)"
 
       # Package: Unix (tar.gz)
       - name: Package binary (Unix)
@@ -133,7 +175,7 @@ jobs:
           cp target/${{ matrix.target }}/release/${{ env.BINARY_NAME }} staging/
           cp README.md LICENSE staging/ 2>/dev/null || true
           cd staging
-          tar czf ../${{ matrix.artifact }} *
+          tar czf ../${{ matrix.artifact }} ./*
 
       # Package: Windows (zip)
       - name: Package binary (Windows)
@@ -178,7 +220,7 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts
-          find . -type f \( -name "*.tar.gz" -o -name "*.zip" \) | while read f; do
+          find . -type f \( -name "*.tar.gz" -o -name "*.zip" \) | while read -r f; do
             sha256sum "$f" >> ../checksums-sha256.txt
           done
           cd ..


### PR DESCRIPTION
## Summary

- Build the existing x86_64 and aarch64 Linux GNU release artifacts with `cargo-zigbuild` against an explicit glibc 2.28 floor.
- Fail the release if the generated ELF requires a newer GLIBC symbol version, preventing runner upgrades from silently raising compatibility requirements again.
- Pin the Zig setup action to an immutable SHA and restrict the version/build jobs to read-only repository permissions.

This preserves the current GNU artifact names and fixes their compatibility directly. PR #183 takes the alternative approach of adding separate musl artifacts while leaving the GNU artifacts unchanged.

## Root cause

The v0.17.1 GNU binaries were built directly on `ubuntu-latest`, so they inherited GLIBC 2.38/2.39 symbols from the hosted runner and failed to start on Ubuntu 22.04 (glibc 2.35).

## Test coverage

No application code paths changed. The release workflow now validates both Linux GNU artifacts against the declared GLIBC floor.

## Verification

- [x] `cargo test --workspace`
- [x] `actionlint`
- [x] Built `x86_64-unknown-linux-gnu.2.28` and `aarch64-unknown-linux-gnu.2.28` with cargo-zigbuild 0.23.4 / Zig 0.16.0
- [x] Confirmed both ELF artifacts require at most `GLIBC_2.28`
- [x] Ran both artifacts successfully on Ubuntu 20.04 and Ubuntu 22.04 containers
- [x] Confirmed the compatibility gate rejects the published v0.17.1 artifact (`GLIBC_2.39`) and accepts the rebuilt artifact (`GLIBC_2.28`)

## Review notes

The remaining non-blocking follow-up is to run baseline-distro smoke tests in PR CI so future loader, shared-library, or CPU-baseline regressions are caught before a release.

Fixes #181
