### PR TITLE
fix(remote): distinguish legacy sync responses

### DIFF
--- a/atomic-remote/src/error.rs
+++ b/atomic-remote/src/error.rs
@@ -133,9 +133,9 @@ pub enum RemoteError {
 
     /// The client and server are running incompatible versions.
     ///
-    /// Surfaces when the binary sync-pack wire format cannot be decoded,
-    /// which almost always means the server is on a different release than
-    /// the client. Downgrade or upgrade one side to match the other.
+    /// Surfaces when a response indicates that the server predates the current
+    /// binary sync protocol and its body cannot be decoded by this client.
+    /// Downgrade or upgrade one side to match the other.
     #[error("{}", version_mismatch_message(client_version, server_version.as_deref()))]
     VersionMismatch {
         /// The local CLI version.

--- a/atomic-remote/src/http/code_sync.rs
+++ b/atomic-remote/src/http/code_sync.rs
@@ -91,20 +91,45 @@ impl HttpRemote {
             .await
             .map_err(|e| RemoteError::connection_failed(&url, e))?;
         crate::check_min_version_header(response.headers());
-        // Capture the server's reported min-version before consuming the body,
-        // so we can include it in a version-mismatch error if decode fails.
-        let server_version = crate::read_min_version_header(response.headers());
+        // Capture compatibility metadata before consuming the body. A server
+        // that predates sync/1 returns its JSON project-info response here,
+        // while a current server promises the binary format via Content-Type.
+        let min_cli_version = crate::read_min_version_header(response.headers());
+        let content_type = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned);
         match response.status() {
             StatusCode::OK => {
                 let bytes = response
                     .bytes()
                     .await
                     .map_err(|e| RemoteError::connection_failed(&url, e))?;
-                SyncPack::decode(&bytes).map_err(|e| match e {
-                    SyncError::Compression(_) | SyncError::Codec(_) => {
-                        RemoteError::version_mismatch(crate::VERSION, server_version, e.to_string())
+                SyncPack::decode(&bytes).map_err(|e| {
+                    let explicitly_legacy_media_type =
+                        content_type.as_deref().is_some_and(is_legacy_media_type);
+                    match e {
+                        SyncError::Compression(_) | SyncError::Codec(_)
+                            if explicitly_legacy_media_type =>
+                        {
+                            RemoteError::version_mismatch(
+                                crate::VERSION,
+                                min_cli_version,
+                                e.to_string(),
+                            )
+                        }
+                        SyncError::Compression(_) | SyncError::Codec(_) => {
+                            RemoteError::protocol(format!(
+                                "remote returned invalid data for protocol {PROTOCOL_SYNC_V1}: \
+                                 {e}. Retry the operation; if it keeps failing, contact the \
+                                 storage owner."
+                            ))
+                        }
+                        SyncError::TooLarge { .. } => {
+                            RemoteError::protocol(format!("failed to decode sync pack: {e}"))
+                        }
                     }
-                    _ => RemoteError::protocol(format!("failed to decode sync pack: {e}")),
                 })
             }
             StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => Err(RemoteError::auth_failed(
@@ -116,5 +141,145 @@ impl HttpRemote {
                 response.text().await.unwrap_or_default(),
             )),
         }
+    }
+}
+
+/// Recognize the JSON response returned by servers that predate `sync/1`.
+fn is_legacy_media_type(content_type: &str) -> bool {
+    let media_type = content_type
+        .split(';')
+        .next()
+        .map(str::trim)
+        .unwrap_or_default();
+    media_type.eq_ignore_ascii_case("application/json")
+        || media_type
+            .rsplit_once('+')
+            .is_some_and(|(_, suffix)| suffix.eq_ignore_ascii_case("json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    use super::*;
+
+    fn serve_once(body: Vec<u8>, content_type: Option<&'static str>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let addr = listener.local_addr().expect("test server address");
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut request = [0_u8; 8192];
+            let _ = stream.read(&mut request);
+            let content_type_header = content_type
+                .map(|value| format!("Content-Type: {value}\r\n"))
+                .unwrap_or_default();
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\n{content_type_header}X-Atomic-Min-Version: 0.16.2\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            )
+            .expect("write response head");
+            stream.write_all(&body).expect("write response body");
+        });
+        format!("http://{addr}/workspaces/w/projects/p/code")
+    }
+
+    async fn pull_from(
+        body: Vec<u8>,
+        content_type: Option<&'static str>,
+    ) -> RemoteResult<SyncPack> {
+        HttpRemote::new(&serve_once(body, content_type))?
+            .sync_pull(&SyncWants::default())
+            .await
+    }
+
+    #[tokio::test]
+    async fn legacy_json_response_reports_version_mismatch() {
+        let err = pull_from(br#"{"success":true}"#.to_vec(), Some("application/json"))
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            &err,
+            RemoteError::VersionMismatch {
+                server_version: Some(version),
+                ..
+            } if version == "0.16.2"
+        ));
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "Failed to decode data from remote — the client and server may be running \
+                 incompatible versions.\n  \
+                 Client version: {}\n  \
+                 Server min-version: 0.16.2\n  \
+                 Hint: run 'atomic update' to upgrade, or ask the storage owner for their server version.",
+                crate::VERSION
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn corrupt_current_protocol_response_is_not_a_version_mismatch() {
+        let err = pull_from(b"not a zstd frame".to_vec(), Some(SYNC_MEDIA_TYPE))
+            .await
+            .unwrap_err();
+        assert!(matches!(&err, RemoteError::ProtocolError { .. }));
+        assert!(err.to_string().contains("Unknown frame descriptor"));
+    }
+
+    #[tokio::test]
+    async fn corrupt_generic_binary_response_is_not_a_version_mismatch() {
+        let err = pull_from(
+            b"not a zstd frame".to_vec(),
+            Some("application/octet-stream"),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(&err, RemoteError::ProtocolError { .. }));
+    }
+
+    #[tokio::test]
+    async fn invalid_postcard_from_current_protocol_is_not_a_version_mismatch() {
+        let body = atomic_objects::encode(&u64::MAX).unwrap();
+        let err = pull_from(body, Some(SYNC_MEDIA_TYPE)).await.unwrap_err();
+        assert!(matches!(&err, RemoteError::ProtocolError { .. }));
+        assert!(err.to_string().contains("sync codec error"));
+    }
+
+    #[tokio::test]
+    async fn invalid_postcard_from_legacy_media_type_reports_version_mismatch() {
+        let body = atomic_objects::encode(&u64::MAX).unwrap();
+        let err = pull_from(body, Some("application/json")).await.unwrap_err();
+        assert!(matches!(&err, RemoteError::VersionMismatch { .. }));
+    }
+
+    #[tokio::test]
+    async fn corrupt_unlabelled_response_is_not_a_version_mismatch() {
+        let err = pull_from(b"not a zstd frame".to_vec(), None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RemoteError::ProtocolError { .. }));
+    }
+
+    #[tokio::test]
+    async fn valid_sync_pack_remains_compatible_with_generic_media_type() {
+        let pack = pull_from(
+            SyncPack::empty().encode().unwrap(),
+            Some("application/octet-stream"),
+        )
+        .await
+        .unwrap();
+        assert!(pack.is_empty());
+    }
+
+    #[test]
+    fn legacy_media_type_allows_parameters_case_and_json_suffix() {
+        assert!(is_legacy_media_type("application/json"));
+        assert!(is_legacy_media_type(
+            "Application/Problem+Json; charset=utf-8"
+        ));
+        assert!(!is_legacy_media_type(SYNC_MEDIA_TYPE));
+        assert!(!is_legacy_media_type("application/octet-stream"));
     }
 }


### PR DESCRIPTION
## Summary

- Preserve PR #180's actionable version-mismatch message when a pre-`sync/1` server returns its JSON project response.
- Treat malformed current-protocol, generic binary, and unlabeled responses as protocol errors instead of falsely blaming a version mismatch.
- Keep the low-level compression or codec cause for genuine corrupt-response diagnostics.

Follow-up to #180. Refs #177.

## Test Coverage

Coverage audit: 15/16 changed paths covered (94%); all three user flows are covered. The remaining `SyncError::TooLarge` HTTP mapping is already exercised at the codec layer and would require a 2 GiB fixture at this layer.

Added HTTP-level regressions for:

- the exact legacy JSON/version-mismatch message, including client and server minimum versions
- corrupt zstd data from current, generic binary, and unlabeled responses
- valid-zstd/invalid-postcard codec failures for legacy and current media types
- valid sync packs served as `application/octet-stream`
- case-insensitive JSON media types, parameters, and `+json` suffixes

## Pre-Landing Review

One test-review finding was fixed: `application/octet-stream` is supported by an existing CLI fixture and must not itself prove a legacy server. Maintainability, security, performance, API contract, and adversarial reviews found no remaining issues.

## Design Review

No frontend files changed — design review skipped.

## Eval Results

No prompt-related files changed — evals skipped.

## Plan Completion

No plan file detected. The requested #177 follow-up behavior is complete.

## Test plan

- [x] `cargo test -p atomic-remote` — 223 passed; 14 doctests passed; 4 ignored
- [x] `cargo test` — full workspace suite passed
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p atomic-remote --all-targets -- -D warnings`

Note: workspace-wide clippy remains blocked by five pre-existing warnings on `dev` in `atomic-repository` and `atomic-agent`; the changed crate is clean.
